### PR TITLE
[ServiceSDK] Add IDisposable to base classes

### DIFF
--- a/service/Microsoft.Azure.Devices/AmqpServiceClient.cs
+++ b/service/Microsoft.Azure.Devices/AmqpServiceClient.cs
@@ -53,9 +53,9 @@ namespace Microsoft.Azure.Devices
                 DefaultOperationTimeout,
                 client => {});
         }
-                
+
         internal AmqpServiceClient(IotHubConnectionString iotHubConnectionString, bool useWebSocketOnly, IHttpClientHelper httpClientHelper) : base()
-        {            
+        {
             this.httpClientHelper = httpClientHelper;
         }
 
@@ -101,7 +101,9 @@ namespace Microsoft.Azure.Devices
 
         public async override Task CloseAsync()
         {
+            await this.faultTolerantSendingLink.CloseAsync();
             await this.feedbackReceiver.CloseAsync();
+            await this.fileNotificationReceiver.CloseAsync();
             await this.iotHubConnection.CloseAsync();
         }
 
@@ -218,6 +220,7 @@ namespace Microsoft.Azure.Devices
             if (disposing)
             {
                 this.faultTolerantSendingLink.Dispose();
+                this.fileNotificationReceiver.Dispose();
                 this.feedbackReceiver.Dispose();
                 this.iotHubConnection.Dispose();
                 this.httpClientHelper.Dispose();

--- a/service/Microsoft.Azure.Devices/AmqpServiceClient.cs
+++ b/service/Microsoft.Azure.Devices/AmqpServiceClient.cs
@@ -101,10 +101,8 @@ namespace Microsoft.Azure.Devices
 
         public async override Task CloseAsync()
         {
-            this.faultTolerantSendingLink.Dispose();
             await this.feedbackReceiver.CloseAsync();
             await this.iotHubConnection.CloseAsync();
-            this.httpClientHelper.Dispose();
         }
 
         public async override Task SendAsync(string deviceId, Message message)
@@ -219,6 +217,7 @@ namespace Microsoft.Azure.Devices
         {
             if (disposing)
             {
+                this.faultTolerantSendingLink.Dispose();
                 this.feedbackReceiver.Dispose();
                 this.iotHubConnection.Dispose();
                 this.httpClientHelper.Dispose();

--- a/service/Microsoft.Azure.Devices/AmqpServiceClient.cs
+++ b/service/Microsoft.Azure.Devices/AmqpServiceClient.cs
@@ -219,8 +219,6 @@ namespace Microsoft.Azure.Devices
         {
             if (disposing)
             {
-                // This is more efficient than async and wait in base.Dispose(bool).
-                this.faultTolerantSendingLink.Dispose();
                 this.feedbackReceiver.Dispose();
                 this.iotHubConnection.Dispose();
                 this.httpClientHelper.Dispose();

--- a/service/Microsoft.Azure.Devices/AmqpServiceClient.cs
+++ b/service/Microsoft.Azure.Devices/AmqpServiceClient.cs
@@ -59,6 +59,15 @@ namespace Microsoft.Azure.Devices
             this.httpClientHelper = httpClientHelper;
         }
 
+        internal AmqpServiceClient(IotHubConnection iotHubConnection, IHttpClientHelper httpClientHelper)
+        {
+            this.iotHubConnection = iotHubConnection;
+            this.faultTolerantSendingLink = new FaultTolerantAmqpObject<SendingAmqpLink>( this.CreateSendingLinkAsync, iotHubConnection.CloseLink );
+            this.feedbackReceiver = new AmqpFeedbackReceiver(iotHubConnection);
+            this.fileNotificationReceiver = new AmqpFileNotificationReceiver(iotHubConnection);
+            this.httpClientHelper = httpClientHelper;
+        }
+
         public TimeSpan OpenTimeout
         {
             get

--- a/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
+++ b/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
@@ -71,11 +71,7 @@ namespace Microsoft.Azure.Devices
 
         public override Task CloseAsync()
         {
-            if (this.httpClientHelper != null)
-            {
-                this.httpClientHelper.Dispose();
-                this.httpClientHelper = null;
-            }
+            this.Dispose();
 
             return TaskHelpers.CompletedTask;
         }

--- a/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
+++ b/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
@@ -71,8 +71,6 @@ namespace Microsoft.Azure.Devices
 
         public override Task CloseAsync()
         {
-            this.Dispose();
-
             return TaskHelpers.CompletedTask;
         }
 

--- a/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
+++ b/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices
     using Microsoft.Azure.Devices.Common.Exceptions;
     using Newtonsoft.Json;
 
-    class HttpRegistryManager : RegistryManager, IDisposable
+    class HttpRegistryManager : RegistryManager
     {
         const string AdminUriFormat = "/$admin/{0}?{1}";
         const string RequestUriFormat = "/devices/{0}?{1}";
@@ -345,20 +345,7 @@ namespace Microsoft.Azure.Devices
                 CancellationToken.None));
         }
 
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            this.Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Dispose resources
-        /// </summary>
-        /// <param name="disposing">
-        /// Governs disposable of managed and native resources
-        /// </param>
-        protected virtual void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (disposing && this.httpClientHelper != null)
             {

--- a/service/Microsoft.Azure.Devices/IotHubConnection.cs
+++ b/service/Microsoft.Azure.Devices/IotHubConnection.cs
@@ -56,6 +56,11 @@ namespace Microsoft.Azure.Devices
             this.useWebSocketOnly = useWebSocketOnly;
         }
 
+        internal IotHubConnection(Func<TimeSpan, Task<AmqpSession>> onCreate, Action<AmqpSession> onClose)
+        {
+            this.faultTolerantSession = new FaultTolerantAmqpObject<AmqpSession>(onCreate, onClose);
+        }
+
         internal IotHubConnectionString ConnectionString
         {
             get

--- a/service/Microsoft.Azure.Devices/JobClient/HttpJobClient.cs
+++ b/service/Microsoft.Azure.Devices/JobClient/HttpJobClient.cs
@@ -58,12 +58,7 @@ namespace Microsoft.Azure.Devices
 
         public override Task CloseAsync()
         {
-            if (this.httpClientHelper != null)
-            {
-                this.httpClientHelper.Dispose();
-                this.httpClientHelper = null;
-            }
-
+            this.Dispose();
             return TaskHelpers.CompletedTask;
         }
 

--- a/service/Microsoft.Azure.Devices/JobClient/HttpJobClient.cs
+++ b/service/Microsoft.Azure.Devices/JobClient/HttpJobClient.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices
     using Microsoft.Azure.Devices.Common;
     using Microsoft.Azure.Devices.Common.Exceptions;
 
-    class HttpJobClient : JobClient, IDisposable
+    class HttpJobClient : JobClient
     {
         const string JobsUriFormat = "/jobs/v2/{0}?{1}";
         const string JobsQueryFormat = "/jobs/v2/query?{0}";
@@ -62,20 +62,7 @@ namespace Microsoft.Azure.Devices
             return TaskHelpers.CompletedTask;
         }
 
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            this.Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Dispose resources
-        /// </summary>
-        /// <param name="disposing">
-        /// Governs disposable of managed and native resources
-        /// </param>
-        protected virtual void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (disposing)
             {

--- a/service/Microsoft.Azure.Devices/JobClient/HttpJobClient.cs
+++ b/service/Microsoft.Azure.Devices/JobClient/HttpJobClient.cs
@@ -58,7 +58,6 @@ namespace Microsoft.Azure.Devices
 
         public override Task CloseAsync()
         {
-            this.Dispose();
             return TaskHelpers.CompletedTask;
         }
 

--- a/service/Microsoft.Azure.Devices/JobClient/JobClient.cs
+++ b/service/Microsoft.Azure.Devices/JobClient/JobClient.cs
@@ -36,14 +36,7 @@ namespace Microsoft.Azure.Devices
         /// Releases unmanaged and - optionally - managed resources.
         /// </summary>
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        protected virtual void Dispose( bool disposing )
-        {
-            if (disposing)
-            {
-                // Call CloseAsync() synchronously avoiding AggregateException.
-                this.CloseAsync().GetAwaiter().GetResult();
-            }
-        }
+        protected virtual void Dispose(bool disposing) {}
 
         /// <summary>
         /// Explicitly open the JobClient instance.

--- a/service/Microsoft.Azure.Devices/JobClient/JobClient.cs
+++ b/service/Microsoft.Azure.Devices/JobClient/JobClient.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Devices
     /// <summary>
     /// Job management
     /// </summary>
-    public abstract class JobClient
+    public abstract class JobClient : IDisposable
     {
         /// <summary>
         /// Creates a JobClient from the Iot Hub connection string.
@@ -23,6 +23,26 @@ namespace Microsoft.Azure.Devices
         {
             var iotHubConnectionString = IotHubConnectionString.Parse(connectionString);
             return new HttpJobClient(iotHubConnectionString);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose( bool disposing )
+        {
+            if (disposing)
+            {
+                // Call CloseAsync() synchronously avoiding AggregateException.
+                this.CloseAsync().GetAwaiter().GetResult();
+            }
         }
 
         /// <summary>

--- a/service/Microsoft.Azure.Devices/RegistryManager.cs
+++ b/service/Microsoft.Azure.Devices/RegistryManager.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices
     /// <summary>
     /// Contains methods that services can use to perform create, remove, update and delete operations on devices.
     /// </summary>
-    public abstract class RegistryManager
+    public abstract class RegistryManager : IDisposable
     {
         /// <summary>
         /// Creates a RegistryManager from the Iot Hub connection string.
@@ -24,6 +24,26 @@ namespace Microsoft.Azure.Devices
         {
             IotHubConnectionString iotHubConnectionString = IotHubConnectionString.Parse(connectionString);
             return new HttpRegistryManager(iotHubConnectionString);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose( bool disposing )
+        {
+            if (disposing)
+            {
+                // Call CloseAsync() synchronously avoiding AggregateException.
+                this.CloseAsync().GetAwaiter().GetResult();
+            }
         }
 
         /// <summary>

--- a/service/Microsoft.Azure.Devices/RegistryManager.cs
+++ b/service/Microsoft.Azure.Devices/RegistryManager.cs
@@ -37,14 +37,7 @@ namespace Microsoft.Azure.Devices
         /// Releases unmanaged and - optionally - managed resources.
         /// </summary>
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        protected virtual void Dispose( bool disposing )
-        {
-            if (disposing)
-            {
-                // Call CloseAsync() synchronously avoiding AggregateException.
-                this.CloseAsync().GetAwaiter().GetResult();
-            }
-        }
+        protected virtual void Dispose(bool disposing) {}
 
         /// <summary>
         /// Explicitly open the RegistryManager instance.

--- a/service/Microsoft.Azure.Devices/ServiceClient.cs
+++ b/service/Microsoft.Azure.Devices/ServiceClient.cs
@@ -56,14 +56,7 @@ namespace Microsoft.Azure.Devices
         /// Releases unmanaged and - optionally - managed resources.
         /// </summary>
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if ( disposing )
-            {
-                // Call CloseAsync() synchronously avoiding AggregateException.
-                this.CloseAsync().GetAwaiter().GetResult();
-            }
-        }
+        protected virtual void Dispose(bool disposing) {}
 
         /// <summary>
         /// Create ServiceClient from the specified connection string using specified Transport Type

--- a/service/Microsoft.Azure.Devices/ServiceClient.cs
+++ b/service/Microsoft.Azure.Devices/ServiceClient.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Azure.Devices
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,7 +26,7 @@ namespace Microsoft.Azure.Devices
     /// <summary>
     /// Contains methods that services can use to send messages to devices
     /// </summary>
-    public abstract class ServiceClient
+    public abstract class ServiceClient : IDisposable
     {
         /// <summary>
         /// Make this constructor internal so that only this library may implement this abstract class.
@@ -42,6 +43,26 @@ namespace Microsoft.Azure.Devices
         public static ServiceClient CreateFromConnectionString(string connectionString)
         {
             return CreateFromConnectionString(connectionString, TransportType.Amqp);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if ( disposing )
+            {
+                // Call CloseAsync() synchronously avoiding AggregateException.
+                this.CloseAsync().GetAwaiter().GetResult();
+            }
         }
 
         /// <summary>

--- a/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/JobClient/HttpJobClientTests.cs
+++ b/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/JobClient/HttpJobClientTests.cs
@@ -68,5 +68,21 @@ namespace Microsoft.Azure.Devices.Api.Test.JobClient
                 It.IsAny<Dictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>>(),
                 It.IsAny<CancellationToken>()), Times.Once);
         }
+
+        [TestMethod]
+        public void DisposeTest()
+        {
+            httpClientHelperMock.Setup(restOp => restOp.Dispose());
+            jobClient.Dispose();
+            httpClientHelperMock.Verify(restOp => restOp.Dispose(), Times.Once());
+        }
+
+        [TestMethod]
+        public async Task CloseAsyncTest()
+        {
+            httpClientHelperMock.Setup(restOp => restOp.Dispose());
+            await jobClient.CloseAsync();
+            httpClientHelperMock.Verify(restOp => restOp.Dispose(), Times.Never());
+        }
     }
 }

--- a/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/RegistryManagerTests.cs
+++ b/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/RegistryManagerTests.cs
@@ -937,5 +937,31 @@ namespace Microsoft.Azure.Devices.Api.Test
             var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);
             await registryManager.UpdateTwins2Async(new List<Twin>() { goodTwin1, goodTwin2 }, false, CancellationToken.None);
         }
+
+        [TestMethod]
+        [TestCategory("CIT")]
+        [TestCategory("API")]
+        public void DisposeTest()
+        {
+            var restOpMock = new Mock<IHttpClientHelper>();
+            restOpMock.Setup(restOp => restOp.Dispose());
+
+            var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);
+            registryManager.Dispose();
+            restOpMock.Verify(restOp => restOp.Dispose(), Times.Once());
+        }
+    
+        [TestMethod]
+        [TestCategory("CIT")]
+        [TestCategory("API")]
+        public async Task CloseAsyncTest()
+        {
+            var restOpMock = new Mock<IHttpClientHelper>();
+            restOpMock.Setup(restOp => restOp.Dispose());
+
+            var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);
+            await registryManager.CloseAsync();
+            restOpMock.Verify(restOp => restOp.Dispose(), Times.Never());
+        }
     }
 }


### PR DESCRIPTION
This PR added `IDisposable` and `protected virtual void Dispose(bool)` to base classes of service SDK to improve API usability and users can use them more stable easily.

### Benefit

* API users should remember cleanup by existence of IDisposable.
    * It is more common for .NET developers to call Dispose() to clean up resources even if they expose CloseAsync(). For example, System.IO.Stream classes still expose Dispose while they expose asynchronous IOs.
    * Many code analysis tools warns about forget of Dispose() call but do not for CloseAsync().

### Changes summary

* I added IDisposable and `protected virtual void Dispose(bool)` to following classes:
    * `ServiceClient`
    * `JobClient`
    * `RegistryManager`
* I integrated `CloseAsync` and `Dispose(bool)` implementation to avoid code duplication.
* I added `IHttpClientHelper.Dispose()` to `AmqpServiceClient.CloseAsync()`. They should be equal effectively.

### Background story

* I faced `FeebackReceiver` unresponsiveness last week because we had forgotten to call `CloseAsync()`. In the investigation of this work, we noticed that non public derived classes implements `IDisiposable` but public base classes do not.
* In addition, it is common to wrap external access including service SDK for unit testing and implements `IDisposable` in it, so implementing `IDisposable` is more natural than only implements `CloseAsync()`.
