### PR TITLE
Support versions with pre-release labels

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <Version>1.7.0</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/iothub/device/src/ProductInfo.cs
+++ b/iothub/device/src/ProductInfo.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices.Client
         public override string ToString()
         {
             const string Name = "Microsoft.Azure.Devices.Client";
-            string version = typeof(DeviceClient).GetTypeInfo().Assembly.GetName().Version.ToString(3);
+            string version = typeof(DeviceClient).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
             string runtime = RuntimeInformation.FrameworkDescription.Trim();
             string operatingSystem = RuntimeInformation.OSDescription.Trim();
             string processorArchitecture = RuntimeInformation.ProcessArchitecture.ToString().Trim();

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.6.0</VersionPrefix>
+    <Version>1.6.0</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <Version>1.1.0</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client SDK</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <Version>1.1.0</Version>
     <Title>Microsoft Azure IoT Provisioning Service Client SDK</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <Version>1.1.0</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client AMQP Transport</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
+++ b/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <Version>1.1.0</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client HTTP Transport</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
+++ b/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <Version>1.1.0</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client MQTT Transport</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
+++ b/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <Version>1.1.0</Version>
     <Title>Microsoft Azure IoT Provisioning Device Security TPM Client</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/shared/src/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/src/Microsoft.Azure.Devices.Shared.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <Version>1.5.0</Version>
     <Title>Microsoft Azure IoT Devices Shared</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/versionupdate.ps1
+++ b/versionupdate.ps1
@@ -32,13 +32,13 @@ Function GetVersion($path) {
     $extension = Split-Path -leaf $path
     
     $x = [xml](Get-Content $path)
-    $versionNode = Select-Xml "//VersionPrefix" $x
+    $versionNode = Select-Xml "//Version" $x
     return $versionNode
 }
 
 Function UpdateVersion($path, $currentVersion, $desiredVersion) {
-    $actual = "<VersionPrefix>$currentVersion</VersionPrefix>"
-    $desired = "<VersionPrefix>$desiredVersion</VersionPrefix>"
+    $actual = "<Version>$currentVersion</Version>"
+    $desired = "<Version>$desiredVersion</Version>"
     (Get-Content $path) -replace $actual, $desired | Set-Content -Encoding UTF8 $path
 }
 


### PR DESCRIPTION
There are two things that prevent us from using a pre-release label on the versions of components in this SDK:

1. Our csproj files store the version in the `<VersionPrefix>` element. We either need to pair this with a `<VersionSuffix>` element which holds the pre-release label, or we can simply use `<Version>`, which holds both the prefix and suffix together. This is the easier solution because it means we don't need to parse our versions into a prefix and suffix.
2. Use the InformationalVersion in our User-Agent (aka ProductInfo) string. The InformationalVersion includes the pre-release label, if one exists.

This PR includes the changes to support pre-release labels in our component versions.