### PR TITLE
Ability for a device to authenticate with registry using token

### DIFF
--- a/common/src/service/AuthenticationMethodFactory.cs
+++ b/common/src/service/AuthenticationMethodFactory.cs
@@ -15,7 +15,14 @@ namespace Microsoft.Azure.Devices
         {
             if (!string.IsNullOrWhiteSpace(iotHubConnectionStringBuilder.DeviceId))
             {
-                return new ServiceAuthenticationWithDeviceCredentials(iotHubConnectionStringBuilder.DeviceId, iotHubConnectionStringBuilder.SharedAccessKey);
+                if (!string.IsNullOrWhiteSpace(iotHubConnectionStringBuilder.SharedAccessKey))
+                {
+                    return new ServiceAuthenticationWithDeviceSharedAccessPolicyKey(iotHubConnectionStringBuilder.DeviceId, iotHubConnectionStringBuilder.SharedAccessKey);
+                }
+                if (!string.IsNullOrWhiteSpace(iotHubConnectionStringBuilder.SharedAccessSignature))
+                {
+                    return new ServiceAuthenticationWithDeviceSharedAccessPolicyToken(iotHubConnectionStringBuilder.DeviceId, iotHubConnectionStringBuilder.SharedAccessSignature);
+                }
             }
             if (string.IsNullOrWhiteSpace(iotHubConnectionStringBuilder.SharedAccessKey))
             {

--- a/service/Microsoft.Azure.Devices.NetStandard/Microsoft.Azure.Devices.NetStandard.csproj
+++ b/service/Microsoft.Azure.Devices.NetStandard/Microsoft.Azure.Devices.NetStandard.csproj
@@ -251,7 +251,6 @@
     <Compile Include="..\Microsoft.Azure.Devices\Receiver.cs" />
     <Compile Include="..\Microsoft.Azure.Devices\RegistryManager.cs" />
     <Compile Include="..\Microsoft.Azure.Devices\RegistryStatistics.cs" />
-    <Compile Include="..\Microsoft.Azure.Devices\ServiceAuthenticationWithDeviceCredentials.cs" />
     <Compile Include="..\Microsoft.Azure.Devices\ServiceAuthenticationWithSharedAccessPolicyKey.cs" />
     <Compile Include="..\Microsoft.Azure.Devices\ServiceAuthenticationWithSharedAccessPolicyToken.cs" />
     <Compile Include="..\Microsoft.Azure.Devices\ServiceClient.cs" />

--- a/service/Microsoft.Azure.Devices.NetStandard/ServiceAuthenticationWithDeviceSharedAccessPolicyKey.cs
+++ b/service/Microsoft.Azure.Devices.NetStandard/ServiceAuthenticationWithDeviceSharedAccessPolicyKey.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Azure.Devices
+{
+    /// <summary>
+    /// Authentication method that uses a device's shared access key to authenticate with service. 
+    /// </summary>
+    public class ServiceAuthenticationWithDeviceSharedAccessPolicyKey : IAuthenticationMethod
+    {
+        public ServiceAuthenticationWithDeviceSharedAccessPolicyKey(string deviceId, string sharedAccessKey)
+        {
+            DeviceId = deviceId;
+            Key = sharedAccessKey;
+        }
+
+        public IotHubConnectionStringBuilder Populate(IotHubConnectionStringBuilder iotHubConnectionStringBuilder)
+        {
+            if (iotHubConnectionStringBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(iotHubConnectionStringBuilder));
+            }
+
+            iotHubConnectionStringBuilder.SharedAccessKey = this.Key;
+            iotHubConnectionStringBuilder.DeviceId = this.DeviceId;
+            iotHubConnectionStringBuilder.SharedAccessSignature = null;
+
+            return iotHubConnectionStringBuilder;
+        }
+
+        /// <summary>
+        /// Shared access key of the device
+        /// </summary>
+        public string Key { get; set; }
+
+        /// <summary>
+        /// Name of device
+        /// </summary>
+        public string DeviceId { get; set; }
+    }
+}

--- a/service/Microsoft.Azure.Devices.NetStandard/ServiceAuthenticationWithDeviceSharedAccessPolicyToken.cs
+++ b/service/Microsoft.Azure.Devices.NetStandard/ServiceAuthenticationWithDeviceSharedAccessPolicyToken.cs
@@ -5,12 +5,15 @@ using System;
 
 namespace Microsoft.Azure.Devices
 {
-    public class ServiceAuthenticationWithDeviceCredentials : IAuthenticationMethod
+    /// <summary>
+    /// Authentication method that uses a device's shared access signature to authenticate with service. 
+    /// </summary>
+    public class ServiceAuthenticationWithDeviceSharedAccessPolicyToken : IAuthenticationMethod
     {
-        public ServiceAuthenticationWithDeviceCredentials(string deviceId, string sharedAccessKey)
+        public ServiceAuthenticationWithDeviceSharedAccessPolicyToken(string deviceId, string sharedAccessSignature)
         {
             DeviceId = deviceId;
-            Key = sharedAccessKey;
+            Token = sharedAccessSignature;
         }
 
         public IotHubConnectionStringBuilder Populate(IotHubConnectionStringBuilder iotHubConnectionStringBuilder)
@@ -20,21 +23,21 @@ namespace Microsoft.Azure.Devices
                 throw new ArgumentNullException(nameof(iotHubConnectionStringBuilder));
             }
 
-            iotHubConnectionStringBuilder.SharedAccessKey = this.Key;
+            iotHubConnectionStringBuilder.SharedAccessKey = null;
             iotHubConnectionStringBuilder.DeviceId = this.DeviceId;
-            iotHubConnectionStringBuilder.SharedAccessSignature = null;
+            iotHubConnectionStringBuilder.SharedAccessSignature = this.Token;
 
             return iotHubConnectionStringBuilder;
         }
 
         /// <summary>
-        /// 
-        /// </summary>
-        public string Key { get; set; }
-
-        /// <summary>
-        /// 
+        /// Name of device
         /// </summary>
         public string DeviceId { get; set; }
+
+        /// <summary>
+        /// Shared access signature generated using device's shared access key
+        /// </summary>
+        public string Token { get; set; }
     }
 }

