### PR TITLE
WIP: ProvisioningDeviceClient API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.suo
 *.user
 *.sln.docstates
+.vs/
 
 # Build results
 
@@ -199,7 +200,6 @@ Buildx86retail.dat
 
 */NuGet/*.exe
 */NuGet/*.nupkg
-*/.vs/*
 */nuget.exe
 
 # .NET Micro Framework Emulator files and folders

--- a/provisioning/device/provisioning_deviceclient.sln
+++ b/provisioning/device/provisioning_deviceclient.sln
@@ -3,9 +3,40 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{19A7EA28-F4A4-426E-9343-D9EE5C3F679D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{5169D289-68A3-402C-85C3-7BBF98C976FF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Devices.Provisioning.Client", "src\Microsoft.Azure.Devices.Provisioning.Client.csproj", "{2DFE4F39-7EC5-42CC-9B79-E271603A4D1A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Devices.Provisioning.Client.UnitTests", "tests\Microsoft.Azure.Devices.Provisioning.Client.UnitTests.csproj", "{EB76B7C4-D21F-40D5-84D7-A43D93A3BE85}"
+EndProject
 Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release_Delay_Sign|Any CPU = Release_Delay_Sign|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2DFE4F39-7EC5-42CC-9B79-E271603A4D1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2DFE4F39-7EC5-42CC-9B79-E271603A4D1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2DFE4F39-7EC5-42CC-9B79-E271603A4D1A}.Release_Delay_Sign|Any CPU.ActiveCfg = Release|Any CPU
+		{2DFE4F39-7EC5-42CC-9B79-E271603A4D1A}.Release_Delay_Sign|Any CPU.Build.0 = Release|Any CPU
+		{2DFE4F39-7EC5-42CC-9B79-E271603A4D1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2DFE4F39-7EC5-42CC-9B79-E271603A4D1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB76B7C4-D21F-40D5-84D7-A43D93A3BE85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB76B7C4-D21F-40D5-84D7-A43D93A3BE85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB76B7C4-D21F-40D5-84D7-A43D93A3BE85}.Release_Delay_Sign|Any CPU.ActiveCfg = Release|Any CPU
+		{EB76B7C4-D21F-40D5-84D7-A43D93A3BE85}.Release_Delay_Sign|Any CPU.Build.0 = Release|Any CPU
+		{EB76B7C4-D21F-40D5-84D7-A43D93A3BE85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB76B7C4-D21F-40D5-84D7-A43D93A3BE85}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{2DFE4F39-7EC5-42CC-9B79-E271603A4D1A} = {19A7EA28-F4A4-426E-9343-D9EE5C3F679D}
+		{EB76B7C4-D21F-40D5-84D7-A43D93A3BE85} = {5169D289-68A3-402C-85C3-7BBF98C976FF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7566ED37-47DE-4312-8F20-E4A4429657BC}

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Azure.Devices.Shared">
+      <HintPath>..\..\..\shared\Microsoft.Azure.Devices.Shared.NetStandard\bin\Debug\Microsoft.Azure.Devices.Shared.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/provisioning/device/src/ProvisioningDeviceClient.cs
+++ b/provisioning/device/src/ProvisioningDeviceClient.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Shared;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices.Provisioning.Client
+{
+    /// <summary>
+    /// Device Provisioning Client
+    /// </summary>
+    public class ProvisioningDeviceClient
+    {
+        /// <summary>
+        /// Creates an instance of the Device Provisioning Client.
+        /// </summary>
+        /// <param name="globalDeviceEndpoint">The global device endpoint host-name.</param>
+        /// <param name="idScope">The IDScope for the Device Provisioning Service.</param>
+        /// <param name="securityClient">The security client instance.</param>
+        /// <param name="transport">The type of transport (e.g. HTTP, AMQP, MQTT).</param>
+        /// <returns>An instance of the DPSDeviceClient</returns>
+        public static ProvisioningDeviceClient Create(
+            string globalDeviceEndpoint, 
+            string idScope, 
+            SecurityClient securityClient, 
+            TransportHandler transport)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Registers the current device using the Device Provisioning Service and assigns it to a Hub.
+        /// </summary>
+        /// <param name="force">Forces the registration by ensuring that all information is rebuilt on the service 
+        /// side.</param>
+        /// <returns>The DPSRegistrationResult.</returns>
+        public async Task<ProvisioningRegistrationResult> RegisterAsync(bool force = false)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Registers the current device using the Device Provisioning Service and assigns it to a Hub.
+        /// </summary>
+        /// <param name="force">Forces the registration by ensuring that all information is rebuilt on the service 
+        /// side.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The DPSRegistrationResult.</returns>
+        public async Task<ProvisioningRegistrationResult> RegisterAsync(bool force, CancellationToken cancellationToken)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Ensures that the communication channel between the device and the service is gracefully closed.
+        /// </summary>
+        public async Task CloseAsync()
+        {
+            // Needed at least for WebSocket close handshake.
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/provisioning/device/src/ProvisioningRegistrationResult.cs
+++ b/provisioning/device/src/ProvisioningRegistrationResult.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Provisioning.Client
+{
+    /// <summary>
+    /// The result of a registration operation.
+    /// </summary>
+    public abstract class ProvisioningRegistrationResult
+    {
+        /// <summary>
+        /// The registration id.
+        /// </summary>
+        public string RegistrationId { get; protected set; }
+
+        /// <summary>
+        /// The time when the device originally registered with the service.
+        /// </summary>
+        public System.DateTime? CreatedDateTimeUtc { get; protected set; }
+
+        /// <summary>
+        /// The assigned Azure IoT Hub.
+        /// </summary>
+        public string AssignedHub { get; protected set; }
+
+        /// <summary>
+        /// The Device ID.
+        /// </summary>
+        public string DeviceId { get; protected set; }
+
+        /// <summary>
+        /// The status of the operation.
+        /// </summary>
+        public ProvisioningRegistrationStatusType Status { get; set; }
+
+        /// <summary>
+        /// The generation ID.
+        /// </summary>
+        public string GenerationId { get; set; }
+
+        /// <summary>
+        /// The time when the device last refreshed the registration.
+        /// </summary>
+        public System.DateTime? LastUpdatedDateTimeUtc { get; set; }
+
+        // TODO: the following APIs may not be required.
+
+        /// <summary>
+        /// TODO: Error code.
+        /// </summary>
+        public int? ErrorCode { get; set; }
+
+
+        /// <summary>
+        /// TODO: Error message.
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
+        /// TODO: The Etag.
+        /// </summary>
+        public string Etag { get; set; }
+    }
+}

--- a/provisioning/device/src/ProvisioningRegistrationResultSasToken.cs
+++ b/provisioning/device/src/ProvisioningRegistrationResultSasToken.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Provisioning.Client
+{
+    /// <summary>
+    /// The DPSRegistrationResult type returned when the SAS Token HSM mode is used.
+    /// </summary>
+    public class ProvisioningRegistrationResultSasToken : ProvisioningRegistrationResult
+    {
+        /// <summary>
+        /// The Registration ID used during device enrollment.
+        /// </summary>
+        public string RegistrationID { get; protected set; }
+
+        /// <summary>
+        /// The AuthenticationKey required by the SAS Token HSM module.
+        /// </summary>
+        public string AuthenticationKey { get; private set; }
+
+        public ProvisioningRegistrationResultSasToken(string registrationId)
+        {
+            RegistrationId = registrationId;
+        }
+    }
+}

--- a/provisioning/device/src/ProvisioningRegistrationResultX509Certificate.cs
+++ b/provisioning/device/src/ProvisioningRegistrationResultX509Certificate.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Provisioning.Client
+{
+    /// <summary>
+    /// The DPSRegistrationResult type returned when the X509 Certificate HSM mode is used.
+    /// </summary>
+    public class ProvisioningRegistrationResultX509Certificate : ProvisioningRegistrationResult
+    {
+        /// <summary>
+        /// TODO: CertificateInformation (AliasCertificate?).
+        /// In the current PoC this is empty.
+        /// </summary>
+        public ProvisioningX509CertificateInfo CertificateInfo { get; set; }
+
+        /// <summary>
+        /// The Enrollment Group Id.
+        /// </summary>
+        public string EnrollmentGroupId { get; set; }
+
+        /// <summary>
+        /// TODO: CertificateInformation (AliasCertificate?).
+        /// In the current PoC this is empty.
+        /// </summary>
+        public ProvisioningX509CertificateInfo SigningCertificateInfo { get; set; }
+    }
+}

--- a/provisioning/device/src/ProvisioningRegistrationStatus.cs
+++ b/provisioning/device/src/ProvisioningRegistrationStatus.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Provisioning.Client
+{
+    /// <summary>
+    /// The DPSRegistrationResult status type.
+    /// </summary>
+    public enum ProvisioningRegistrationStatusType
+    {
+        /// <summary>
+        /// Device has not yet come on-line
+        /// </summary>
+        Unassigned = 1,
+
+        /// <summary>
+        /// Device has connected to the DRS but IoT Hub ID has not yet been returned to the device
+        /// </summary>
+        Assigning = 2,
+
+        /// <summary>
+        /// DRS successfully returned a device ID and connection string to the device
+        /// </summary>
+        Assigned = 3,
+
+        /// <summary>
+        /// Device enrollment failed
+        /// </summary>
+        Failed = 4,
+
+        /// <summary>
+        /// Device is disabled
+        /// </summary>
+        Disabled = 5
+    }
+}

--- a/provisioning/device/src/ProvisioningX509CertificateInfo.cs
+++ b/provisioning/device/src/ProvisioningX509CertificateInfo.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Provisioning.Client
+{
+    /// <summary>
+    /// Certificate information returned by the Device Provisioning Service.
+    /// </summary>
+    public class ProvisioningX509CertificateInfo
+    {
+        /// <summary>
+        /// Certificate Subject Name.
+        /// </summary>
+        public string SubjectName { get; private set; }
+
+        /// <summary>
+        /// SHA1 Thumbprint of the certificate.
+        /// </summary>
+        public string Sha1Thumbprint { get; private set; }
+
+        /// <summary>
+        /// SHA256 Thumbprint of the certificate.
+        /// </summary>
+        public string Sha256Thumbprint { get; private set; }
+
+        /// <summary>
+        /// Certificate issuer name.
+        /// </summary>
+        public string IssuerName { get; private set; }
+
+        /// <summary>
+        /// Certificate validity start time.
+        /// </summary>
+        public System.DateTime? NotBeforeUtc { get; private set; }
+
+        /// <summary>
+        /// Certificate expiration.
+        /// </summary>
+        public System.DateTime? NotAfterUtc { get; private set; }
+
+        /// <summary>
+        /// Certificate serial number.
+        /// </summary>
+        public string SerialNumber { get; private set; }
+
+        /// <summary>
+        /// Certificate version.
+        /// </summary>
+        public int? Version { get; private set; }
+    }
+}

--- a/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.UnitTests.csproj
+++ b/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.UnitTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Microsoft.Azure.Devices.Provisioning.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.UnitTests.csproj
+++ b/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.UnitTests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+  </ItemGroup>
+
+</Project>

--- a/shared/Microsoft.Azure.Devices.Shared.NetStandard/Microsoft.Azure.Devices.Shared.NetStandard.csproj
+++ b/shared/Microsoft.Azure.Devices.Shared.NetStandard/Microsoft.Azure.Devices.Shared.NetStandard.csproj
@@ -22,7 +22,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -57,6 +57,14 @@
     <Compile Include="..\Microsoft.Azure.Devices.Shared\TwinJsonConverter.cs" />
     <Compile Include="..\Microsoft.Azure.Devices.Shared\TwinProperties.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(DefineConstants2)' == 'WIP_PROVISIONING'">
+    <!-- WIP: ProvisioningDeviceClient -->
+    <Compile Include="..\Microsoft.Azure.Devices.Shared\SecurityClient.cs" />
+    <Compile Include="..\Microsoft.Azure.Devices.Shared\SecurityClientSasToken.cs" />
+    <Compile Include="..\Microsoft.Azure.Devices.Shared\SecurityClientX509Certificate.cs" />
+    <Compile Include="..\Microsoft.Azure.Devices.Shared\TransportFallbackType.cs" />
+    <Compile Include="..\Microsoft.Azure.Devices.Shared\TransportHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/shared/Microsoft.Azure.Devices.Shared/SecurityClient.cs
+++ b/shared/Microsoft.Azure.Devices.Shared/SecurityClient.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// The Security Client used during device provisioning and IoT Hub hardware-based authentication.
+    /// </summary>
+    public abstract class SecurityClient
+    {
+    }
+}

--- a/shared/Microsoft.Azure.Devices.Shared/SecurityClientSasToken.cs
+++ b/shared/Microsoft.Azure.Devices.Shared/SecurityClientSasToken.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// The Device Security Client for SAS Token authentication (TPM authentication).
+    /// </summary>
+    public abstract class SecurityClientSasToken : SecurityClient
+    {
+        /// <summary>
+        /// The Registration ID used during device enrollment.
+        /// </summary>
+        public string RegistrationID { get; protected set; }
+
+        /// <summary>
+        /// Initializes a new instance of the SecurityClientSasToken class.
+        /// </summary>
+        /// <param name="registrationId"></param>
+        public SecurityClientSasToken(string registrationId)
+        {
+            RegistrationID = registrationId;
+        }
+
+        /// <summary>
+        /// Gets the Base64 encoded EndorsmentKey.
+        /// </summary>
+        /// <returns>Base64 encoded EK.</returns>
+        public abstract string GetEndorsmentKey();
+
+        /// <summary>
+        /// Gets the Base64 encoded StorageRootKey.
+        /// </summary>
+        /// <returns>Base64 encoded SRK.</returns>
+        public abstract string GetStorageRootKey();
+
+        /// <summary>
+        /// Activates a symmetric identity within the Hardware Security Module.
+        /// </summary>
+        /// <param name="activation">The authentication challenge key supplied by the service.</param>
+        public abstract void ActivateSymmetricIdentity(byte[] activation);
+
+        /// <summary>
+        /// Signs the data using the Hardware Security Module.
+        /// </summary>
+        /// <param name="data">The data to be signed.</param>
+        /// <returns>The signed data.</returns>
+        public abstract byte[] Sign(byte[] data);
+    }
+}

--- a/shared/Microsoft.Azure.Devices.Shared/SecurityClientX509Certificate.cs
+++ b/shared/Microsoft.Azure.Devices.Shared/SecurityClientX509Certificate.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// The Device Security Client for X509 authentication (DICE/RIoT authentication).
+    /// </summary>
+    public abstract class SecurityClientX509Certificate : SecurityClient
+    {
+        /// <summary>
+        /// Gets the certificate used for TLS authentication by the device from the HSM.
+        /// </summary>
+        /// <returns>The client certificate used during TLS communications.</returns>
+        public abstract X509Certificate2 GetAuthenticationCertificate();
+        
+        // TODO: Do we need another public API to extract the chain? (Is installing the chain in Trusted Root cert-store sufficient?)
+    }
+}

--- a/shared/Microsoft.Azure.Devices.Shared/TransportFallbackType.cs
+++ b/shared/Microsoft.Azure.Devices.Shared/TransportFallbackType.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// Defines the transport fall-back types for AMQP and MQTT.
+    /// </summary>
+    public enum TransportFallbackType
+    {
+        TcpWithWebSocketFallback = 0,
+        WebSocketOnly = 1,
+        TcpOnly = 2,
+    }
+}

--- a/shared/Microsoft.Azure.Devices.Shared/TransportHandler.cs
+++ b/shared/Microsoft.Azure.Devices.Shared/TransportHandler.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    public abstract class TransportHandler : IDisposable
+    {
+        public TransportFallbackType TransportFallback
+        {
+            get;
+            private set;
+        }
+
+        public TransportHandler()
+        {
+
+        }
+
+        public TransportHandler(TransportFallbackType transportFallback)
+        {
+            TransportFallback = transportFallback;
+        }
+
+        public abstract void Dispose();
+    }
+}


### PR DESCRIPTION
WIP: Adding projects and public API for ProvisioningDeviceClient.

To build:
1. Build the shared folder using `build --wip-provisioning --config DEBUG`. (Temporary workaround.)
2. Use either the build script, `dotnet build` or VS build.

