### PR TITLE
Use device twin for configuring e2e diagnostic setting remotely

### DIFF
--- a/device/Microsoft.Azure.Devices.Client.Shared/IoTHubClientDiagnostic.cs
+++ b/device/Microsoft.Azure.Devices.Client.Shared/IoTHubClientDiagnostic.cs
@@ -3,14 +3,72 @@
 
 namespace Microsoft.Azure.Devices.Client
 {
+    using Shared;
     using System;
     using System.Globalization;
+    using System.Threading.Tasks;
 
     internal class IoTHubClientDiagnostic
     {
         private const string Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
         private const string DiagnosticCreationTimeUtcKey = "creationtimeutc";
         private static readonly DateTime Dt1970 = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        internal const string TwinDiagSamplingRateKey = "__e2e_diag_sample_rate";
+        internal const string TwinDiagErrorKey = "__e2e_diag_info";
+
+        internal DeviceClient deviceClient;
+        internal int currentSamplingRate = 0;
+        private bool isStarted;
+
+        internal IoTHubClientDiagnostic(DeviceClient device)
+        {
+            this.deviceClient = device;
+        }
+
+        internal async Task StartListeningE2EDiagnosticSettingChanges()
+        {
+            await this.Start();
+        }
+
+        internal void ParseDiagnosticInfoFromTwin(TwinCollection desiredProperties, bool receivedFullTwinForTheFirstTime = false)
+        {
+            if (desiredProperties.Contains(TwinDiagSamplingRateKey))
+            {
+                if (desiredProperties[TwinDiagSamplingRateKey] == null)
+                {
+                    this.currentSamplingRate = 0;
+                    this.ReportDiagnosticSettings($"Property {TwinDiagSamplingRateKey} is set to null, so set it to 0.");
+                }
+                else
+                {
+                    try
+                    {
+                        var rate = (int)desiredProperties[TwinDiagSamplingRateKey].Value;
+                        if (rate < 0 || rate > 100)
+                        {
+                            this.ReportDiagnosticSettings($"Property {TwinDiagSamplingRateKey} = {desiredProperties[TwinDiagSamplingRateKey].ToString()} must between [0, 100].");
+                        }
+                        else
+                        {
+                            this.currentSamplingRate = rate;
+                            this.ReportDiagnosticSettings();
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        this.ReportDiagnosticSettings($"Cannot parse {TwinDiagSamplingRateKey} = {desiredProperties[TwinDiagSamplingRateKey].ToString()} property from twin settings.");
+                    }
+                }
+            }
+            else if (receivedFullTwinForTheFirstTime)
+            {
+                this.currentSamplingRate = 0;
+                this.ReportDiagnosticSettings($"Property {TwinDiagSamplingRateKey} is not exist.");
+            }
+
+            this.OnDiagnosticSettingsChanged(this.currentSamplingRate);
+        }
 
         internal static bool AddDiagnosticInfoIfNecessary(Message message, int diagnosticSamplingPercentage, ref int currentMessageCount)
         {
@@ -30,6 +88,47 @@ namespace Microsoft.Azure.Devices.Client
         internal static bool HasDiagnosticProperties(Message message)
         {
             return message.SystemProperties.ContainsKey(MessageSystemPropertyNames.DiagId) && message.SystemProperties.ContainsKey(MessageSystemPropertyNames.DiagCorrelationContext);
+        }
+
+        private void DisableE2EDiagnostic()
+        {
+            this.isStarted = false;
+            this.OnDiagnosticSettingsChanged(0);
+        }
+
+        private void ReportDiagnosticSettings(string message = "")
+        {
+            var reportedProperties = new TwinCollection();
+            reportedProperties[TwinDiagSamplingRateKey] = this.currentSamplingRate;
+            reportedProperties[TwinDiagErrorKey] = message;
+
+            this.deviceClient.UpdateReportedPropertiesAsync(reportedProperties);
+        }
+
+        private void OnDiagnosticSettingsChanged(int samplingPercentage)
+        {
+            this.deviceClient.diagnosticSamplingPercentage = samplingPercentage;
+        }
+
+        private async Task Start()
+        {
+            if (!this.isStarted)
+            {
+                try
+                {
+                    Twin twin = await this.deviceClient.GetTwinAsync();
+                    if (twin != null)
+                    {
+                        this.ParseDiagnosticInfoFromTwin(twin.Properties.Desired, true);
+                    }
+                    this.isStarted = true;
+                }
+                catch (Exception)
+                {
+                    this.isStarted = false;
+                    this.DisableE2EDiagnostic();
+                }
+            }
         }
 
         private static string GenerateEightRandomCharacters()

--- a/device/Microsoft.Azure.Devices.Client.Shared/IoTHubClientDiagnostic.cs
+++ b/device/Microsoft.Azure.Devices.Client.Shared/IoTHubClientDiagnostic.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Client
                 if (desiredProperties[TwinDiagSamplingRateKey] == null)
                 {
                     this.currentSamplingRate = 0;
-                    this.ReportDiagnosticSettings($"Property {TwinDiagSamplingRateKey} is set to null, so set it to 0.");
+                    this.ReportDiagnosticSettings($"Property {TwinDiagSamplingRateKey} is null, so disable E2E diagnostic by setting sampling percentage to 0.");
                 }
                 else
                 {
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Devices.Client
                         var rate = (int)desiredProperties[TwinDiagSamplingRateKey].Value;
                         if (rate < 0 || rate > 100)
                         {
-                            this.ReportDiagnosticSettings($"Property {TwinDiagSamplingRateKey} = {desiredProperties[TwinDiagSamplingRateKey].ToString()} must between [0, 100].");
+                            this.ReportDiagnosticSettings($"Property {TwinDiagSamplingRateKey} = {desiredProperties[TwinDiagSamplingRateKey].ToString()} should be between [0, 100].");
                         }
                         else
                         {
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Client
             else if (receivedFullTwinForTheFirstTime)
             {
                 this.currentSamplingRate = 0;
-                this.ReportDiagnosticSettings($"Property {TwinDiagSamplingRateKey} is not exist.");
+                this.ReportDiagnosticSettings($"Property {TwinDiagSamplingRateKey} is not exist, so disable E2E diagnostic by setting sampling percentage to 0.");
             }
 
             this.OnDiagnosticSettingsChanged(this.currentSamplingRate);

--- a/device/Microsoft.Azure.Devices.Client/DeviceClient.cs
+++ b/device/Microsoft.Azure.Devices.Client/DeviceClient.cs
@@ -133,8 +133,8 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
                 }
                 else
                 {
-                    // codes_SRS_DEVICECLIENT_19_002: [ `DiagnosticSamplingPercentage` shall throw an `InvalidOperationException` exception if `EnableE2EDiagnosticsWithCloudSetting` has already been called. ]
-                    throw new InvalidOperationException("The call is not supported because the E2E diagnostic had been enabled by calling EnableE2EDiagnosticsWithCloudSetting");
+                    // codes_SRS_DEVICECLIENT_19_002: [ `DiagnosticSamplingPercentage` shall throw an `InvalidOperationException` exception if `EnableE2EDiagnosticWithCloudSetting` has already been called. ]
+                    throw new InvalidOperationException("The call is not supported because the E2E diagnostic had been enabled by calling EnableE2EDiagnosticWithCloudSetting");
                 }
             }
         }
@@ -1482,18 +1482,18 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
         }
 
         /// <summary>
-        /// Enable E2E diagnostics with cloud setting, the device will get diagnostic settings from server using device twin.
+        /// Enable E2E diagnostic with cloud setting, the device will get diagnostic settings from server using device twin.
         /// </summary>
-        public async Task EnableE2EDiagnosticsWithCloudSetting()
+        public async Task EnableE2EDiagnosticWithCloudSetting()
         {
             if (Diagnostic != null)
             {
-                // codes_SRS_DEVICECLIENT_19_003: [ `EnableE2EDiagnosticsWithCloudSetting` shall throw an `InvalidOperationException` exception if it has been called multiple times. ]
-                throw new InvalidOperationException("Cannot enable E2E Diagnostic feature multiple times through calling EnableE2EDiagnosticsWithCloudSetting");
+                // codes_SRS_DEVICECLIENT_19_003: [ `EnableE2EDiagnosticWithCloudSetting` shall throw an `InvalidOperationException` exception if it has been called multiple times. ]
+                throw new InvalidOperationException("Cannot enable E2E Diagnostic feature multiple times through calling EnableE2EDiagnosticWithCloudSetting");
             }
             else if (diagnosticSamplingPercentage != -1)
             {
-                // codes_SRS_DEVICECLIENT_19_004: [ `EnableE2EDiagnosticsWithCloudSetting` shall throw an `InvalidOperationException` exception if the DiagnosticSamplingPercentage has already been set. ]
+                // codes_SRS_DEVICECLIENT_19_004: [ `EnableE2EDiagnosticWithCloudSetting` shall throw an `InvalidOperationException` exception if the DiagnosticSamplingPercentage has already been set. ]
                 throw new InvalidOperationException("The call is not supported because the E2E diagnostic had been enabled by setting DiagnosticSamplingPercentage");
             }
 
@@ -1508,7 +1508,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
             }
             else
             {
-                // codes_SRS_DEVICECLIENT_19_005: [ `EnableE2EDiagnosticsWithCloudSetting` shall throw a `NotSupportedException` exception if the transport protocal is not AMQP or MQTT. ]
+                // codes_SRS_DEVICECLIENT_19_005: [ `EnableE2EDiagnosticWithCloudSetting` shall throw a `NotSupportedException` exception if the transport protocal is not AMQP or MQTT. ]
                 throw new NotSupportedException($"{transportType} protocal doesn't support E2E diagnostic feature");
             }
         }

--- a/device/Microsoft.Azure.Devices.Client/DeviceClient.cs
+++ b/device/Microsoft.Azure.Devices.Client/DeviceClient.cs
@@ -109,25 +109,38 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
         const string DeviceIdParameterPattern = @"(^\s*?|.*;\s*?)" + DeviceId + @"\s*?=.*";
         IotHubConnectionString iotHubConnectionString = null;
 
+        internal int diagnosticSamplingPercentage = -1;
+
         /// <summary> 
         /// Diagnostic sampling percentage value, [0-100];  
-        /// 0 means no message will carry on diag info 
+        /// 0 means no message will carry on diag info
         /// </summary>
-        int _diagnosticSamplingPercentage = 0;
         public int DiagnosticSamplingPercentage
         {
-            get { return _diagnosticSamplingPercentage; }
+            get { return diagnosticSamplingPercentage; }
+
             set
             {
-                if (value > 100 || value < 0)
+                if (Diagnostic == null)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(DiagnosticSamplingPercentage), DiagnosticSamplingPercentage, 
-                        "The range of diagnostic sampling percentage should between [0,100].");
+                    if (value > 100 || value < 0)
+                    {
+                        // codes_SRS_DEVICECLIENT_19_001: [ `DiagnosticSamplingPercentage` shall throw an `ArgumentOutOfRangeException` exception if sampling percentage is not between [0,100]. ]
+                        throw new ArgumentOutOfRangeException(nameof(DiagnosticSamplingPercentage), DiagnosticSamplingPercentage,
+                            "The range of diagnostic sampling percentage should between [0,100].");
+                    }
+                    diagnosticSamplingPercentage = value;
                 }
-
-                _diagnosticSamplingPercentage = value;
+                else
+                {
+                    // codes_SRS_DEVICECLIENT_19_002: [ `DiagnosticSamplingPercentage` shall throw an `InvalidOperationException` exception if `EnableE2EDiagnosticsWithCloudSetting` has already been called. ]
+                    throw new InvalidOperationException("The call is not supported because the E2E diagnostic had been enabled by calling EnableE2EDiagnosticsWithCloudSetting");
+                }
             }
         }
