### PR TITLE
Enable Twin and Direct Methods on AMQP

### DIFF
--- a/device/Microsoft.Azure.Devices.Client/Transport/AmqpTransportHandler.cs
+++ b/device/Microsoft.Azure.Devices.Client/Transport/AmqpTransportHandler.cs
@@ -209,7 +209,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override Task RecoverConnections(object link, CancellationToken cancellationToken)
         {
-#if WIP_C2D_METHODS_AMQP
             Func<Task> enableMethodLinkAsyncFunc = null;
 
             var amqpLink = link as AmqpLink;
@@ -249,14 +248,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     throw AmqpClientHelper.ToIotHubClientContract(ex);
                 }
             }, cancellationToken);
-#else
-            throw new NotImplementedException();
-#endif
         }
 
         public override async Task EnableMethodsAsync(CancellationToken cancellationToken)
         {
-#if WIP_C2D_METHODS_AMQP
             if (this.faultTolerantMethodSendingLink == null)
             {
                 this.faultTolerantMethodSendingLink = new Client.FaultTolerantAmqpObject<SendingAmqpLink>(this.CreateMethodSendingLinkAsync, this.IotHubConnection.CloseLink);
@@ -287,14 +282,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     throw AmqpClientHelper.ToIotHubClientContract(ex);
                 }
             }, cancellationToken);
-#else
-            throw new NotImplementedException();
-#endif
         }
 
         public override async Task EnableTwinPatchAsync(CancellationToken cancellationToken)
         {
-#if WIP_C2D_METHODS_AMQP
             if (this.faultTolerantTwinSendingLink == null)
             {
                 this.faultTolerantTwinSendingLink = new Client.FaultTolerantAmqpObject<SendingAmqpLink>(this.CreateTwinSendingLinkAsync, this.IotHubConnection.CloseLink);
@@ -325,13 +316,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     throw AmqpClientHelper.ToIotHubClientContract(ex);
                 }
             }, cancellationToken);
-#else
-            throw new NotImplementedException();
-#endif
         }
 
-
-#if WIP_C2D_METHODS_AMQP
         private async Task EnableMethodSendingLinkAsync(CancellationToken cancellationToken)
         {
             SendingAmqpLink methodSendingLink = await this.GetMethodSendingLinkAsync(cancellationToken);
@@ -359,11 +345,9 @@ namespace Microsoft.Azure.Devices.Client.Transport
             this.SafeAddClosedTwinReceivingLinkHandler = this.linkClosedListener;
             twinReceivingLink.SafeAddClosed((o, ea) => this.SafeAddClosedTwinReceivingLinkHandler(o, new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTwinReceiving, ConnectionStatus = ConnectionStatus.Disconnected_Retrying, ConnectionStatusChangeReason = ConnectionStatusChangeReason.No_Network }));
         }
-#endif
 
         public override async Task DisableMethodsAsync(CancellationToken cancellationToken)
         {
-#if WIP_C2D_METHODS_AMQP
             Task receivingLinkCloseTask;
             
             this.SafeAddClosedMethodSendingLinkHandler = (o, ea) => {};
@@ -397,15 +381,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
             this.linkClosedListener(
                 this.faultTolerantMethodReceivingLink, 
                 new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpMethodReceiving, ConnectionStatus = ConnectionStatus.Disabled, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Client_Close });
-
-#else
-            throw new NotImplementedException();
-#endif
         }
 
         public async Task DisableTwinAsync(CancellationToken cancellationToken)
         {
-#if WIP_C2D_METHODS_AMQP
             Task receivingLinkCloseTask;
 
             this.SafeAddClosedTwinSendingLinkHandler = (o, ea) => {};
@@ -439,9 +418,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
             this.linkClosedListener(
                 this.faultTolerantTwinReceivingLink, 
                 new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTwinReceiving, ConnectionStatus = ConnectionStatus.Disabled, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Client_Close });
-#else
-            throw new NotImplementedException();
-#endif
         }
         
         public override async Task SendMethodResponseAsync(MethodResponseInternal methodResponse, CancellationToken cancellationToken)
