### PR TITLE
add CreateTwinQuery and obsolete GetDevicesAsync

### DIFF
--- a/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
+++ b/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
@@ -306,11 +306,13 @@ namespace Microsoft.Azure.Devices
             return this.httpClientHelper.GetAsync<Device>(GetRequestUri(deviceId), errorMappingOverrides, null, false, cancellationToken);
         }
 
+        [Obsolete("Use CreateQuery(\"select * from devices\", pageSize);")]
         public override Task<IEnumerable<Device>> GetDevicesAsync(int maxCount)
         {
             return this.GetDevicesAsync(maxCount, CancellationToken.None);
         }
 
+        [Obsolete("Use CreateQuery(\"select * from devices\", pageSize);")]
         public override Task<IEnumerable<Device>> GetDevicesAsync(int maxCount, CancellationToken cancellationToken)
         {
             this.EnsureInstanceNotClosed();

--- a/service/Microsoft.Azure.Devices/RegistryManager.cs
+++ b/service/Microsoft.Azure.Devices/RegistryManager.cs
@@ -343,6 +343,7 @@ namespace Microsoft.Azure.Devices
         /// <returns>
         /// The list of devices
         /// </returns>
+        [Obsolete("Use CreateQuery(\"select * from devices\", pageSize);")]
         public abstract Task<IEnumerable<Device>> GetDevicesAsync(int maxCount);
 
         /// <summary>
@@ -352,6 +353,7 @@ namespace Microsoft.Azure.Devices
         /// <returns>
         /// The list of devices
         /// </returns>
+        [Obsolete("Use CreateQuery(\"select * from devices\", pageSize);")]
         public abstract Task<IEnumerable<Device>> GetDevicesAsync(int maxCount, CancellationToken cancellationToken);
 
         /// <summary>

--- a/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/RegistryManagerTests.cs
+++ b/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/RegistryManagerTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Devices.Api.Test
     using System.Linq;
     using System.Net;
     using System.Net.Http;
+    using System.Net.Http.Headers;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices;
@@ -71,14 +72,18 @@ namespace Microsoft.Azure.Devices.Api.Test
         [TestMethod]
         [TestCategory("CIT")]
         [TestCategory("API")]
-        [Ignore] //Issue #318
         public async Task GetDevicesAsyncTest()
         {
             List<Device> devicesToReturn = new List<Device>();
             devicesToReturn.Add(new Device("a") { ConnectionState = DeviceConnectionState.Connected });
-
+            
             var restOpMock = new Mock<IHttpClientHelper>();
-            restOpMock.Setup(restOp => restOp.GetAsync<IEnumerable<Device>>(It.IsAny<Uri>(), It.IsAny<IDictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>>(), null, It.IsAny<CancellationToken>())).ReturnsAsync(devicesToReturn);
+            restOpMock.Setup(restOp => restOp.GetAsync<IEnumerable<Device>>(It.IsAny<Uri>(), 
+                It.IsAny<TimeSpan>(),
+                null,
+                null, 
+                true, 
+                It.IsAny<CancellationToken>())).ReturnsAsync(devicesToReturn);
 
             var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);
 

--- a/tools/DeviceExplorer/DeviceExplorer.sln
+++ b/tools/DeviceExplorer/DeviceExplorer.sln
@@ -1,14 +1,19 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{D557470D-B427-49B7-B133-DBD9E4BA3DAD}"
 	ProjectSection(SolutionItems) = preProject
+		..\..\service\Microsoft.Azure.Devices\AmqpFeedbackReceiver.cs = ..\..\service\Microsoft.Azure.Devices\AmqpFeedbackReceiver.cs
 		doc\DeviceExplorer_Requirements.docx = doc\DeviceExplorer_Requirements.docx
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeviceExplorer", "DeviceExplorer\DeviceExplorer.csproj", "{6EC48194-96D3-4B82-976D-F7957AF58AC4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Devices", "..\..\service\Microsoft.Azure.Devices\Microsoft.Azure.Devices.csproj", "{7FC2A03F-36FE-44C5-A1EF-5B1F11458350}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Devices.Shared", "..\..\shared\Microsoft.Azure.Devices.Shared\Microsoft.Azure.Devices.Shared.csproj", "{835230FC-8D03-4CD1-8845-5A9D1B0B837D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,8 +37,35 @@ Global
 		{6EC48194-96D3-4B82-976D-F7957AF58AC4}.Release|x64.Build.0 = Release|Any CPU
 		{6EC48194-96D3-4B82-976D-F7957AF58AC4}.Release|x86.ActiveCfg = Release|Any CPU
 		{6EC48194-96D3-4B82-976D-F7957AF58AC4}.Release|x86.Build.0 = Release|Any CPU
+		{7FC2A03F-36FE-44C5-A1EF-5B1F11458350}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FC2A03F-36FE-44C5-A1EF-5B1F11458350}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FC2A03F-36FE-44C5-A1EF-5B1F11458350}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7FC2A03F-36FE-44C5-A1EF-5B1F11458350}.Debug|x64.Build.0 = Debug|Any CPU
+		{7FC2A03F-36FE-44C5-A1EF-5B1F11458350}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7FC2A03F-36FE-44C5-A1EF-5B1F11458350}.Debug|x86.Build.0 = Debug|Any CPU
+		{7FC2A03F-36FE-44C5-A1EF-5B1F11458350}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7FC2A03F-36FE-44C5-A1EF-5B1F11458350}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7FC2A03F-36FE-44C5-A1EF-5B1F11458350}.Release|x64.ActiveCfg = Release|Any CPU
+		{7FC2A03F-36FE-44C5-A1EF-5B1F11458350}.Release|x64.Build.0 = Release|Any CPU
+		{7FC2A03F-36FE-44C5-A1EF-5B1F11458350}.Release|x86.ActiveCfg = Release|Any CPU
+		{7FC2A03F-36FE-44C5-A1EF-5B1F11458350}.Release|x86.Build.0 = Release|Any CPU
+		{835230FC-8D03-4CD1-8845-5A9D1B0B837D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{835230FC-8D03-4CD1-8845-5A9D1B0B837D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{835230FC-8D03-4CD1-8845-5A9D1B0B837D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{835230FC-8D03-4CD1-8845-5A9D1B0B837D}.Debug|x64.Build.0 = Debug|Any CPU
+		{835230FC-8D03-4CD1-8845-5A9D1B0B837D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{835230FC-8D03-4CD1-8845-5A9D1B0B837D}.Debug|x86.Build.0 = Debug|Any CPU
+		{835230FC-8D03-4CD1-8845-5A9D1B0B837D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{835230FC-8D03-4CD1-8845-5A9D1B0B837D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{835230FC-8D03-4CD1-8845-5A9D1B0B837D}.Release|x64.ActiveCfg = Release|Any CPU
+		{835230FC-8D03-4CD1-8845-5A9D1B0B837D}.Release|x64.Build.0 = Release|Any CPU
+		{835230FC-8D03-4CD1-8845-5A9D1B0B837D}.Release|x86.ActiveCfg = Release|Any CPU
+		{835230FC-8D03-4CD1-8845-5A9D1B0B837D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {74AA4428-85E4-4490-8316-BB20AE6FBE2F}
 	EndGlobalSection
 EndGlobal

--- a/tools/DeviceExplorer/DeviceExplorer/App.config
+++ b/tools/DeviceExplorer/DeviceExplorer/App.config
@@ -12,7 +12,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/tools/DeviceExplorer/DeviceExplorer/DeviceEntity.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/DeviceEntity.cs
@@ -11,10 +11,10 @@
         public string SecondaryThumbPrint { get; set; }
         public string ConnectionString { get; set; }
         public string ConnectionState { get; set; }
-        public DateTime LastActivityTime { get; set; }
-        public DateTime LastConnectionStateUpdatedTime { get; set; }
-        public DateTime LastStateUpdatedTime { get; set; }
-        public int MessageCount { get; set; }
+        public DateTime? LastActivityTime { get; set; }
+        public DateTime? LastConnectionStateUpdatedTime { get; set; }
+        public DateTime? LastStateUpdatedTime { get; set; }
+        public int? MessageCount { get; set; }
         public string State { get; set; }
         public string SuspensionReason { get; set; }
 

--- a/tools/DeviceExplorer/DeviceExplorer/DeviceExplorer.csproj
+++ b/tools/DeviceExplorer/DeviceExplorer/DeviceExplorer.csproj
@@ -125,17 +125,8 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.Amqp, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Amqp.2.0.6\lib\net45\Microsoft.Azure.Amqp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Devices, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Devices.1.3.1\lib\net451\Microsoft.Azure.Devices.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Devices.Shared, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Devices.Shared.1.1.0\lib\net45\Microsoft.Azure.Devices.Shared.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Azure.Amqp, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Amqp.2.1.3\lib\net45\Microsoft.Azure.Amqp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -154,9 +145,8 @@
       <HintPath>..\packages\Mono.Security.3.2.3.0\lib\net45\Mono.Security.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PCLCrypto, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
       <HintPath>..\packages\PCLCrypto.2.0.147\lib\net45\PCLCrypto.dll</HintPath>
@@ -199,6 +189,16 @@
       <HintPath>..\packages\Validation.2.2.8\lib\dotnet\Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\service\Microsoft.Azure.Devices\Microsoft.Azure.Devices.csproj">
+      <Project>{7fc2a03f-36fe-44c5-a1ef-5b1f11458350}</Project>
+      <Name>Microsoft.Azure.Devices</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\shared\Microsoft.Azure.Devices.Shared\Microsoft.Azure.Devices.Shared.csproj">
+      <Project>{835230fc-8d03-4cd1-8845-5a9d1b0b837d}</Project>
+      <Name>Microsoft.Azure.Devices.Shared</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/tools/DeviceExplorer/DeviceExplorer/packages.config
+++ b/tools/DeviceExplorer/DeviceExplorer/packages.config
@@ -2,13 +2,13 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />
-  <package id="Microsoft.Azure.Amqp" version="2.0.6" targetFramework="net451" />
+  <package id="Microsoft.Azure.Amqp" version="2.1.3" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices" version="1.3.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Shared" version="1.1.0" targetFramework="net451" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
   <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net451" />
   <package id="PCLCrypto" version="2.0.147" targetFramework="net451" />
   <package id="PInvoke.BCrypt" version="0.3.2" targetFramework="net451" />


### PR DESCRIPTION
add CreateTwinQuery() and obsolete GetDevicesAsync().
- CreateTwinQuery() work like a pre-canned query which returns Twin and supports paging.
- Modified Device Explorer to use CreateTwinQuery().