+
+        ITransportSettings[] transportSettings;
+        internal IoTHubClientDiagnostic Diagnostic { get; private set; }
 
 #if !WINDOWS_UWP && !PCL
         internal X509Certificate2 Certificate { get; set; }
@@ -247,7 +260,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
         /// </summary>
         Object twinPatchCallbackContext = null;
 
-        private int _currentMessageCount = 0;
+        private int currentMessageCount = 0;
 
         DeviceClient(IotHubConnectionString iotHubConnectionString, ITransportSettings[] transportSettings, IDeviceClientPipelineBuilder pipelineBuilder)
         {
@@ -265,6 +278,8 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
             IDelegatingHandler innerHandler = pipelineBuilder.Build(pipelineContext);
 
             this.InnerHandler = innerHandler;
+
+            this.transportSettings = transportSettings;
         }
 
         DeviceClient(IotHubConnectionString iotHubConnectionString)
@@ -807,7 +822,8 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
                 throw Fx.Exception.ArgumentNull("message");
             }
 
-            IoTHubClientDiagnostic.AddDiagnosticInfoIfNecessary(message, _diagnosticSamplingPercentage, ref _currentMessageCount);
+            IoTHubClientDiagnostic.AddDiagnosticInfoIfNecessary(message, diagnosticSamplingPercentage, ref currentMessageCount);
+
             // Codes_SRS_DEVICECLIENT_28_019: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication or quota exceed) occurs.]
             return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.SendEventAsync(message, operationTimeoutCancellationToken));
         }
