### PR TITLE
Device Explorer new C2D listening Tab

### DIFF
--- a/tools/DeviceExplorer/DeviceExplorer/CommandAction.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/CommandAction.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DeviceExplorer
+{
+    /// <summary>
+    /// Actions for C2D messages
+    /// </summary>
+    internal enum CommandAction
+    {
+        None = 0,
+        Complete = 1,
+        Abandon = 2
+    }
+}

--- a/tools/DeviceExplorer/DeviceExplorer/DeviceExplorer.csproj
+++ b/tools/DeviceExplorer/DeviceExplorer/DeviceExplorer.csproj
@@ -34,6 +34,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CommandAction.cs" />
     <Compile Include="CreateDeviceForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/tools/DeviceExplorer/DeviceExplorer/DeviceExplorer.csproj
+++ b/tools/DeviceExplorer/DeviceExplorer/DeviceExplorer.csproj
@@ -125,18 +125,65 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Amqp.1.1.5\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetty.Buffers, Version=0.4.4.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetty.Buffers.0.4.4\lib\net45\DotNetty.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Codecs, Version=0.4.4.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetty.Codecs.0.4.4\lib\net45\DotNetty.Codecs.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.4.4.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetty.Codecs.Mqtt.0.4.4\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Common, Version=0.4.4.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetty.Common.0.4.4\lib\net45\DotNetty.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Handlers, Version=0.4.4.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetty.Handlers.0.4.4\lib\net45\DotNetty.Handlers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Transport, Version=0.4.4.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetty.Transport.0.4.4\lib\net45\DotNetty.Transport.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Amqp, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Amqp.2.0.6\lib\net45\Microsoft.Azure.Amqp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.Devices.1.1.0-preview-004\lib\net451\Microsoft.Azure.Devices.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Azure.Devices.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Devices.Client.1.3.0\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Devices.Shared, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Devices.Shared.1.0.11\lib\net45\Microsoft.Azure.Devices.Shared.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAzure.ServiceBus.4.1.2\lib\net45\Microsoft.ServiceBus.dll</HintPath>
@@ -146,6 +193,9 @@
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.7.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
     <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Security.3.2.3.0\lib\net45\Mono.Security.dll</HintPath>
       <Private>True</Private>
@@ -154,23 +204,51 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PCLCrypto, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCLCrypto.2.0.147\lib\net45\PCLCrypto.dll</HintPath>
+    </Reference>
+    <Reference Include="PInvoke.BCrypt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
+      <HintPath>..\packages\PInvoke.BCrypt.0.3.2\lib\net40\PInvoke.BCrypt.dll</HintPath>
+    </Reference>
+    <Reference Include="PInvoke.Kernel32, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
+      <HintPath>..\packages\PInvoke.Kernel32.0.3.2\lib\net40\PInvoke.Kernel32.dll</HintPath>
+    </Reference>
+    <Reference Include="PInvoke.NCrypt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
+      <HintPath>..\packages\PInvoke.NCrypt.0.3.2\lib\net40\PInvoke.NCrypt.dll</HintPath>
+    </Reference>
+    <Reference Include="PInvoke.Windows.Core, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
+      <HintPath>..\packages\PInvoke.Windows.Core.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.Windows.Core.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="Validation, Version=2.2.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Validation.2.2.8\lib\dotnet\Validation.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/tools/DeviceExplorer/DeviceExplorer/MainForm.Designer.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/MainForm.Designer.cs
@@ -69,6 +69,7 @@
             this.showDevicePropertiesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tabData = new System.Windows.Forms.TabPage();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.enableSystemProperties = new System.Windows.Forms.CheckBox();
             this.consumerGroupCheckBox = new System.Windows.Forms.CheckBox();
             this.label6 = new System.Windows.Forms.Label();
             this.groupNameTextBox = new System.Windows.Forms.TextBox();
@@ -119,8 +120,18 @@
             this.label17 = new System.Windows.Forms.Label();
             this.label14 = new System.Windows.Forms.Label();
             this.label13 = new System.Windows.Forms.Label();
+            this.tabCommandReceiver = new System.Windows.Forms.TabPage();
+            this.groupBox9 = new System.Windows.Forms.GroupBox();
+            this.deviceCommandsRichTxtBox = new System.Windows.Forms.RichTextBox();
+            this.groupBox8 = new System.Windows.Forms.GroupBox();
+            this.cancelReceiveCommandsBtn = new System.Windows.Forms.Button();
+            this.clearCommandsBtn = new System.Windows.Forms.Button();
+            this.receiveCommandsBtn = new System.Windows.Forms.Button();
+            this.label24 = new System.Windows.Forms.Label();
+            this.actionComboBoxForCommandReceiver = new System.Windows.Forms.ComboBox();
+            this.label23 = new System.Windows.Forms.Label();
+            this.deviceIDComboBoxForCommandReceiver = new System.Windows.Forms.ComboBox();
             this.ehStringToolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.enableSystemProperties = new System.Windows.Forms.CheckBox();
             this.tabCallDeviceMethod.SuspendLayout();
             this.tabPage2.SuspendLayout();
             this.groupBox5.SuspendLayout();
