### PR TITLE
Removing references to PCLCrypto.

### DIFF
--- a/device/Microsoft.Azure.Devices.Client.NetStandard/Microsoft.Azure.Devices.Client.NetStandard.csproj
+++ b/device/Microsoft.Azure.Devices.Client.NetStandard/Microsoft.Azure.Devices.Client.NetStandard.csproj
@@ -61,7 +61,6 @@
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
     <PackageReference Include="System.Threading.Overlapped" Version="4.3.0" />
-    <PackageReference Include="Validation" Version="2.4.18" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.7.0" />
   </ItemGroup>
 

--- a/device/Microsoft.Azure.Devices.Client.UWP/Microsoft.Azure.Devices.Client.UWP.csproj
+++ b/device/Microsoft.Azure.Devices.Client.UWP/Microsoft.Azure.Devices.Client.UWP.csproj
@@ -204,9 +204,6 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>10.0.3</Version>
     </PackageReference>
-    <PackageReference Include="PCLCrypto">
-      <Version>2.0.147</Version>
-    </PackageReference>
     <PackageReference Include="System.AppContext">
       <Version>4.3.0</Version>
     </PackageReference>
@@ -215,9 +212,6 @@
     </PackageReference>
     <PackageReference Include="System.Security.Cryptography.X509Certificates">
       <Version>4.3.2</Version>
-    </PackageReference>
-    <PackageReference Include="Validation">
-      <Version>2.4.18</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>8.7.0</Version>

--- a/device/Microsoft.Azure.Devices.Client/Common/Security/SharedAccessSignature.cs
+++ b/device/Microsoft.Azure.Devices.Client/Common/Security/SharedAccessSignature.cs
@@ -8,14 +8,8 @@ namespace Microsoft.Azure.Devices.Client
     using System.Collections.Generic;
     using System.Globalization;
     using System.Text;
-#if !PCL
-#if !NETSTANDARD1_3
-    using PCLCrypto;
-#else
     using System.IO;
     using System.Security.Cryptography;
-#endif
-#endif
 
     sealed class SharedAccessSignature : ISharedAccessSignatureCredential
     {
@@ -211,20 +205,10 @@ namespace Microsoft.Azure.Devices.Client
 
         internal static string Sign(byte[] key, string value)
         {
-#if PCL
-            throw new NotImplementedException();
-#elif !NETSTANDARD1_3
-            var algorithm = WinRTCrypto.MacAlgorithmProvider.OpenAlgorithm(MacAlgorithm.HmacSha256);
-            var hash = algorithm.CreateHash(key);
-            hash.Append(Encoding.UTF8.GetBytes(value));
-            var mac = hash.GetValueAndReset();
-            return Convert.ToBase64String(mac);
-#else
             using (var algorithm = new HMACSHA256(key))
             {
                 return Convert.ToBase64String(algorithm.ComputeHash(Encoding.UTF8.GetBytes(value)));
             }
-#endif
         }
 
         static IDictionary<string, string> ExtractFieldValues(string sharedAccessSignature)

--- a/device/Microsoft.Azure.Devices.Client/Common/Security/SharedAccessSignatureBuilder.cs
+++ b/device/Microsoft.Azure.Devices.Client/Common/Security/SharedAccessSignatureBuilder.cs
@@ -8,12 +8,8 @@ namespace Microsoft.Azure.Devices.Client
     using Microsoft.Azure.Devices.Client.Extensions;
 #if !NETMF
     using System.Collections.Generic;
-#if !NETSTANDARD1_3
-    using PCLCrypto;
-#else
     using System.IO;
     using System.Security.Cryptography;
-#endif
 #endif
     using System.Globalization;
 #if WINDOWS_UWP
@@ -149,18 +145,10 @@ namespace Microsoft.Azure.Devices.Client
 #else
         protected virtual string Sign(string requestString, string key)
         {
-#if !NETSTANDARD1_3
-            var algorithm = WinRTCrypto.MacAlgorithmProvider.OpenAlgorithm(MacAlgorithm.HmacSha256);
-            var hash = algorithm.CreateHash(Convert.FromBase64String(key));
-            hash.Append(Encoding.UTF8.GetBytes(requestString));
-            var mac = hash.GetValueAndReset();
-            return Convert.ToBase64String(mac);
-#else
             using (var algorithm = new HMACSHA256(Convert.FromBase64String(key)))
             {
                 return Convert.ToBase64String(algorithm.ComputeHash(Encoding.UTF8.GetBytes(requestString)));
             }
-#endif
         }
 #endif
     }

