### PR TITLE
Add support for receiving events for modules over AMQP

### DIFF
--- a/device/Microsoft.Azure.Devices.Client/AmqpTransportSettings.cs
+++ b/device/Microsoft.Azure.Devices.Client/AmqpTransportSettings.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Client
 {
     using System;
 #if !WINDOWS_UWP && !PCL
+    using System.Net.Security;
     using System.Security.Cryptography.X509Certificates;
 #endif
 
@@ -79,6 +80,8 @@ namespace Microsoft.Azure.Devices.Client
 
 #if !WINDOWS_UWP && !PCL
         public X509Certificate2 ClientCertificate { get; set; }
+
+        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 #endif
 
         public AmqpConnectionPoolSettings AmqpConnectionPoolSettings { get; set; }

--- a/device/Microsoft.Azure.Devices.Client/IotHubConnection.cs
+++ b/device/Microsoft.Azure.Devices.Client/IotHubConnection.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Azure.Devices.Client
         public enum ReceivingLinkType {
             C2DMessages,
             Methods,
-            Twin
+            Twin,
+            Messages
         };
 
         protected IotHubConnection(string hostName, int port, AmqpTransportSettings amqpTransportSettings)
@@ -155,6 +156,7 @@ namespace Microsoft.Azure.Devices.Client
             switch (linkType)
             {
                 case ReceivingLinkType.C2DMessages:
+                case ReceivingLinkType.Messages:
                     linkSettings.SndSettleMode = null; // SenderSettleMode.Unsettled (null as it is the default and to avoid bytes on the wire)
                     linkSettings.RcvSettleMode = (byte)ReceiverSettleMode.Second;
                     break;
@@ -454,7 +456,7 @@ namespace Microsoft.Azure.Devices.Client
                 TargetHost = this.hostName,
 #if !WINDOWS_UWP && !PCL // Not supported in UWP/PCL
                 Certificate = null,
-                CertificateValidationCallback = OnRemoteCertificateValidation
+                CertificateValidationCallback = this.AmqpTransportSettings.RemoteCertificateValidationCallback ?? OnRemoteCertificateValidation
 #endif
             };
 

--- a/device/Microsoft.Azure.Devices.Client/IotHubConnection.cs
+++ b/device/Microsoft.Azure.Devices.Client/IotHubConnection.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Devices.Client
             C2DMessages,
             Methods,
             Twin,
-            Messages
+            Events
         };
 
         protected IotHubConnection(string hostName, int port, AmqpTransportSettings amqpTransportSettings)
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Devices.Client
             switch (linkType)
             {
                 case ReceivingLinkType.C2DMessages:
-                case ReceivingLinkType.Messages:
+                case ReceivingLinkType.Events:
                     linkSettings.SndSettleMode = null; // SenderSettleMode.Unsettled (null as it is the default and to avoid bytes on the wire)
                     linkSettings.RcvSettleMode = (byte)ReceiverSettleMode.Second;
                     break;

--- a/device/Microsoft.Azure.Devices.Client/Transport/AmqpTransportHandler.cs
+++ b/device/Microsoft.Azure.Devices.Client/Transport/AmqpTransportHandler.cs
@@ -967,7 +967,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             string path = this.BuildPath(CommonConstants.DeviceEventPathTemplate, CommonConstants.ModuleEventPathTemplate);
 
-            ReceivingAmqpLink messageReceivingLink = await this.IotHubConnection.CreateReceivingLinkAsync(path, this.iotHubConnectionString, this.deviceId, IotHubConnection.ReceivingLinkType.Messages, this.prefetchCount, timeout, this.productInfo, cancellationToken);
+            ReceivingAmqpLink messageReceivingLink = await this.IotHubConnection.CreateReceivingLinkAsync(path, this.iotHubConnectionString, this.deviceId, IotHubConnection.ReceivingLinkType.Events, this.prefetchCount, timeout, this.productInfo, cancellationToken);
             messageReceivingLink.RegisterMessageListener(amqpMessage => this.ProcessReceivedEventMessage(amqpMessage));
 
             MyStringCopy(messageReceivingLink.Name, out eventReceivingLinkName);

--- a/device/Microsoft.Azure.Devices.Client/Transport/AmqpTransportHandler.cs
+++ b/device/Microsoft.Azure.Devices.Client/Transport/AmqpTransportHandler.cs
@@ -16,11 +16,11 @@ namespace Microsoft.Azure.Devices.Client.Transport
     using Microsoft.Azure.Devices.Client.Extensions;
     using Microsoft.Azure.Devices.Shared;
     using System.Collections.Concurrent;
-    using System.Linq.Expressions;
     using Newtonsoft.Json;
 
     sealed class AmqpTransportHandler : TransportHandler
     {
+        const string InputNameKey = "x-opt-input-name";
         static readonly IotHubConnectionCache TcpConnectionCache = new IotHubConnectionCache();
         static readonly IotHubConnectionCache WsConnectionCache = new IotHubConnectionCache();
         readonly string deviceId;
@@ -991,7 +991,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         private async void ProcessReceivedEventMessage(AmqpMessage amqpMessage)
         {
-            amqpMessage.MessageAnnotations.Map.TryGetValue("InputName", out string inputName);
+            amqpMessage.MessageAnnotations.Map.TryGetValue(InputNameKey, out string inputName);
             Message message = new Message(amqpMessage)
             {
                 LockToken = new Guid(amqpMessage.DeliveryTag.Array).ToString()

--- a/device/Microsoft.Azure.Devices.Client/Transport/TransportHandlerFactory.cs
+++ b/device/Microsoft.Azure.Devices.Client/Transport/TransportHandlerFactory.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         context, connectionString, transportSetting[0] as AmqpTransportSettings,
                         new Action<object, ConnectionEventArgs>(OnConnectionOpenedCallback),
                         new Func<object, ConnectionEventArgs, Task>(OnConnectionClosedCallback),
-                        new Func<MethodRequestInternal, Task>(onMethodCallback), onDesiredStatePatchReceived);
+                        new Func<MethodRequestInternal, Task>(onMethodCallback), onDesiredStatePatchReceived,
+                        new Func<string, Message, Task>(onReceiveCallback));
                 case TransportType.Http1:
                     return new HttpTransportHandler(context, connectionString, transportSetting[0] as Http1TransportSettings);
 #if !NETMF && !PCL


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] This pull-request is submitted against the `modules-preview` branch, since this change is modules specific

# Description of the changes
- Added support for receiving events for Modules over AMQP. Currently this support exists only for MQTT.