### PR TITLE
Better error message for provisioning\service\samples\GroupCertificateVerificationSample

### DIFF
--- a/provisioning/service/samples/GroupCertificateVerificationSample/GroupCertificateVerificationSample.csproj
+++ b/provisioning/service/samples/GroupCertificateVerificationSample/GroupCertificateVerificationSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/provisioning/service/samples/GroupCertificateVerificationSample/Program.cs
+++ b/provisioning/service/samples/GroupCertificateVerificationSample/Program.cs
@@ -30,6 +30,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Samples
                 certificatePassword, 
                 X509KeyStorageFlags.Exportable);
 
+            if (!certificate.HasPrivateKey)
+            {
+                Console.WriteLine("ERROR: The certificate does not have a private key.");
+                return 1;
+            }
+
             X509Certificate2 verificationCertificate = 
                 VerificationCertificateGenerator.GenerateSignedCertificate(certificate, verificationCode);
 


### PR DESCRIPTION
Adding a better error message if the user passes a *.cer or *.pfx file that doesn't have the private key.
Bouncycastle doesn't support netcoreapp yet. Switching this sample to .Net Framework.

Fixes #338.