--- a/device/Microsoft.Azure.Devices.Client/Microsoft.Azure.Devices.Client.csproj
+++ b/device/Microsoft.Azure.Devices.Client/Microsoft.Azure.Devices.Client.csproj
@@ -131,10 +131,6 @@
       <HintPath>$(SolutionDir)\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="PCLCrypto, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\PCLCrypto.2.0.147\lib\net45\PCLCrypto.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.configuration" />
@@ -166,9 +162,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="Validation, Version=2.4.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Validation.2.4.18\lib\net45\Validation.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\Api\ApiResources.Designer.cs">

--- a/device/Microsoft.Azure.Devices.Client/packages.config
+++ b/device/Microsoft.Azure.Devices.Client/packages.config
@@ -22,7 +22,6 @@
   <package id="NETStandard.Library" version="2.0.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net451" />
-  <package id="PCLCrypto" version="2.0.147" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
   <package id="System.ComponentModel" version="4.3.0" targetFramework="net451" />

--- a/device/NuGet/Microsoft.Azure.Devices.Client.nuspec
+++ b/device/NuGet/Microsoft.Azure.Devices.Client.nuspec
@@ -20,7 +20,6 @@
                 <dependency id="DotNetty.Handlers" version="0.4.7" />
                 <dependency id="Microsoft.Azure.Amqp" version="2.1.3" />
                 <dependency id="Newtonsoft.Json" version="10.0.3" />
-                <dependency id="Validation" version="2.4.18" /> 
                 <dependency id="WindowsAzure.Storage" version="8.7.0" />
 
                 <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304" />
@@ -32,7 +31,6 @@
                 <dependency id="Microsoft.Owin" version="3.1.0" />
                 <dependency id="Mono.Security" version="5.4.0.201" />
                 <dependency id="NETStandard.Library" version="2.0.1" />
-                <dependency id="PCLCrypto" version="2.0.147" />
                 <dependency id="System.Net.Http" version="4.3.3" />
                 <dependency id="System.Runtime" version="4.3.0" />
                 <dependency id="System.Spatial" version="5.8.3" />
@@ -45,11 +43,9 @@
                 <dependency id="DotNetty.Handlers" version="0.4.7" />
                 <dependency id="Microsoft.Azure.Amqp" version="2.1.3" />
                 <dependency id="Newtonsoft.Json" version="10.0.3" />
-                <dependency id="Validation" version="2.4.18" /> 
                 <dependency id="WindowsAzure.Storage" version="8.7.0" />
 
                 <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304" />
-                <dependency id="PCLCrypto" version="2.0.147" />
                 <dependency id="System.AppContext" version="4.3.0" />
                 <dependency id="System.Net.WebSockets.Client" version="4.3.2" />
                 <dependency id="System.Security.Cryptography.X509Certificates" version="4.3.2" />
@@ -61,7 +57,6 @@
                 <dependency id="DotNetty.Handlers" version="0.4.7" />
                 <dependency id="Microsoft.Azure.Amqp" version="2.1.3" />
                 <dependency id="Newtonsoft.Json" version="10.0.3" />
-                <dependency id="Validation" version="2.4.18" /> 
                 <dependency id="WindowsAzure.Storage" version="8.7.0" />
 
                 <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />

--- a/device/doc/devbox_setup.md
+++ b/device/doc/devbox_setup.md
@@ -128,28 +128,6 @@ For building Android sample open **csharp\device\samples\DeviceClientSampleAndro
 
 To check for any latest Xamarin update for Visual Studio check Tools->Options->Xamarin->Other.
 
-### Building and running CppUWPSample (Universal Windows) C++ sample application
-
-Select CppUWPSample as as StartUp Project. Replace the connection string with a valid connection string in `MainPage.xaml.cpp` file
-On running the applciation, you will see "Could not load file or assembly Microsoft.Azure.Amqp.Uwp" error.
-
-> To workaround this error copy 3 assemblies that application has dependencies on. Copy **Microsoft.Azure.Amqp.Uwp.dll**, PCLCrypto.dll and Validation.dll into **CppUWPSample AppX** folder from **UWPSample** folder.
-
-For example for building debug version for x64 copy these 3 files from device\samples\UWPSample\bin\x64\Debug into device\x64\Debug\CppUWPSample\AppX folder.
-
-After this redeploy and re-run the application.
-
-### Building and running JSSample (Universal Windows) JavaScript sample application
-
-Open **JSSample.sln** file from samples\JSSample in VS 2015 IDE. Replace the connecting string with a valid connection string in `default.js` file. Deploy and run the application. The application will throw System.IO.FileNotFoundException : "Could not load file or assembly Microsoft.Azure.Amqp.Uwp".
-
-> To workaround this error copy assemblies that application has dependencies on. Copy **Microsoft.Azure.Amqp.Uwp.dll**, PCLCrypto.dll and Validation.dll into **JSSample AppX** folder from **UWPSample** folder.
-
-For example for building debug version for x64 copy these 3 files from device\samples\UWPSample\bin\x64\Debug into JSSample\bin\x64\Debug\AppX folder.
-
-After this redeploy and re-run the application.
-
-
 
 [visual-studio]: https://www.visualstudio.com/
 [readme]: ../readme.md