@@ -1442,6 +1458,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
         //  Codes_SRS_DEVICECLIENT_18_005: When a patch is received from the service, the `callback` shall be called.
         internal void OnReportedStatePatchReceived(TwinCollection patch)
         {
+            Diagnostic?.ParseDiagnosticInfoFromTwin(patch);
             if (this.desiredPropertyUpdateCallback != null)
             {
                 this.desiredPropertyUpdateCallback(patch, this.twinPatchCallbackContext);
@@ -1461,6 +1478,38 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
             if (this.deviceMethods == null && this.deviceDefaultMethodCallback == null)
             {
                 await ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.DisableMethodsAsync(operationTimeoutCancellationToken)).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Enable E2E diagnostics with cloud setting, the device will get diagnostic settings from server using device twin.
+        /// </summary>
+        public async Task EnableE2EDiagnosticsWithCloudSetting()
+        {
+            if (Diagnostic != null)
+            {
+                // codes_SRS_DEVICECLIENT_19_003: [ `EnableE2EDiagnosticsWithCloudSetting` shall throw an `InvalidOperationException` exception if it has been called multiple times. ]
+                throw new InvalidOperationException("Cannot enable E2E Diagnostic feature multiple times through calling EnableE2EDiagnosticsWithCloudSetting");
+            }
+            else if (diagnosticSamplingPercentage != -1)
+            {
+                // codes_SRS_DEVICECLIENT_19_004: [ `EnableE2EDiagnosticsWithCloudSetting` shall throw an `InvalidOperationException` exception if the DiagnosticSamplingPercentage has already been set. ]
+                throw new InvalidOperationException("The call is not supported because the E2E diagnostic had been enabled by setting DiagnosticSamplingPercentage");
+            }
+
+            var transportSetting = this.transportSettings.FirstOrDefault();
+            var transportType = transportSetting.GetTransportType();
+            if (transportType == TransportType.Amqp_WebSocket_Only || transportType == TransportType.Amqp_Tcp_Only
+                || transportType == TransportType.Mqtt_WebSocket_Only || transportType == TransportType.Mqtt_Tcp_Only)
+            {
+                Diagnostic = new IoTHubClientDiagnostic(this);
+                await this.InnerHandler.EnableTwinPatchAsync(CancellationToken.None);
+                await Diagnostic.StartListeningE2EDiagnosticSettingChanges();
+            }
+            else
+            {
+                // codes_SRS_DEVICECLIENT_19_005: [ `EnableE2EDiagnosticsWithCloudSetting` shall throw a `NotSupportedException` exception if the transport protocal is not AMQP or MQTT. ]
+                throw new NotSupportedException($"{transportType} protocal doesn't support E2E diagnostic feature");
             }
         }
     }

--- a/device/Microsoft.Azure.Devices.Client/DeviceClient.cs
+++ b/device/Microsoft.Azure.Devices.Client/DeviceClient.cs
@@ -134,7 +134,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
                 else
                 {
                     // codes_SRS_DEVICECLIENT_19_002: [ `DiagnosticSamplingPercentage` shall throw an `InvalidOperationException` exception if `EnableE2EDiagnosticWithCloudSetting` has already been called. ]
-                    throw new InvalidOperationException("The call is not supported because the E2E diagnostic had been enabled by calling EnableE2EDiagnosticWithCloudSetting");
+                    throw new InvalidOperationException("The call is not supported because the E2E diagnostic has been enabled by calling EnableE2EDiagnosticWithCloudSetting.");
                 }
             }
         }
