### PR TITLE
Remove the Uri encoding for query

### DIFF
--- a/provisioning/service/src/Query.cs
+++ b/provisioning/service/src/Query.cs
@@ -257,7 +257,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
 
         private static Uri GetQueryUri(string path)
         {
-            path = WebUtility.UrlEncode(path);
             return new Uri(QueryUriFormat.FormatInvariant(path, SDKUtils.ApiVersionQueryString), UriKind.Relative);
         }
     }


### PR DESCRIPTION
# Description of the problem
There was a bug in Query Uri with a '\' being escaped. This was returning a 404 for CreateEnrollmentGroupRegistrationStateQuery Api. This is a bug reported [here](https://github.com/Azure/azure-iot-sdk-csharp/issues/377)

# Description of the solution
Removed the Uri encoding in the query

Fixes #377