### PR TITLE
Bump version of shared.NetStandard

### DIFF
--- a/shared/Microsoft.Azure.Devices.Shared.NetStandard/Properties/AssemblyInfo.cs
+++ b/shared/Microsoft.Azure.Devices.Shared.NetStandard/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using System.Reflection;
 
 // Version information for an assembly follows semantic versioning 1.0.0 (because
 // NuGet didn't support semver 2.0.0 before VS 2015). See semver.org for details.
-[assembly: AssemblyInformationalVersion("1.15.0-preview-001")]
+[assembly: AssemblyInformationalVersion("1.15.0-preview-002")]


### PR DESCRIPTION
Looks like there is a bug in the bump_version script against modules-preview branch. It missed updating the assembly version of shared.NetStandard. But this might not be a problem after we FI with master.