### PR TITLE
fix amqp twin connection prefix

### DIFF
--- a/device/Microsoft.Azure.Devices.Client/Common/CommonConstants.cs
+++ b/device/Microsoft.Azure.Devices.Client/Common/CommonConstants.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.Client
         public const string DeviceEventPathTemplate = "/devices/{0}/messages/events";
         public const string DeviceBoundPathTemplate = "/devices/{0}/messages/deviceBound";
         public const string DeviceMethodPathTemplate = "/devices/{0}/methods/deviceBound";
-        public const string DeviceTwinPathTemplate = "/devices/{0}/twin/";
+        public const string DeviceTwinPathTemplate = "/devices/{0}/twin";
         public const string BlobUploadStatusPathTemplate = "/devices/{0}/files/";
         public const string BlobUploadPathTemplate = "/devices/{0}/files";
         public const string DeviceBoundPathCompleteTemplate = DeviceBoundPathTemplate + "/{1}";

--- a/device/Microsoft.Azure.Devices.Client/Transport/AmqpTransportHandler.cs
+++ b/device/Microsoft.Azure.Devices.Client/Transport/AmqpTransportHandler.cs
@@ -617,7 +617,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             link.DisposeDelivery(message, true, AmqpConstants.AcceptedOutcome);
 
-            string correlationId = message.Properties.CorrelationId?.ToString();
+            string correlationId = message.Properties?.CorrelationId?.ToString();
             if (correlationId != null)
             {
                 // If we have a correlation id, it must be a response, complete the task.


### PR DESCRIPTION
- remove trailing slash on twin amqp connection path
- add null checking on incoming property for twin messages