### PR TITLE
Adding NetStandard E2E tests.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -12,6 +12,7 @@ Builds Azure IoT SDK binaries.
 Parameters:
     -clean
     -notests
+    -e2etests
     -configuration {Debug|Release}
     -verbosity: Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
@@ -32,6 +33,7 @@ https://github.com/azure/azure-iot-sdk-csharp
 Param(
     [switch] $clean,
     [switch] $notests,
+    [switch] $e2etests,
     [string] $configuration = "Debug",
     [string] $verbosity = "q",
 
@@ -66,7 +68,7 @@ Function RunTests($path, $message) {
     Write-Host -ForegroundColor Cyan "TEST: --- " $message " ---"
     cd (Join-Path $rootDir $path)
 
-    & dotnet test --verbosity $verbosity --configuration $configuration --logger "trx"
+    & dotnet test --verbosity normal --configuration $configuration --logger "trx"
 
     if ($LASTEXITCODE -ne 0) {
         throw "Build failed."
@@ -148,6 +150,15 @@ try {
             RunTests security\dice\tests "SecurityClient for DICE"
             RunTests security\tpm\tests "SecurityClient for TPM"
         }
+    }
+
+    if ($e2etests)
+    {
+        Write-Host
+        Write-Host -ForegroundColor Cyan "End-to-end Test execution"
+        Write-Host
+
+        RunTests e2e\Microsoft.Azure.Devices.E2ETests.NetStandard "End-to-end Tests"
     }
 
     $buildFailed = $false

--- a/e2e/Microsoft.Azure.Devices.E2ETests.NetStandard/Microsoft.Azure.Devices.E2ETests.NetStandard.csproj
+++ b/e2e/Microsoft.Azure.Devices.E2ETests.NetStandard/Microsoft.Azure.Devices.E2ETests.NetStandard.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
+    <Features Condition=" '$(Configuration)' == 'Debug' ">IOperation</Features>
+    <RootNamespace>Microsoft.Azure.Devices.E2ETests</RootNamespace>
+    <AssemblyName>Microsoft.Azure.Devices.E2ETests</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Microsoft.Azure.Devices.E2ETests\FileUploadE2ETests.cs" />
+    <Compile Include="..\Microsoft.Azure.Devices.E2ETests\MethodE2ETests.cs" />
+    <Compile Include="..\Microsoft.Azure.Devices.E2ETests\TestUtil.cs" />
+    <Compile Include="..\Microsoft.Azure.Devices.E2ETests\TwinE2ETests.cs" />
+
+    <!-- TODO #193: Port to .Net Standard compatible new Azure EventHubs and ServiceBus NuGet packages:
+    <Compile Include="..\Microsoft.Azure.Devices.E2ETests\X509E2ETests.cs" />
+    <Compile Include="..\Microsoft.Azure.Devices.E2ETests\MessageE2ETests.cs" />
+    -->
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.3" />
+    <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="1.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\device\Microsoft.Azure.Devices.Client.NetStandard\Microsoft.Azure.Devices.Client.NetStandard.csproj">
+      <Project>{8988AB0E-0FDD-4BD4-A65F-6479BB2C5AF8}</Project>
+      <Name>Microsoft.Azure.Devices.Client.NetStandard</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\service\Microsoft.Azure.Devices.NetStandard\Microsoft.Azure.Devices.NetStandard.csproj">
+      <Project>{3081D7CD-2F05-4431-9FEF-4F8A19591AD4}</Project>
+      <Name>Microsoft.Azure.Devices.NetStandard</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\shared\Microsoft.Azure.Devices.Shared.NetStandard\Microsoft.Azure.Devices.Shared.NetStandard.csproj">
+      <Project>{91DFB837-D8A3-4F54-AE0D-45C95ACD0C2A}</Project>
+      <Name>Microsoft.Azure.Devices.Shared.NetStandard</Name>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/e2e/Microsoft.Azure.Devices.E2ETests/FileUploadE2ETests.cs
+++ b/e2e/Microsoft.Azure.Devices.E2ETests/FileUploadE2ETests.cs
@@ -48,11 +48,19 @@ namespace Microsoft.Azure.Devices.E2ETests
             TestUtil.UnInitializeEnvironment(registryManager);
         }
 
+#if NETSTANDARD1_3
         [TestInitialize]
-        public async void Initialize()
+        public async Task Initialize()
         {
             await sequentialTestSemaphore.WaitAsync();
         }
+#else
+        [TestInitialize]
+        public void Initialize()
+        {
+            sequentialTestSemaphore.Wait();
+        }
+#endif
 
         [TestCleanup]
         public void Cleanup()

--- a/e2e/Microsoft.Azure.Devices.E2ETests/TwinE2ETests.cs
+++ b/e2e/Microsoft.Azure.Devices.E2ETests/TwinE2ETests.cs
@@ -460,6 +460,10 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             Tuple<string, string> deviceInfo = TestUtil.CreateDevice(DevicePrefix, hostName, registryManager);
             var deviceClient = DeviceClient.CreateFromConnectionString(deviceInfo.Item2, transport);
+
+// TODO: #193
+// DeviceClient.SetDesiredPropertyUpdateCallback(DesiredPropertyUpdateCallback, object)' is obsolete: 'Please use SetDesiredPropertyUpdateCallbackAsync.            
+#pragma warning disable CS0618
             await deviceClient.SetDesiredPropertyUpdateCallback((patch, context) =>
             {
                 return Task.Run(() =>
@@ -479,6 +483,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 });
 
             }, null);
+#pragma warning restore CS0618
 
             var twinPatch = new Twin();
             twinPatch.Properties.Desired[propName] = propValue;

--- a/jenkins/windows_csharp_wip.cmd
+++ b/jenkins/windows_csharp_wip.cmd
@@ -8,7 +8,7 @@ rem // resolve to fully qualified path
 for %%i in ("%build-root%") do set build-root=%%~fi
 
 cd %build-root%
-call build.cmd -clean -configuration Release -wip_provisioning
+call build.cmd -clean -configuration Release -wip_provisioning -e2etests
 if errorlevel 1 goto :eof
 
 REM -- Run C# device SDK unit Tests  --


### PR DESCRIPTION
This allows us to run E2E tests on Linux and add new Provisioning E2E tests.
Issue #193 is tracking switching test code to use the netstandard ServiceBus and EventHub SDKs as well as moving from the obsoleted APIs from our SDK.