--- a/service/Microsoft.Azure.Devices.Uwp/Microsoft.Azure.Devices.Uwp.csproj
+++ b/service/Microsoft.Azure.Devices.Uwp/Microsoft.Azure.Devices.Uwp.csproj
@@ -237,7 +237,6 @@
     <Compile Include="..\Microsoft.Azure.Devices\Receiver.cs" />
     <Compile Include="..\Microsoft.Azure.Devices\RegistryManager.cs" />
     <Compile Include="..\Microsoft.Azure.Devices\RegistryStatistics.cs" />
-    <Compile Include="..\Microsoft.Azure.Devices\ServiceAuthenticationWithDeviceCredentials.cs" />
     <Compile Include="..\Microsoft.Azure.Devices\ServiceAuthenticationWithSharedAccessPolicyKey.cs" />
     <Compile Include="..\Microsoft.Azure.Devices\ServiceAuthenticationWithSharedAccessPolicyToken.cs" />
     <Compile Include="..\Microsoft.Azure.Devices\ServiceClient.cs" />
@@ -247,6 +246,8 @@
     <Compile Include="..\Microsoft.Azure.Devices\Common\IOThreadTimerSlim.cs" />
     <Compile Include="..\Microsoft.Azure.Devices\X509ThumbprintExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ServiceAuthenticationWithDeviceSharedAccessPolicyKey.cs" />
+    <Compile Include="ServiceAuthenticationWithDeviceSharedAccessPolicyToken.cs" />
     <EmbeddedResource Include="Properties\Microsoft.Azure.Devices.Uwp.rd.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/service/Microsoft.Azure.Devices.Uwp/ServiceAuthenticationWithDeviceSharedAccessPolicyKey.cs
+++ b/service/Microsoft.Azure.Devices.Uwp/ServiceAuthenticationWithDeviceSharedAccessPolicyKey.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Azure.Devices
+{
+    /// <summary>
+    /// Authentication method that uses a device's shared access key to authenticate with service. 
+    /// </summary>
+    public class ServiceAuthenticationWithDeviceSharedAccessPolicyKey : IAuthenticationMethod
+    {
+        public ServiceAuthenticationWithDeviceSharedAccessPolicyKey(string deviceId, string sharedAccessKey)
+        {
+            DeviceId = deviceId;
+            Key = sharedAccessKey;
+        }
+
+        public IotHubConnectionStringBuilder Populate(IotHubConnectionStringBuilder iotHubConnectionStringBuilder)
+        {
+            if (iotHubConnectionStringBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(iotHubConnectionStringBuilder));
+            }
+
+            iotHubConnectionStringBuilder.SharedAccessKey = this.Key;
+            iotHubConnectionStringBuilder.DeviceId = this.DeviceId;
+            iotHubConnectionStringBuilder.SharedAccessSignature = null;
+
+            return iotHubConnectionStringBuilder;
+        }
+
+        /// <summary>
+        /// Shared access key of the device
+        /// </summary>
+        public string Key { get; set; }
+
+        /// <summary>
+        /// Name of device
+        /// </summary>
+        public string DeviceId { get; set; }
+    }
+}

