### PR TITLE
Add ConnectionStatusChangeReason to ConnectionEventArgs

### DIFF
--- a/device/Microsoft.Azure.Devices.Client/ConnectionEventArgs.cs
+++ b/device/Microsoft.Azure.Devices.Client/ConnectionEventArgs.cs
@@ -13,5 +13,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         public string ConnectionKey { get; set; }
 
         public ConnectionStatus ConnectionStatus { get; set; }
+
+        public ConnectionStatusChangeReason ConnectionStatusChangeReason { get; set; }
     }
 }

--- a/device/Microsoft.Azure.Devices.Client/DeviceClient.cs
+++ b/device/Microsoft.Azure.Devices.Client/DeviceClient.cs
@@ -1008,7 +1008,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
             if (result.IsClientStatusChanged && (connectionStatusChangesHandler != null))
             {
                 // codes_SRS_DEVICECLIENT_28_024: [** `OnConnectionOpened` shall invoke the connectionStatusChangesHandler if ConnectionStatus is changed **]**  
-                this.connectionStatusChangesHandler(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
+                this.connectionStatusChangesHandler(ConnectionStatus.Connected, e.ConnectionStatusChangeReason);
             }
         }
 
@@ -1030,7 +1030,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
                         result = this.connectionStatusManager.ChangeTo(e.ConnectionKey, ConnectionStatus.Disconnected_Retrying, ConnectionStatus.Connected, operationTimeoutCancellationTokenSource);
                         if (result.IsClientStatusChanged && (connectionStatusChangesHandler != null))
                         {
-                            this.connectionStatusChangesHandler(ConnectionStatus.Disconnected_Retrying, ConnectionStatusChangeReason.No_Network);
+                            this.connectionStatusChangesHandler(e.ConnectionStatus, e.ConnectionStatusChangeReason);
                         }
 
                         return this.InnerHandler.RecoverConnections(sender, operationTimeoutCancellationTokenSource.Token);
@@ -1051,7 +1051,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
                 result = this.connectionStatusManager.ChangeTo(e.ConnectionKey, ConnectionStatus.Disabled);
                 if (result.IsClientStatusChanged && (connectionStatusChangesHandler != null))
                 {
-                    this.connectionStatusChangesHandler(ConnectionStatus.Disabled, ConnectionStatusChangeReason.Client_Close);
+                    this.connectionStatusChangesHandler(ConnectionStatus.Disabled, e.ConnectionStatusChangeReason);
                 }
             }
         }

--- a/device/Microsoft.Azure.Devices.Client/Transport/AmqpTransportHandler.cs
+++ b/device/Microsoft.Azure.Devices.Client/Transport/AmqpTransportHandler.cs
@@ -100,8 +100,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
                      await Task.WhenAll(
                          this.faultTolerantEventSendingLink.OpenAsync(this.openTimeout, cancellationToken),
                          this.faultTolerantDeviceBoundReceivingLink.OpenAsync(this.openTimeout, cancellationToken));
-                     this.linkOpenedListener(this.faultTolerantEventSendingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTelemetry, ConnectionStatus = ConnectionStatus.Connected });
-                     this.linkOpenedListener(this.faultTolerantDeviceBoundReceivingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMessaging, ConnectionStatus = ConnectionStatus.Connected });
+                     this.linkOpenedListener(
+                         this.faultTolerantEventSendingLink, 
+                         new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTelemetry, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
+                     this.linkOpenedListener(
+                         this.faultTolerantDeviceBoundReceivingLink, 
+                         new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMessaging, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
                  }
                  catch (Exception exception)
                  {
@@ -232,8 +236,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     if (this.messageListener != null)
                     {
                         await enableMethodLinkAsyncFunc();
-                        this.linkOpenedListener(this.faultTolerantMethodSendingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodSending, ConnectionStatus = ConnectionStatus.Connected });
-                        this.linkOpenedListener(this.faultTolerantMethodReceivingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodReceiving, ConnectionStatus = ConnectionStatus.Connected });
+                        this.linkOpenedListener(
+                            this.faultTolerantMethodSendingLink, 
+                            new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodSending, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
+                        this.linkOpenedListener(
+                            this.faultTolerantMethodReceivingLink, 
+                            new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodReceiving, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
                     }
                 }
                 catch (Exception ex) when (!ex.IsFatal())
@@ -266,8 +274,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     if (this.messageListener != null)
                     {
                         await Task.WhenAll(EnableMethodSendingLinkAsync(cancellationToken), EnableMethodReceivingLinkAsync(cancellationToken));
-                        this.linkOpenedListener(this.faultTolerantMethodSendingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodSending, ConnectionStatus = ConnectionStatus.Connected });
-                        this.linkOpenedListener(this.faultTolerantMethodReceivingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodReceiving, ConnectionStatus = ConnectionStatus.Connected });
+                        this.linkOpenedListener(
+                            this.faultTolerantMethodSendingLink, 
+                            new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodSending, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
+                        this.linkOpenedListener(
+                            this.faultTolerantMethodReceivingLink, 
+                            new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodReceiving, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
                     }
                 }
                 catch (Exception ex) when (!ex.IsFatal())
