### PR TITLE
registryManager.UpdateTwinAsync is not awaited.

### DIFF
--- a/tools/DeviceExplorer/DeviceExplorer/DeviceTwinAndMethod.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/DeviceTwinAndMethod.cs
@@ -79,7 +79,7 @@ namespace DeviceExplorer
                         dynamic dp = JsonConvert.DeserializeObject(updateJson, typeFound);
                         dp.DeviceId = deviceName;
                         dp.ETag = deviceTwin.ETag;
-                        registryManager.UpdateTwinAsync(dp.DeviceId, dp, dp.ETag);
+                        await registryManager.UpdateTwinAsync(dp.DeviceId, dp, dp.ETag);
                     }
                     else
                     {


### PR DESCRIPTION
There is a Task.Delay that completes the task, but without the await, errors cannot be catched on that task