--- a/service/Microsoft.Azure.Devices.Uwp/ServiceAuthenticationWithDeviceSharedAccessPolicyToken.cs
+++ b/service/Microsoft.Azure.Devices.Uwp/ServiceAuthenticationWithDeviceSharedAccessPolicyToken.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Azure.Devices
+{
+    /// <summary>
+    /// Authentication method that uses a device's shared access signature to authenticate with service. 
+    /// </summary>
+    public class ServiceAuthenticationWithDeviceSharedAccessPolicyToken : IAuthenticationMethod
+    {
+        public ServiceAuthenticationWithDeviceSharedAccessPolicyToken(string deviceId, string sharedAccessSignature)
+        {
+            DeviceId = deviceId;
+            Token = sharedAccessSignature;
+        }
+
+        public IotHubConnectionStringBuilder Populate(IotHubConnectionStringBuilder iotHubConnectionStringBuilder)
+        {
+            if (iotHubConnectionStringBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(iotHubConnectionStringBuilder));
+            }
+
+            iotHubConnectionStringBuilder.SharedAccessKey = null;
+            iotHubConnectionStringBuilder.DeviceId = this.DeviceId;
+            iotHubConnectionStringBuilder.SharedAccessSignature = this.Token;
+
+            return iotHubConnectionStringBuilder;
+        }
+
+        /// <summary>
+        /// Name of device
+        /// </summary>
+        public string DeviceId { get; set; }
+
+        /// <summary>
+        /// Shared access signature generated using device's shared access key
+        /// </summary>
+        public string Token { get; set; }
+    }
+}

--- a/service/Microsoft.Azure.Devices/Microsoft.Azure.Devices.csproj
+++ b/service/Microsoft.Azure.Devices/Microsoft.Azure.Devices.csproj
@@ -289,7 +289,8 @@
     <Compile Include="Receiver.cs" />
     <Compile Include="RegistryManager.cs" />
     <Compile Include="RegistryStatistics.cs" />
-    <Compile Include="ServiceAuthenticationWithDeviceCredentials.cs" />
+    <Compile Include="ServiceAuthenticationWithDeviceSharedAccessPolicyToken.cs" />
+    <Compile Include="ServiceAuthenticationWithDeviceSharedAccessPolicyKey.cs" />
     <Compile Include="ServiceAuthenticationWithSharedAccessPolicyKey.cs" />
     <Compile Include="ServiceAuthenticationWithSharedAccessPolicyToken.cs" />
     <Compile Include="ServiceClient.cs" />

--- a/service/Microsoft.Azure.Devices/ServiceAuthenticationWithDeviceSharedAccessPolicyKey.cs
+++ b/service/Microsoft.Azure.Devices/ServiceAuthenticationWithDeviceSharedAccessPolicyKey.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Azure.Devices
+{
+    /// <summary>
+    /// Authentication method that uses a device's shared access key to authenticate with service. 
+    /// </summary>
+    public class ServiceAuthenticationWithDeviceSharedAccessPolicyKey : IAuthenticationMethod
+    {
+        public ServiceAuthenticationWithDeviceSharedAccessPolicyKey(string deviceId, string sharedAccessKey)
+        {
+            DeviceId = deviceId;
+            Key = sharedAccessKey;
+        }
+
+        public IotHubConnectionStringBuilder Populate(IotHubConnectionStringBuilder iotHubConnectionStringBuilder)
+        {
+            if (iotHubConnectionStringBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(iotHubConnectionStringBuilder));
+            }
+
+            iotHubConnectionStringBuilder.SharedAccessKey = this.Key;
+            iotHubConnectionStringBuilder.DeviceId = this.DeviceId;
+            iotHubConnectionStringBuilder.SharedAccessSignature = null;
+
+            return iotHubConnectionStringBuilder;
+        }
+
+        /// <summary>
+        /// Shared access key of the device
+        /// </summary>
+        public string Key { get; set; }
+
+        /// <summary>
+        /// Name of device
+        /// </summary>
+        public string DeviceId { get; set; }
+    }
+}

--- a/service/Microsoft.Azure.Devices/ServiceAuthenticationWithDeviceSharedAccessPolicyToken.cs
+++ b/service/Microsoft.Azure.Devices/ServiceAuthenticationWithDeviceSharedAccessPolicyToken.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Azure.Devices
+{
+    /// <summary>
+    /// Authentication method that uses a device's shared access signature to authenticate with service. 
+    /// </summary>
+    public class ServiceAuthenticationWithDeviceSharedAccessPolicyToken : IAuthenticationMethod
+    {
+        public ServiceAuthenticationWithDeviceSharedAccessPolicyToken(string deviceId, string sharedAccessSignature)
+        {
+            DeviceId = deviceId;
+            Token = sharedAccessSignature;
+        }
+
+        public IotHubConnectionStringBuilder Populate(IotHubConnectionStringBuilder iotHubConnectionStringBuilder)
+        {
+            if (iotHubConnectionStringBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(iotHubConnectionStringBuilder));
+            }
+
+            iotHubConnectionStringBuilder.SharedAccessKey = null;
+            iotHubConnectionStringBuilder.DeviceId = this.DeviceId;
+            iotHubConnectionStringBuilder.SharedAccessSignature = this.Token;
+
+            return iotHubConnectionStringBuilder;
+        }
+
+        /// <summary>
+        /// Name of device
+        /// </summary>
+        public string DeviceId { get; set; }
+
+        /// <summary>
+        /// Shared access signature generated using device's shared access key
+        /// </summary>
+        public string Token { get; set; }
+    }
+}


### PR DESCRIPTION
IoTHub service supports devices connecting to registry manager with a device scoped key for module operations. This change allows devices to also connect to registry manager for the same set of module operations with a token. This is used when the key is obtained on the device by the device provisioning flow and a token is generated using the key.