### PR TITLE
Updated to allow non-base64 values for EK and null/empty/non-base64 values for SRK.

### DIFF
--- a/provisioning/service/src/Config/ParserUtility.cs
+++ b/provisioning/service/src/Config/ParserUtility.cs
@@ -45,34 +45,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         }
 
         /// <summary>
-        /// Helper to validate if the provided string is not null, empty, and Base64.
-        /// </summary>
-        /// <param name="input">the <code>string</code> to be validated</param>
-        /// <exception cref="ArgumentException">if the provided <code>string</code> do not fits the criteria</exception>
-        public static void EnsureBase64String(string input)
-        {
-            if (string.IsNullOrWhiteSpace(input))
-            {
-                /* Codes_SRS_PARSER_UTILITY_21_005: [The IsValidBase64 shall throw ArgumentException if the provided string 
-                                                    is null or empty.] */
-                throw new ArgumentException("parameter cannot be null or whiteSpace");
-            }
-
-            /* Codes_SRS_PARSER_UTILITY_21_006: [The IsValidBase64 shall throw ArgumentException if the provided string 
-                                                    contains a non Base64 content.] */
-            try
-            {
-                Convert.FromBase64String(input);
-            }
-            catch (FormatException e)
-            {
-                throw new ArgumentException("parameter is not a valid Base64 string", e);
-            }
-
-            /* Codes_SRS_PARSER_UTILITY_21_004: [The IsValidBase64 shall do nothing if the string is valid.] */
-        }
-
-        /// <summary>
         /// Helper to validate RegistrationId.
         /// </summary>
         /// <remarks>

--- a/provisioning/service/src/Config/TpmAttestation.cs
+++ b/provisioning/service/src/Config/TpmAttestation.cs
@@ -58,9 +58,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             }
             private set
             {
-                /* SRS_TPM_ATTESTATION_21_001: [The EndorsementKey setter shall throws ArgumentException if the provided 
-                                                endorsementKey is null or invalid.] */
-                ParserUtils.EnsureBase64String(value);
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    /* SRS_TPM_ATTESTATION_21_001: [The EndorsementKey setter shall throws ArgumentNullException if the provided 
+                                                endorsementKey is null or white space.] */
+                    throw new ArgumentNullException(nameof(EndorsementKey));
+                }
                 _endorsementKey = value;
             }
         }
@@ -78,12 +81,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             }
             private set
             {
-                /* SRS_TPM_ATTESTATION_21_002: [The StorageRootKey setter shall throws ArgumentException if the provided 
-                                                storageRootKey is not null but invalid.] */
-                if (value != null)
-                {
-                    ParserUtils.EnsureBase64String(value);
-                }
+                /* SRS_TPM_ATTESTATION_21_002: [The StorageRootKey setter shall store the storageRootKey passed.] */
                 _storageRootKey = value;
             }
         }

--- a/provisioning/service/tests/Config/ParserUtilsTests.cs
+++ b/provisioning/service/tests/Config/ParserUtilsTests.cs
@@ -31,29 +31,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
             TestAssert.Throws<ArgumentException>(() => ParserUtils.EnsureUTF8String("this is not a valid UTF8 \u1234"));
         }
 
-        /* Codes_SRS_PARSER_UTILITY_21_004: [The IsValidBase64 shall do nothing if the string is valid.] */
-        [TestMethod]
-        [TestCategory("DevService")]
-        public void ParserUtils_IsValidBase64_SucceedOnBase64()
-        {
-            // arrange - act - assert
-            ParserUtils.EnsureBase64String("thisisavalidbase64==");
-        }
-
-        /* Codes_SRS_PARSER_UTILITY_21_005: [The IsValidBase64 shall throw ArgumentException if the provided string is null or empty.] */
-        /* Codes_SRS_PARSER_UTILITY_21_006: [The IsValidBase64 shall throw ArgumentException if the provided string contains a non Base64 content.] */
-        [TestMethod]
-        [TestCategory("DevService")]
-        public void ParserUtils_IsValidBase64_ThrowsOnInvalidBase64()
-        {
-            // arrange - act - assert
-            TestAssert.Throws<ArgumentException>(() => ParserUtils.EnsureBase64String(null));
-            TestAssert.Throws<ArgumentException>(() => ParserUtils.EnsureBase64String(""));
-            TestAssert.Throws<ArgumentException>(() => ParserUtils.EnsureBase64String("  "));
-            TestAssert.Throws<ArgumentException>(() => ParserUtils.EnsureBase64String("thisisnotavalidbase64="));
-            TestAssert.Throws<ArgumentException>(() => ParserUtils.EnsureBase64String("this is not a valid UTF8 \u1234"));
-        }
-
         /* Codes_SRS_PARSER_UTILITY_21_007: [The IsValidRegistrationId shall do nothing if the string is a valid ID.] */
         [TestMethod]
         [TestCategory("DevService")]