@@ -139,6 +150,9 @@
             this.groupBox4.SuspendLayout();
             this.tabDeviceMethod.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.callDeviceMethodNumericUpDown)).BeginInit();
+            this.tabCommandReceiver.SuspendLayout();
+            this.groupBox9.SuspendLayout();
+            this.groupBox8.SuspendLayout();
             this.SuspendLayout();
             // 
             // tabCallDeviceMethod
@@ -151,6 +165,7 @@
             this.tabCallDeviceMethod.Controls.Add(this.tabData);
             this.tabCallDeviceMethod.Controls.Add(this.tabMessagesToDevice);
             this.tabCallDeviceMethod.Controls.Add(this.tabDeviceMethod);
+            this.tabCallDeviceMethod.Controls.Add(this.tabCommandReceiver);
             this.tabCallDeviceMethod.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.tabCallDeviceMethod.Location = new System.Drawing.Point(12, 12);
             this.tabCallDeviceMethod.Name = "tabCallDeviceMethod";
@@ -604,6 +619,16 @@
             this.groupBox3.TabIndex = 26;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Monitoring";
+            // 
+            // enableSystemProperties
+            // 
+            this.enableSystemProperties.AutoSize = true;
+            this.enableSystemProperties.Location = new System.Drawing.Point(563, 208);
+            this.enableSystemProperties.Name = "enableSystemProperties";
+            this.enableSystemProperties.Size = new System.Drawing.Size(170, 20);
+            this.enableSystemProperties.TabIndex = 30;
+            this.enableSystemProperties.Text = "Show system properties";
+            this.enableSystemProperties.UseVisualStyleBackColor = true;
             // 
             // consumerGroupCheckBox
             // 
@@ -1158,15 +1183,122 @@
             this.label13.TabIndex = 0;
             this.label13.Text = "Call Method on Device";
             // 
-            // enableSystemProperties
+            // tabCommandReceiver
             // 