--- a/device/samples/DeviceClientAmqpSample/DeviceClientAmqpSample.csproj
+++ b/device/samples/DeviceClientAmqpSample/DeviceClientAmqpSample.csproj
@@ -45,10 +45,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Validation, Version=2.2.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Validation.2.2.8\lib\dotnet\Validation.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/device/samples/DeviceClientFileUploadSample/DeviceClientFileUploadSample.csproj
+++ b/device/samples/DeviceClientFileUploadSample/DeviceClientFileUploadSample.csproj
@@ -33,26 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Mono.Security.3.2.3.0\lib\net45\Mono.Security.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PInvoke.BCrypt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.BCrypt.0.3.2\lib\net40\PInvoke.BCrypt.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PInvoke.Kernel32, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.Kernel32.0.3.2\lib\net40\PInvoke.Kernel32.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PInvoke.NCrypt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.NCrypt.0.3.2\lib\net40\PInvoke.NCrypt.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PInvoke.Windows.Core, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.Windows.Core.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.Windows.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/device/samples/DeviceClientHttpSample/DeviceClientHttpSample.csproj
+++ b/device/samples/DeviceClientHttpSample/DeviceClientHttpSample.csproj
@@ -45,10 +45,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Validation, Version=2.2.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Validation.2.2.8\lib\dotnet\Validation.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/device/samples/DeviceClientMqttSample/DeviceClientMqttSample.csproj
+++ b/device/samples/DeviceClientMqttSample/DeviceClientMqttSample.csproj
@@ -45,10 +45,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Validation, Version=2.2.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Validation.2.2.8\lib\dotnet\Validation.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/device/samples/DeviceClientSampleAndroid/DeviceClientSampleAndroid.csproj
+++ b/device/samples/DeviceClientSampleAndroid/DeviceClientSampleAndroid.csproj
@@ -92,22 +92,6 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="PCLCrypto, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PCLCrypto.2.0.147\lib\MonoAndroid23\PCLCrypto.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PInvoke.BCrypt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.BCrypt.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.BCrypt.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PInvoke.Kernel32, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.Kernel32.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.Kernel32.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PInvoke.Windows.Core, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.Windows.Core.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.Windows.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
@@ -120,10 +104,6 @@
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
-    <Reference Include="Validation, Version=2.2.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Validation.2.2.8\lib\dotnet\Validation.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/device/samples/DeviceClientSampleAndroid/Resources/Resource.Designer.cs
+++ b/device/samples/DeviceClientSampleAndroid/Resources/Resource.Designer.cs
@@ -27,8 +27,6 @@ namespace DeviceClientSampleAndroid
 		public static void UpdateIdValues()
 		{
 			global::Microsoft.Azure.Amqp.Amqp.Resource.String.ApplicationName = global::DeviceClientSampleAndroid.Resource.String.ApplicationName;
-			global::PCLCrypto.Resource.String.ApplicationName = global::DeviceClientSampleAndroid.Resource.String.ApplicationName;
-			global::PCLCrypto.Resource.String.Hello = global::DeviceClientSampleAndroid.Resource.String.Hello;
 		}
 		
 		public partial class Attribute

--- a/device/samples/DeviceClientSampleAndroid/packages.config
+++ b/device/samples/DeviceClientSampleAndroid/packages.config
@@ -18,11 +18,6 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="monoandroid71" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="monoandroid71" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="monoandroid71" />
-  <package id="PCLCrypto" version="2.0.147" targetFramework="monoandroid60" />
-  <package id="PInvoke.BCrypt" version="0.3.2" targetFramework="monoandroid60" />
-  <package id="PInvoke.Kernel32" version="0.3.2" targetFramework="monoandroid60" />
-  <package id="PInvoke.NCrypt" version="0.3.2" targetFramework="monoandroid60" />
-  <package id="PInvoke.Windows.Core" version="0.3.2" targetFramework="monoandroid60" />
   <package id="System.AppContext" version="4.3.0" targetFramework="monoandroid71" />
   <package id="System.Collections" version="4.3.0" targetFramework="monoandroid71" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="monoandroid71" />
@@ -75,6 +70,5 @@
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="monoandroid71" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="monoandroid71" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="monoandroid71" />
-  <package id="Validation" version="2.2.8" targetFramework="monoandroid60" />
   <package id="WindowsAzure.Storage" version="8.7.0" targetFramework="monoandroid71" />
 </packages>

