### PR TITLE
Allow SHA256 thumbprints for X.509 self-signed certificates

### DIFF
--- a/iothub/service/src/ApiResources.Designer.cs
+++ b/iothub/service/src/ApiResources.Designer.cs
@@ -335,10 +335,13 @@ namespace Microsoft.Azure.Devices {
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid X.509 thumbprint.
         /// </summary>
-        internal static string StringIsNotThumbprint {
-            get {
+        internal static string StringIsNotThumbprint
+        {
+            get
+            {
                 return ResourceManager.GetString("StringIsNotThumbprint", resourceCulture);
             }
+        }
   
         /// <summary>
         ///   Looks up a localized string similar to The size of the X.509 primary thumbprint must match that of the secondary thumbprint..

--- a/iothub/service/src/ApiResources.Designer.cs
+++ b/iothub/service/src/ApiResources.Designer.cs
@@ -339,6 +339,16 @@ namespace Microsoft.Azure.Devices {
             get {
                 return ResourceManager.GetString("StringIsNotThumbprint", resourceCulture);
             }
+  
+        /// <summary>
+        ///   Looks up a localized string similar to The size of the X.509 primary thumbprint must match that of the secondary thumbprint..
+        /// </summary>
+        internal static string ThumbprintSizesMustMatch
+        {
+            get
+            {
+                return ResourceManager.GetString("ThumbprintSizesMustMatch", resourceCulture);
+            }
         }
     }
 }

--- a/iothub/service/src/ApiResources.resx
+++ b/iothub/service/src/ApiResources.resx
@@ -210,4 +210,7 @@
   <data name="InvalidImportMode" xml:space="preserve">
     <value>ImportMode not handled: {0}</value>
   </data>
+  <data name="ThumbprintSizesMustMatch" xml:space="preserve">
+    <value>The size of the X.509 primary thumbprint must match that of the secondary thumbprint.</value>
+  </data>
 </root>

--- a/iothub/service/src/X509ThumbprintExtensions.cs
+++ b/iothub/service/src/X509ThumbprintExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Devices
@@ -12,8 +12,9 @@ namespace Microsoft.Azure.Devices
     /// </summary>
     public static class X509ThumbprintExtensions
     {
-        static readonly Regex ThumbprintRegex = new Regex(@"^([A-Fa-f0-9]{2}){20}$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
+        static readonly Regex SHA1ThumbprintRegex = new Regex(@"^([a-f0-9]{2}){20}$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        static readonly Regex SHA256ThumbprintRegex = new Regex(@"^([a-f0-9]{2}){32}$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        
         /// <summary>
         /// Checks if contents are valid
         /// </summary>
@@ -23,6 +24,17 @@ namespace Microsoft.Azure.Devices
         {
             if (!x509Thumbprint.IsEmpty())
             {
+                int primaryThumbprintLength = this.PrimaryThumbprint?.Length ?? 0;
+                int secondaryThumbprintLength = this.SecondaryThumbprint?.Length ?? 0;
+
+                if (primaryThumbprintLength != secondaryThumbprintLength)
+                {
+                    if (primaryThumbprintLength != 0 && secondaryThumbprintLength != 0)
+                    {
+                        throw new ArgumentException(ApiResources.StringIsNotThumbprint.FormatInvariant(x509Thumbprint.PrimaryThumbprint), "Primary Thumbprint"));
+                    }
+                }
+                
                 bool primaryThumbprintIsValid = X509ThumbprintExtensions.IsValidThumbprint(x509Thumbprint.PrimaryThumbprint);
                 bool secondaryThumbprintIsValid = X509ThumbprintExtensions.IsValidThumbprint(x509Thumbprint.SecondaryThumbprint);
 
@@ -90,7 +102,8 @@ namespace Microsoft.Azure.Devices
 
         public static bool IsValidThumbprint(string thumbprint)
         {
-            return thumbprint != null && ThumbprintRegex.IsMatch(thumbprint);
+            return thumbprint != null &&
+                ( SHA1ThumbprintRegex.IsMatch(thumbprint) || (SHA256ThumbprintRegex.IsMatch(thumbprint)));
         }
     }
 }

--- a/iothub/service/src/X509ThumbprintExtensions.cs
+++ b/iothub/service/src/X509ThumbprintExtensions.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Azure.Devices
         {
             if (!x509Thumbprint.IsEmpty())
             {
-                int primaryThumbprintLength = this.PrimaryThumbprint?.Length ?? 0;
-                int secondaryThumbprintLength = this.SecondaryThumbprint?.Length ?? 0;
+                int primaryThumbprintLength = x509Thumbprint.PrimaryThumbprint?.Length ?? 0;
+                int secondaryThumbprintLength = x509Thumbprint.SecondaryThumbprint?.Length ?? 0;
 
                 if (primaryThumbprintLength != secondaryThumbprintLength)
                 {

--- a/iothub/service/src/X509ThumbprintExtensions.cs
+++ b/iothub/service/src/X509ThumbprintExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices
                 {
                     if (primaryThumbprintLength != 0 && secondaryThumbprintLength != 0)
                     {
-                        throw new ArgumentException(ApiResources.StringIsNotThumbprint.FormatInvariant(x509Thumbprint.PrimaryThumbprint), "Primary Thumbprint"));
+                        throw new ArgumentException(ApiResources.ThumbprintSizesMustMatch);
                     }
                 }
                 

--- a/iothub/service/tests/DeviceAuthenticationTests.cs
+++ b/iothub/service/tests/DeviceAuthenticationTests.cs
@@ -197,6 +197,35 @@ namespace Microsoft.Azure.Devices.Api.Test
         [TestMethod]
         [TestCategory("CIT")]
         [TestCategory("Auth")]
+        public async Task DeviceAuthenticationGoodAuthSHA256()
+        {
+            var deviceBadAuthConfig = new Device("123")
+            {
+                ConnectionState = DeviceConnectionState.Connected,
+                Authentication = new AuthenticationMechanism()
+                {
+                    SymmetricKey = null,
+                    X509Thumbprint = new X509Thumbprint()
+                    {
+                        PrimaryThumbprint = "921BC9694ADEB8929D4F7FE4B9A3A6DE58B0790B7FE4B9A3A6DE58B0790B790B",
+                        SecondaryThumbprint = "781BC9694ADEB8929D4F7FE4B9A3A6DE58B079527FE4B9A3A6DE58B079527952"
+                    }
+                }
+            };
+
+            var restOpMock = new Mock<IHttpClientHelper>();
+            restOpMock.Setup(
+                restOp =>
+                    restOp.PutAsync(It.IsAny<Uri>(), It.IsAny<Device>(), It.IsAny<PutOperationType>(),
+                        It.IsAny<IDictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>>(),
+                        It.IsAny<CancellationToken>())).ReturnsAsync(deviceBadAuthConfig);
+            var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);
+            await registryManager.AddDeviceAsync(deviceBadAuthConfig).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("CIT")]
+        [TestCategory("Auth")]
         [ExpectedException(typeof (ArgumentException))]
         public async Task DeviceAuthenticationBadAuthConfigTest1()
         {
@@ -632,6 +661,36 @@ namespace Microsoft.Azure.Devices.Api.Test
                         It.IsAny<CancellationToken>())).ReturnsAsync(deviceBadThumbprint);
             var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);
             await registryManager.AddDeviceAsync(deviceBadThumbprint).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("CIT")]
+        [TestCategory("Auth")]
+        [ExpectedException(typeof(ArgumentException))]
+        public async Task DeviceAuthenticationBadThumbprintSHA256Test()
+        {
+            var deviceBadAuthConfig = new Device("123")
+            {
+                ConnectionState = DeviceConnectionState.Connected,
+                Authentication = new AuthenticationMechanism()
+                {
+                    SymmetricKey = null,
+                    X509Thumbprint = new X509Thumbprint()
+                    {
+                        PrimaryThumbprint = "921BC9694ADEB8929D4F7FE4B9A3A6DE58B0790B7FE4B9A3A6DE58B0790B790B",
+                        SecondaryThumbprint = "781BC9694ADEB8929D4F7FE4B9A3A6DE58B07952"
+                    }
+                }
+            };
+
+            var restOpMock = new Mock<IHttpClientHelper>();
+            restOpMock.Setup(
+                restOp =>
+                    restOp.PutAsync(It.IsAny<Uri>(), It.IsAny<Device>(), It.IsAny<PutOperationType>(),
+                        It.IsAny<IDictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>>(),
+                        It.IsAny<CancellationToken>())).ReturnsAsync(deviceBadAuthConfig);
+            var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);
+            await registryManager.AddDeviceAsync(deviceBadAuthConfig).ConfigureAwait(false);
         }
 
         [TestMethod]


### PR DESCRIPTION
Allow SHA256 thumbprints for X.509 self-signed certificates

<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

# Checklist
- [x ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

# Description of the changes
<!-- Itemized list of changes. -->
Allow SHA256 thumbprints  for X.509 self-signed certificates
# Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