-            this.enableSystemProperties.AutoSize = true;
-            this.enableSystemProperties.Location = new System.Drawing.Point(563, 208);
-            this.enableSystemProperties.Name = "enableSystemProperties";
-            this.enableSystemProperties.Size = new System.Drawing.Size(170, 20);
-            this.enableSystemProperties.TabIndex = 30;
-            this.enableSystemProperties.Text = "Show system properties";
-            this.enableSystemProperties.UseVisualStyleBackColor = true;
+            this.tabCommandReceiver.Controls.Add(this.groupBox9);
+            this.tabCommandReceiver.Controls.Add(this.groupBox8);
+            this.tabCommandReceiver.Location = new System.Drawing.Point(4, 25);
+            this.tabCommandReceiver.Name = "tabCommandReceiver";
+            this.tabCommandReceiver.Padding = new System.Windows.Forms.Padding(3);
+            this.tabCommandReceiver.Size = new System.Drawing.Size(751, 601);
+            this.tabCommandReceiver.TabIndex = 5;
+            this.tabCommandReceiver.Text = "Command Receiver";
+            this.tabCommandReceiver.UseVisualStyleBackColor = true;
+            // 
+            // groupBox9
+            // 
+            this.groupBox9.Controls.Add(this.deviceCommandsRichTxtBox);
+            this.groupBox9.Location = new System.Drawing.Point(6, 167);
+            this.groupBox9.Name = "groupBox9";
+            this.groupBox9.Size = new System.Drawing.Size(739, 428);
+            this.groupBox9.TabIndex = 1;
+            this.groupBox9.TabStop = false;
+            this.groupBox9.Text = "Commands";
+            // 
+            // deviceCommandsRichTxtBox
+            // 
+            this.deviceCommandsRichTxtBox.Location = new System.Drawing.Point(6, 21);
+            this.deviceCommandsRichTxtBox.Name = "deviceCommandsRichTxtBox";
+            this.deviceCommandsRichTxtBox.Size = new System.Drawing.Size(727, 454);
+            this.deviceCommandsRichTxtBox.TabIndex = 0;
+            this.deviceCommandsRichTxtBox.Text = "";
+            // 
+            // groupBox8
+            // 
+            this.groupBox8.Controls.Add(this.cancelReceiveCommandsBtn);
+            this.groupBox8.Controls.Add(this.clearCommandsBtn);
+            this.groupBox8.Controls.Add(this.receiveCommandsBtn);
+            this.groupBox8.Controls.Add(this.label24);
+            this.groupBox8.Controls.Add(this.actionComboBoxForCommandReceiver);
+            this.groupBox8.Controls.Add(this.label23);
+            this.groupBox8.Controls.Add(this.deviceIDComboBoxForCommandReceiver);
+            this.groupBox8.Location = new System.Drawing.Point(6, 6);
+            this.groupBox8.Name = "groupBox8";
+            this.groupBox8.Size = new System.Drawing.Size(739, 155);
+            this.groupBox8.TabIndex = 0;
+            this.groupBox8.TabStop = false;
+            this.groupBox8.Text = "Command Receiver";
+            // 
+            // cancelReceiveCommandsBtn
+            // 
+            this.cancelReceiveCommandsBtn.Location = new System.Drawing.Point(182, 109);
+            this.cancelReceiveCommandsBtn.Name = "cancelReceiveCommandsBtn";
+            this.cancelReceiveCommandsBtn.Size = new System.Drawing.Size(133, 30);
+            this.cancelReceiveCommandsBtn.TabIndex = 29;
+            this.cancelReceiveCommandsBtn.Text = "Stop";
+            this.cancelReceiveCommandsBtn.UseVisualStyleBackColor = true;
+            this.cancelReceiveCommandsBtn.Click += new System.EventHandler(this.cancelReceiveCommandsBtn_Click);
+            // 
+            // clearCommandsBtn
+            // 
+            this.clearCommandsBtn.Location = new System.Drawing.Point(353, 109);
+            this.clearCommandsBtn.Name = "clearCommandsBtn";
+            this.clearCommandsBtn.Size = new System.Drawing.Size(120, 30);
+            this.clearCommandsBtn.TabIndex = 28;
+            this.clearCommandsBtn.Text = "Clear";
+            this.clearCommandsBtn.UseVisualStyleBackColor = true;
+            this.clearCommandsBtn.Click += new System.EventHandler(this.clearCommandsBtn_Click);
+            // 
+            // receiveCommandsBtn
+            // 
+            this.receiveCommandsBtn.Location = new System.Drawing.Point(21, 109);
+            this.receiveCommandsBtn.Name = "receiveCommandsBtn";
+            this.receiveCommandsBtn.Size = new System.Drawing.Size(120, 30);
+            this.receiveCommandsBtn.TabIndex = 27;
+            this.receiveCommandsBtn.Text = "Start";
+            this.receiveCommandsBtn.UseVisualStyleBackColor = true;
+            this.receiveCommandsBtn.Click += new System.EventHandler(this.receiveCommandsBtn_Click);
+            // 
+            // label24
+            // 
+            this.label24.AutoSize = true;
+            this.label24.Location = new System.Drawing.Point(11, 62);
+            this.label24.Name = "label24";
+            this.label24.Size = new System.Drawing.Size(45, 16);
+            this.label24.TabIndex = 21;
+            this.label24.Text = "Action";
+            // 
+            // actionComboBoxForCommandReceiver
+            // 
+            this.actionComboBoxForCommandReceiver.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.actionComboBoxForCommandReceiver.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.actionComboBoxForCommandReceiver.FormattingEnabled = true;
+            this.actionComboBoxForCommandReceiver.Location = new System.Drawing.Point(90, 59);
+            this.actionComboBoxForCommandReceiver.Name = "actionComboBoxForCommandReceiver";
+            this.actionComboBoxForCommandReceiver.Size = new System.Drawing.Size(622, 24);
+            this.actionComboBoxForCommandReceiver.TabIndex = 22;
+            // 
+            // label23
+            // 
+            this.label23.AutoSize = true;
+            this.label23.Location = new System.Drawing.Point(11, 29);
+            this.label23.Name = "label23";
+            this.label23.Size = new System.Drawing.Size(70, 16);
+            this.label23.TabIndex = 19;
+            this.label23.Text = "Device ID:";
+            // 
+            // deviceIDComboBoxForCommandReceiver
+            // 
+            this.deviceIDComboBoxForCommandReceiver.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.deviceIDComboBoxForCommandReceiver.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.deviceIDComboBoxForCommandReceiver.FormattingEnabled = true;
+            this.deviceIDComboBoxForCommandReceiver.Location = new System.Drawing.Point(90, 26);
+            this.deviceIDComboBoxForCommandReceiver.Name = "deviceIDComboBoxForCommandReceiver";
+            this.deviceIDComboBoxForCommandReceiver.Size = new System.Drawing.Size(622, 24);
+            this.deviceIDComboBoxForCommandReceiver.TabIndex = 20;
+            this.deviceIDComboBoxForCommandReceiver.SelectionChangeCommitted += new System.EventHandler(this.deviceIDComboBoxForCommandReceiver_SelectionChangeCommitted);
             // 
             // MainForm
             // 
@@ -1203,6 +1335,10 @@
             this.tabDeviceMethod.ResumeLayout(false);
             this.tabDeviceMethod.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.callDeviceMethodNumericUpDown)).EndInit();
