### PR TITLE
changed deprecated dotnetty nuget dependency to mainstream

### DIFF
--- a/device/Microsoft.Azure.Devices.Client.NetStandard/project.json
+++ b/device/Microsoft.Azure.Devices.Client.NetStandard/project.json
@@ -1,8 +1,8 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "DotNetty.Codecs.Mqtt": "0.4.0",
-    "DotNetty.Handlers": "0.4.0",
+    "DotNetty.Codecs.Mqtt": "0.4.3",
+    "DotNetty.Handlers": "0.4.3",
     "Microsoft.Azure.Amqp": "2.0.4",
     "NETStandard.Library": "1.6.1",
     "Newtonsoft.Json": "9.0.1",

--- a/device/Microsoft.Azure.Devices.Client/Microsoft.Azure.Devices.Client.csproj
+++ b/device/Microsoft.Azure.Devices.Client/Microsoft.Azure.Devices.Client.csproj
@@ -59,34 +59,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <Choose>
-    <When Condition="'$(DotNettyPath)' == ''">
-      <ItemGroup>
-        <Reference Include="DotNetty.Buffers, Version=0.3.2.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-          <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.2\lib\net45\DotNetty.Buffers.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="DotNetty.Codecs, Version=0.3.2.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-          <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.2\lib\net45\DotNetty.Codecs.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.2.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-          <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.2\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="DotNetty.Common, Version=0.3.2.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-          <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.2\lib\net45\DotNetty.Common.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="DotNetty.Handlers, Version=0.3.2.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-          <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.2\lib\net45\DotNetty.Handlers.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="DotNetty.Transport, Version=0.3.2.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-          <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.2\lib\net45\DotNetty.Transport.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
+    <When Condition="'$(DotNettyPath)' == ''" />
     <Otherwise>
       <ItemGroup>
         <ProjectReference Include="$(DotNettyPath)\src\DotNetty.Buffers\DotNetty.Buffers.csproj">
@@ -117,6 +90,24 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Reference Include="DotNetty.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Codecs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetty.Codecs.Mqtt.0.4.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Handlers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetty.Handlers.0.4.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Transport, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.Azure.Amqp.2.0.3\lib\net45\Microsoft.Azure.Amqp.dll</HintPath>
       <Private>True</Private>
@@ -136,6 +127,15 @@
     <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
@@ -166,14 +166,20 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -182,6 +188,7 @@
     </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -221,7 +228,7 @@
     <Compile Include="Transport\FileUploadNotificationResponse.cs" />
     <Compile Include="Transport\FileUploadRequest.cs" />
     <Compile Include="Transport\FileUploadResponse.cs" />
-<!--
+    <!--
     <Compile Include="Transport\ITransportHandlerFactory.cs" />
 -->
     <Compile Include="Transport\Mqtt\ChannelMessageProcessingException.cs" />

--- a/device/Microsoft.Azure.Devices.Client/Microsoft.Azure.Devices.Client.csproj
+++ b/device/Microsoft.Azure.Devices.Client/Microsoft.Azure.Devices.Client.csproj
@@ -59,7 +59,28 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <Choose>
-    <When Condition="'$(DotNettyPath)' == ''" />
+    <When Condition="'$(DotNettyPath)' == ''" >
+	<ItemGroup>
+    <Reference Include="DotNetty.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Codecs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt.0.4.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Handlers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers.0.4.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Transport, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
+    </Reference>
+	</ItemGroup>
+-   </When>
     <Otherwise>
       <ItemGroup>
         <ProjectReference Include="$(DotNettyPath)\src\DotNetty.Buffers\DotNetty.Buffers.csproj">
@@ -90,24 +111,6 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetty.Codecs.Mqtt.0.4.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetty.Handlers.0.4.3\lib\net45\DotNetty.Handlers.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.Azure.Amqp.2.0.3\lib\net45\Microsoft.Azure.Amqp.dll</HintPath>
       <Private>True</Private>
@@ -129,13 +132,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>

--- a/device/Microsoft.Azure.Devices.Client/packages.config
+++ b/device/Microsoft.Azure.Devices.Client/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.3.2" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.2" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.3.2" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.3.2" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.3.2" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.3.2" targetFramework="net451" />
+  <package id="DotNetty.Buffers" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Codecs" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Common" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Handlers" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Transport" version="0.4.3" targetFramework="net451" />
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="2.0.3" targetFramework="net451" />
@@ -13,12 +13,48 @@
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Logging" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net451" />
   <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net451" />
   <package id="PCLCrypto" version="2.0.147" targetFramework="net451" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net451" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
   <package id="Validation" version="2.2.8" targetFramework="net451" />
   <package id="WindowsAzure.Storage" version="7.0.0" targetFramework="net451" />
 </packages>

--- a/device/tests/Microsoft.Azure.Devices.Client.Test/Microsoft.Azure.Devices.Client.Test.csproj
+++ b/device/tests/Microsoft.Azure.Devices.Client.Test/Microsoft.Azure.Devices.Client.Test.csproj
@@ -86,34 +86,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <Choose>
-    <When Condition="'$(DotNettyPath)' == ''">
-      <ItemGroup>
-        <Reference Include="DotNetty.Buffers, Version=0.3.2.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-          <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.2\lib\net45\DotNetty.Buffers.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="DotNetty.Codecs, Version=0.3.2.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-          <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.2\lib\net45\DotNetty.Codecs.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.2.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-          <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.2\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="DotNetty.Common, Version=0.3.2.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-          <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.2\lib\net45\DotNetty.Common.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="DotNetty.Handlers, Version=0.3.2.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-          <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.2\lib\net45\DotNetty.Handlers.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="DotNetty.Transport, Version=0.3.2.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-          <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.2\lib\net45\DotNetty.Transport.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
+    <When Condition="'$(DotNettyPath)' == ''" />
     <Otherwise>
       <ItemGroup>
         <ProjectReference Include="$(DotNettyPath)\src\DotNetty.Buffers\DotNetty.Buffers.csproj">