--- a/device/samples/DeviceClientSampleiOS/DeviceClientSampleiOS.csproj
+++ b/device/samples/DeviceClientSampleiOS/DeviceClientSampleiOS.csproj
@@ -151,21 +151,6 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\netstandard1.3\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="PCLCrypto, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PCLCrypto.2.0.147\lib\xamarinios10\PCLCrypto.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.BCrypt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.BCrypt.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.BCrypt.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.Kernel32, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.Kernel32.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.Kernel32.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.NCrypt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.NCrypt.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.NCrypt.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.Windows.Core, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.Windows.Core.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.Windows.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
@@ -175,9 +160,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="Validation, Version=2.2.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Validation.2.2.8\lib\dotnet\Validation.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>

--- a/device/samples/DeviceClientSampleiOS/packages.config
+++ b/device/samples/DeviceClientSampleiOS/packages.config
@@ -19,11 +19,6 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="xamarinios10" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="xamarinios10" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="xamarinios10" />
-  <package id="PCLCrypto" version="2.0.147" targetFramework="xamarinios10" />
-  <package id="PInvoke.BCrypt" version="0.3.2" targetFramework="xamarinios10" />
-  <package id="PInvoke.Kernel32" version="0.3.2" targetFramework="xamarinios10" />
-  <package id="PInvoke.NCrypt" version="0.3.2" targetFramework="xamarinios10" />
-  <package id="PInvoke.Windows.Core" version="0.3.2" targetFramework="xamarinios10" />
   <package id="System.AppContext" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="xamarinios10" />

--- a/device/tests/Microsoft.Azure.Devices.Client.Test/Microsoft.Azure.Devices.Client.Test.csproj
+++ b/device/tests/Microsoft.Azure.Devices.Client.Test/Microsoft.Azure.Devices.Client.Test.csproj
@@ -162,18 +162,6 @@
     <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="PInvoke.BCrypt, Version=0.5.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.BCrypt.0.5.111\lib\net45\PInvoke.BCrypt.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.Kernel32, Version=0.5.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.Kernel32.0.5.111\lib\net45\PInvoke.Kernel32.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.NCrypt, Version=0.5.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.NCrypt.0.5.111\lib\net45\PInvoke.NCrypt.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.Windows.Core, Version=0.5.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PInvoke.Windows.Core.0.5.111\lib\net35\PInvoke.Windows.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
@@ -203,9 +191,6 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="Validation, Version=2.4.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Validation.2.4.18\lib\net45\Validation.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/device/tests/Microsoft.Azure.Devices.Client.Test/app.config
+++ b/device/tests/Microsoft.Azure.Devices.Client.Test/app.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Validation" publicKeyToken="2fc06f0d701809a7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.KeyVault.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
@@ -29,14 +25,6 @@
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="PInvoke.BCrypt" publicKeyToken="9e300f9f87f04a7a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.5.0.0" newVersion="0.5.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="PInvoke.NCrypt" publicKeyToken="9e300f9f87f04a7a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.5.0.0" newVersion="0.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/device/tests/Microsoft.Azure.Devices.Client.Test/packages.config
+++ b/device/tests/Microsoft.Azure.Devices.Client.Test/packages.config
@@ -19,10 +19,6 @@
   <package id="NETStandard.Library" version="2.0.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net451" />
-  <package id="PInvoke.BCrypt" version="0.5.111" targetFramework="net451" />
-  <package id="PInvoke.Kernel32" version="0.5.111" targetFramework="net451" />
-  <package id="PInvoke.NCrypt" version="0.5.111" targetFramework="net451" />
-  <package id="PInvoke.Windows.Core" version="0.5.111" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
   <package id="System.ComponentModel" version="4.3.0" targetFramework="net451" />
@@ -56,5 +52,4 @@
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
-  <package id="Validation" version="2.4.18" targetFramework="net451" />
 </packages>

--- a/device/thirdpartynotice.txt
+++ b/device/thirdpartynotice.txt
@@ -6,7 +6,7 @@ The original copyright notice and license, under which Microsoft Corporation rec
 are set out below.  This Third Party Code is licensed to you under their original license terms set forth below.  
 Microsoft Corporation reserves all other rights not expressly granted, whether by implication, estoppel or otherwise.  
 
-1. Json.NET v6.0.8, obtained from https://www.nuget.org/packages/Newtonsoft.Json
+1. Newtonsoft.Json, obtained from https://raw.githubusercontent.com/JamesNK/Newtonsoft.Json/master/LICENSE.md
 
 The MIT License (MIT)
 
