### PR TITLE
Enabling FXCop for new projects.

### DIFF
--- a/provisioning/device/provisioning_deviceclient.sln
+++ b/provisioning/device/provisioning_deviceclient.sln
@@ -15,6 +15,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "inc_int", "inc_int", "{4D71
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Devices.Shared.NetStandard", "..\..\shared\Microsoft.Azure.Devices.Shared.NetStandard\Microsoft.Azure.Devices.Shared.NetStandard.csproj", "{91DFB837-D8A3-4F54-AE0D-45C95ACD0C2A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Devices.Provisioning.Transport.Http", "..\..\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj", "{63EAC3B1-7CE3-41FE-A456-AA24EE2B4303}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Devices.Provisioning.Transport.Amqp", "..\..\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj", "{DC213C94-B2F8-4003-A631-2FCC18119840}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Devices.Provisioning.Transport.Mqtt", "..\..\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj", "{1E222472-6526-4B9F-995A-BE4F1787A1E7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -40,6 +46,24 @@ Global
 		{91DFB837-D8A3-4F54-AE0D-45C95ACD0C2A}.Release_Delay_Sign|Any CPU.Build.0 = Release|Any CPU
 		{91DFB837-D8A3-4F54-AE0D-45C95ACD0C2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{91DFB837-D8A3-4F54-AE0D-45C95ACD0C2A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63EAC3B1-7CE3-41FE-A456-AA24EE2B4303}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63EAC3B1-7CE3-41FE-A456-AA24EE2B4303}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63EAC3B1-7CE3-41FE-A456-AA24EE2B4303}.Release_Delay_Sign|Any CPU.ActiveCfg = Release|Any CPU
+		{63EAC3B1-7CE3-41FE-A456-AA24EE2B4303}.Release_Delay_Sign|Any CPU.Build.0 = Release|Any CPU
+		{63EAC3B1-7CE3-41FE-A456-AA24EE2B4303}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63EAC3B1-7CE3-41FE-A456-AA24EE2B4303}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC213C94-B2F8-4003-A631-2FCC18119840}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC213C94-B2F8-4003-A631-2FCC18119840}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC213C94-B2F8-4003-A631-2FCC18119840}.Release_Delay_Sign|Any CPU.ActiveCfg = Release|Any CPU
+		{DC213C94-B2F8-4003-A631-2FCC18119840}.Release_Delay_Sign|Any CPU.Build.0 = Release|Any CPU
+		{DC213C94-B2F8-4003-A631-2FCC18119840}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC213C94-B2F8-4003-A631-2FCC18119840}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E222472-6526-4B9F-995A-BE4F1787A1E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E222472-6526-4B9F-995A-BE4F1787A1E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E222472-6526-4B9F-995A-BE4F1787A1E7}.Release_Delay_Sign|Any CPU.ActiveCfg = Release|Any CPU
+		{1E222472-6526-4B9F-995A-BE4F1787A1E7}.Release_Delay_Sign|Any CPU.Build.0 = Release|Any CPU
+		{1E222472-6526-4B9F-995A-BE4F1787A1E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E222472-6526-4B9F-995A-BE4F1787A1E7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -48,6 +72,9 @@ Global
 		{2DFE4F39-7EC5-42CC-9B79-E271603A4D1A} = {19A7EA28-F4A4-426E-9343-D9EE5C3F679D}
 		{EB76B7C4-D21F-40D5-84D7-A43D93A3BE85} = {5169D289-68A3-402C-85C3-7BBF98C976FF}
 		{91DFB837-D8A3-4F54-AE0D-45C95ACD0C2A} = {4D71317B-7058-499A-B245-B8F523694E6C}
+		{63EAC3B1-7CE3-41FE-A456-AA24EE2B4303} = {4D71317B-7058-499A-B245-B8F523694E6C}
+		{DC213C94-B2F8-4003-A631-2FCC18119840} = {4D71317B-7058-499A-B245-B8F523694E6C}
+		{1E222472-6526-4B9F-995A-BE4F1787A1E7} = {4D71317B-7058-499A-B245-B8F523694E6C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7566ED37-47DE-4312-8F20-E4A4429657BC}

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -1,15 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors> 
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\shared\Microsoft.Azure.Devices.Shared.NetStandard\Microsoft.Azure.Devices.Shared.NetStandard.csproj">
       <Project>{91dfb837-d8a3-4f54-ae0d-45c95acd0c2a}</Project>
       <Name>Microsoft.Azure.Devices.Shared.NetStandard</Name>
     </ProjectReference>
   </ItemGroup>
-
+  <ItemGroup>
+    <!-- FXCop -->
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" />
+  </ItemGroup>
 </Project>

--- a/provisioning/device/src/ProvisioningDeviceClient.cs
+++ b/provisioning/device/src/ProvisioningDeviceClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Azure.Devices.Shared;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,6 +21,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// <param name="securityClient">The security client instance.</param>
         /// <param name="transport">The type of transport (e.g. HTTP, AMQP, MQTT).</param>
         /// <returns>An instance of the DPSDeviceClient</returns>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "context", Justification = "Work in progress")]
         public static ProvisioningDeviceClient Create(
             string globalDeviceEndpoint, 
             string idScope, 
@@ -35,6 +37,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// <param name="force">Forces the registration by ensuring that all information is rebuilt on the service 
         /// side.</param>
         /// <returns>The DPSRegistrationResult.</returns>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "context", Justification = "Work in progress")]
         public Task<ProvisioningRegistrationResult> RegisterAsync(bool force = false)
         {
             throw new System.NotImplementedException();
@@ -47,6 +50,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// side.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The DPSRegistrationResult.</returns>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "context", Justification = "Work in progress")]
         public Task<ProvisioningRegistrationResult> RegisterAsync(bool force, CancellationToken cancellationToken)
         {
             throw new System.NotImplementedException();

--- a/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.UnitTests.csproj
+++ b/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.UnitTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features> 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors> 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors> 
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,6 +33,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+
+    <!-- FXCop TODO: #176
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" />
+    -->
   </ItemGroup>
 
   <ItemGroup>

--- a/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.UnitTests.csproj
+++ b/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors> 
     <IsPackable>false</IsPackable>
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
   </PropertyGroup>
 
   <ItemGroup>

--- a/security/dice/src/Microsoft.Azure.Devices.Provisioning.Security.Dice.csproj
+++ b/security/dice/src/Microsoft.Azure.Devices.Provisioning.Security.Dice.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors> 
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,5 +12,8 @@
       <Name>Microsoft.Azure.Devices.Shared.NetStandard</Name>
     </ProjectReference>
   </ItemGroup>
-
+  <ItemGroup>
+    <!-- FXCop -->
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" />
+  </ItemGroup>
 </Project>

--- a/security/dice/tests/Microsoft.Azure.Devices.Provisioning.Security.Dice.UnitTests.csproj
+++ b/security/dice/tests/Microsoft.Azure.Devices.Provisioning.Security.Dice.UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors> 
     <IsPackable>false</IsPackable>
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
   </PropertyGroup>
 
   <ItemGroup>

--- a/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
+++ b/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
@@ -3,10 +3,14 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TSS" Version="1.0.6" />
+
+    <!-- FXCop -->
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/security/tpm/tests/Microsoft.Azure.Devices.Provisioning.Security.Tpm.UnitTests.csproj
+++ b/security/tpm/tests/Microsoft.Azure.Devices.Provisioning.Security.Tpm.UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
   </PropertyGroup>
 
   <ItemGroup>

--- a/transport/amqp/src/AmqpTransportClient.cs
+++ b/transport/amqp/src/AmqpTransportClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Azure.Devices.Shared;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Azure.Devices.Client.Transport
 {
@@ -12,6 +13,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         }
 
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "context", Justification = "Work in progress")]
         public AmqpTransportClient(TransportFallbackType transportFallback) : base(transportFallback)
         {
         }

--- a/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
   </PropertyGroup>
   
   <ItemGroup>
@@ -12,4 +13,8 @@
     </ProjectReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- FXCop -->
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" />
+  </ItemGroup>
 </Project>

--- a/transport/amqp/tests/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.UnitTests.csproj
+++ b/transport/amqp/tests/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
   </PropertyGroup>
 
   <ItemGroup>

--- a/transport/http/src/HttpTransportClient.cs
+++ b/transport/http/src/HttpTransportClient.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Azure.Devices.Shared;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Azure.Devices.Client.Transport
 {
@@ -13,6 +14,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         }
 
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "context", Justification = "Work in progress")]
         public HttpTransportClient(TransportFallbackType transportFallback)
         {
             throw new NotSupportedException();

--- a/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
+++ b/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
   </PropertyGroup>
  
   <ItemGroup>
@@ -10,6 +11,11 @@
       <Project>{91dfb837-d8a3-4f54-ae0d-45c95acd0c2a}</Project>
       <Name>Microsoft.Azure.Devices.Shared.NetStandard</Name>
     </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- FXCop -->
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" />
   </ItemGroup>
 
 </Project>

--- a/transport/http/tests/Microsoft.Azure.Devices.Provisioning.Transport.Http.UnitTests.csproj
+++ b/transport/http/tests/Microsoft.Azure.Devices.Provisioning.Transport.Http.UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
   </PropertyGroup>
 
   <ItemGroup>

--- a/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
+++ b/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,6 +11,11 @@
       <Project>{91dfb837-d8a3-4f54-ae0d-45c95acd0c2a}</Project>
       <Name>Microsoft.Azure.Devices.Shared.NetStandard</Name>
     </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- FXCop -->
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" />
   </ItemGroup>
 
 </Project>

--- a/transport/mqtt/src/MqttTransportClient.cs
+++ b/transport/mqtt/src/MqttTransportClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Azure.Devices.Shared;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Azure.Devices.Client.Transport
 {
@@ -12,6 +13,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         }
 
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "context", Justification = "Work in progress")]
         public MqttTransportClient(TransportFallbackType transportFallback) : base(transportFallback)
         {
         }

--- a/transport/mqtt/tests/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.UnitTests.csproj
+++ b/transport/mqtt/tests/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Enabling FXCop for all new projects. Old projects have warnings and cannot have FXCop enabled easily at this moment (tracked by #181). 