@@ -1489,12 +1489,12 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
             if (Diagnostic != null)
             {
                 // codes_SRS_DEVICECLIENT_19_003: [ `EnableE2EDiagnosticWithCloudSetting` shall throw an `InvalidOperationException` exception if it has been called multiple times. ]
-                throw new InvalidOperationException("Cannot enable E2E Diagnostic feature multiple times through calling EnableE2EDiagnosticWithCloudSetting");
+                throw new InvalidOperationException("Cannot enable E2E Diagnostic feature multiple times by calling EnableE2EDiagnosticWithCloudSetting.");
             }
             else if (diagnosticSamplingPercentage != -1)
             {
                 // codes_SRS_DEVICECLIENT_19_004: [ `EnableE2EDiagnosticWithCloudSetting` shall throw an `InvalidOperationException` exception if the DiagnosticSamplingPercentage has already been set. ]
-                throw new InvalidOperationException("The call is not supported because the E2E diagnostic had been enabled by setting DiagnosticSamplingPercentage");
+                throw new InvalidOperationException("The call is not supported because the E2E diagnostic has been enabled by setting DiagnosticSamplingPercentage.");
             }
 
             var transportSetting = this.transportSettings.FirstOrDefault();
@@ -1509,7 +1509,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
             else
             {
                 // codes_SRS_DEVICECLIENT_19_005: [ `EnableE2EDiagnosticWithCloudSetting` shall throw a `NotSupportedException` exception if the transport protocal is not AMQP or MQTT. ]
-                throw new NotSupportedException($"{transportType} protocal doesn't support E2E diagnostic feature");
+                throw new NotSupportedException($"{transportType} protocal doesn't support E2E diagnostic.");
             }
         }
     }