@@ -497,13 +473,11 @@ namespace Microsoft.Azure.Devices.Client.Transport
             GC.SuppressFinalize(this);
             Task eventSendingLinkCloseTask = this.faultTolerantEventSendingLink.CloseAsync();
             Task deviceBoundReceivingLinkCloseTask = this.faultTolerantDeviceBoundReceivingLink.CloseAsync();
-#if WIP_C2D_METHODS_AMQP
+
             Task disabledMethodTask = this.DisableMethodsAsync(CancellationToken.None);
             Task disableTwinTask = this.DisableTwinAsync(CancellationToken.None);
             await Task.WhenAll(eventSendingLinkCloseTask, deviceBoundReceivingLinkCloseTask, disabledMethodTask, disableTwinTask);
-#else
-            await Task.WhenAll(eventSendingLinkCloseTask, deviceBoundReceivingLinkCloseTask);
-#endif
+
             this.linkClosedListener(
                 this.faultTolerantEventSendingLink, 
                 new ConnectionEventArgs { ConnectionKey = ConnectionKeys.AmqpTelemetry, ConnectionStatus = ConnectionStatus.Disabled, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Client_Close });
@@ -835,7 +809,5 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
             return link;
         }
-    
     }
-
 }

--- a/device/samples/DeviceClientMethodSample/Program.cs
+++ b/device/samples/DeviceClientMethodSample/Program.cs
@@ -63,12 +63,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
         {
             TransportType transport = TransportType.Mqtt;
 
-#if WIP_C2D_METHODS_AMQP
             if (args.Length == 1 && args[0].ToLower().Equals("amqp"))
             {
                 transport = TransportType.Amqp;
             }
-#endif
+
             DeviceClient deviceClient = null;
             try
             {

--- a/device/samples/DeviceClientTwinSample/Program.cs
+++ b/device/samples/DeviceClientTwinSample/Program.cs
@@ -47,12 +47,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 DeviceConnectionString = environmentConnectionString;
             }
 
-#if WIP_C2D_METHODS_AMQP
             if (args.Length == 1 && args[0].ToLower().Equals("amqp"))
             {
                 transport = TransportType.Amqp;
             }
-#endif
+
             try
             {
                 Console.WriteLine("Connecting to hub");

--- a/e2e/Microsoft.Azure.Devices.E2ETests/MethodE2ETests.cs
+++ b/e2e/Microsoft.Azure.Devices.E2ETests/MethodE2ETests.cs
@@ -116,8 +116,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 TestUtil.DefaultDelayInSec);
         }
 
-
-#if WIP_C2D_METHODS_AMQP
         [TestMethod]
         [TestCategory("Method-E2E")]
         public async Task Method_DeviceReceivesMethodAndResponse_Amqp()
@@ -264,7 +262,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 TestUtil.FaultCloseReason_Bye,
                 TestUtil.DefaultDelayInSec);
         }
-#endif
+
         private async Task ServiceSendMethodAndVerifyResponse(string deviceName, string methodName, string respJson, string reqJson, TaskCompletionSource<Tuple<bool, bool>> rel)
         {
             ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(hubConnectionString);

--- a/e2e/Microsoft.Azure.Devices.E2ETests/TwinE2ETests.cs
+++ b/e2e/Microsoft.Azure.Devices.E2ETests/TwinE2ETests.cs
@@ -90,7 +90,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 TestUtil.DefaultDelayInSec);
         }
         
-#if WIP_C2D_METHODS_AMQP
         [Ignore]
         [TestMethod]
         [TestCategory("Twin-E2E")]
@@ -114,7 +113,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 TestUtil.FaultCloseReason_Boom,
                 TestUtil.DefaultDelayInSec);
         }
-#endif 
 
         [Ignore]
         [TestMethod]
@@ -140,7 +138,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 TestUtil.DefaultDelayInSec);
         }
 
-#if WIP_C2D_METHODS_AMQP
         [Ignore]
         [TestMethod]
         [TestCategory("Twin-E2E")]
@@ -164,7 +161,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 TestUtil.FaultCloseReason_Bye,
                 TestUtil.DefaultDelayInSec);
         }
-#endif
 
         [TestMethod]
         [TestCategory("Twin-E2E")]
