### PR TITLE
The build will no longer be corrupted by a user's powershell profile.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -8,8 +8,8 @@ if "%1" EQU "-h" goto get-help
 if "%1" EQU "-help" goto get-help
 if "%1" EQU "--help" goto get-help
 
-powershell -command ".\build.ps1 %*; exit $LASTEXITCODE"
+powershell -noprofile -command ".\build.ps1 %*; exit $LASTEXITCODE"
 exit /b %ERRORLEVEL%
 
 :get-help
-powershell -command "Get-Help .\build.ps1"
+powershell -noprofile -command "Get-Help .\build.ps1"

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,6 @@ if [ "$1" == "-?" -o "$1" == "-h" -o "$1" == "-help" -o "$1" == "--help" ]; then
 	exit;
 fi
 
-pwsh -command ".\build.ps1" $@ "; exit \$LASTEXITCODE"
+pwsh -NoProfile -command ".\build.ps1" $@ "; exit \$LASTEXITCODE"
 
 exit $?


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
The build was inheriting the current powershell profile breaking the build in certain scenarios and making its success variable.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Configured powershell to no longer use the user profile when running.