+            this.tabCommandReceiver.ResumeLayout(false);
+            this.groupBox9.ResumeLayout(false);
+            this.groupBox8.ResumeLayout(false);
+            this.groupBox8.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -1301,6 +1437,17 @@
         private System.Windows.Forms.NumericUpDown callDeviceMethodNumericUpDown;
         private System.Windows.Forms.Button callDeviceMethodCancelButton;
         private System.Windows.Forms.CheckBox enableSystemProperties;
+        private System.Windows.Forms.TabPage tabCommandReceiver;
+        private System.Windows.Forms.GroupBox groupBox8;
+        private System.Windows.Forms.Label label24;
+        private System.Windows.Forms.ComboBox actionComboBoxForCommandReceiver;
+        private System.Windows.Forms.Label label23;
+        private System.Windows.Forms.ComboBox deviceIDComboBoxForCommandReceiver;
+        private System.Windows.Forms.GroupBox groupBox9;
+        private System.Windows.Forms.RichTextBox deviceCommandsRichTxtBox;
+        private System.Windows.Forms.Button cancelReceiveCommandsBtn;
+        private System.Windows.Forms.Button clearCommandsBtn;
+        private System.Windows.Forms.Button receiveCommandsBtn;
     }
 }
 

--- a/tools/DeviceExplorer/DeviceExplorer/MainForm.Designer.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/MainForm.Designer.cs
@@ -1192,7 +1192,7 @@
             this.tabCommandReceiver.Padding = new System.Windows.Forms.Padding(3);
             this.tabCommandReceiver.Size = new System.Drawing.Size(751, 601);
             this.tabCommandReceiver.TabIndex = 5;
-            this.tabCommandReceiver.Text = "Command Receiver";
+            this.tabCommandReceiver.Text = "Command Receiver (C2D)";
             this.tabCommandReceiver.UseVisualStyleBackColor = true;
             // 
             // groupBox9

--- a/tools/DeviceExplorer/DeviceExplorer/MainForm.Designer.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/MainForm.Designer.cs
@@ -132,6 +132,8 @@
             this.label23 = new System.Windows.Forms.Label();
             this.deviceIDComboBoxForCommandReceiver = new System.Windows.Forms.ComboBox();
             this.ehStringToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.iotHubNameTextBoxForCommandReceiver = new System.Windows.Forms.TextBox();
+            this.label25 = new System.Windows.Forms.Label();
             this.tabCallDeviceMethod.SuspendLayout();
             this.tabPage2.SuspendLayout();
             this.groupBox5.SuspendLayout();
@@ -1198,9 +1200,9 @@
             // groupBox9
             // 
             this.groupBox9.Controls.Add(this.deviceCommandsRichTxtBox);
-            this.groupBox9.Location = new System.Drawing.Point(6, 167);
+            this.groupBox9.Location = new System.Drawing.Point(6, 213);
             this.groupBox9.Name = "groupBox9";
-            this.groupBox9.Size = new System.Drawing.Size(739, 428);
+            this.groupBox9.Size = new System.Drawing.Size(739, 382);
             this.groupBox9.TabIndex = 1;
             this.groupBox9.TabStop = false;
             this.groupBox9.Text = "Commands";
@@ -1215,6 +1217,8 @@
             // 
             // groupBox8
             // 
+            this.groupBox8.Controls.Add(this.iotHubNameTextBoxForCommandReceiver);
+            this.groupBox8.Controls.Add(this.label25);
             this.groupBox8.Controls.Add(this.cancelReceiveCommandsBtn);
             this.groupBox8.Controls.Add(this.clearCommandsBtn);
             this.groupBox8.Controls.Add(this.receiveCommandsBtn);
@@ -1224,14 +1228,14 @@
             this.groupBox8.Controls.Add(this.deviceIDComboBoxForCommandReceiver);
             this.groupBox8.Location = new System.Drawing.Point(6, 6);
             this.groupBox8.Name = "groupBox8";
-            this.groupBox8.Size = new System.Drawing.Size(739, 155);
+            this.groupBox8.Size = new System.Drawing.Size(739, 201);
             this.groupBox8.TabIndex = 0;
             this.groupBox8.TabStop = false;
             this.groupBox8.Text = "Command Receiver";
             // 
             // cancelReceiveCommandsBtn
             // 
-            this.cancelReceiveCommandsBtn.Location = new System.Drawing.Point(182, 109);
+            this.cancelReceiveCommandsBtn.Location = new System.Drawing.Point(182, 156);
             this.cancelReceiveCommandsBtn.Name = "cancelReceiveCommandsBtn";
             this.cancelReceiveCommandsBtn.Size = new System.Drawing.Size(133, 30);
             this.cancelReceiveCommandsBtn.TabIndex = 29;
@@ -1241,7 +1245,7 @@
             // 
             // clearCommandsBtn
             // 
