### PR TITLE
Update TokenRefresh loop wait period

### DIFF
--- a/device/Microsoft.Azure.Devices.Client/IotHubConnectionString.Core.cs
+++ b/device/Microsoft.Azure.Devices.Client/IotHubConnectionString.Core.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.Client
             else
             {
                 tokenValue = await this.TokenRefresher.GetTokenAsync(this.Audience);
-                expiresOn = this.TokenRefresher.RefreshesOn;
+                expiresOn = this.TokenRefresher.ExpiresOn;
             }
 
             return new CbsToken(tokenValue, CbsConstants.IotHubSasTokenType, expiresOn);

--- a/device/Microsoft.Azure.Devices.Client/IotHubTokenRefresher.cs
+++ b/device/Microsoft.Azure.Devices.Client/IotHubTokenRefresher.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Azure.Devices.Client
         private static readonly string[] AccessRightsStringArray = 
             AccessRightsHelper.AccessRightsToStringArray(AccessRights.DeviceConnect);
 
+        static readonly TimeSpan BufferPeriod = TimeSpan.FromSeconds(120);
+
         private readonly AmqpSession amqpSession;
         private readonly IotHubConnectionString connectionString;
         private readonly string audience;
@@ -125,6 +127,7 @@ namespace Microsoft.Azure.Devices.Client
                 return false;
             }
 
+            waitTime = waitTime > BufferPeriod ? waitTime - BufferPeriod : TimeSpan.Zero;
             await Task.Delay(waitTime, cancellationToken).ConfigureAwait(false);
             return true;
         }


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `modules-preview` branch. 

# Reference/Link to the issue solved with this PR (if any) - https://github.com/Azure/azure-iot-sdk-csharp/issues/319

# Description of the problem
IoTHubConnectionString.GetTokenAsync sets the expiresOn value to RefreshesOn (instead of the actual expiresOn value for the token). This causes IoTHubTokenRefresher loop to terminate at times. When that happens, a new token is never sent on the CBS link, and the link dies.

# Description of the solution
This change sets the expiresOn value to the actual expiry time for the token. This way the loop in IoTHubTokenRefresher does not terminate, and a new token keeps getting sent as expected.

Fixes https://github.com/Azure/azure-iot-sdk-csharp/issues/319