--- a/device/tests/Microsoft.Azure.Devices.Client.Test/DeviceClientTests.cs
+++ b/device/tests/Microsoft.Azure.Devices.Client.Test/DeviceClientTests.cs
@@ -111,7 +111,7 @@
             }
             catch (NotSupportedException e)
             {
-                Assert.AreEqual(e.Message, $"{TransportType.Http1} protocal doesn't support E2E diagnostic feature");
+                Assert.AreEqual(e.Message, $"{TransportType.Http1} protocal doesn't support E2E diagnostic.");
             }
         }
 
@@ -131,7 +131,7 @@
             }
             catch (InvalidOperationException e)
             {
-                Assert.AreEqual(e.Message, "Cannot enable E2E Diagnostic feature multiple times through calling EnableE2EDiagnosticWithCloudSetting");
+                Assert.AreEqual(e.Message, "Cannot enable E2E Diagnostic feature multiple times by calling EnableE2EDiagnosticWithCloudSetting.");
             }
 
             DeviceClient deviceClient2 = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Amqp);
@@ -145,7 +145,7 @@
             }
             catch (InvalidOperationException e)
             {
-                Assert.AreEqual(e.Message, "The call is not supported because the E2E diagnostic had been enabled by calling EnableE2EDiagnosticWithCloudSetting");
+                Assert.AreEqual(e.Message, "The call is not supported because the E2E diagnostic has been enabled by calling EnableE2EDiagnosticWithCloudSetting.");
             }
 
             DeviceClient deviceClient3 = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Amqp);
@@ -159,7 +159,7 @@
             }
             catch (InvalidOperationException e)
             {
-                Assert.AreEqual(e.Message, "The call is not supported because the E2E diagnostic had been enabled by setting DiagnosticSamplingPercentage");
+                Assert.AreEqual(e.Message, "The call is not supported because the E2E diagnostic has been enabled by setting DiagnosticSamplingPercentage.");
             }
         }
 

--- a/device/tests/Microsoft.Azure.Devices.Client.Test/DeviceClientTests.cs
+++ b/device/tests/Microsoft.Azure.Devices.Client.Test/DeviceClientTests.cs
@@ -94,19 +94,19 @@
             DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
             var innerHandler = Substitute.For<IDelegatingHandler>();
             deviceClient.InnerHandler = innerHandler;
-            await deviceClient.EnableE2EDiagnosticsWithCloudSetting();
+            await deviceClient.EnableE2EDiagnosticWithCloudSetting();
             Assert.IsNotNull(deviceClient.Diagnostic);
         }
 
         [TestMethod]
         [TestCategory("IoTHubClientDiagnostic")]
-        // Tests_SRS_DEVICECLIENT_29_02: [ If transport type is not AMQP or MQTT, a `NotSupportedException` exception will throw when try to call EnableE2EDiagnosticsWithCloudSetting. ]
+        // Tests_SRS_DEVICECLIENT_29_02: [ If transport type is not AMQP or MQTT, a `NotSupportedException` exception will throw when try to call EnableE2EDiagnosticWithCloudSetting. ]
         public async Task DeviceClient_StartDiagThatDoNotSupport_ThrowException()
         {
             DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Http1);
             try
             {
-                await deviceClient.EnableE2EDiagnosticsWithCloudSetting();
+                await deviceClient.EnableE2EDiagnosticWithCloudSetting();
                 Assert.Fail();
             }
             catch (NotSupportedException e)
@@ -117,7 +117,7 @@
 
         [TestMethod]
         [TestCategory("IoTHubClientDiagnostic")]