-            this.clearCommandsBtn.Location = new System.Drawing.Point(353, 109);
+            this.clearCommandsBtn.Location = new System.Drawing.Point(353, 156);
             this.clearCommandsBtn.Name = "clearCommandsBtn";
             this.clearCommandsBtn.Size = new System.Drawing.Size(120, 30);
             this.clearCommandsBtn.TabIndex = 28;
@@ -1251,7 +1255,7 @@
             // 
             // receiveCommandsBtn
             // 
-            this.receiveCommandsBtn.Location = new System.Drawing.Point(21, 109);
+            this.receiveCommandsBtn.Location = new System.Drawing.Point(21, 156);
             this.receiveCommandsBtn.Name = "receiveCommandsBtn";
             this.receiveCommandsBtn.Size = new System.Drawing.Size(120, 30);
             this.receiveCommandsBtn.TabIndex = 27;
@@ -1262,7 +1266,7 @@
             // label24
             // 
             this.label24.AutoSize = true;
-            this.label24.Location = new System.Drawing.Point(11, 62);
+            this.label24.Location = new System.Drawing.Point(11, 107);
             this.label24.Name = "label24";
             this.label24.Size = new System.Drawing.Size(45, 16);
             this.label24.TabIndex = 21;
@@ -1274,7 +1278,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.actionComboBoxForCommandReceiver.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.actionComboBoxForCommandReceiver.FormattingEnabled = true;
-            this.actionComboBoxForCommandReceiver.Location = new System.Drawing.Point(90, 59);
+            this.actionComboBoxForCommandReceiver.Location = new System.Drawing.Point(93, 104);
             this.actionComboBoxForCommandReceiver.Name = "actionComboBoxForCommandReceiver";
             this.actionComboBoxForCommandReceiver.Size = new System.Drawing.Size(622, 24);
             this.actionComboBoxForCommandReceiver.TabIndex = 22;
@@ -1282,7 +1286,7 @@
             // label23
             // 
             this.label23.AutoSize = true;
-            this.label23.Location = new System.Drawing.Point(11, 29);
+            this.label23.Location = new System.Drawing.Point(11, 74);
             this.label23.Name = "label23";
             this.label23.Size = new System.Drawing.Size(70, 16);
             this.label23.TabIndex = 19;
@@ -1294,11 +1298,30 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.deviceIDComboBoxForCommandReceiver.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.deviceIDComboBoxForCommandReceiver.FormattingEnabled = true;
-            this.deviceIDComboBoxForCommandReceiver.Location = new System.Drawing.Point(90, 26);
+            this.deviceIDComboBoxForCommandReceiver.Location = new System.Drawing.Point(93, 66);
             this.deviceIDComboBoxForCommandReceiver.Name = "deviceIDComboBoxForCommandReceiver";
             this.deviceIDComboBoxForCommandReceiver.Size = new System.Drawing.Size(622, 24);
             this.deviceIDComboBoxForCommandReceiver.TabIndex = 20;
             this.deviceIDComboBoxForCommandReceiver.SelectionChangeCommitted += new System.EventHandler(this.deviceIDComboBoxForCommandReceiver_SelectionChangeCommitted);
+            // 
+            // iotHubNameTextBoxForCommandReceiver
+            // 
+            this.iotHubNameTextBoxForCommandReceiver.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.iotHubNameTextBoxForCommandReceiver.Location = new System.Drawing.Point(93, 31);
+            this.iotHubNameTextBoxForCommandReceiver.Name = "iotHubNameTextBoxForCommandReceiver";
+            this.iotHubNameTextBoxForCommandReceiver.ReadOnly = true;
+            this.iotHubNameTextBoxForCommandReceiver.Size = new System.Drawing.Size(622, 22);
+            this.iotHubNameTextBoxForCommandReceiver.TabIndex = 31;
+            // 
+            // label25
+            // 
+            this.label25.AutoSize = true;
+            this.label25.Location = new System.Drawing.Point(14, 35);
+            this.label25.Name = "label25";
+            this.label25.Size = new System.Drawing.Size(59, 16);
+            this.label25.TabIndex = 30;
+            this.label25.Text = "IoT Hub:";
             // 
             // MainForm
             // 
@@ -1448,6 +1471,8 @@
         private System.Windows.Forms.Button cancelReceiveCommandsBtn;
         private System.Windows.Forms.Button clearCommandsBtn;
         private System.Windows.Forms.Button receiveCommandsBtn;
+        private System.Windows.Forms.TextBox iotHubNameTextBoxForCommandReceiver;
+        private System.Windows.Forms.Label label25;
     }
 }
 

--- a/tools/DeviceExplorer/DeviceExplorer/MainForm.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/MainForm.cs
@@ -902,7 +902,7 @@ namespace DeviceExplorer
 
                     var msgString = Encoding.UTF8.GetString(bytes);
 
