### PR TITLE
Bump version of device client, service and shared packages

### DIFF
--- a/common/src/service/Utils.cs
+++ b/common/src/service/Utils.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Devices.Common
 #if WINDOWS_UWP || NETSTANDARD1_3
             // System.Reflection.Assembly.GetExecutingAssembly() does not exist for UWP, therefore use a hard-coded version name
             // (This string is picked up by the bump_version script, so don't change the line below)
-            var UWPAssemblyVersion = "1.16.0-preview-001";
+            var UWPAssemblyVersion = "1.16.0-preview-002";
             return UWPAssemblyVersion;
 #else
             var a = Assembly.GetExecutingAssembly();

--- a/device/Microsoft.Azure.Devices.Client.NetStandard/Properties/AssemblyInfo.cs
+++ b/device/Microsoft.Azure.Devices.Client.NetStandard/Properties/AssemblyInfo.cs
@@ -39,4 +39,4 @@ using System.Runtime.InteropServices;
 
 // Version information for an assembly follows semantic versioning 1.0.0 (because
 // NuGet didn't support semver 2.0.0 before VS 2015). See semver.org for details.
-[assembly: AssemblyInformationalVersion("1.17.0-preview-001")]
+[assembly: AssemblyInformationalVersion("1.17.0-preview-002")]

--- a/device/Microsoft.Azure.Devices.Client.UWP/Properties/AssemblyInfo.cs
+++ b/device/Microsoft.Azure.Devices.Client.UWP/Properties/AssemblyInfo.cs
@@ -30,4 +30,4 @@ using System.Runtime.InteropServices;
 
 // Version information for an assembly follows semantic versioning 1.0.0 (because
 // NuGet didn't support semver 2.0.0 before VS 2015). See semver.org for details.
-[assembly: AssemblyInformationalVersion("1.17.0-preview-001")]
+[assembly: AssemblyInformationalVersion("1.17.0-preview-002")]

--- a/device/Microsoft.Azure.Devices.Client/ProductInfo.cs
+++ b/device/Microsoft.Azure.Devices.Client/ProductInfo.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.Client
             string userAgent = $"{Name}/{Version} (PCL)";
 #else
             // DO NOT EDIT the following line; it is updated by the bump_version script (https://github.com/Azure/iot-sdks-internals/blob/master/release/csharp/inputs.js)
-            const string Version = "1.17.0-preview-001"; // CommonAssemblyVersion
+            const string Version = "1.17.0-preview-002"; // CommonAssemblyVersion
 
             string runtime = RuntimeInformation.FrameworkDescription.Trim();
             string operatingSystem = RuntimeInformation.OSDescription.Trim();

--- a/device/Microsoft.Azure.Devices.Client/Properties/AssemblyInfo.cs
+++ b/device/Microsoft.Azure.Devices.Client/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 
 // Version information for an assembly follows semantic versioning 1.0.0 (because
 // NuGet didn't support semver 2.0.0 before VS 2015). See semver.org for details.
-[assembly: AssemblyInformationalVersion("1.17.0-preview-001")]
+[assembly: AssemblyInformationalVersion("1.17.0-preview-002")]

--- a/device/NuGet/Microsoft.Azure.Devices.Client.nuspec
+++ b/device/NuGet/Microsoft.Azure.Devices.Client.nuspec
@@ -15,7 +15,7 @@
         <language>en-US</language>
         <dependencies>
             <group targetFramework="net451" >
-                <dependency id="Microsoft.Azure.Devices.Shared" version="1.15.0-preview-001" />
+                <dependency id="Microsoft.Azure.Devices.Shared" version="1.15.0-preview-002" />
                 <dependency id="DotNetty.Codecs.Mqtt" version="0.4.7" />
                 <dependency id="DotNetty.Handlers" version="0.4.7" />
                 <dependency id="Microsoft.Azure.Amqp" version="2.1.3" />
@@ -38,7 +38,7 @@
             </group>
 
             <group targetFramework="uap10.0">
-                <dependency id="Microsoft.Azure.Devices.Shared" version="1.15.0-preview-001" />
+                <dependency id="Microsoft.Azure.Devices.Shared" version="1.15.0-preview-002" />
                 <dependency id="DotNetty.Codecs.Mqtt" version="0.4.7" />
                 <dependency id="DotNetty.Handlers" version="0.4.7" />
                 <dependency id="Microsoft.Azure.Amqp" version="2.1.3" />
@@ -52,7 +52,7 @@
             </group>
 
             <group targetFramework="netstandard1.3" >
-                <dependency id="Microsoft.Azure.Devices.Shared" version="1.15.0-preview-001" />
+                <dependency id="Microsoft.Azure.Devices.Shared" version="1.15.0-preview-002" />
                 <dependency id="DotNetty.Codecs.Mqtt" version="0.4.7" />
                 <dependency id="DotNetty.Handlers" version="0.4.7" />
                 <dependency id="Microsoft.Azure.Amqp" version="2.1.3" />