@@ -29,9 +29,9 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-2. OWIN 1.0, obtained from https://github.com/owin-contrib/owin-hosting/blob/master/LICENSE.txt
- 
-                                  Apache License
+2. OWIN, obtained from https://github.com/owin-contrib/owin-hosting/blob/master/LICENSE.txt
+
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
@@ -232,65 +232,3 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-3. PCLCrypto, obtained from https://github.com/AArnott/PCLCrypto/blob/master/LICENSE
-
-Microsoft Public License (Ms-PL)
-
-This license governs use of the accompanying software. 
-If you use the software, you accept this license. 
-If you do not accept the license, do not use the software.
-
-1. Definitions
-
-The terms "reproduce," "reproduction," "derivative works," and "distribution"
-have the same meaning here as under U.S. copyright law.
-
-A "contribution" is the original software, or any additions or changes to the
-software.
-
-A "contributor" is any person that distributes its contribution under this
-license.
-
-"Licensed patents" are a contributor's patent claims that read directly on
-its contribution.
-
-2. Grant of Rights
-
-(A) Copyright Grant- Subject to the terms of this license, including the
-license conditions and limitations in section 3, each contributor grants you a
-non-exclusive, worldwide, royalty-free copyright license to reproduce its
-contribution, prepare derivative works of its contribution, and distribute its
-contribution or any derivative works that you create.
-
-(B) Patent Grant- Subject to the terms of this license, including the license
-conditions and limitations in section 3, each contributor grants you a
-non-exclusive, worldwide, royalty-free license under its licensed patents to
-make, have made, use, sell, offer for sale, import, and/or otherwise dispose
-of its contribution in the software or derivative works of the contribution
-in the software.
-
-3. Conditions and Limitations
-
-(A) No Trademark License- This license does not grant you rights to use any
-contributors' name, logo, or trademarks.
-
-(B) If you bring a patent claim against any contributor over patents that you
-claim are infringed by the software, your patent license from such contributor
-to the software ends automatically.
-
-(C) If you distribute any portion of the software, you must retain all copyright,
-patent, trademark, and attribution notices that are present in the software.
-
-(D) If you distribute any portion of the software in source code form, you may
-do so only under this license by including a complete copy of this license with
-your distribution. If you distribute any portion of the software in compiled or
-object code form, you may only do so under a license that complies with this
-license.
-
-(E) The software is licensed "as-is." You bear the risk of using it. The
-contributors give no express warranties, guarantees or conditions. You may
-have additional consumer rights under your local laws which this license
-cannot change. To the extent permitted under your local laws, the contributors
-exclude the implied warranties of merchantability, fitness for a particular
-purpose and non-infringement.

--- a/e2e/Microsoft.Azure.Devices.E2ETests/Microsoft.Azure.Devices.E2ETests.csproj
+++ b/e2e/Microsoft.Azure.Devices.E2ETests/Microsoft.Azure.Devices.E2ETests.csproj
@@ -50,9 +50,6 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
-    <Reference Include="Validation, Version=2.4.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Validation.2.4.18\lib\net45\Validation.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/e2e/Microsoft.Azure.Devices.E2ETests/app.config
+++ b/e2e/Microsoft.Azure.Devices.E2ETests/app.config
@@ -22,18 +22,6 @@
         <assemblyIdentity name="Microsoft.Azure.KeyVault.Core" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="PInvoke.BCrypt" publicKeyToken="9e300f9f87f04a7a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-0.5.0.0" newVersion="0.5.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="PInvoke.NCrypt" publicKeyToken="9e300f9f87f04a7a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-0.5.0.0" newVersion="0.5.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Validation" publicKeyToken="2fc06f0d701809a7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0"/>
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.serviceModel>

--- a/provisioning/service/src/Auth/SharedAccessSignature.cs
+++ b/provisioning/service/src/Auth/SharedAccessSignature.cs
@@ -4,11 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-#if WINDOWS_UWP
-    using PCLCrypto;
-#else
 using System.Security.Cryptography;
-#endif
 using System.Text;
 using System.Net;
 
@@ -199,17 +195,6 @@ namespace Microsoft.Azure.Devices.Common.Service.Auth
 
         public string ComputeSignature(byte[] key)
         {
-#if WINDOWS_UWP
-            var fields = new List<string>();
-            fields.Add(_encodedAudience);
-            fields.Add(_expiry);
-            string value = string.Join("\n", fields);
-            var algorithm = WinRTCrypto.MacAlgorithmProvider.OpenAlgorithm(MacAlgorithm.HmacSha256);
-            var hash = algorithm.CreateHash(key);
-            hash.Append(Encoding.UTF8.GetBytes(value));
-            var mac = hash.GetValueAndReset();
-            return Convert.ToBase64String(mac);
-#else
             List<string> fields = new List<string>();
             fields.Add(_encodedAudience);
             fields.Add(_expiry);
@@ -219,7 +204,6 @@ namespace Microsoft.Azure.Devices.Common.Service.Auth
                 string value = string.Join("\n", fields);
                 return Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(value)));
             }