@@ -300,8 +312,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     if (this.messageListener != null)
                     {
                         await Task.WhenAll(EnableTwinSendingLinkAsync(cancellationToken), EnableTwinReceivingLinkAsync(cancellationToken));
-                        this.linkOpenedListener(this.faultTolerantTwinSendingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTwinSending, ConnectionStatus = ConnectionStatus.Connected });
-                        this.linkOpenedListener(this.faultTolerantTwinReceivingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTwinReceiving, ConnectionStatus = ConnectionStatus.Connected });
+                        this.linkOpenedListener(
+                            this.faultTolerantTwinSendingLink, 
+                            new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTwinSending, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
+                        this.linkOpenedListener(
+                            this.faultTolerantTwinReceivingLink, 
+                            new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTwinReceiving, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
                     }
                 }
                 catch (Exception ex) when (!ex.IsFatal())
@@ -320,28 +336,28 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             SendingAmqpLink methodSendingLink = await this.GetMethodSendingLinkAsync(cancellationToken);
             this.SafeAddClosedMethodSendingLinkHandler = this.linkClosedListener;
-            methodSendingLink.SafeAddClosed((o, ea) => this.SafeAddClosedMethodSendingLinkHandler(o, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMessaging, ConnectionStatus = ConnectionStatus.Disconnected_Retrying }));
+            methodSendingLink.SafeAddClosed((o, ea) => this.SafeAddClosedMethodSendingLinkHandler(o, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMessaging, ConnectionStatus = ConnectionStatus.Disconnected_Retrying, ConnectionStatusChangeReason = ConnectionStatusChangeReason.No_Network }));
         }
 
         private async Task EnableMethodReceivingLinkAsync(CancellationToken cancellationToken)
         {
             ReceivingAmqpLink methodReceivingLink = await this.GetMethodReceivingLinkAsync(cancellationToken);
             this.SafeAddClosedMethodReceivingLinkHandler = this.linkClosedListener;
-            methodReceivingLink.SafeAddClosed((o, ea) => this.SafeAddClosedMethodReceivingLinkHandler(o, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodReceiving, ConnectionStatus = ConnectionStatus.Disconnected_Retrying }));
+            methodReceivingLink.SafeAddClosed((o, ea) => this.SafeAddClosedMethodReceivingLinkHandler(o, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodReceiving, ConnectionStatus = ConnectionStatus.Disconnected_Retrying, ConnectionStatusChangeReason = ConnectionStatusChangeReason.No_Network }));
         }
         
         private async Task EnableTwinSendingLinkAsync(CancellationToken cancellationToken)
         {
             SendingAmqpLink twinSendingLink = await this.GetTwinSendingLinkAsync(cancellationToken);
             this.SafeAddClosedTwinSendingLinkHandler = this.linkClosedListener;
-            twinSendingLink.SafeAddClosed((o, ea) => this.SafeAddClosedTwinSendingLinkHandler(o, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTwinSending, ConnectionStatus = ConnectionStatus.Disconnected_Retrying }));
+            twinSendingLink.SafeAddClosed((o, ea) => this.SafeAddClosedTwinSendingLinkHandler(o, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTwinSending, ConnectionStatus = ConnectionStatus.Disconnected_Retrying, ConnectionStatusChangeReason = ConnectionStatusChangeReason.No_Network }));
         }
 
         private async Task EnableTwinReceivingLinkAsync(CancellationToken cancellationToken)
         {
             ReceivingAmqpLink twinReceivingLink = await this.GetTwinReceivingLinkAsync(cancellationToken);
             this.SafeAddClosedTwinReceivingLinkHandler = this.linkClosedListener;
-            twinReceivingLink.SafeAddClosed((o, ea) => this.SafeAddClosedTwinReceivingLinkHandler(o, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTwinReceiving, ConnectionStatus = ConnectionStatus.Disconnected_Retrying }));
+            twinReceivingLink.SafeAddClosed((o, ea) => this.SafeAddClosedTwinReceivingLinkHandler(o, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTwinReceiving, ConnectionStatus = ConnectionStatus.Disconnected_Retrying, ConnectionStatusChangeReason = ConnectionStatusChangeReason.No_Network }));
         }
 #endif
 