-                    deviceCommandsRichTxtBox.AppendText("Received Command:" + Environment.NewLine);
+                    deviceCommandsRichTxtBox.AppendText($"Received Command with MessageId {message.MessageId}:" + Environment.NewLine);
                     deviceCommandsRichTxtBox.AppendText(msgString);
                     deviceCommandsRichTxtBox.AppendText(Environment.NewLine);
 

--- a/tools/DeviceExplorer/DeviceExplorer/MainForm.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/MainForm.cs
@@ -130,6 +130,7 @@ namespace DeviceExplorer
                 iotHubNameTextBox.Text = iotHubName;
                 eventHubNameTextBoxForDataTab.Text = iotHubName;
                 iotHubNameTextBoxForDeviceMethod.Text = iotHubName;
+                iotHubNameTextBoxForCommandReceiver.Text = iotHubName;
 
                 activeIoTHubConnectionString = connectionString;
             }

--- a/tools/DeviceExplorer/DeviceExplorer/MainForm.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/MainForm.cs
@@ -12,6 +12,7 @@ using Microsoft.ServiceBus.Messaging;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Microsoft.Azure.Devices.Client;
 
 namespace DeviceExplorer
 {
@@ -37,10 +38,13 @@ namespace DeviceExplorer
         private static int deviceSelectedIndexForEvent = 0;
         private static int deviceSelectedIndexForC2DMessage = 0;
         private static int deviceSelectedIndexForDeviceMethod = 0;
+        private static int deviceSelectedIndexForCommandReceiver = 0;
+        private static int actionSelectedIndexForCommandReceiver = 0;
 
         private static CancellationTokenSource ctsForDataMonitoring;
         private static CancellationTokenSource ctsForFeedbackMonitoring;
         private static CancellationTokenSource ctsForDeviceMethod;
+        private static CancellationTokenSource ctsForReceiveCommand;
 
         private const string DEFAULT_CONSUMER_GROUP = "$Default";
         #endregion
@@ -115,7 +119,7 @@ namespace DeviceExplorer
         {
             try
             {
-                var builder = IotHubConnectionStringBuilder.Create(connectionString);
+                var builder = Microsoft.Azure.Devices.IotHubConnectionStringBuilder.Create(connectionString);
                 iotHubHostName = builder.HostName;
 
                 targetTextBox.Text = builder.HostName;
@@ -138,6 +142,18 @@ namespace DeviceExplorer
             }
         }
 
+        private void fillCommandReceiverActionComboBox(bool runIfNullOrEmpty = true)
+        {
+            if (actionComboBoxForCommandReceiver.Items.Count == 0 || runIfNullOrEmpty)
+            {
+                actionComboBoxForCommandReceiver.Items.Add("None");
+                actionComboBoxForCommandReceiver.Items.Add("Complete");
+                actionComboBoxForCommandReceiver.Items.Add("Abondon");
+
+                actionComboBoxForCommandReceiver.SelectedIndex = actionSelectedIndexForCommandReceiver;
+            }
+        }
+
         private async Task updateDeviceIdsComboBoxes(bool runIfNullOrEmpty = true)
         {
             if (!String.IsNullOrEmpty(activeIoTHubConnectionString) || runIfNullOrEmpty)
@@ -145,23 +161,28 @@ namespace DeviceExplorer
                 List<string> deviceIdsForEvent = new List<string>();
                 List<string> deviceIdsForC2DMessage = new List<string>();
                 List<string> deviceIdsForDeviceMethod = new List<string>();
+                List<string> deviceIdsForDeviceEmulation = new List<string>();
                 RegistryManager registryManager = RegistryManager.CreateFromConnectionString(activeIoTHubConnectionString);
 
                 var devices = await registryManager.GetDevicesAsync(MAX_COUNT_OF_DEVICES);
-                foreach (var device in devices)
-                {
-                    deviceIdsForEvent.Add(device.Id);
-                    deviceIdsForC2DMessage.Add(device.Id);
-                    deviceIdsForDeviceMethod.Add(device.Id);
-                }
+
+                var orderedDeviceIds = devices.Select(d => d.Id).OrderBy(c => c);
+
+                deviceIdsForEvent.AddRange(orderedDeviceIds);
+                deviceIdsForC2DMessage.AddRange(orderedDeviceIds);
+                deviceIdsForDeviceMethod.AddRange(orderedDeviceIds);
+                deviceIdsForDeviceEmulation.AddRange(orderedDeviceIds);
+
                 await registryManager.CloseAsync();
-                deviceIDsComboBoxForEvent.DataSource = deviceIdsForEvent.OrderBy(c => c).ToList();
-                deviceIDsComboBoxForCloudToDeviceMessage.DataSource = deviceIdsForC2DMessage.OrderBy(c => c).ToList();
-                deviceIDsComboBoxForDeviceMethod.DataSource = deviceIdsForDeviceMethod.OrderBy(c => c).ToList();
+                deviceIDsComboBoxForEvent.DataSource = deviceIdsForEvent;
+                deviceIDsComboBoxForCloudToDeviceMessage.DataSource = deviceIdsForC2DMessage;
+                deviceIDsComboBoxForDeviceMethod.DataSource = deviceIdsForDeviceMethod;
+                deviceIDComboBoxForCommandReceiver.DataSource = deviceIdsForDeviceEmulation;
 
                 deviceIDsComboBoxForEvent.SelectedIndex = deviceSelectedIndexForEvent;
                 deviceIDsComboBoxForCloudToDeviceMessage.SelectedIndex = deviceSelectedIndexForC2DMessage;
                 deviceIDsComboBoxForDeviceMethod.SelectedIndex = deviceSelectedIndexForDeviceMethod;
+                deviceIDComboBoxForCommandReceiver.SelectedIndex = deviceSelectedIndexForCommandReceiver;
             }
         }
         private void persistSettingsToAppConfig()