-#endif
         }
 
         private static IDictionary<string, string> ExtractFieldValues(string sharedAccessSignature)

--- a/provisioning/service/src/Auth/SharedAccessSignatureBuilder.cs
+++ b/provisioning/service/src/Auth/SharedAccessSignatureBuilder.cs
@@ -4,11 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-#if WINDOWS_UWP
-    using PCLCrypto;
-#else
 using System.Security.Cryptography;
-#endif
 using System.Text;
 using System.Net;
 
@@ -91,18 +87,10 @@ namespace Microsoft.Azure.Devices.Common.Service.Auth
 
         private static string Sign(string requestString, string key)
         {
-#if WINDOWS_UWP
-            var algorithm = WinRTCrypto.MacAlgorithmProvider.OpenAlgorithm(MacAlgorithm.HmacSha256);
-            var hash = algorithm.CreateHash(Convert.FromBase64String(key));
-            hash.Append(Encoding.UTF8.GetBytes(requestString));
-            var mac = hash.GetValueAndReset();
-            return Convert.ToBase64String(mac);
-#else
             using (var hmac = new HMACSHA256(Convert.FromBase64String(key)))
             {
                 return Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(requestString)));
             }
-#endif
         }
     }
 }

--- a/service/Microsoft.Azure.Devices.Uwp/Microsoft.Azure.Devices.Uwp.csproj
+++ b/service/Microsoft.Azure.Devices.Uwp/Microsoft.Azure.Devices.Uwp.csproj
@@ -264,9 +264,6 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>10.0.3</Version>
     </PackageReference>
-    <PackageReference Include="PCLCrypto">
-      <Version>2.0.147</Version>
-    </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/service/Microsoft.Azure.Devices/Common/Security/SharedAccessSignature.cs
+++ b/service/Microsoft.Azure.Devices/Common/Security/SharedAccessSignature.cs
@@ -3,19 +3,14 @@
 
 namespace Microsoft.Azure.Devices.Common.Security
 {
+    using Microsoft.Azure.Devices.Common.Data;
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-#if WINDOWS_UWP
-    using PCLCrypto;
-#else
-    using System.Security.Cryptography;
-#endif
-    using System.Text;
     using System.Net;
+    using System.Security.Cryptography;
+    using System.Text;
 
-    using Microsoft.Azure.Devices.Common.Data;
-    
     public sealed class SharedAccessSignature : ISharedAccessSignatureCredential
     {
         readonly string iotHubName;
@@ -198,17 +193,6 @@ namespace Microsoft.Azure.Devices.Common.Security
 
         public string ComputeSignature(byte[] key)
         {
-#if WINDOWS_UWP
-            var fields = new List<string>();
-            fields.Add(this.encodedAudience);
-            fields.Add(this.expiry);
-            string value = string.Join("\n", fields);
-            var algorithm = WinRTCrypto.MacAlgorithmProvider.OpenAlgorithm(MacAlgorithm.HmacSha256);
-            var hash = algorithm.CreateHash(key);
-            hash.Append(Encoding.UTF8.GetBytes(value));
-            var mac = hash.GetValueAndReset();
-            return Convert.ToBase64String(mac);
-#else
             List<string> fields = new List<string>();
             fields.Add(this.encodedAudience);
             fields.Add(this.expiry);
@@ -218,7 +202,6 @@ namespace Microsoft.Azure.Devices.Common.Security
                 string value = string.Join("\n", fields);
                 return Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(value)));
             }
-#endif
         }
 
         static IDictionary<string, string> ExtractFieldValues(string sharedAccessSignature)

--- a/service/Microsoft.Azure.Devices/Common/Security/SharedAccessSignatureBuilder.cs
+++ b/service/Microsoft.Azure.Devices/Common/Security/SharedAccessSignatureBuilder.cs
@@ -6,13 +6,9 @@ namespace Microsoft.Azure.Devices.Common.Security
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-#if WINDOWS_UWP
-    using PCLCrypto;
-#else
-    using System.Security.Cryptography;
-#endif
-    using System.Text;
     using System.Net;
+    using System.Security.Cryptography;
+    using System.Text;
 
     public sealed class SharedAccessSignatureBuilder
     {
@@ -91,18 +87,10 @@ namespace Microsoft.Azure.Devices.Common.Security
 
         static string Sign(string requestString, string key)
         {
-#if WINDOWS_UWP
-            var algorithm = WinRTCrypto.MacAlgorithmProvider.OpenAlgorithm(MacAlgorithm.HmacSha256);
-            var hash = algorithm.CreateHash(Convert.FromBase64String(key));
-            hash.Append(Encoding.UTF8.GetBytes(requestString));
-            var mac = hash.GetValueAndReset();
-            return Convert.ToBase64String(mac);
-#else
             using (var hmac = new HMACSHA256(Convert.FromBase64String(key)))
             {
                 return Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(requestString)));
             }