@@ -180,7 +176,6 @@ namespace Microsoft.Azure.Devices.E2ETests
             await _Twin_ServiceSetsDesiredPropertyAndDeviceReceivesEvent(Client.TransportType.Mqtt_WebSocket_Only);
         }
         
-#if WIP_C2D_METHODS_AMQP
         [TestMethod]
         [TestCategory("Twin-E2E")]
         public async Task Twin_ServiceSetsDesiredPropertyAndDeviceReceivesEvent_Amqp()
@@ -194,7 +189,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             await _Twin_ServiceSetsDesiredPropertyAndDeviceReceivesEvent(Client.TransportType.Amqp_WebSocket_Only);
         }
-#endif
 
         [TestMethod]
         [TestCategory("Twin-E2E")]
@@ -210,7 +204,6 @@ namespace Microsoft.Azure.Devices.E2ETests
             await _Twin_ServiceSetsDesiredPropertyAndDeviceReceivesEvent_WithObseleteCallbackSetter(Client.TransportType.Mqtt_WebSocket_Only);
         }
 
-#if WIP_C2D_METHODS_AMQP
         [TestMethod]
         [TestCategory("Twin-E2E")]
         public async Task Twin_ServiceSetsDesiredPropertyAndDeviceReceivesEvent_WithObseleteCallbackSetter_Amqp()
@@ -224,7 +217,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             await _Twin_ServiceSetsDesiredPropertyAndDeviceReceivesEvent_WithObseleteCallbackSetter(Client.TransportType.Amqp_WebSocket_Only);
         }
-#endif
 
         [Ignore]
         [TestMethod]
@@ -250,7 +242,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 TestUtil.DefaultDelayInSec);
         }
         
-#if WIP_C2D_METHODS_AMQP
         [Ignore]
         [TestMethod]
         [TestCategory("Twin-E2E")]
@@ -274,7 +265,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 TestUtil.FaultCloseReason_Boom,
                 TestUtil.DefaultDelayInSec);
         }
-#endif
 
         [Ignore]
         [TestMethod]
@@ -300,7 +290,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 TestUtil.DefaultDelayInSec);
         }
         
-#if WIP_C2D_METHODS_AMQP
         [Ignore]
         [TestMethod]
         [TestCategory("Twin-E2E")]
@@ -323,8 +312,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 TestUtil.FaultType_GracefulShutdownAmqp,
                 TestUtil.FaultCloseReason_Bye,
                 TestUtil.DefaultDelayInSec);
-        }
-#endif 
+        } 
 
         [TestMethod]
         [TestCategory("Twin-E2E")]
@@ -340,7 +328,6 @@ namespace Microsoft.Azure.Devices.E2ETests
             await _Twin_ServiceSetsDesiredPropertyAndDeviceReceivesItOnNextGet(Client.TransportType.Mqtt_WebSocket_Only);
         }
 
-#if WIP_C2D_METHODS_AMQP
         [TestMethod]
         [TestCategory("Twin-E2E")]
         public async Task Twin_ServiceSetsDesiredPropertyAndDeviceReceivesItOnNextGet_Amqp()
@@ -354,7 +341,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             await _Twin_ServiceSetsDesiredPropertyAndDeviceReceivesItOnNextGet(Client.TransportType.Amqp_WebSocket_Only);
         }
-#endif
 
         [TestMethod]
         [TestCategory("Twin-E2E")]
@@ -370,7 +356,6 @@ namespace Microsoft.Azure.Devices.E2ETests
             await _Twin_DeviceSetsReportedPropertyAndServiceReceivesIt(Client.TransportType.Mqtt_WebSocket_Only);
         }
 
-#if WIP_C2D_METHODS_AMQP
         [TestMethod]
         [TestCategory("Twin-E2E")]
         public async Task Twin_DeviceSetsReportedPropertyAndServiceReceivesIt_Amqp()
@@ -384,7 +369,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             await _Twin_DeviceSetsReportedPropertyAndServiceReceivesIt(Client.TransportType.Amqp_WebSocket_Only);
         }
-#endif 
 
         private async Task _Twin_DeviceSetsReportedPropertyAndGetsItBack(Client.TransportType transport)
         {


### PR DESCRIPTION
Remove WIP compile flag to enable Twin and Direct Methods on AMQP by default