@@ -638,7 +659,7 @@ namespace DeviceExplorer
                 ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(activeIoTHubConnectionString);
 
                 var serviceMessage = new Microsoft.Azure.Devices.Message(Encoding.ASCII.GetBytes(cloudToDeviceMessage));
-                serviceMessage.Ack = DeliveryAcknowledgement.Full;
+                serviceMessage.Ack = Microsoft.Azure.Devices.DeliveryAcknowledgement.Full;
                 serviceMessage.MessageId = Guid.NewGuid().ToString();
 
                 for (var i = 0; i < messagePropertiesGrid.Rows.Count - 1; i++)
@@ -740,9 +761,14 @@ namespace DeviceExplorer
         {
             try
             {
-                if (e.TabPage == tabData || e.TabPage == tabMessagesToDevice || e.TabPage == tabDeviceMethod)
+                if (e.TabPage == tabData || e.TabPage == tabMessagesToDevice || e.TabPage == tabDeviceMethod || e.TabPage == tabCommandReceiver)
                 {
                     await updateDeviceIdsComboBoxes(runIfNullOrEmpty: false);
+                }
+
+                if (e.TabPage == tabCommandReceiver)
+                {
+                    fillCommandReceiverActionComboBox(runIfNullOrEmpty: false);
                 }
 
                 if (e.TabPage == tabManagement)
@@ -848,6 +874,51 @@ namespace DeviceExplorer
             sasTokenButton.Enabled = true;
         }
 
+        private async Task ReceiveCommands(CancellationToken ct, string deviceId)
+        {
+            using (DeviceClient client = DeviceClient.CreateFromConnectionString(activeIoTHubConnectionString, deviceId))
+            {
+
+                while (!ct.IsCancellationRequested)
+                {
+                    var message = await client.ReceiveAsync();
+
+                    if (message == null)
+                        continue;
+
+                    var bytes = message.GetBytes();
+
+                    var msgString = Encoding.UTF8.GetString(bytes);
+
+                    deviceCommandsRichTxtBox.AppendText("Received Command:" + Environment.NewLine);
+                    deviceCommandsRichTxtBox.AppendText(msgString);
+                    deviceCommandsRichTxtBox.AppendText(Environment.NewLine);
+
+                    var action = actionComboBoxForCommandReceiver.SelectedItem?.ToString();
+
+                    switch (action)
+                    {
+                        case "Complete":
+                            {
+                                await client.CompleteAsync(message);
+                                deviceCommandsRichTxtBox.AppendText($"Command was completed succesful.");
+                                deviceCommandsRichTxtBox.AppendText(Environment.NewLine);
+                                break;
+                            }
+                        case "Abondon":
+                            {
+                                await client.AbandonAsync(message);
+                                deviceCommandsRichTxtBox.AppendText($"Command was abondened succesful.");
+                                deviceCommandsRichTxtBox.AppendText(Environment.NewLine);
+                                break;
+                            }
+                        case "None":
+                            break;
+                    }
+                }
+            }
+        }
+
         private async Task MonitorFeedback(CancellationToken ct, string deviceId)
         {
             ServiceClient serviceClient = null;
@@ -875,6 +946,27 @@ namespace DeviceExplorer
             if (serviceClient != null)
             {
                 await serviceClient.CloseAsync();
+            }
+        }
+
+        private async Task StartReceiveCommand()
+        {
+            ctsForReceiveCommand = new CancellationTokenSource();
+            deviceCommandsRichTxtBox.AppendText($"Started receiving commands for device {deviceIDComboBoxForCommandReceiver.SelectedItem.ToString()}.");
+            deviceCommandsRichTxtBox.AppendText(Environment.NewLine);
+
+            await ReceiveCommands(ctsForReceiveCommand.Token, deviceIDComboBoxForCommandReceiver.SelectedItem.ToString());
+        }
+
+        private void StopReceiveCommands()
+        {
+            if (ctsForReceiveCommand != null)
+            {
+                deviceCommandsRichTxtBox.AppendText("Stopped receiving commands.");
+                deviceCommandsRichTxtBox.AppendText(Environment.NewLine);
+
+                ctsForReceiveCommand.Cancel();
+                ctsForReceiveCommand = null;
             }
         }
 
@@ -951,6 +1043,36 @@ namespace DeviceExplorer
         private void deviceTwinPropertiesBtn_Click(object sender, EventArgs e)
         {
             showDevicePropertiesToolStripMenuItem_Click(this, null);
+        }
+
+        private void clearCommandsBtn_Click(object sender, EventArgs e)
+        {
+            deviceCommandsRichTxtBox.Clear();
+        }
+
+        private async void receiveCommandsBtn_Click(object sender, EventArgs e)
+        {
+            deviceIDComboBoxForCommandReceiver.Enabled = false;
+            actionComboBoxForCommandReceiver.Enabled = false;
+            receiveCommandsBtn.Enabled = false;
+            cancelReceiveCommandsBtn.Enabled = true;
+
+            await StartReceiveCommand();
+        }
+
+        private void cancelReceiveCommandsBtn_Click(object sender, EventArgs e)
+        {
+            StopReceiveCommands();
+
+            deviceIDComboBoxForCommandReceiver.Enabled = true;
+            actionComboBoxForCommandReceiver.Enabled = true;
+            receiveCommandsBtn.Enabled = true;
+            cancelReceiveCommandsBtn.Enabled = false;
+        }
+
+        private void deviceIDComboBoxForCommandReceiver_SelectionChangeCommitted(object sender, EventArgs e)
+        {
+            deviceSelectedIndexForCommandReceiver = ((ComboBox)sender).SelectedIndex;
         }
     }
 }