-#endif
         }
     }
 }

--- a/service/Microsoft.Azure.Devices/Microsoft.Azure.Devices.csproj
+++ b/service/Microsoft.Azure.Devices/Microsoft.Azure.Devices.csproj
@@ -57,22 +57,6 @@
       <HintPath>$(SolutionDir)\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="PCLCrypto, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCLCrypto.2.0.147\lib\net45\PCLCrypto.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PInvoke.BCrypt, Version=0.5.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PInvoke.BCrypt.0.5.111\lib\net45\PInvoke.BCrypt.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.Kernel32, Version=0.5.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PInvoke.Kernel32.0.5.111\lib\net45\PInvoke.Kernel32.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.NCrypt, Version=0.5.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PInvoke.NCrypt.0.5.111\lib\net45\PInvoke.NCrypt.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.Windows.Core, Version=0.5.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PInvoke.Windows.Core.0.5.111\lib\net35\PInvoke.Windows.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
@@ -91,9 +75,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
-    <Reference Include="Validation, Version=2.4.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Validation.2.4.18\lib\net45\Validation.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\common\src\service\AssertionFailedException.cs">

--- a/service/Microsoft.Azure.Devices/app.config
+++ b/service/Microsoft.Azure.Devices/app.config
@@ -10,18 +10,6 @@
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="PInvoke.BCrypt" publicKeyToken="9e300f9f87f04a7a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.5.0.0" newVersion="0.5.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="PInvoke.NCrypt" publicKeyToken="9e300f9f87f04a7a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.5.0.0" newVersion="0.5.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Validation" publicKeyToken="2fc06f0d701809a7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/service/Microsoft.Azure.Devices/packages.config
+++ b/service/Microsoft.Azure.Devices/packages.config
@@ -6,10 +6,5 @@
   <package id="Microsoft.Owin" version="3.1.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net451" />
-  <package id="PCLCrypto" version="2.0.147" targetFramework="net451" />
-  <package id="PInvoke.BCrypt" version="0.5.111" targetFramework="net451" />
-  <package id="PInvoke.Kernel32" version="0.5.111" targetFramework="net451" />
-  <package id="PInvoke.NCrypt" version="0.5.111" targetFramework="net451" />
-  <package id="PInvoke.Windows.Core" version="0.5.111" targetFramework="net451" />
   <package id="Validation" version="2.4.18" targetFramework="net451" />
 </packages>

--- a/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/Microsoft.Azure.Devices.Api.Test.csproj
+++ b/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/Microsoft.Azure.Devices.Api.Test.csproj
@@ -136,21 +136,6 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="PCLCrypto, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\PCLCrypto.2.0.147\lib\net45\PCLCrypto.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.BCrypt, Version=0.5.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\PInvoke.BCrypt.0.5.111\lib\net45\PInvoke.BCrypt.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.Kernel32, Version=0.5.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\PInvoke.Kernel32.0.5.111\lib\net45\PInvoke.Kernel32.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.NCrypt, Version=0.5.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\PInvoke.NCrypt.0.5.111\lib\net45\PInvoke.NCrypt.dll</HintPath>
-    </Reference>
-    <Reference Include="PInvoke.Windows.Core, Version=0.5.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\PInvoke.Windows.Core.0.5.111\lib\net35\PInvoke.Windows.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
@@ -177,9 +162,6 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="Validation, Version=2.4.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Validation.2.4.18\lib\net45\Validation.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/app.config
+++ b/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/app.config
@@ -15,20 +15,8 @@
         <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="PCLCrypto" publicKeyToken="d4421c8a4786956c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="PInvoke.BCrypt" publicKeyToken="9e300f9f87f04a7a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.5.0.0" newVersion="0.5.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="PInvoke.NCrypt" publicKeyToken="9e300f9f87f04a7a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.5.0.0" newVersion="0.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/packages.config
+++ b/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/packages.config
@@ -23,11 +23,6 @@
   <package id="Moq" version="4.7.145" targetFramework="net451" />
   <package id="NETStandard.Library" version="2.0.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
-  <package id="PCLCrypto" version="2.0.147" targetFramework="net451" />
-  <package id="PInvoke.BCrypt" version="0.5.111" targetFramework="net451" />
-  <package id="PInvoke.Kernel32" version="0.5.111" targetFramework="net451" />
-  <package id="PInvoke.NCrypt" version="0.5.111" targetFramework="net451" />
-  <package id="PInvoke.Windows.Core" version="0.5.111" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
   <package id="System.ComponentModel" version="4.3.0" targetFramework="net451" />

