### PR TITLE
Fix bug: the properties `CreatedTimeUtc` and `EndTimeUtc` in model `JobResponse` are always null

### DIFF
--- a/service/Microsoft.Azure.Devices/JobClient/JobResponse.cs
+++ b/service/Microsoft.Azure.Devices/JobClient/JobResponse.cs
@@ -34,14 +34,14 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// System generated.  Ignored at creation.
         /// </summary>
-        [JsonProperty(PropertyName = "startTimeUtc", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty(PropertyName = "startTime", NullValueHandling = NullValueHandling.Ignore)]
         public DateTime? StartTimeUtc { get; internal set; }
 
         /// <summary>
         /// System generated.  Ignored at creation.
         /// Represents the time the job stopped processing.
         /// </summary>
-        [JsonProperty(PropertyName = "endTimeUtc", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty(PropertyName = "endTime", NullValueHandling = NullValueHandling.Ignore)]
         public DateTime? EndTimeUtc { get; internal set; }
 
         /// <summary>

--- a/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/QueryTests.cs
+++ b/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/QueryTests.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Azure.Devices.Api.Test
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -136,7 +137,9 @@ namespace Microsoft.Azure.Devices.Api.Test
                     DeviceId = "123456",
                     JobId = "789",
                     Type = JobType.ScheduleUpdateTwin,
-                    Status = JobStatus.Completed
+                    Status = JobStatus.Completed,
+                    StartTimeUtc = DateTime.MinValue,
+                    EndTimeUtc = DateTime.MinValue
                 }
             };
 
@@ -148,7 +151,7 @@ namespace Microsoft.Azure.Devices.Api.Test
 
             // serialize
             var jsonQueryResult = JsonConvert.SerializeObject(serverQueryResult);
-            Assert.AreEqual("{\"type\":\"jobResponse\",\"items\":[{\"jobId\":\"789\",\"type\":\"scheduleUpdateTwin\",\"status\":\"completed\",\"deviceId\":\"123456\"}],\"continuationToken\":null}", jsonQueryResult);
+            Assert.AreEqual("{\"type\":\"jobResponse\",\"items\":[{\"jobId\":\"789\",\"startTime\":\"0001-01-01T00:00:00\",\"endTime\":\"0001-01-01T00:00:00\",\"type\":\"scheduleUpdateTwin\",\"status\":\"completed\",\"deviceId\":\"123456\"}],\"continuationToken\":null}", jsonQueryResult);
 
             // deserialize
             var clientQueryResult = JsonConvert.DeserializeObject<QueryResult>(jsonQueryResult);
@@ -166,6 +169,8 @@ namespace Microsoft.Azure.Devices.Api.Test
             Assert.AreEqual("789", content.ElementAt(0).JobId);
             Assert.AreEqual(JobType.ScheduleUpdateTwin, content.ElementAt(0).Type);
             Assert.AreEqual(JobStatus.Completed, content.ElementAt(0).Status);
+            Assert.AreEqual(DateTime.MinValue, content.ElementAt(0).StartTimeUtc);
+            Assert.AreEqual(DateTime.MinValue, content.ElementAt(0).EndTimeUtc);
         }
 
         [TestMethod]


### PR DESCRIPTION
The [issue](https://github.com/Azure/azure-iot-sdk-csharp/issues/169) was caused by the incorrect Json property names: IoTHub returns items in "startTime" and "endTime", while the SDK requires "startTimeUtc" and "endTimeUtc"