### PR TITLE
fix user agent version

### DIFF
--- a/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 {
                     ClientId = this.deviceId,
                     HasUsername = true,
-                    Username = this.iotHubHostName + "/" + this.deviceId +"/api-version=" + ClientApiVersionHelper.ApiVersionString + "/DeviceClientType=" + Utils.GetClientVersion(),
+                    Username = this.iotHubHostName + "/" + this.deviceId +"/api-version=" + ClientApiVersionHelper.ApiVersionString + "&DeviceClientType=" + Uri.EscapeDataString(Utils.GetClientVersion()),
                     HasPassword = !string.IsNullOrEmpty(this.password),
                     Password = this.password,
                     KeepAliveInSeconds = this.mqttTransportSettings.KeepAliveInSeconds,


### PR DESCRIPTION
"/" is reserved for MQTT which server will ignore the rest of the segments after the "/" behind the device id which causes DeviceClientType property to be dropped.  Uri encoded the string for it to go through