--- a/service/NuGet/Microsoft.Azure.Devices.nuspec
+++ b/service/NuGet/Microsoft.Azure.Devices.nuspec
@@ -20,15 +20,11 @@
         <dependency id="Microsoft.Azure.Amqp" version="2.1.3" />
         <dependency id="Microsoft.Owin" version="3.1.0" />
         <dependency id="Newtonsoft.Json" version="10.0.3" />
-        <dependency id="PCLCrypto" version="2.0.147" />
-        <dependency id="PInvoke.NCrypt" version="0.5.111" />
-        <dependency id="Validation" version="2.4.18" />
       </group>
       <group targetFramework="uap10.0">
         <dependency id="Microsoft.Azure.Devices.Shared" version="1.4.1" />
         <dependency id="Microsoft.Azure.Amqp" version="2.1.3" />
         <dependency id="Newtonsoft.Json" version="10.0.3" />
-        <dependency id="PCLCrypto" version="2.0.147" />
       </group>
       <group targetFramework="netstandard1.3" >
           <dependency id="Microsoft.Azure.Devices.Shared" version="1.4.1" />

--- a/service/Samples/ConsoleJobsSample/App.config
+++ b/service/Samples/ConsoleJobsSample/App.config
@@ -3,20 +3,4 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="PInvoke.BCrypt" publicKeyToken="9e300f9f87f04a7a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.5.0.0" newVersion="0.5.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="PInvoke.NCrypt" publicKeyToken="9e300f9f87f04a7a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.5.0.0" newVersion="0.5.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Validation" publicKeyToken="2fc06f0d701809a7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/service/Samples/ConsoleSample/App.config
+++ b/service/Samples/ConsoleSample/App.config
@@ -6,18 +6,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="PInvoke.BCrypt" publicKeyToken="9e300f9f87f04a7a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.5.0.0" newVersion="0.5.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="PInvoke.NCrypt" publicKeyToken="9e300f9f87f04a7a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.5.0.0" newVersion="0.5.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Validation" publicKeyToken="2fc06f0d701809a7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>

--- a/tools/DeviceExplorer/DeviceExplorer/DeviceExplorer.csproj
+++ b/tools/DeviceExplorer/DeviceExplorer/DeviceExplorer.csproj
@@ -148,26 +148,6 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="PCLCrypto, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCLCrypto.2.0.147\lib\net45\PCLCrypto.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PInvoke.BCrypt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PInvoke.BCrypt.0.3.2\lib\net40\PInvoke.BCrypt.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PInvoke.Kernel32, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PInvoke.Kernel32.0.3.2\lib\net40\PInvoke.Kernel32.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PInvoke.NCrypt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PInvoke.NCrypt.0.3.2\lib\net40\PInvoke.NCrypt.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PInvoke.Windows.Core, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PInvoke.Windows.Core.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.Windows.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Data" />
@@ -185,10 +165,6 @@
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="Validation, Version=2.2.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Validation.2.2.8\lib\dotnet\Validation.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\service\Microsoft.Azure.Devices\Microsoft.Azure.Devices.csproj">

--- a/tools/DeviceExplorer/DeviceExplorer/packages.config
+++ b/tools/DeviceExplorer/DeviceExplorer/packages.config
@@ -7,14 +7,8 @@
   <package id="Microsoft.Azure.Devices.Shared" version="1.1.0" targetFramework="net451" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
-  <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net451" />
-  <package id="PCLCrypto" version="2.0.147" targetFramework="net451" />
-  <package id="PInvoke.BCrypt" version="0.3.2" targetFramework="net451" />
-  <package id="PInvoke.Kernel32" version="0.3.2" targetFramework="net451" />
-  <package id="PInvoke.NCrypt" version="0.3.2" targetFramework="net451" />
-  <package id="PInvoke.Windows.Core" version="0.3.2" targetFramework="net451" />
   <package id="Validation" version="2.2.8" targetFramework="net451" />
   <package id="WindowsAzure.ServiceBus" version="4.1.2" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
- Removing PCLCrypto references and all its dependencies. The reasons for removing this dependency:
  - The UWP SDK has issues loading PCLCrypto's OS level dependencies when the application is compiled (AOT) - see #315
  - .NET Framework, Core 1.0 have support for the HMAC256 API through System.Cryptography. 
  - The currently supported UWP profile supports .NET Standard 2.0 which has support through the same framework API.
  - The PCL support has been previously deprecated.
  - This decreases the disk footprint of the IoT Hub Device SDK
- Small build script enhancement: also display the failed project name on the last output line
- Minor updates to the thirdpartynotice.txt

Fixes  #315 