### PR TITLE
Update shared csproj to use SolutionDir for dependencies

### DIFF
--- a/device/Microsoft.Azure.Devices.Client/Microsoft.Azure.Devices.Client.csproj
+++ b/device/Microsoft.Azure.Devices.Client/Microsoft.Azure.Devices.Client.csproj
@@ -162,7 +162,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="PCLCrypto, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCLCrypto.2.0.147\lib\net45\PCLCrypto.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\PCLCrypto.2.0.147\lib\net45\PCLCrypto.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/shared/Microsoft.Azure.Devices.Shared/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/Microsoft.Azure.Devices.Shared/Microsoft.Azure.Devices.Shared.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Microsoft.Azure.Devices.Shared</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -41,7 +42,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
Solutions including the device client as a git submodule cannot resolve dependencies properly.