-        // Tests_SRS_DEVICECLIENT_29_03: [ If try to start E2E diagnostic multiple times, the `InvalidOperationException` will be throw. ]
+        // Tests_SRS_DEVICECLIENT_29_02: [ If try to start E2E diagnostic multiple times, the `InvalidOperationException` will be throw. ]
         public async Task DeviceClient_StartDiagMutipleTimes_ThrowException()
         {
             DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Amqp);
@@ -125,13 +125,13 @@
             deviceClient.InnerHandler = innerHandler;
             try
             {
-                await deviceClient.EnableE2EDiagnosticsWithCloudSetting();
-                await deviceClient.EnableE2EDiagnosticsWithCloudSetting();
+                await deviceClient.EnableE2EDiagnosticWithCloudSetting();
+                await deviceClient.EnableE2EDiagnosticWithCloudSetting();
                 Assert.Fail();
             }
             catch (InvalidOperationException e)
             {
-                Assert.AreEqual(e.Message, "Cannot enable E2E Diagnostic feature multiple times through calling EnableE2EDiagnosticsWithCloudSetting");
+                Assert.AreEqual(e.Message, "Cannot enable E2E Diagnostic feature multiple times through calling EnableE2EDiagnosticWithCloudSetting");
             }
 
             DeviceClient deviceClient2 = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Amqp);
@@ -139,13 +139,13 @@
 
             try
             {
-                await deviceClient2.EnableE2EDiagnosticsWithCloudSetting();
+                await deviceClient2.EnableE2EDiagnosticWithCloudSetting();
                 deviceClient2.DiagnosticSamplingPercentage = 50;
                 Assert.Fail();
             }
             catch (InvalidOperationException e)
             {
-                Assert.AreEqual(e.Message, "The call is not supported because the E2E diagnostic had been enabled by calling EnableE2EDiagnosticsWithCloudSetting");
+                Assert.AreEqual(e.Message, "The call is not supported because the E2E diagnostic had been enabled by calling EnableE2EDiagnosticWithCloudSetting");
             }
 
             DeviceClient deviceClient3 = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Amqp);
@@ -154,7 +154,7 @@
             try
             {
                 deviceClient3.DiagnosticSamplingPercentage = 50;
-                await deviceClient3.EnableE2EDiagnosticsWithCloudSetting();
+                await deviceClient3.EnableE2EDiagnosticWithCloudSetting();
                 Assert.Fail();
             }
             catch (InvalidOperationException e)
@@ -180,7 +180,7 @@
             twin.Properties.Desired = twinCollection;
 
             innerHandler.SendTwinGetAsync(Arg.Any<CancellationToken>()).Returns(twin);
-            await deviceClient.EnableE2EDiagnosticsWithCloudSetting();
+            await deviceClient.EnableE2EDiagnosticWithCloudSetting();
 
             Assert.AreEqual(deviceClient.Diagnostic.currentSamplingRate, samplingRate);
         }
@@ -193,7 +193,7 @@
 
             var innerHandler = Substitute.For<IDelegatingHandler>();
             deviceClient.InnerHandler = innerHandler;
-            await deviceClient.EnableE2EDiagnosticsWithCloudSetting();
+            await deviceClient.EnableE2EDiagnosticWithCloudSetting();
 
             int samplingRate = 50;
             var twinCollection = new TwinCollection();

--- a/device/tests/Microsoft.Azure.Devices.Client.Test/IoTHubClientDiagnosticTest.cs
+++ b/device/tests/Microsoft.Azure.Devices.Client.Test/IoTHubClientDiagnosticTest.cs
@@ -217,7 +217,7 @@
             DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
             var innerHandler = Substitute.For<IDelegatingHandler>();
             deviceClient.InnerHandler = innerHandler;
-            await deviceClient.EnableE2EDiagnosticsWithCloudSetting();
+            await deviceClient.EnableE2EDiagnosticWithCloudSetting();
 
             int samplingRate1 = 50;
             Twin twin = GenerateDiagTwin(samplingRate1);


### PR DESCRIPTION
This is P1 scenario for E2E diagnostic.
Please refer to design doc [E2E Diagnostics Design Using Device Twin](https://microsoft.sharepoint.com/:w:/r/teams/Azure_IoT/Shared%20Documents/SDKs/Specifications/E2E%20Diagnostics%20Design%20Using%20Device%20Twin.docx?d=we399724bc0a1492785ab278fd91aaeb6&csf=1)