--- a/provisioning/service/tests/Config/TpmAttestationTests.cs
+++ b/provisioning/service/tests/Config/TpmAttestationTests.cs
@@ -10,13 +10,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
     [TestClass]
     public class TpmAttestationTests
     {
-        private const string KEY = "AToAAQALAAMAsgAgg3GXZ0SEs/gakMyNRqXXJP1S124GUgtk8qHaGzMUaaoABgCAAEMAEAgAAAAAAAEAxsj" +
+        private const string Key = "AToAAQALAAMAsgAgg3GXZ0SEs/gakMyNRqXXJP1S124GUgtk8qHaGzMUaaoABgCAAEMAEAgAAAAAAAEAxsj" +
            "2gUScTk1UjuioeTlfGYZrrimExB+bScH75adUMRIi2UOMxG1kw4y+9RW/IVoMl4e620VxZad0ARX2gUqVjYO7KPVt3dyKhZS3dkcvfBisB" +
            "hP1XH9B33VqHG9SHnbnQXdBUaCgKAfxome8UmBKfe+naTsE5fkvjb/do3/dD6l4sGBwFCnKRdln4XpM03zLpoHFao8zOwt8l/uP3qUIxmC" +
            "Yv9A7m69Ms+5/pCkTu/rK4mRDsfhZ0QLfbzVI6zQFOKF/rwsfBtFeWlWtcuJMKlXdD8TXWElTzgh7JS4qhFzreL0c1mI0GCj+Aws0usZh7" +
            "dLIVPnlgZcBhgy1SSDQMQ==";
 
-        /* SRS_TPM_ATTESTATION_21_001: [The EndorsementKey setter shall throws ArgumentException if the provided endorsementKey is null or invalid.] */
+        /* SRS_TPM_ATTESTATION_21_001: [The EndorsementKey setter shall throws ArgumentNullException if the provided 
+         *                              endorsementKey is null or white space.] */
         [TestMethod]
         [TestCategory("DevService")]
         public void TpmAttestation_ThrowsOnNullEndorsementKey()
@@ -30,7 +31,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
 
         [TestMethod]
         [TestCategory("DevService")]
-        public void TpmAttestation_ThrowsOnEnptyEndorsementKey()
+        public void TpmAttestation_ThrowsOnEmptyEndorsementKey()
         {
             // arrange
             string endorsementKey = "";
@@ -39,24 +40,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
             TestAssert.Throws<ProvisioningServiceClientException>(() => new TpmAttestation(endorsementKey));
         }
 
-        [TestMethod]
-        [TestCategory("DevService")]
-        public void TpmAttestation_ThrowsOnNonBase64EndorsementKey()
-        {
-            // arrange
-            string endorsementKey = "This is not base64";
-
-            // act - assert
-            TestAssert.Throws<ProvisioningServiceClientException>(() => new TpmAttestation(endorsementKey));
-        }
-
-        /* SRS_TPM_ATTESTATION_21_002: [The StorageRootKey setter shall throws ArgumentException if the provided storageRootKey is not null but invalid.] */
+        /* SRS_TPM_ATTESTATION_21_002: [The StorageRootKey setter shall store the storageRootKey passed.] */
         [TestMethod]
         [TestCategory("DevService")]
         public void TpmAttestation_SucceedOnNullStorageRootKey()
         {
             // arrange
-            string endorsementKey = KEY;
+            string endorsementKey = Key;
             string storageRootKey = null;
 
             // act - assert
@@ -69,26 +59,18 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
 
         [TestMethod]
         [TestCategory("DevService")]
-        public void TpmAttestation_ThrowsOnEnptyStorageRootKey()
+        public void TpmAttestation_SucceedOnEmptyStorageRootKey()
         {
             // arrange
-            string endorsementKey = KEY;
+            string endorsementKey = Key;
             string storageRootKey = "";
 
             // act - assert
-            TestAssert.Throws<ProvisioningServiceClientException>(() => new TpmAttestation(endorsementKey, storageRootKey));
-        }
+            TpmAttestation tpmAttestation = new TpmAttestation(endorsementKey, storageRootKey);
 
-        [TestMethod]
-        [TestCategory("DevService")]
-        public void TpmAttestation_ThrowsOnNonBase64StorageRootKey()
-        {
-            // arrange
-            string endorsementKey = KEY;
-            string storageRootKey = "This is not base64";
-
-            // act - assert
-            TestAssert.Throws<ProvisioningServiceClientException>(() => new TpmAttestation(endorsementKey, storageRootKey));
+            // assert
+            Assert.AreEqual(endorsementKey, tpmAttestation.EndorsementKey);
+            Assert.AreEqual(storageRootKey, tpmAttestation.StorageRootKey);
         }
 
         /* SRS_TPM_ATTESTATION_21_003: [The constructor shall store the provided endorsementKey and storageRootKey.] */
@@ -97,7 +79,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TpmAttestation_SucceedOnValidEndorsementKey()
         {
             // arrange
-            string endorsementKey = KEY;
+            string endorsementKey = Key;
 
             // act
             TpmAttestation tpmAttestation = new TpmAttestation(endorsementKey);
@@ -112,8 +94,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TpmAttestation_SucceedOnValidEndorsementKeyAndStorageRootKey()
         {
             // arrange
-            string endorsementKey = KEY;
-            string storageRootKey = KEY;
+            string endorsementKey = Key;
+            string storageRootKey = Key;
 
             // act
             TpmAttestation tpmAttestation = new TpmAttestation(endorsementKey, storageRootKey);
@@ -129,8 +111,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TpmAttestation_SucceedOnSerialization()
         {
             // arrange
-            string endorsementKey = KEY;
-            string storageRootKey = KEY;
+            string endorsementKey = Key;
+            string storageRootKey = Key;
             string expectedJson = 
                 "{" +
                 "  \"endorsementKey\":\""+endorsementKey+"\"," +
@@ -150,7 +132,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TpmAttestation_SucceedOnSerializationWithoutStorageRootKey()
         {
             // arrange
-            string endorsementKey = KEY;
+            string endorsementKey = Key;
             string expectedJson =
                 "{" +
                 "  \"endorsementKey\":\"" + endorsementKey + "\"" +
@@ -166,11 +148,32 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
 
         [TestMethod]
         [TestCategory("DevService")]
+        public void TpmAttestation_SucceedOnSerializationWithEmptyStorageRootKey()
+        {
+            // arrange
+            string endorsementKey = Key;
+            string storageRootKey = "";
+            string expectedJson =
+                "{" +
+                "  \"endorsementKey\":\"" + endorsementKey + "\"," +
+                "  \"storageRootKey\":\"" + storageRootKey + "\"" +
+                "}";
+            TpmAttestation tpmAttestation = new TpmAttestation(endorsementKey, storageRootKey);
+
+            // act
+            string json = Newtonsoft.Json.JsonConvert.SerializeObject(tpmAttestation);
+
+            // assert
+            TestAssert.AreEqualJson(expectedJson, json);
+        }
+
+        [TestMethod]
+        [TestCategory("DevService")]
         public void TpmAttestation_SucceedOnDeserialization()
         {
             // arrange
-            string endorsementKey = KEY;
-            string storageRootKey = KEY;
+            string endorsementKey = Key;
+            string storageRootKey = Key;
             string json =
                 "{" +
                 "  \"endorsementKey\":\"" + endorsementKey + "\"," +
@@ -190,7 +193,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TpmAttestation_ThrowsOnDeserializationWithoutEndorsementKey()
         {
             // arrange
-            string storageRootKey = KEY;
+            string storageRootKey = Key;
             string json =
                 "{" +
                 "  \"storageRootKey\":\"" + storageRootKey + "\"" +
@@ -205,7 +208,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TpmAttestation_ThrowsOnDeserializationWithEmptyEndorsementKey()
         {
             // arrange
-            string storageRootKey = KEY;
+            string storageRootKey = Key;
             string json =
                 "{" +
                 "  \"endorsementKey\":\"\"," +
@@ -214,6 +217,45 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
 
             // act - assert
             TestAssert.Throws<ProvisioningServiceClientException>(() => Newtonsoft.Json.JsonConvert.DeserializeObject<TpmAttestation>(json));
+        }
+
+        [TestMethod]
+        [TestCategory("DevService")]
+        public void TpmAttestation_SucceedOnDeserializationWithoutStorageRootKey()
+        {
+            // arrange
+            string endorsementKey = Key;
+            string json =
+                "{" +
+                "  \"endorsementKey\":\"" + endorsementKey + "\"," +
+                "}";
+
+            // act
+            TpmAttestation tpmAttestation = Newtonsoft.Json.JsonConvert.DeserializeObject<TpmAttestation>(json);
+
+            // assert
+            Assert.AreEqual(endorsementKey, tpmAttestation.EndorsementKey);
+        }
+
+        [TestMethod]
+        [TestCategory("DevService")]
+        public void TpmAttestation_SucceedOnDeserializationWithEmptyStorageRootKey()
+        {
+            // arrange
+            string endorsementKey = Key;
+            string storageRootKey = "";
+            string json =
+                "{" +
+                "  \"endorsementKey\":\"" + endorsementKey + "\"," +
+                "  \"storageRootKey\":\"" + storageRootKey + "\"" +
+                "}";
+
+            // act
+            TpmAttestation tpmAttestation = Newtonsoft.Json.JsonConvert.DeserializeObject<TpmAttestation>(json);
+
+            // assert
+            Assert.AreEqual(endorsementKey, tpmAttestation.EndorsementKey);
+            Assert.AreEqual(storageRootKey, tpmAttestation.StorageRootKey);
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

# Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

# Description of the changes

- Modified the DPS Service code to allow non-base64 values for Endorsement Key and null/empty/non-base64 values for Storage Root Key.

# Reference/Link to the issue solved with this PR (if any)
Fixes #378