@@ -375,8 +391,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
 
             await Task.WhenAll(receivingLinkCloseTask, sendingLinkCloseTask);
-            this.linkClosedListener(this.faultTolerantMethodSendingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodSending, ConnectionStatus = ConnectionStatus.Disabled });
-            this.linkClosedListener(this.faultTolerantMethodReceivingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodReceiving, ConnectionStatus = ConnectionStatus.Disabled });
+            this.linkClosedListener(
+                this.faultTolerantMethodSendingLink, 
+                new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodSending, ConnectionStatus = ConnectionStatus.Disabled, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Client_Close });
+            this.linkClosedListener(
+                this.faultTolerantMethodReceivingLink, 
+                new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodReceiving, ConnectionStatus = ConnectionStatus.Disabled, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Client_Close });
 
 #else
             throw new NotImplementedException();
@@ -413,8 +433,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
 
             await Task.WhenAll(receivingLinkCloseTask, sendingLinkCloseTask);
-            this.linkClosedListener(this.faultTolerantTwinSendingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTwinSending, ConnectionStatus = ConnectionStatus.Disabled });
-            this.linkClosedListener(this.faultTolerantTwinReceivingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTwinReceiving, ConnectionStatus = ConnectionStatus.Disabled });
+            this.linkClosedListener(
+                this.faultTolerantTwinSendingLink, 
+                new ConnectionEventArgs {ConnectionKey = ConnectionKeys.AmqpTwinSending, ConnectionStatus = ConnectionStatus.Disabled, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Client_Close });
+            this.linkClosedListener(
+                this.faultTolerantTwinReceivingLink, 
+                new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTwinReceiving, ConnectionStatus = ConnectionStatus.Disabled, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Client_Close });
 #else
             throw new NotImplementedException();
 #endif
@@ -480,8 +504,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
 #else
             await Task.WhenAll(eventSendingLinkCloseTask, deviceBoundReceivingLinkCloseTask);
 #endif
-            this.linkClosedListener(this.faultTolerantEventSendingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTelemetry, ConnectionStatus = ConnectionStatus.Disabled });
-            this.linkClosedListener(this.faultTolerantDeviceBoundReceivingLink, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMessaging, ConnectionStatus = ConnectionStatus.Disabled });
+            this.linkClosedListener(
+                this.faultTolerantEventSendingLink, 
+                new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTelemetry, ConnectionStatus = ConnectionStatus.Disabled, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Client_Close });
+            this.linkClosedListener(
+                this.faultTolerantDeviceBoundReceivingLink, 
+                new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMessaging, ConnectionStatus = ConnectionStatus.Disabled, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Client_Close });
 
             this.IotHubConnection.Release(this.deviceId);
         }

--- a/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/MqttTransportHandler.cs
+++ b/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/MqttTransportHandler.cs
@@ -376,7 +376,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             if (this.TryStop())
             {
                 await this.closeRetryPolicy.ExecuteAsync(this.CleanupAsync);
-                this.connectionClosedListener(this.channel, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.MqttConnection, ConnectionStatus = ConnectionStatus.Disabled });
+                this.connectionClosedListener(this.channel, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.MqttConnection, ConnectionStatus = ConnectionStatus.Disabled, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Client_Close });
             }
             else
             {
@@ -395,7 +395,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             if (this.TryStateTransition(TransportState.Opening, TransportState.Open))
             {
                 this.connectCompletion.TryComplete();
-                this.connectionOpenedListener(this.channel, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.MqttConnection, ConnectionStatus = ConnectionStatus.Connected });
+                this.connectionOpenedListener(this.channel, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok});
             }
         }
 
@@ -495,7 +495,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if ((previousState & TransportState.Open) == TransportState.Open)
                 {
-                    this.connectionClosedListener(this.channel, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.MqttConnection, ConnectionStatus = ConnectionStatus.Disconnected_Retrying });
+                    this.connectionClosedListener(this.channel, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.MqttConnection, ConnectionStatus = ConnectionStatus.Disconnected_Retrying, ConnectionStatusChangeReason = ConnectionStatusChangeReason.No_Network});
                 }
 
             }


### PR DESCRIPTION
Add ConnectionStatusChangeReason field in ConnectionEventArgs for population when the information is available from transports (mqtt or amqp).