--- a/tools/DeviceExplorer/DeviceExplorer/MainForm.resx
+++ b/tools/DeviceExplorer/DeviceExplorer/MainForm.resx
@@ -136,6 +136,6 @@
     <value>17, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>149</value>
+    <value>73</value>
   </metadata>
 </root>

--- a/tools/DeviceExplorer/DeviceExplorer/MainForm.resx
+++ b/tools/DeviceExplorer/DeviceExplorer/MainForm.resx
@@ -126,12 +126,6 @@
   <metadata name="ValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="KeyColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="ehStringToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>

--- a/tools/DeviceExplorer/DeviceExplorer/packages.config
+++ b/tools/DeviceExplorer/DeviceExplorer/packages.config
@@ -1,13 +1,70 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="DotNetty.Buffers" version="0.4.4" targetFramework="net451" />
+  <package id="DotNetty.Codecs" version="0.4.4" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt" version="0.4.4" targetFramework="net451" />
+  <package id="DotNetty.Common" version="0.4.4" targetFramework="net451" />
+  <package id="DotNetty.Handlers" version="0.4.4" targetFramework="net451" />
+  <package id="DotNetty.Transport" version="0.4.4" targetFramework="net451" />
+  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />
-  <package id="Microsoft.Azure.Amqp" version="1.1.5" targetFramework="net451" />
+  <package id="Microsoft.Azure.Amqp" version="2.0.6" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices" version="1.1.0-preview-004" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.Client" version="1.3.0" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.Shared" version="1.0.11" targetFramework="net451" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Logging" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
   <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net451" />
+  <package id="PCLCrypto" version="2.0.147" targetFramework="net451" />
+  <package id="PInvoke.BCrypt" version="0.3.2" targetFramework="net451" />
+  <package id="PInvoke.Kernel32" version="0.3.2" targetFramework="net451" />
+  <package id="PInvoke.NCrypt" version="0.3.2" targetFramework="net451" />
+  <package id="PInvoke.Windows.Core" version="0.3.2" targetFramework="net451" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net451" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
+  <package id="Validation" version="2.2.8" targetFramework="net451" />
   <package id="WindowsAzure.ServiceBus" version="4.1.2" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="7.0.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
# Device Explorer
I implemented a new Tab for the Device Explorer.
You can receive cloud to device messages in this tab and also complete/abondon them.

## Scenario
You can now send messages to a device in the already existing "Messages to Device", then receive those messages with the newly implemented tab and complete/abondon them. Then you will see (if feedback receive is activated) the feedback in the "Messages to Device" tab.

This is very useful when simulating devices.

## Changes
- new C2D listening Tab
- improvements in `updateDeviceIdsComboBoxes` method
- added Microsoft.Azure.Devices.Client nuget package for C2D receive

I tried to not change the existing coding style with my changes.

**Please tell me if I need to change something, before this gets approved.**

## Screenshots
![image](https://user-images.githubusercontent.com/736807/28060647-13833ef4-6628-11e7-874d-d893bda71b85.png)