--- a/service/Microsoft.Azure.Devices.NetStandard/Properties/AssemblyInfo.cs
+++ b/service/Microsoft.Azure.Devices.NetStandard/Properties/AssemblyInfo.cs
@@ -39,4 +39,4 @@ using System.Runtime.InteropServices;
 
 // Version information for an assembly follows semantic versioning 1.0.0 (because
 // NuGet didn't support semver 2.0.0 before VS 2015). See semver.org for details.
-[assembly: AssemblyInformationalVersion("1.16.0-preview-001")]
+[assembly: AssemblyInformationalVersion("1.16.0-preview-002")]

--- a/service/Microsoft.Azure.Devices.Uwp/Properties/AssemblyInfo.cs
+++ b/service/Microsoft.Azure.Devices.Uwp/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 
 // Version information for an assembly follows semantic versioning 1.0.0 (because
 // NuGet didn't support semver 2.0.0 before VS 2015). See semver.org for details.
-[assembly: AssemblyInformationalVersion("1.16.0-preview-001")]
+[assembly: AssemblyInformationalVersion("1.16.0-preview-002")]
 
 #if (!DEBUG)
 [assembly: AssemblyDelaySignAttribute(true)]

--- a/service/Microsoft.Azure.Devices/Properties/AssemblyInfo.cs
+++ b/service/Microsoft.Azure.Devices/Properties/AssemblyInfo.cs
@@ -27,7 +27,7 @@ using Microsoft.Azure.Devices.Common;
 
 // Version information for an assembly follows semantic versioning 1.0.0 (because
 // NuGet didn't support semver 2.0.0 before VS 2015). See semver.org for details.
-[assembly: AssemblyInformationalVersion("1.16.0-preview-001")]
+[assembly: AssemblyInformationalVersion("1.16.0-preview-002")]
 
 // Type forwarding
 [assembly: TypeForwardedTo(typeof(AuthenticationType))]

--- a/service/NuGet/Microsoft.Azure.Devices.nuspec
+++ b/service/NuGet/Microsoft.Azure.Devices.nuspec
@@ -15,19 +15,19 @@
     <language>en-US</language>
     <dependencies>
       <group targetFramework="net45" >
-        <dependency id="Microsoft.Azure.Devices.Shared" version="1.15.0-preview-001" />
+        <dependency id="Microsoft.Azure.Devices.Shared" version="1.15.0-preview-002" />
         <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.3" />
         <dependency id="Microsoft.Azure.Amqp" version="2.1.3" />
         <dependency id="Microsoft.Owin" version="3.1.0" />
         <dependency id="Newtonsoft.Json" version="10.0.3" />
       </group>
       <group targetFramework="uap10.0">
-        <dependency id="Microsoft.Azure.Devices.Shared" version="1.15.0-preview-001" />
+        <dependency id="Microsoft.Azure.Devices.Shared" version="1.15.0-preview-002" />
         <dependency id="Microsoft.Azure.Amqp" version="2.1.3" />
         <dependency id="Newtonsoft.Json" version="10.0.3" />
       </group>
       <group targetFramework="netstandard1.3" >
-          <dependency id="Microsoft.Azure.Devices.Shared" version="1.15.0-preview-001" />
+          <dependency id="Microsoft.Azure.Devices.Shared" version="1.15.0-preview-002" />
           <dependency id="Microsoft.Azure.Amqp" version="2.1.3" exclude="Build,Analyzers" />
           <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
           <dependency id="Newtonsoft.Json" version="10.0.3" exclude="Build,Analyzers" />

--- a/shared/Microsoft.Azure.Devices.Shared.UWP/Properties/AssemblyInfo.cs
+++ b/shared/Microsoft.Azure.Devices.Shared.UWP/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 
 // Version information for an assembly follows semantic versioning 1.0.0 (because
 // NuGet didn't support semver 2.0.0 before VS 2015). See semver.org for details.
-[assembly: AssemblyInformationalVersion("1.15.0-preview-001")]
+[assembly: AssemblyInformationalVersion("1.15.0-preview-002")]

--- a/shared/Microsoft.Azure.Devices.Shared/Properties/AssemblyInfo.cs
+++ b/shared/Microsoft.Azure.Devices.Shared/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 
 // Version information for an assembly follows semantic versioning 1.0.0 (because
 // NuGet didn't support semver 2.0.0 before VS 2015). See semver.org for details.
-[assembly: AssemblyInformationalVersion("1.15.0-preview-001")]
+[assembly: AssemblyInformationalVersion("1.15.0-preview-002")]


### PR DESCRIPTION
New versions:

"shared": "1.15.0-preview-002",
"device": "1.17.0-preview-002",
 "service": "1.16.0-preview-002",