### PR TITLE
Added a try-catch around the OnMessageReceived method in the MQTT tra…

### DIFF
--- a/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/MqttTransportHandler.cs
+++ b/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/MqttTransportHandler.cs
@@ -454,25 +454,31 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         public async void OnMessageReceived(Message message)
         {
-            if ((this.State & TransportState.Open) == TransportState.Open)
+            try
             {
-                if (message.MqttTopicName.StartsWith(twinResponseTopicPrefix))
+                if ((this.State & TransportState.Open) == TransportState.Open)
                 {
-                    twinResponseEvent(message);
+                    if (message.MqttTopicName.StartsWith(twinResponseTopicPrefix))
+                    {
+                        twinResponseEvent(message);
+                    }
+                    else if (message.MqttTopicName.StartsWith(twinPatchTopicPrefix))
+                    {
+                        await HandleIncomingTwinPatch(message).ConfigureAwait(false);
+                    }
+                    else if (message.MqttTopicName.StartsWith(methodPostTopicPrefix))
+                    {
+                        await HandleIncomingMethodPost(message).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        this.messageQueue.Enqueue(message);
+                        this.receivingSemaphore.Release();
+                    }
                 }
-                else if (message.MqttTopicName.StartsWith(twinPatchTopicPrefix))
-                {
-                    await HandleIncomingTwinPatch(message).ConfigureAwait(false);
-                }
-                else if (message.MqttTopicName.StartsWith(methodPostTopicPrefix))
-                {
-                    await HandleIncomingMethodPost(message).ConfigureAwait(false);
-                }
-                else
-                {
-                    this.messageQueue.Enqueue(message);
-                    this.receivingSemaphore.Release();
-                }
+            }
+            catch(Exception)
+            { 
             }
         }
 


### PR DESCRIPTION
…nsport handler to prevent a thread crash deep in the kernel after the service has run for 24 to 48 hours.

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
Service crashes in the MQTT Message handler with an unknown threading exception after the service runs for 24 to 48 hours.  There are no signs of memory leaks that could cause this issue.  The try-catch prevents the crash, and the service then runs for days.
# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
Put a try-catch around the whole OnMessageRecieved method.  It is brute force and ugly, but it works.