### PR TITLE
Update nuspec to fix deprecated DotNetty libs

### DIFF
--- a/device/NuGet/Microsoft.Azure.Devices.Client.nuspec
+++ b/device/NuGet/Microsoft.Azure.Devices.Client.nuspec
@@ -24,8 +24,8 @@
             <group targetFramework="net45" >
                 <dependency id="PCLCrypto" version="2.0.147" />
                 <dependency id="Microsoft.Azure.Amqp" version="2.0.4" />
-                <dependency id="DotNetty.Codecs.Mqtt-signed" version="0.4.4" />
-                <dependency id="DotNetty.Handlers-signed" version="0.4.4" />
+                <dependency id="DotNetty.Codecs.Mqtt" version="0.4.4" />
+                <dependency id="DotNetty.Handlers" version="0.4.4" />
                 <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304" />
                 <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.3" />
                 <dependency id="WindowsAzure.Storage" version="7.0.0" />


### PR DESCRIPTION
DotNetty.Codecs.Mqtt and DotNetty.Handlers don't exist in the 0.4.4 version with -signed