@@ -144,11 +117,38 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Reference Include="DotNetty.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Codecs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.4.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Handlers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers.0.4.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Transport, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.Azure.Amqp.2.0.3\lib\net45\Microsoft.Azure.Amqp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
     </Reference>
@@ -185,10 +185,16 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
@@ -197,6 +203,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/device/tests/Microsoft.Azure.Devices.Client.Test/Microsoft.Azure.Devices.Client.Test.csproj
+++ b/device/tests/Microsoft.Azure.Devices.Client.Test/Microsoft.Azure.Devices.Client.Test.csproj
@@ -86,7 +86,28 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <Choose>
-    <When Condition="'$(DotNettyPath)' == ''" />
+    <When Condition="'$(DotNettyPath)' == ''" >
+	<ItemGroup>
+	<Reference Include="DotNetty.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Codecs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt.0.4.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Handlers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers.0.4.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Transport, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
+    </Reference>
+	</ItemGroup>
+	</When>
     <Otherwise>
       <ItemGroup>
         <ProjectReference Include="$(DotNettyPath)\src\DotNetty.Buffers\DotNetty.Buffers.csproj">
@@ -117,37 +138,19 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.4.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers.0.4.3\lib\net45\DotNetty.Handlers.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.Azure.Amqp.2.0.3\lib\net45\Microsoft.Azure.Amqp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
@@ -169,19 +172,19 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="PInvoke.BCrypt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.BCrypt.0.3.2\lib\net40\PInvoke.BCrypt.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\PInvoke.BCrypt.0.3.2\lib\net40\PInvoke.BCrypt.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PInvoke.Kernel32, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.Kernel32.0.3.2\lib\net40\PInvoke.Kernel32.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\PInvoke.Kernel32.0.3.2\lib\net40\PInvoke.Kernel32.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PInvoke.NCrypt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.NCrypt.0.3.2\lib\net40\PInvoke.NCrypt.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\PInvoke.NCrypt.0.3.2\lib\net40\PInvoke.NCrypt.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PInvoke.Windows.Core, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.Windows.Core.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.Windows.Core.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\PInvoke.Windows.Core.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.Windows.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -194,7 +197,7 @@
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/device/tests/Microsoft.Azure.Devices.Client.Test/packages.config
+++ b/device/tests/Microsoft.Azure.Devices.Client.Test/packages.config
@@ -1,20 +1,56 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.3.2" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.2" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.3.2" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.3.2" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.3.2" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.3.2" targetFramework="net451" />
+  <package id="DotNetty.Buffers" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Codecs" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Common" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Handlers" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Transport" version="0.4.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="2.0.3" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Logging" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
   <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net451" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net451" />
   <package id="PInvoke.BCrypt" version="0.3.2" targetFramework="net451" />
   <package id="PInvoke.Kernel32" version="0.3.2" targetFramework="net451" />
   <package id="PInvoke.NCrypt" version="0.3.2" targetFramework="net451" />
   <package id="PInvoke.Windows.Core" version="0.3.2" targetFramework="net451" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net451" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
 </packages>

--- a/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/Microsoft.Azure.Devices.Api.Test.csproj
+++ b/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/Microsoft.Azure.Devices.Api.Test.csproj
@@ -94,22 +94,22 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="DotNetty.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="DotNetty.Codecs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
     </Reference>
     <Reference Include="DotNetty.Codecs.Mqtt, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\DotNetty.Codecs.Mqtt.0.4.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt.0.4.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
     </Reference>
     <Reference Include="DotNetty.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
     </Reference>
     <Reference Include="DotNetty.Handlers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\DotNetty.Handlers.0.4.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers.0.4.3\lib\net45\DotNetty.Handlers.dll</HintPath>
     </Reference>
     <Reference Include="DotNetty.Transport, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.Azure.Amqp.2.0.3\lib\net45\Microsoft.Azure.Amqp.dll</HintPath>
@@ -120,13 +120,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
@@ -155,7 +155,7 @@
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>

--- a/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/Microsoft.Azure.Devices.Api.Test.csproj
+++ b/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/Microsoft.Azure.Devices.Api.Test.csproj
@@ -93,29 +93,23 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetty.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetty.Codecs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\DotNetty.Codecs.Mqtt.0.4.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetty.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetty.Handlers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\DotNetty.Handlers.0.4.3\lib\net45\DotNetty.Handlers.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetty.Transport, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.Azure.Amqp.2.0.3\lib\net45\Microsoft.Azure.Amqp.dll</HintPath>
@@ -124,6 +118,15 @@
     <Reference Include="Microsoft.Azure.Devices.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.Azure.Devices.Client.1.0.9\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
@@ -143,15 +146,23 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/packages.config
+++ b/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/packages.config
@@ -1,17 +1,53 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Buffers" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Codecs" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Common" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Handlers" version="0.4.3" targetFramework="net451" />
+  <package id="DotNetty.Transport" version="0.4.3" targetFramework="net451" />
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="2.0.3" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.9" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Logging" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
   <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net451" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net451" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Azure.Devices.Client nuget has dependencies on dotnetty signed nugets which are deprecated and has different public token in the dlls than the mainstream ones. Since Azure.Devices.Client is also used in https://github.com/Azure/azure-iot-protocol-gateway, it's makes it impossible to update dotnetty nugets there because of difference of publictoken. Protocol Gateway needs to move to dotnetty mainstream nugets and this issue is preventing that.

#76