### PR TITLE
DeviceClient / ModuleClient split

### DIFF
--- a/iothub/device/src/BaseClient.cs
+++ b/iothub/device/src/BaseClient.cs
@@ -106,7 +106,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
     /// <summary>
     /// Contains methods that a device can use to send messages to and receive from the service.
     /// </summary>
-    public abstract class BaseClient : IDisposable
+    public class BaseClient : IDisposable
     {
         internal const string DeviceId = "DeviceId";
         internal const string DeviceIdParameterPattern = @"(^\s*?|.*;\s*?)" + DeviceId + @"\s*?=.*";

--- a/iothub/device/src/BaseClient.cs
+++ b/iothub/device/src/BaseClient.cs
@@ -1,0 +1,1031 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Client
+{
+    using Common;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+#if NETSTANDARD1_3
+    using System.Net.Http;
+#endif
+    using System.Text.RegularExpressions;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Client.Extensions;
+    using Microsoft.Azure.Devices.Client.Transport;
+    using Microsoft.Azure.Devices.Shared;
+    using Newtonsoft.Json.Linq;
+    using Microsoft.Azure.Devices.Client.Transport.Mqtt;
+    using System.Security.Cryptography.X509Certificates;
+
+    /// <summary>
+    /// Delegate for desired property update callbacks.  This will be called
+    /// every time we receive a PATCH from the service.
+    /// </summary>
+    /// <param name="desiredProperties">Properties that were contained in the update that was received from the service</param>
+    /// <param name="userContext">Context object passed in when the callback was registered</param>
+    public delegate Task DesiredPropertyUpdateCallback(TwinCollection desiredProperties, object userContext);
+
+    /// <summary>
+    ///      Delegate for method call. This will be called every time we receive a method call that was registered.
+    /// </summary>
+    /// <param name="methodRequest">Class with details about method.</param>
+    /// <param name="userContext">Context object passed in when the callback was registered.</param>
+    /// <returns>MethodResponse</returns>
+    public delegate Task<MethodResponse> MethodCallback(MethodRequest methodRequest, object userContext);
+
+    /// <summary>
+    /// Delegate for connection status changed.
+    /// </summary>
+    /// <param name="status">The updated connection status</param>
+    /// <param name="reason">The reason for the connection status change</param>
+    public delegate void ConnectionStatusChangesHandler(ConnectionStatus status, ConnectionStatusChangeReason reason);
+
+    /*
+     * Class Diagram and Chain of Responsibility in Device Client 
+                                     +--------------------+
+                                     | <<interface>>      |
+                                     | IDelegatingHandler |
+                                     |  * Open            |
+                                     |  * Close           |
+                                     |  * SendEvent       |
+                                     |  * SendEvents      |
+                                     |  * Receive         |
+                                     |  * Complete        |
+                                     |  * Abandon         |
+                                     |  * Reject          |
+                                     +-------+------------+
+                                             |
+                                             |implements
+                                             |
+                                             |
+                                     +-------+-------+
+                                     |  <<abstract>> |     
+                                     |  Default      |
+             +---+inherits----------->  Delegating   <------inherits-----------------+
+             |                       |  Handler      |                               |
+             |           +--inherits->               <--inherits----+                |
+             |           |           +-------^-------+              |                |
+             |           |                   |inherits              |                |
+             |           |                   |                      |                |
++------------+       +---+---------+      +--+----------+       +---+--------+       +--------------+
+|            |       |             |      |             |       |            |       | <<abstract>> |
+| GateKeeper |  use  | Retry       | use  |  Error      |  use  | Routing    |  use  | Transport    |
+| Delegating +-------> Delegating  +------>  Delegating +-------> Delegating +-------> Delegating   |
+| Handler    |       | Handler     |      |  Handler    |       | Handler    |       | Handler      |
+|            |       |             |      |             |       |            |       |              |
+| overrides: |       | overrides:  |      |  overrides  |       | overrides: |       | overrides:   |
+|  Open      |       |  Open       |      |   Open      |       |  Open      |       |  Receive     |
+|  Close     |       |  SendEvent  |      |   SendEvent |       |            |       |              |
+|            |       |  SendEvents |      |   SendEvents|       +------------+       +--^--^---^----+
++------------+       |  Receive    |      |   Receive   |                               |  |   |
+                     |  Reject     |      |   Reject    |                               |  |   |
+                     |  Abandon    |      |   Abandon   |                               |  |   |
+                     |  Complete   |      |   Complete  |                               |  |   |
+                     |             |      |             |                               |  |   |
+                     +-------------+      +-------------+     +-------------+-+inherits-+  |   +---inherits-+-------------+
+                                                              |             |              |                |             |
+                                                              | AMQP        |              inherits         | HTTP        |
+                                                              | Transport   |              |                | Transport   |
+                                                              | Handler     |          +---+---------+      | Handler     |
+                                                              |             |          |             |      |             |
+                                                              | overrides:  |          | MQTT        |      | overrides:  |
+                                                              |  everything |          | Transport   |      |  everything |
+                                                              |             |          | Handler     |      |             |
+                                                              +-------------+          |             |      +-------------+
+                                                                                       | overrides:  |
+                                                                                       |  everything |
+                                                                                       |             |
+                                                                                       +-------------+
+TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have to many overloads in most of the classes.
+*/
+
+    /// <summary>
+    /// Contains methods that a device can use to send messages to and receive from the service.
+    /// </summary>
+    public abstract class BaseClient : IDisposable
+    {
+        internal const string DeviceId = "DeviceId";
+        internal const string DeviceIdParameterPattern = @"(^\s*?|.*;\s*?)" + DeviceId + @"\s*?=.*";
+
+        internal IotHubConnectionString IotHubConnectionString { get; }
+
+        /// <summary> 
+        /// Diagnostic sampling percentage value, [0-100];  
+        /// 0 means no message will carry on diag info 
+        /// </summary>
+        int _diagnosticSamplingPercentage = 0;
+        public int DiagnosticSamplingPercentage
+        {
+            get { return _diagnosticSamplingPercentage; }
+            set
+            {
+                if (value > 100 || value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(DiagnosticSamplingPercentage), DiagnosticSamplingPercentage,
+                        "The range of diagnostic sampling percentage should between [0,100].");
+                }
+
+                if (IsE2EDiagnosticSupportedProtocol())
+                {
+                    _diagnosticSamplingPercentage = value;
+                }
+            }
+        }
+
+        ITransportSettings[] transportSettings;
+
+        internal X509Certificate2 Certificate { get; set; }
+        const RegexOptions RegexOptions = System.Text.RegularExpressions.RegexOptions.Compiled | System.Text.RegularExpressions.RegexOptions.IgnoreCase;
+        internal static readonly Regex DeviceIdParameterRegex = new Regex(DeviceIdParameterPattern, RegexOptions);
+
+        internal IDelegatingHandler InnerHandler { get; set; }
+
+        SemaphoreSlim methodsDictionarySemaphore = new SemaphoreSlim(1, 1);
+
+        public const string ModuleTwinsPropertyName = "moduleTwins";
+        public const string MetadataName = "$metadata";
+
+        DeviceClientConnectionStatusManager connectionStatusManager = new DeviceClientConnectionStatusManager();
+
+        public const uint DefaultOperationTimeoutInMilliseconds = 4 * 60 * 1000;
+
+        /// <summary>
+        /// Stores the timeout used in the operation retries.
+        /// </summary>
+        // Codes_SRS_DEVICECLIENT_28_002: [This property shall be defaulted to 240000 (4 minutes).]
+        public uint OperationTimeoutInMilliseconds { get; set; } = DefaultOperationTimeoutInMilliseconds;
+
+        /// <summary>
+        /// Stores the retry strategy used in the operation retries.
+        /// </summary>
+        // Codes_SRS_DEVICECLIENT_28_001: [This property shall be defaulted to the exponential retry strategy with backoff 
+        // parameters for calculating delay in between retries.]
+        [Obsolete("This method has been deprecated.  Please use Microsoft.Azure.Devices.Client.SetRetryPolicy(IRetryPolicy retryPolicy) instead.")]
+        public RetryPolicyType RetryPolicy { get; set; }
+
+        /// <summary>
+        /// Sets the retry policy used in the operation retries.
+        /// </summary>
+        /// <param name="retryPolicy">The retry policy. The default is new ExponentialBackoff(int.MaxValue, TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(100));</param>
+        // Codes_SRS_DEVICECLIENT_28_001: [This property shall be defaulted to the exponential retry strategy with backoff 
+        // parameters for calculating delay in between retries.]
+        public void SetRetryPolicy(IRetryPolicy retryPolicy)
+        {
+            var retryDelegatingHandler = GetDelegateHandler<RetryDelegatingHandler>();
+            if (retryDelegatingHandler == null)
+            {
+                throw new NotSupportedException();
+            }
+
+            retryDelegatingHandler.SetRetryPolicy(retryPolicy);
+        }
+
+
+        private T GetDelegateHandler<T>() where T : DefaultDelegatingHandler
+        {
+            var handler = this.InnerHandler as DefaultDelegatingHandler;
+            bool isFound = false;
+
+            while (!isFound || handler == null)
+            {
+                if (handler is T)
+                {
+                    isFound = true;
+                }
+                else
+                {
+                    handler = handler.InnerHandler as DefaultDelegatingHandler;
+                }
+            }
+
+            if (!isFound)
+            {
+                return default(T);
+            }
+
+            return (T)handler;
+        }
+
+        /// <summary>
+        /// Stores Methods supported by the client device and their associated delegate.
+        /// </summary>
+        volatile Dictionary<string, Tuple<MethodCallback, object>> deviceMethods;
+
+        volatile Tuple<MethodCallback, object> deviceDefaultMethodCallback;
+
+        volatile ConnectionStatusChangesHandler connectionStatusChangesHandler;
+
+        internal delegate Task OnMethodCalledDelegate(MethodRequestInternal methodRequestInternal);
+
+        internal delegate Task OnConnectionClosedDelegate(object sender, ConnectionEventArgs e);
+
+        internal delegate void OnConnectionOpenedDelegate(object sender, ConnectionEventArgs e);
+
+        internal delegate Task OnReceiveEventMessageCalledDelegate(string input, Message message);
+
+        /// <summary>
+        /// Callback to call whenever the twin's desired state is updated by the service
+        /// </summary>
+        internal DesiredPropertyUpdateCallback desiredPropertyUpdateCallback;
+
+        /// <summary>
+        /// Has twin funcitonality been enabled with the service?
+        /// </summary>
+        Boolean patchSubscribedWithService = false;
+
+        /// <summary>
+        /// userContext passed when registering the twin patch callback
+        /// </summary>
+        Object twinPatchCallbackContext = null;
+
+        private int _currentMessageCount = 0;
+
+        internal BaseClient(IotHubConnectionString iotHubConnectionString, ITransportSettings[] transportSettings)
+        {
+            this.IotHubConnectionString = iotHubConnectionString;
+            this.transportSettings = transportSettings;
+        }
+
+        internal static void ValidateTransportSettings(ITransportSettings[] transportSettings)
+        {
+            foreach (ITransportSettings transportSetting in transportSettings)
+            {
+                switch (transportSetting.GetTransportType())
+                {
+                    case TransportType.Amqp_WebSocket_Only:
+                    case TransportType.Amqp_Tcp_Only:
+                        if (!(transportSetting is AmqpTransportSettings))
+                        {
+                            throw new InvalidOperationException("Unknown implementation of ITransportSettings type");
+                        }
+                        break;
+                    case TransportType.Http1:
+                        if (!(transportSetting is Http1TransportSettings))
+                        {
+                            throw new InvalidOperationException("Unknown implementation of ITransportSettings type");
+                        }
+                        break;
+                    case TransportType.Mqtt_WebSocket_Only:
+                    case TransportType.Mqtt_Tcp_Only:
+                        if (!(transportSetting is MqttTransportSettings))
+                        {
+                            throw new InvalidOperationException("Unknown implementation of ITransportSettings type");
+                        }
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unsupported Transport Type {0}".FormatInvariant(transportSetting.GetTransportType()));
+                }
+            }
+        }
+
+        internal static ITransportSettings[] GetTransportSettings(TransportType transportType)
+        {
+            switch (transportType)
+            {
+                case TransportType.Amqp:
+                    return new ITransportSettings[]
+                    {
+                        new AmqpTransportSettings(TransportType.Amqp_Tcp_Only),
+                        new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
+                    };
+
+                case TransportType.Mqtt:
+                    return new ITransportSettings[]
+                    {
+                        new MqttTransportSettings(TransportType.Mqtt_Tcp_Only),
+                        new MqttTransportSettings(TransportType.Mqtt_WebSocket_Only)
+                    };
+
+                case TransportType.Amqp_WebSocket_Only:
+                case TransportType.Amqp_Tcp_Only:
+                    return new ITransportSettings[]
+                    {
+                        new AmqpTransportSettings(transportType)
+                    };
+
+                case TransportType.Mqtt_WebSocket_Only:
+                case TransportType.Mqtt_Tcp_Only:
+                    return new ITransportSettings[]
+                    {
+                        new MqttTransportSettings(transportType)
+                    };
+
+                case TransportType.Http1:
+                    return new ITransportSettings[] { new Http1TransportSettings() };
+
+                default:
+                    throw new InvalidOperationException("Unsupported Transport Type {0}".FormatInvariant(transportType));
+            }
+        }
+
+        internal static IDeviceClientPipelineBuilder BuildPipeline()
+        {
+            var transporthandlerFactory = new TransportHandlerFactory();
+            IDeviceClientPipelineBuilder pipelineBuilder = new DeviceClientPipelineBuilder()
+                .With(ctx => new GateKeeperDelegatingHandler(ctx))
+                .With(ctx => new RetryDelegatingHandler(ctx))
+                .With(ctx => new ErrorDelegatingHandler(ctx))
+                .With(ctx => new ProtocolRoutingDelegatingHandler(ctx))
+                .With(ctx => transporthandlerFactory.Create(ctx));
+            return pipelineBuilder;
+        }
+
+        internal Task SendMethodResponseAsync(MethodResponseInternal methodResponse)
+        {
+            return ApplyTimeout(operationTimeoutCancellationToken =>
+            {
+                return this.InnerHandler.SendMethodResponseAsync(methodResponse, operationTimeoutCancellationToken);
+            });
+        }
+
+        CancellationTokenSource GetOperationTimeoutCancellationTokenSource()
+        {
+            return new CancellationTokenSource(TimeSpan.FromMilliseconds(OperationTimeoutInMilliseconds));
+        }
+
+        /// <summary>
+        /// Explicitly open the DeviceClient instance.
+        /// </summary>
+
+        public Task OpenAsync()
+        {
+            // Codes_SRS_DEVICECLIENT_28_007: [ The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable(authentication, quota exceed) error occurs.]
+            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.OpenAsync(true, operationTimeoutCancellationToken));
+        }
+
+        /// <summary>
+        /// Close the DeviceClient instance
+        /// </summary>
+        /// <returns></returns>
+        public Task CloseAsync()
+        {
+            return this.InnerHandler.CloseAsync();
+        }
+
+        /// <summary>
+        /// Sends an event to device hub
+        /// </summary>
+        /// <returns>The message containing the event</returns>
+        public Task SendEventAsync(Message message)
+        {
+            if (message == null)
+            {
+                throw Fx.Exception.ArgumentNull("message");
+            }
+
+            IoTHubClientDiagnostic.AddDiagnosticInfoIfNecessary(message, _diagnosticSamplingPercentage, ref _currentMessageCount);
+            // Codes_SRS_DEVICECLIENT_28_019: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication or quota exceed) occurs.]
+            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.SendEventAsync(message, operationTimeoutCancellationToken));
+        }
+
+        /// <summary>
+        /// Sends a batch of events to device hub
+        /// </summary>
+        /// <returns>The task containing the event</returns>
+        public Task SendEventBatchAsync(IEnumerable<Message> messages)
+        {
+            if (messages == null)
+            {
+                throw Fx.Exception.ArgumentNull("messages");
+            }
+
+            // Codes_SRS_DEVICECLIENT_28_019: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication or quota exceed) occurs.]
+            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.SendEventAsync(messages, operationTimeoutCancellationToken));
+        }
+
+        protected Task ApplyTimeout(Func<CancellationTokenSource, Task> operation)
+        {
+            if (OperationTimeoutInMilliseconds == 0)
+            {
+                var cancellationTokenSource = new CancellationTokenSource();
+                return operation(cancellationTokenSource)
+                    .WithTimeout(TimeSpan.MaxValue, () => Resources.OperationTimeoutExpired, cancellationTokenSource.Token);
+            }
+
+            CancellationTokenSource operationTimeoutCancellationTokenSource = GetOperationTimeoutCancellationTokenSource();
+
+            var result = operation(operationTimeoutCancellationTokenSource)
+                .WithTimeout(TimeSpan.FromMilliseconds(OperationTimeoutInMilliseconds), () => Resources.OperationTimeoutExpired, operationTimeoutCancellationTokenSource.Token);
+
+            return result.ContinueWith(t =>
+            {
+
+                // operationTimeoutCancellationTokenSource will be disposed by GC. 
+                // Cannot dispose here since we don't know if both tasks created by WithTimeout ran to completion.
+                if (t.IsCanceled)
+                {
+                    throw new TimeoutException(Resources.OperationTimeoutExpired);
+                }
+
+                if (t.IsFaulted)
+                {
+                    throw t.Exception.InnerException;
+                }
+            });
+        }
+
+        internal Task ApplyTimeout(Func<CancellationToken, Task> operation)
+        {
+            if (OperationTimeoutInMilliseconds == 0)
+            {
+                return operation(CancellationToken.None)
+                    .WithTimeout(TimeSpan.MaxValue, () => Resources.OperationTimeoutExpired, CancellationToken.None);
+            }
+
+            CancellationTokenSource operationTimeoutCancellationTokenSource = GetOperationTimeoutCancellationTokenSource();
+
+            Debug.WriteLine(operationTimeoutCancellationTokenSource.Token.GetHashCode() + " DeviceClient.ApplyTimeout()");
+
+            var result = operation(operationTimeoutCancellationTokenSource.Token)
+                .WithTimeout(TimeSpan.FromMilliseconds(OperationTimeoutInMilliseconds), () => Resources.OperationTimeoutExpired, operationTimeoutCancellationTokenSource.Token);
+
+            return result.ContinueWith(t =>
+            {
+                // operationTimeoutCancellationTokenSource will be disposed by GC. 
+                // Cannot dispose here since we don't know if both tasks created by WithTimeout ran to completion.
+                if (t.IsFaulted)
+                {
+                    throw t.Exception.InnerException;
+                }
+            }, TaskContinuationOptions.NotOnCanceled);
+        }
+
+        internal Task<Message> ApplyTimeoutMessage(Func<CancellationToken, Task<Message>> operation)
+        {
+            if (OperationTimeoutInMilliseconds == 0)
+            {
+                return operation(CancellationToken.None)
+                    .WithTimeout(TimeSpan.MaxValue, () => Resources.OperationTimeoutExpired, CancellationToken.None);
+            }
+
+            CancellationTokenSource operationTimeoutCancellationTokenSource = GetOperationTimeoutCancellationTokenSource();
+
+            var result = operation(operationTimeoutCancellationTokenSource.Token)
+                .WithTimeout(TimeSpan.FromMilliseconds(OperationTimeoutInMilliseconds), () => Resources.OperationTimeoutExpired, operationTimeoutCancellationTokenSource.Token);
+
+            return result.ContinueWith(t =>
+            {
+                // operationTimeoutCancellationTokenSource will be disposed by GC. 
+                // Cannot dispose here since we don't know if both tasks created by WithTimeout ran to completion.
+                if (t.IsFaulted)
+                {
+                    throw t.Exception.InnerException;
+                }
+                return t.Result;
+            });
+        }
+
+        Task<Twin> ApplyTimeoutTwin(Func<CancellationToken, Task<Twin>> operation)
+        {
+            if (OperationTimeoutInMilliseconds == 0)
+            {
+                return operation(CancellationToken.None)
+                    .WithTimeout(TimeSpan.MaxValue, () => Resources.OperationTimeoutExpired, CancellationToken.None);
+            }
+
+            CancellationTokenSource operationTimeoutCancellationTokenSource = GetOperationTimeoutCancellationTokenSource();
+
+            var result = operation(operationTimeoutCancellationTokenSource.Token)
+                .WithTimeout(TimeSpan.FromMilliseconds(OperationTimeoutInMilliseconds), () => Resources.OperationTimeoutExpired, operationTimeoutCancellationTokenSource.Token);
+
+            return result.ContinueWith(t =>
+            {
+                // operationTimeoutCancellationTokenSource will be disposed by GC. 
+                // Cannot dispose here since we don't know if both tasks created by WithTimeout ran to completion.
+                if (t.IsFaulted)
+                {
+                    throw t.Exception.InnerException;
+                }
+                return t.Result;
+            });
+        }
+
+        internal Task CompleteInternalAsync(string lockToken)
+        {
+            if (string.IsNullOrEmpty(lockToken))
+            {
+                throw Fx.Exception.ArgumentNull("lockToken");
+            }
+
+            // Codes_SRS_DEVICECLIENT_28_013: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication, quota exceed) occurs.]
+            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.CompleteAsync(lockToken, operationTimeoutCancellationToken.Token));
+        }
+
+        internal Task RejectInternalAsync(string lockToken)
+        {
+            if (string.IsNullOrEmpty(lockToken))
+            {
+                throw Fx.Exception.ArgumentNull("lockToken");
+            }
+
+            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.RejectAsync(lockToken, operationTimeoutCancellationToken));
+        }
+
+        internal Task AbandonInternalAsync(string lockToken)
+        {
+            if (string.IsNullOrEmpty(lockToken))
+            {
+                throw Fx.Exception.ArgumentNull("lockToken");
+            }
+            // Codes_SRS_DEVICECLIENT_28_015: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication, quota exceed) occurs.]
+            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.AbandonAsync(lockToken, operationTimeoutCancellationToken));
+        }
+
+        /// <summary>
+        /// Registers a new delegate for the named method. If a delegate is already associated with
+        /// the named method, it will be replaced with the new delegate.
+        /// <param name="methodName">The name of the method to associate with the delegate.</param>
+        /// <param name="methodHandler">The delegate to be used when a method with the given name is called by the cloud service.</param>
+        /// <param name="userContext">generic parameter to be interpreted by the client code.</param>
+        /// </summary>
+        public async Task SetMethodHandlerAsync(string methodName, MethodCallback methodHandler, object userContext)
+        {
+            try
+            {
+                await methodsDictionarySemaphore.WaitAsync().ConfigureAwait(false);
+
+                if (methodHandler != null)
+                {
+                    // codes_SRS_DEVICECLIENT_10_005: [ It shall EnableMethodsAsync when called for the first time. ]
+                    await this.EnableMethodAsync().ConfigureAwait(false);
+
+                    // codes_SRS_DEVICECLIENT_10_001: [ It shall lazy-initialize the deviceMethods property. ]
+                    if (this.deviceMethods == null)
+                    {
+                        this.deviceMethods = new Dictionary<string, Tuple<MethodCallback, object>>();
+                    }
+                    this.deviceMethods[methodName] = new Tuple<MethodCallback, object>(methodHandler, userContext);
+                }
+                else
+                {
+                    // codes_SRS_DEVICECLIENT_10_002: [ If the given methodName already has an associated delegate, the existing delegate shall be removed. ]
+                    // codes_SRS_DEVICECLIENT_10_003: [ The given delegate will only be added if it is not null. ]
+                    if (this.deviceMethods != null)
+                    {
+                        this.deviceMethods.Remove(methodName);
+
+                        if (this.deviceMethods.Count == 0)
+                        {
+                            // codes_SRS_DEVICECLIENT_10_004: [ The deviceMethods property shall be deleted if the last delegate has been removed. ]
+                            this.deviceMethods = null;
+                        }
+
+                        // codes_SRS_DEVICECLIENT_10_006: [ It shall DisableMethodsAsync when the last delegate has been removed. ]
+                        await this.DisableMethodAsync().ConfigureAwait(false);
+                    }
+                }
+            }
+            finally
+            {
+                methodsDictionarySemaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Registers a new delegate that is called for a method that doesn't have a delegate registered for its name. 
+        /// If a default delegate is already registered it will replace with the new delegate.
+        /// </summary>
+        /// <param name="methodHandler">The delegate to be used when a method is called by the cloud service and there is no delegate registered for that method name.</param>
+        /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
+        public async Task SetMethodDefaultHandlerAsync(MethodCallback methodHandler, object userContext)
+        {
+            try
+            {
+                await methodsDictionarySemaphore.WaitAsync().ConfigureAwait(false);
+                if (methodHandler != null)
+                {
+                    // codes_SRS_DEVICECLIENT_10_005: [ It shall EnableMethodsAsync when called for the first time. ]
+                    await this.EnableMethodAsync().ConfigureAwait(false);
+
+                    // codes_SRS_DEVICECLIENT_24_001: [ If the default callback has already been set, it is replaced with the new callback. ]
+                    this.deviceDefaultMethodCallback = new Tuple<MethodCallback, object>(methodHandler, userContext);
+                }
+                else
+                {
+                    this.deviceDefaultMethodCallback = null;
+
+                    // codes_SRS_DEVICECLIENT_10_006: [ It shall DisableMethodsAsync when the last delegate has been removed. ]
+                    await this.DisableMethodAsync().ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                methodsDictionarySemaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Registers a new delegate for the named method. If a delegate is already associated with
+        /// the named method, it will be replaced with the new delegate.
+        /// <param name="methodName">The name of the method to associate with the delegate.</param>
+        /// <param name="methodHandler">The delegate to be used when a method with the given name is called by the cloud service.</param>
+        /// <param name="userContext">generic parameter to be interpreted by the client code.</param>
+        /// </summary>
+
+        [Obsolete("Please use SetMethodHandlerAsync.")]
+        public void SetMethodHandler(string methodName, MethodCallback methodHandler, object userContext)
+        {
+            methodsDictionarySemaphore.Wait();
+
+            try
+            {
+                if (methodHandler != null)
+                {
+                    // codes_SRS_DEVICECLIENT_10_001: [ It shall lazy-initialize the deviceMethods property. ]
+                    if (this.deviceMethods == null)
+                    {
+                        this.deviceMethods = new Dictionary<string, Tuple<MethodCallback, object>>();
+
+                        // codes_SRS_DEVICECLIENT_10_005: [ It shall EnableMethodsAsync when called for the first time. ]
+                        ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.EnableMethodsAsync(operationTimeoutCancellationToken)).Wait();
+                    }
+                    this.deviceMethods[methodName] = new Tuple<MethodCallback, object>(methodHandler, userContext);
+                }
+                else
+                {
+                    // codes_SRS_DEVICECLIENT_10_002: [ If the given methodName already has an associated delegate, the existing delegate shall be removed. ]
+                    // codes_SRS_DEVICECLIENT_10_003: [ The given delegate will only be added if it is not null. ]
+                    if (this.deviceMethods != null)
+                    {
+                        this.deviceMethods.Remove(methodName);
+
+                        if (this.deviceMethods.Count == 0)
+                        {
+                            // codes_SRS_DEVICECLIENT_10_006: [ It shall DisableMethodsAsync when the last delegate has been removed. ]
+                            ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.DisableMethodsAsync(operationTimeoutCancellationToken)).Wait();
+
+                            // codes_SRS_DEVICECLIENT_10_004: [ The deviceMethods property shall be deleted if the last delegate has been removed. ]
+                            this.deviceMethods = null;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                methodsDictionarySemaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Registers a new delegate for the connection status changed callback. If a delegate is already associated, 
+        /// it will be replaced with the new delegate.
+        /// <param name="statusChangesHandler">The name of the method to associate with the delegate.</param>
+        /// </summary>
+        public void SetConnectionStatusChangesHandler(ConnectionStatusChangesHandler statusChangesHandler)
+        {
+            // codes_SRS_DEVICECLIENT_28_025: [** `SetConnectionStatusChangesHandler` shall set connectionStatusChangesHandler **]**
+            // codes_SRS_DEVICECLIENT_28_026: [** `SetConnectionStatusChangesHandler` shall unset connectionStatusChangesHandler if `statusChangesHandler` is null **]**
+            this.connectionStatusChangesHandler = statusChangesHandler;
+        }
+
+        /// <summary>
+        /// The delegate for handling disrupted connection/links in the transport layer.
+        /// </summary>
+        internal void OnConnectionOpened(object sender, ConnectionEventArgs e)
+        {
+            ConnectionStatusChangeResult result = this.connectionStatusManager.ChangeTo(e.ConnectionType, ConnectionStatus.Connected);
+            if (result.IsClientStatusChanged && (connectionStatusChangesHandler != null))
+            {
+                // codes_SRS_DEVICECLIENT_28_024: [** `OnConnectionOpened` shall invoke the connectionStatusChangesHandler if ConnectionStatus is changed **]**  
+                this.connectionStatusChangesHandler(ConnectionStatus.Connected, e.ConnectionStatusChangeReason);
+            }
+        }
+
+        /// <summary>
+        /// The delegate for handling disrupted connection/links in the transport layer.
+        /// </summary>
+        internal async Task OnConnectionClosed(object sender, ConnectionEventArgs e)
+        {
+            ConnectionStatusChangeResult result = null;
+
+            // codes_SRS_DEVICECLIENT_28_023: [** `OnConnectionClosed` shall notify ConnectionStatusManager of the connection updates. **]**
+            if (e.ConnectionStatus == ConnectionStatus.Disconnected_Retrying)
+            {
+                try
+                {
+                    // codes_SRS_DEVICECLIENT_28_022: [** `OnConnectionClosed` shall invoke the RecoverConnections operation. **]**          
+                    await ApplyTimeout(async operationTimeoutCancellationTokenSource =>
+                    {
+                        result = this.connectionStatusManager.ChangeTo(e.ConnectionType, ConnectionStatus.Disconnected_Retrying, ConnectionStatus.Connected);
+                        if (result.IsClientStatusChanged && (connectionStatusChangesHandler != null))
+                        {
+                            this.connectionStatusChangesHandler(e.ConnectionStatus, e.ConnectionStatusChangeReason);
+                        }
+
+                        using (CancellationTokenSource linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(result.StatusChangeCancellationTokenSource.Token, operationTimeoutCancellationTokenSource.Token))
+                        {
+                            await this.InnerHandler.RecoverConnections(sender, e.ConnectionType, linkedTokenSource.Token).ConfigureAwait(false);
+                        }
+
+                    }).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    // codes_SRS_DEVICECLIENT_28_027: [** `OnConnectionClosed` shall invoke the connectionStatusChangesHandler if RecoverConnections throw exception **]**
+                    result = this.connectionStatusManager.ChangeTo(e.ConnectionType, ConnectionStatus.Disconnected);
+                    if (result.IsClientStatusChanged && (connectionStatusChangesHandler != null))
+                    {
+                        this.connectionStatusChangesHandler(ConnectionStatus.Disconnected, ConnectionStatusChangeReason.Retry_Expired);
+                    }
+                }
+            }
+            else
+            {
+                result = this.connectionStatusManager.ChangeTo(e.ConnectionType, ConnectionStatus.Disabled);
+                if (result.IsClientStatusChanged && (connectionStatusChangesHandler != null))
+                {
+                    this.connectionStatusChangesHandler(ConnectionStatus.Disabled, e.ConnectionStatusChangeReason);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The delegate for handling direct methods received from service.
+        /// </summary>
+        internal async Task OnMethodCalled(MethodRequestInternal methodRequestInternal)
+        {
+            Tuple<MethodCallback, object> m = null;
+
+            // codes_SRS_DEVICECLIENT_10_012: [ If the given methodRequestInternal argument is null, fail silently ]
+            if (methodRequestInternal != null)
+            {
+                MethodResponseInternal methodResponseInternal;
+                byte[] requestData = methodRequestInternal.GetBytes();
+
+                await methodsDictionarySemaphore.WaitAsync().ConfigureAwait(false);
+                try
+                {
+                    Utils.ValidateDataIsEmptyOrJson(requestData);
+                    this.deviceMethods?.TryGetValue(methodRequestInternal.Name, out m);
+                    if (m == null)
+                    {
+                        m = this.deviceDefaultMethodCallback;
+                    }
+                }
+                catch (Exception)
+                {
+                    // codes_SRS_DEVICECLIENT_28_020: [ If the given methodRequestInternal data is not valid json, respond with status code 400 (BAD REQUEST) ]
+                    methodResponseInternal = new MethodResponseInternal(methodRequestInternal.RequestId, (int)MethodResposeStatusCode.BadRequest);
+                    await this.SendMethodResponseAsync(methodResponseInternal).ConfigureAwait(false);
+                    return;
+                }
+                finally
+                {
+                    methodsDictionarySemaphore.Release();
+                }
+
+                if (m != null)
+                {
+                    try
+                    {
+                        // codes_SRS_DEVICECLIENT_10_011: [ The OnMethodCalled shall invoke the specified delegate. ]
+                        // codes_SRS_DEVICECLIENT_24_002: [ The OnMethodCalled shall invoke the default delegate if there is no specified delegate for that method. ]
+                        MethodResponse rv = await m.Item1(new MethodRequest(methodRequestInternal.Name, requestData), m.Item2).ConfigureAwait(false);
+
+                        // codes_SRS_DEVICECLIENT_03_012: [If the MethodResponse does not contain result, the MethodResponseInternal constructor shall be invoked with no results.]
+                        if (rv.Result == null)
+                        {
+                            methodResponseInternal = new MethodResponseInternal(methodRequestInternal.RequestId, rv.Status);
+                        }
+                        // codes_SRS_DEVICECLIENT_03_013: [Otherwise, the MethodResponseInternal constructor shall be invoked with the result supplied.]
+                        else
+                        {
+                            methodResponseInternal = new MethodResponseInternal(rv.Result, methodRequestInternal.RequestId, rv.Status);
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // codes_SRS_DEVICECLIENT_28_021: [ If the MethodResponse from the MethodHandler is not valid json, respond with status code 500 (USER CODE EXCEPTION) ]
+                        methodResponseInternal = new MethodResponseInternal(methodRequestInternal.RequestId, (int)MethodResposeStatusCode.UserCodeException);
+                    }
+                }
+                else
+                {
+                    // codes_SRS_DEVICECLIENT_10_013: [ If the given method does not have an associated delegate and no default delegate was registered, respond with status code 501 (METHOD NOT IMPLEMENTED) ]
+                    methodResponseInternal = new MethodResponseInternal(methodRequestInternal.RequestId, (int)MethodResposeStatusCode.MethodNotImplemented);
+                }
+                await this.SendMethodResponseAsync(methodResponseInternal).ConfigureAwait(false);
+            }
+        }
+
+        public void Dispose()
+        {
+            this.InnerHandler?.Dispose();
+        }
+
+        internal static ITransportSettings[] PopulateCertificateInTransportSettings(IotHubConnectionStringBuilder connectionStringBuilder, TransportType transportType)
+        {
+            switch (transportType)
+            {
+                case TransportType.Amqp:
+                    return new ITransportSettings[]
+                    {
+                        new AmqpTransportSettings(TransportType.Amqp_Tcp_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        },
+                        new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                case TransportType.Amqp_Tcp_Only:
+                    return new ITransportSettings[]
+                    {
+                        new AmqpTransportSettings(TransportType.Amqp_Tcp_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                case TransportType.Amqp_WebSocket_Only:
+                    return new ITransportSettings[]
+                    {
+                        new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                case TransportType.Http1:
+                    return new ITransportSettings[]
+                    {
+                        new Http1TransportSettings()
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                case TransportType.Mqtt:
+                    return new ITransportSettings[]
+                    {
+                        new MqttTransportSettings(TransportType.Mqtt_Tcp_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        },
+                        new MqttTransportSettings(TransportType.Mqtt_WebSocket_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                case TransportType.Mqtt_Tcp_Only:
+                    return new ITransportSettings[]
+                    {
+                        new MqttTransportSettings(TransportType.Mqtt_Tcp_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                case TransportType.Mqtt_WebSocket_Only:
+                    return new ITransportSettings[]
+                    {
+                        new MqttTransportSettings(TransportType.Mqtt_WebSocket_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                default:
+                    throw new InvalidOperationException("Unsupported Transport {0}".FormatInvariant(transportType));
+            }
+        }
+
+        internal static ITransportSettings[] PopulateCertificateInTransportSettings(IotHubConnectionStringBuilder connectionStringBuilder, ITransportSettings[] transportSettings)
+        {
+            foreach (var transportSetting in transportSettings)
+            {
+                switch (transportSetting.GetTransportType())
+                {
+                    case TransportType.Amqp_WebSocket_Only:
+                    case TransportType.Amqp_Tcp_Only:
+                        ((AmqpTransportSettings)transportSetting).ClientCertificate = connectionStringBuilder.Certificate;
+                        break;
+                    case TransportType.Http1:
+                        ((Http1TransportSettings)transportSetting).ClientCertificate = connectionStringBuilder.Certificate;
+                        break;
+                    case TransportType.Mqtt_WebSocket_Only:
+                    case TransportType.Mqtt_Tcp_Only:
+                        ((MqttTransportSettings)transportSetting).ClientCertificate = connectionStringBuilder.Certificate;
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unsupported Transport {0}".FormatInvariant(transportSetting.GetTransportType()));
+                }
+            }
+
+            return transportSettings;
+        }
+
+        /// <summary>
+        /// Set a callback that will be called whenever the client receives a state update 
+        /// (desired or reported) from the service.  This has the side-effect of subscribing
+        /// to the PATCH topic on the service.
+        /// </summary>
+        /// <param name="callback">Callback to call after the state update has been received and applied</param>
+        /// <param name="userContext">Context object that will be passed into callback</param>
+        [Obsolete("Please use SetDesiredPropertyUpdateCallbackAsync.")]
+        public Task SetDesiredPropertyUpdateCallback(DesiredPropertyUpdateCallback callback, object userContext)
+        {
+            return SetDesiredPropertyUpdateCallbackAsync(callback, userContext);
+        }
+
+        /// <summary>
+        /// Set a callback that will be called whenever the client receives a state update 
+        /// (desired or reported) from the service.  This has the side-effect of subscribing
+        /// to the PATCH topic on the service.
+        /// </summary>
+        /// <param name="callback">Callback to call after the state update has been received and applied</param>
+        /// <param name="userContext">Context object that will be passed into callback</param>
+        public Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback callback, object userContext)
+        {
+            // Codes_SRS_DEVICECLIENT_18_007: `SetDesiredPropertyUpdateCallbackAsync` shall throw an `ArgumentNull` exception if `callback` is null
+            if (callback == null)
+            {
+                throw Fx.Exception.ArgumentNull("callback");
+            }
+
+            return ApplyTimeout(async operationTimeoutCancellationToken =>
+            {
+                // Codes_SRS_DEVICECLIENT_18_003: `SetDesiredPropertyUpdateCallbackAsync` shall call the transport to register for PATCHes on it's first call.
+                // Codes_SRS_DEVICECLIENT_18_004: `SetDesiredPropertyUpdateCallbackAsync` shall not call the transport to register for PATCHes on subsequent calls
+                if (!this.patchSubscribedWithService)
+                {
+                    await this.InnerHandler.EnableTwinPatchAsync(operationTimeoutCancellationToken).ConfigureAwait(false);
+                    patchSubscribedWithService = true;
+                }
+
+                this.desiredPropertyUpdateCallback = callback;
+                this.twinPatchCallbackContext = userContext;
+            });
+        }
+
+        /// <summary>
+        /// Retrieve a device twin object for the current device.
+        /// </summary>
+        /// <returns>The device twin object for the current device</returns>
+        public Task<Twin> GetTwinAsync()
+        {
+            return ApplyTimeoutTwin(async operationTimeoutCancellationToken =>
+            {
+                // Codes_SRS_DEVICECLIENT_18_001: `GetTwinAsync` shall call `SendTwinGetAsync` on the transport to get the twin state
+                return await this.InnerHandler.SendTwinGetAsync(operationTimeoutCancellationToken).ConfigureAwait(false);
+            });
+        }
+
+        /// <summary>
+        /// Push reported property changes up to the service.
+        /// </summary>
+        /// <param name="reportedProperties">Reported properties to push</param>
+        public Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties)
+        {
+            // Codes_SRS_DEVICECLIENT_18_006: `UpdateReportedPropertiesAsync` shall throw an `ArgumentNull` exception if `reportedProperties` is null
+            if (reportedProperties == null)
+            {
+                throw Fx.Exception.ArgumentNull("reportedProperties");
+            }
+            return ApplyTimeout(async operationTimeoutCancellationToken =>
+            {
+                // Codes_SRS_DEVICECLIENT_18_002: `UpdateReportedPropertiesAsync` shall call `SendTwinPatchAsync` on the transport to update the reported properties
+                await this.InnerHandler.SendTwinPatchAsync(reportedProperties, operationTimeoutCancellationToken).ConfigureAwait(false);
+            });
+        }
+
+        //  Codes_SRS_DEVICECLIENT_18_005: When a patch is received from the service, the `callback` shall be called.
+        internal void OnReportedStatePatchReceived(TwinCollection patch)
+        {
+            if (this.desiredPropertyUpdateCallback != null)
+            {
+                this.desiredPropertyUpdateCallback(patch, this.twinPatchCallbackContext);
+            }
+        }
+
+        private async Task EnableMethodAsync()
+        {
+            if (this.deviceMethods == null && this.deviceDefaultMethodCallback == null)
+            {
+                await ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.EnableMethodsAsync(operationTimeoutCancellationToken)).ConfigureAwait(false);
+            }
+        }
+
+        private async Task DisableMethodAsync()
+        {
+            if (this.deviceMethods == null && this.deviceDefaultMethodCallback == null)
+            {
+                await ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.DisableMethodsAsync(operationTimeoutCancellationToken)).ConfigureAwait(false);
+            }
+        }
+
+        private bool IsE2EDiagnosticSupportedProtocol()
+        {
+            foreach (ITransportSettings transportSetting in this.transportSettings)
+            {
+                var transportType = transportSetting.GetTransportType();
+                if (!(transportType == TransportType.Amqp_WebSocket_Only || transportType == TransportType.Amqp_Tcp_Only
+                    || transportType == TransportType.Mqtt_WebSocket_Only || transportType == TransportType.Mqtt_Tcp_Only))
+                {
+                    throw new NotSupportedException($"{transportType} protocal doesn't support E2E diagnostic.");
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/iothub/device/src/ClientFactory.cs
+++ b/iothub/device/src/ClientFactory.cs
@@ -1,0 +1,485 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Client.Edge;
+
+namespace Microsoft.Azure.Devices.Client
+{
+    using System;
+    using System.Text.RegularExpressions;
+    using Microsoft.Azure.Devices.Client.Extensions;
+    using Microsoft.Azure.Devices.Client.Transport;
+    using Microsoft.Azure.Devices.Client.Transport.Mqtt;
+
+    internal class ClientFactory
+    {
+        const string DeviceId = "DeviceId";
+        const string DeviceIdParameterPattern = @"(^\s*?|.*;\s*?)" + DeviceId + @"\s*?=.*";
+        const RegexOptions RegexOptions = System.Text.RegularExpressions.RegexOptions.Compiled | System.Text.RegularExpressions.RegexOptions.IgnoreCase;
+        static readonly Regex DeviceIdParameterRegex = new Regex(DeviceIdParameterPattern, RegexOptions);
+
+        /// <summary>
+        /// Create an Amqp InternalClient from individual parameters
+        /// </summary>
+        /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
+        /// <param name="authenticationMethod">The authentication method that is used</param>
+        /// <returns>InternalClient</returns>
+        public static InternalClient Create(string hostname, IAuthenticationMethod authenticationMethod)
+        {
+            return Create(hostname, authenticationMethod, TransportType.Amqp);
+        }
+
+        /// <summary>
+        /// Create an Amqp InternalClient from individual parameters
+        /// </summary>
+        /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
+        /// <param name="authenticationMethod">The authentication method that is used</param>
+        /// <param name="gatewayHostname">The fully-qualified DNS hostname of Gateway</param>
+        /// <returns>InternalClient</returns>
+        public static InternalClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod)
+        {
+            return Create(hostname, gatewayHostname, authenticationMethod, TransportType.Amqp);
+        }
+
+        /// <summary>
+        /// Create a InternalClient from individual parameters
+        /// </summary>
+        /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
+        /// <param name="authenticationMethod">The authentication method that is used</param>
+        /// <param name="transportType">The transportType used (Http1 or Amqp)</param>
+        /// <returns>InternalClient</returns>
+        public static InternalClient Create(string hostname, IAuthenticationMethod authenticationMethod, TransportType transportType)
+        {
+            return Create(hostname, null, authenticationMethod, transportType);
+        }
+
+        /// <summary>
+        /// Create a InternalClient from individual parameters
+        /// </summary>
+        /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
+        /// <param name="gatewayHostname">The fully-qualified DNS hostname of Gateway</param>
+        /// <param name="authenticationMethod">The authentication method that is used</param>
+        /// <param name="transportType">The transportType used (Http1 or Amqp)</param>
+        /// <returns>InternalClient</returns>
+        public static InternalClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod, TransportType transportType)
+        {
+            if (hostname == null)
+            {
+                throw new ArgumentNullException(nameof(hostname));
+            }
+
+            if (authenticationMethod == null)
+            {
+                throw new ArgumentNullException(nameof(authenticationMethod));
+            }
+
+            IotHubConnectionStringBuilder connectionStringBuilder = IotHubConnectionStringBuilder.Create(hostname, gatewayHostname, authenticationMethod);
+
+#if !NETMF
+            if (authenticationMethod is DeviceAuthenticationWithX509Certificate)
+            {
+                if (connectionStringBuilder.Certificate == null)
+                {
+                    throw new ArgumentException("certificate must be present in DeviceAuthenticationWithX509Certificate");
+                }
+
+                if (!connectionStringBuilder.Certificate.HasPrivateKey)
+                {
+                    throw new ArgumentException("certificate in DeviceAuthenticationWithX509Certificate must have a private key");
+                }
+
+                InternalClient dc = CreateFromConnectionString(connectionStringBuilder.ToString(), PopulateCertificateInTransportSettings(connectionStringBuilder, transportType));
+                dc.Certificate = connectionStringBuilder.Certificate;
+                return dc;
+            }
+#endif
+
+            return CreateFromConnectionString(connectionStringBuilder.ToString(), authenticationMethod, transportType, null);
+        }
+
+        /// <summary>
+        /// Create a InternalClient from individual parameters
+        /// </summary>
+        /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
+        /// <param name="authenticationMethod">The authentication method that is used</param>
+        /// <param name="transportSettings">Prioritized list of transportTypes and their settings</param>
+        /// <returns>InternalClient</returns>
+        public static InternalClient Create(string hostname, IAuthenticationMethod authenticationMethod,
+            ITransportSettings[] transportSettings)
+        {
+            return Create(hostname, null, authenticationMethod, transportSettings);
+        }
+
+        /// <summary>
+        /// Create a InternalClient from individual parameters
+        /// </summary>
+        /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
+        /// <param name="gatewayHostname">The fully-qualified DNS hostname of Gateway</param>
+        /// <param name="authenticationMethod">The authentication method that is used</param>
+        /// <param name="transportSettings">Prioritized list of transportTypes and their settings</param>
+        /// <returns>InternalClient</returns>
+        public static InternalClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod,
+            ITransportSettings[] transportSettings)
+        {
+            if (hostname == null)
+            {
+                throw new ArgumentNullException("hostname");
+            }
+
+            if (authenticationMethod == null)
+            {
+                throw new ArgumentNullException("authenticationMethod");
+            }
+
+            var connectionStringBuilder = IotHubConnectionStringBuilder.Create(hostname, gatewayHostname, authenticationMethod);
+#if !NETMF
+            if (authenticationMethod is DeviceAuthenticationWithX509Certificate)
+            {
+                if (connectionStringBuilder.Certificate == null)
+                {
+                    throw new ArgumentException("certificate must be present in DeviceAuthenticationWithX509Certificate");
+                }
+
+                if (!connectionStringBuilder.Certificate.HasPrivateKey)
+                {
+                    throw new ArgumentException("certificate in DeviceAuthenticationWithX509Certificate must have a private key");
+                }
+
+                InternalClient dc = CreateFromConnectionString(connectionStringBuilder.ToString(), PopulateCertificateInTransportSettings(connectionStringBuilder, transportSettings));
+                dc.Certificate = connectionStringBuilder.Certificate;
+                return dc;
+            }
+#endif
+            return CreateFromConnectionString(connectionStringBuilder.ToString(), authenticationMethod, transportSettings, null);
+        }
+
+        /// <summary>
+        /// Create a InternalClient using Amqp transport from the specified connection string
+        /// </summary>
+        /// <param name="connectionString">Connection string for the IoT hub (including DeviceId)</param>
+        /// <returns>InternalClient</returns>
+        public static InternalClient CreateFromConnectionString(string connectionString)
+        {
+            return CreateFromConnectionString(connectionString, TransportType.Amqp);
+        }
+
+        /// <summary>
+        /// Create a InternalClient using Amqp transport from the specified connection string
+        /// </summary>
+        /// <param name="connectionString">IoT Hub-Scope Connection string for the IoT hub (without DeviceId)</param>
+        /// <param name="deviceId">Id of the Device</param>
+        /// <returns>InternalClient</returns>
+        public static InternalClient CreateFromConnectionString(string connectionString, string deviceId)
+        {
+            return CreateFromConnectionString(connectionString, deviceId, TransportType.Amqp);
+        }
+
+        /// <summary>
+        /// Create InternalClient from the specified connection string using the specified transport type
+        /// </summary>
+        /// <param name="connectionString">Connection string for the IoT hub (including DeviceId)</param>
+        /// <param name="transportType">Specifies whether Amqp or Http transport is used</param>
+        /// <returns>InternalClient</returns>
+        public static InternalClient CreateFromConnectionString(string connectionString, TransportType transportType)
+        {
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }
+
+            return CreateFromConnectionString(connectionString, null, transportType, null);
+        }
+
+        /// <summary>
+        /// Create InternalClient from the specified connection string using the specified transport type
+        /// </summary>
+        /// <param name="connectionString">IoT Hub-Scope Connection string for the IoT hub (without DeviceId)</param>
+        /// <param name="deviceId">Id of the device</param>
+        /// <param name="transportType">The transportType used (Http1 or Amqp)</param>
+        /// <returns>InternalClient</returns>
+        public static InternalClient CreateFromConnectionString(string connectionString, string deviceId, TransportType transportType)
+        {
+            if (connectionString == null)
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }
+
+            if (deviceId == null)
+            {
+                throw new ArgumentNullException(nameof(deviceId));
+            }
+
+            if (DeviceIdParameterRegex.IsMatch(connectionString))
+            {
+                throw new ArgumentException("Connection string must not contain DeviceId keyvalue parameter", nameof(connectionString));
+            }
+
+            return CreateFromConnectionString(connectionString + ";" + DeviceId + "=" + deviceId, transportType);
+        }
+
+        /// <summary>
+        /// Create InternalClient from the specified connection string using a prioritized list of transports
+        /// </summary>
+        /// <param name="connectionString">Connection string for the IoT hub (with DeviceId)</param>
+        /// <param name="transportSettings">Prioritized list of transports and their settings</param>
+        /// <returns>InternalClient</returns>
+        public static InternalClient CreateFromConnectionString(string connectionString,
+            ITransportSettings[] transportSettings)
+        {
+            return CreateFromConnectionString(connectionString, null, transportSettings, null);
+        }
+
+
+        /// <summary>
+        /// Create InternalClient from the specified connection string using the prioritized list of transports
+        /// </summary>
+        /// <param name="connectionString">Connection string for the IoT hub (without DeviceId)</param>
+        /// <param name="deviceId">Id of the device</param>
+        /// <param name="transportSettings">Prioritized list of transportTypes and their settings</param>
+        /// <returns>InternalClient</returns>
+        public static InternalClient CreateFromConnectionString(string connectionString, string deviceId,
+            ITransportSettings[] transportSettings)
+        {
+            if (connectionString == null)
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }
+
+            if (deviceId == null)
+            {
+                throw new ArgumentNullException(nameof(deviceId));
+            }
+
+            if (DeviceIdParameterRegex.IsMatch(connectionString))
+            {
+                throw new ArgumentException("Connection string must not contain DeviceId keyvalue parameter", nameof(connectionString));
+            }
+
+            return CreateFromConnectionString(connectionString + ";" + DeviceId + "=" + deviceId, transportSettings);
+        }
+
+        internal static InternalClient CreateFromConnectionString(
+            string connectionString,
+            IAuthenticationMethod authenticationMethod,
+            TransportType transportType,
+            IDeviceClientPipelineBuilder pipelineBuilder)
+        {
+            ITransportSettings[] transportSettings = GetTransportSettings(transportType);
+            return CreateFromConnectionString(connectionString, authenticationMethod, transportSettings,
+                pipelineBuilder);
+        }
+
+        internal static ITransportSettings[] GetTransportSettings(TransportType transportType)
+        {
+            switch (transportType)
+            {
+                case TransportType.Amqp:
+                    return new ITransportSettings[]
+                    {
+                        new AmqpTransportSettings(TransportType.Amqp_Tcp_Only),
+                        new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
+                    };
+
+                case TransportType.Mqtt:
+                    return new ITransportSettings[]
+                    {
+                        new MqttTransportSettings(TransportType.Mqtt_Tcp_Only),
+                        new MqttTransportSettings(TransportType.Mqtt_WebSocket_Only)
+                    };
+
+                case TransportType.Amqp_WebSocket_Only:
+                case TransportType.Amqp_Tcp_Only:
+                    return new ITransportSettings[]
+                    {
+                        new AmqpTransportSettings(transportType)
+                    };
+
+                case TransportType.Mqtt_WebSocket_Only:
+                case TransportType.Mqtt_Tcp_Only:
+                    return new ITransportSettings[]
+                    {
+                        new MqttTransportSettings(transportType)
+                    };
+
+                case TransportType.Http1:
+                    return new ITransportSettings[] { new Http1TransportSettings() };
+
+                default:
+                    throw new InvalidOperationException("Unsupported Transport Type {0}".FormatInvariant(transportType));
+            }
+        }
+
+        internal static InternalClient CreateFromConnectionString(
+            string connectionString,
+            IAuthenticationMethod authenticationMethod,
+            ITransportSettings[] transportSettings,
+            IDeviceClientPipelineBuilder pipelineBuilder)
+        {
+            if (connectionString == null)
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }
+
+            if (transportSettings == null)
+            {
+                throw new ArgumentNullException(nameof(transportSettings));
+            }
+
+            if (transportSettings.Length == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(connectionString), "Must specify at least one TransportSettings instance");
+            }
+
+            var builder = IotHubConnectionStringBuilder.CreateWithIAuthenticationOverride(
+                connectionString,
+                authenticationMethod);
+
+            IotHubConnectionString iotHubConnectionString = builder.ToIotHubConnectionString();
+
+            foreach (ITransportSettings transportSetting in transportSettings)
+            {
+                switch (transportSetting.GetTransportType())
+                {
+                    case TransportType.Amqp_WebSocket_Only:
+                    case TransportType.Amqp_Tcp_Only:
+                        if (!(transportSetting is AmqpTransportSettings))
+                        {
+                            throw new InvalidOperationException("Unknown implementation of ITransportSettings type");
+                        }
+                        break;
+                    case TransportType.Http1:
+                        if (!(transportSetting is Http1TransportSettings))
+                        {
+                            throw new InvalidOperationException("Unknown implementation of ITransportSettings type");
+                        }
+                        break;
+                    case TransportType.Mqtt_WebSocket_Only:
+                    case TransportType.Mqtt_Tcp_Only:
+                        if (!(transportSetting is MqttTransportSettings))
+                        {
+                            throw new InvalidOperationException("Unknown implementation of ITransportSettings type");
+                        }
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unsupported Transport Type {0}".FormatInvariant(transportSetting.GetTransportType()));
+                }
+            }
+
+            pipelineBuilder = pipelineBuilder ?? BuildPipeline();
+
+            // Defer concrete InternalClient creation to OpenAsync
+            return new InternalClient(iotHubConnectionString, transportSettings, pipelineBuilder);
+        }
+
+
+        static IDeviceClientPipelineBuilder BuildPipeline()
+        {
+            var transporthandlerFactory = new TransportHandlerFactory();
+            IDeviceClientPipelineBuilder pipelineBuilder = new DeviceClientPipelineBuilder()
+                .With(ctx => new GateKeeperDelegatingHandler(ctx))
+                .With(ctx => new RetryDelegatingHandler(ctx))
+                .With(ctx => new ErrorDelegatingHandler(ctx))
+                .With(ctx => new ProtocolRoutingDelegatingHandler(ctx))
+                .With(ctx => transporthandlerFactory.Create(ctx));
+            return pipelineBuilder;
+        }
+
+        static ITransportSettings[] PopulateCertificateInTransportSettings(IotHubConnectionStringBuilder connectionStringBuilder, TransportType transportType)
+        {
+            switch (transportType)
+            {
+                case TransportType.Amqp:
+                    return new ITransportSettings[]
+                    {
+                        new AmqpTransportSettings(TransportType.Amqp_Tcp_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        },
+                        new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                case TransportType.Amqp_Tcp_Only:
+                    return new ITransportSettings[]
+                    {
+                        new AmqpTransportSettings(TransportType.Amqp_Tcp_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                case TransportType.Amqp_WebSocket_Only:
+                    return new ITransportSettings[]
+                    {
+                        new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                case TransportType.Http1:
+                    return new ITransportSettings[]
+                    {
+                        new Http1TransportSettings()
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                case TransportType.Mqtt:
+                    return new ITransportSettings[]
+                    {
+                        new MqttTransportSettings(TransportType.Mqtt_Tcp_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        },
+                        new MqttTransportSettings(TransportType.Mqtt_WebSocket_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                case TransportType.Mqtt_Tcp_Only:
+                    return new ITransportSettings[]
+                    {
+                        new MqttTransportSettings(TransportType.Mqtt_Tcp_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                case TransportType.Mqtt_WebSocket_Only:
+                    return new ITransportSettings[]
+                    {
+                        new MqttTransportSettings(TransportType.Mqtt_WebSocket_Only)
+                        {
+                            ClientCertificate = connectionStringBuilder.Certificate
+                        }
+                    };
+                default:
+                    throw new InvalidOperationException("Unsupported Transport {0}".FormatInvariant(transportType));
+            }
+        }
+
+        static ITransportSettings[] PopulateCertificateInTransportSettings(IotHubConnectionStringBuilder connectionStringBuilder, ITransportSettings[] transportSettings)
+        {
+            foreach (var transportSetting in transportSettings)
+            {
+                switch (transportSetting.GetTransportType())
+                {
+                    case TransportType.Amqp_WebSocket_Only:
+                    case TransportType.Amqp_Tcp_Only:
+                        ((AmqpTransportSettings)transportSetting).ClientCertificate = connectionStringBuilder.Certificate;
+                        break;
+                    case TransportType.Http1:
+                        ((Http1TransportSettings)transportSetting).ClientCertificate = connectionStringBuilder.Certificate;
+                        break;
+                    case TransportType.Mqtt_WebSocket_Only:
+                    case TransportType.Mqtt_Tcp_Only:
+                        ((MqttTransportSettings)transportSetting).ClientCertificate = connectionStringBuilder.Certificate;
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unsupported Transport {0}".FormatInvariant(transportSetting.GetTransportType()));
+                }
+            }
+
+            return transportSettings;
+        }
+    }
+}

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="methodHandler">The delegate to be used when a method with the given name is called by the cloud service.</param>
         /// <param name="userContext">generic parameter to be interpreted by the client code.</param>
         /// </summary>
-        public async Task SetMethodHandlerAsync(string methodName, MethodCallback methodHandler, object userContext) =>
+        public Task SetMethodHandlerAsync(string methodName, MethodCallback methodHandler, object userContext) =>
             this.internalClient.SetMethodHandlerAsync(methodName, methodHandler, userContext);
 
         /// <summary>
@@ -335,7 +335,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="methodHandler">The delegate to be used when a method is called by the cloud service and there is no delegate registered for that method name.</param>
         /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
-        public async Task SetMethodDefaultHandlerAsync(MethodCallback methodHandler, object userContext) =>
+        public Task SetMethodDefaultHandlerAsync(MethodCallback methodHandler, object userContext) =>
             this.internalClient.SetMethodDefaultHandlerAsync(methodHandler, userContext);
 
         /// <summary>

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -85,23 +85,6 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
     /// </summary>
     public sealed class DeviceClient : BaseClient
     {
-        /// <summary>
-        /// Callback to call whenever the twin's desired state is updated by the service
-        /// </summary>
-        internal DesiredPropertyUpdateCallback desiredPropertyUpdateCallback;
-
-        /// <summary>
-        /// Has twin funcitonality been enabled with the service?
-        /// </summary>
-        Boolean patchSubscribedWithService = false;
-
-        /// <summary>
-        /// userContext passed when registering the twin patch callback
-        /// </summary>
-        Object twinPatchCallbackContext = null;
-
-        private int _currentMessageCount = 0;
-
         private ProductInfo productInfo = new ProductInfo();
 
         /// <summary>

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Azure.Devices.Client
         DeviceClient(InternalClient internalClient)
         {
             this.internalClient = internalClient ?? throw new ArgumentNullException(nameof(internalClient));
+
+            if (this.internalClient.IotHubConnectionString?.ModuleId != null)
+            {
+                throw new ArgumentException("A module ID was specified in the connection string - please use ModuleClient for modules.");
+            }
         }
 
         /// <summary>

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Devices.Client
 
         private readonly InternalClient internalClient;
 
-        DeviceClient(InternalClient internalClient)
+        private DeviceClient(InternalClient internalClient)
         {
             this.internalClient = internalClient ?? throw new ArgumentNullException(nameof(internalClient));
 

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -3,23 +3,14 @@
 
 namespace Microsoft.Azure.Devices.Client
 {
-    using Common;
     using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
 #if NETSTANDARD1_3
     using System.Net.Http;
 #endif
-    using System.Text.RegularExpressions;
-    using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Devices.Client.Extensions;
     using Microsoft.Azure.Devices.Client.Transport;
     using Microsoft.Azure.Devices.Shared;
-    using Newtonsoft.Json.Linq;
-    using Microsoft.Azure.Devices.Client.Transport.Mqtt;
-    using System.Security.Cryptography.X509Certificates;
 
     /*
      * Class Diagram and Chain of Responsibility in Device Client 
@@ -430,66 +421,6 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
         {
             // Codes_SRS_DEVICECLIENT_28_011: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable(authentication, quota exceed) error occurs.]
             return ApplyTimeoutMessage(operationTimeoutCancellationToken => this.InnerHandler.ReceiveAsync(timeout, operationTimeoutCancellationToken));
-        }
-
-        /// <summary>
-        /// Deletes a received message from the device queue
-        /// </summary>
-        /// <returns>The lock identifier for the previously received message</returns>
-        public Task CompleteAsync(string lockToken) => this.CompleteInternalAsync(lockToken);
-
-        /// <summary>
-        /// Deletes a received message from the device queue
-        /// </summary>
-        /// <returns>The previously received message</returns>
-        public Task CompleteAsync(Message message)
-        {
-            if (message == null)
-            {
-                throw Fx.Exception.ArgumentNull("message");
-            }
-            // Codes_SRS_DEVICECLIENT_28_015: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication, quota exceed) occurs.]
-            return this.CompleteAsync(message.LockToken);
-        }
-
-        /// <summary>
-        /// Puts a received message back onto the device queue
-        /// </summary>
-        /// <returns>The previously received message</returns>
-        public Task AbandonAsync(string lockToken) => this.AbandonInternalAsync(lockToken);
-
-        /// <summary>
-        /// Puts a received message back onto the device queue
-        /// </summary>
-        /// <returns>The lock identifier for the previously received message</returns>
-        public Task AbandonAsync(Message message)
-        {
-            if (message == null)
-            {
-                throw Fx.Exception.ArgumentNull("message");
-            }
-
-            return this.AbandonAsync(message.LockToken);
-        }
-
-        /// <summary>
-        /// Deletes a received message from the device queue and indicates to the server that the message could not be processed.
-        /// </summary>
-        /// <returns>The previously received message</returns>
-        public Task RejectAsync(string lockToken) => this.RejectInternalAsync(lockToken);
-
-        /// <summary>
-        /// Deletes a received message from the device queue and indicates to the server that the message could not be processed.
-        /// </summary>
-        /// <returns>The lock identifier for the previously received message</returns>
-        public Task RejectAsync(Message message)
-        {
-            if (message == null)
-            {
-                throw Fx.Exception.ArgumentNull("message");
-            }
-            // Codes_SRS_DEVICECLIENT_28_017: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication, quota exceed) occurs.]
-            return this.RejectAsync(message.LockToken);
         }
 
         /// <summary>

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Client
 
         DeviceClient(InternalClient internalClient)
         {
-            this.internalClient = internalClient;
+            this.internalClient = internalClient ?? throw new ArgumentNullException(nameof(internalClient));
         }
 
         /// <summary>

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -21,47 +21,6 @@ namespace Microsoft.Azure.Devices.Client
     using Microsoft.Azure.Devices.Client.Transport.Mqtt;
     using System.Security.Cryptography.X509Certificates;
 
-    /// <summary>
-    /// Delegate for desired property update callbacks.  This will be called
-    /// every time we receive a PATCH from the service.
-    /// </summary>
-    /// <param name="desiredProperties">Properties that were contained in the update that was received from the service</param>
-    /// <param name="userContext">Context object passed in when the callback was registered</param>
-    public delegate Task DesiredPropertyUpdateCallback(TwinCollection desiredProperties, object userContext);
-
-    /// <summary>
-    ///      Delegate for method call. This will be called every time we receive a method call that was registered.
-    /// </summary>
-    /// <param name="methodRequest">Class with details about method.</param>
-    /// <param name="userContext">Context object passed in when the callback was registered.</param>
-    /// <returns>MethodResponse</returns>
-    public delegate Task<MethodResponse> MethodCallback(MethodRequest methodRequest, object userContext);
-
-    /// <summary>
-    ///    Status of handling a message. 
-    ///    None - Means Device SDK won't send an ackowledge of receipt.
-    ///    Completed - Means Device SDK will Complete the event. Removing from the queue.
-    ///    Abandoned - Event will be Abandoned. 
-    /// </summary>
-    public enum MessageResponse { None, Completed, Abandoned };
-
-
-
-    /// <summary>
-    /// Delegate that gets called when a message is received on a particular input.
-    /// </summary>
-    /// <param name="message">The message received</param>
-    /// <param name="userContext">The context object passed in</param>
-    /// <returns>MessageResponse</returns>
-    public delegate Task<MessageResponse> MessageHandler(Message message, object userContext);
-
-    /// <summary>
-    /// Delegate for connection status changed.
-    /// </summary>
-    /// <param name="status">The updated connection status</param>
-    /// <param name="reason">The reason for the connection status change</param>
-    public delegate void ConnectionStatusChangesHandler(ConnectionStatus status, ConnectionStatusChangeReason reason);
-
     /*
      * Class Diagram and Chain of Responsibility in Device Client 
                                      +--------------------+
@@ -124,144 +83,8 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
     /// <summary>
     /// Contains methods that a device can use to send messages to and receive from the service.
     /// </summary>
-    public sealed class DeviceClient : IDisposable
+    public sealed class DeviceClient : BaseClient
     {
-        const string DeviceId = "DeviceId";
-        const string DeviceIdParameterPattern = @"(^\s*?|.*;\s*?)" + DeviceId + @"\s*?=.*";
-        IotHubConnectionString iotHubConnectionString = null;
-
-        /// <summary> 
-        /// Diagnostic sampling percentage value, [0-100];  
-        /// 0 means no message will carry on diag info 
-        /// </summary>
-        int _diagnosticSamplingPercentage = 0;
-        public int DiagnosticSamplingPercentage
-        {
-            get { return _diagnosticSamplingPercentage; }
-            set
-            {
-                if (value > 100 || value < 0)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(DiagnosticSamplingPercentage), DiagnosticSamplingPercentage, 
-                        "The range of diagnostic sampling percentage should between [0,100].");
-                }
-
-                if (IsE2EDiagnosticSupportedProtocol())
-                {
-                    _diagnosticSamplingPercentage = value;
-                }
-            }
-        }
-
-        ITransportSettings[] transportSettings;
-
-        internal X509Certificate2 Certificate { get; set; }
-        const RegexOptions RegexOptions = System.Text.RegularExpressions.RegexOptions.Compiled | System.Text.RegularExpressions.RegexOptions.IgnoreCase;
-        static readonly Regex DeviceIdParameterRegex = new Regex(DeviceIdParameterPattern, RegexOptions);
-
-        internal IDelegatingHandler InnerHandler { get; set; }
-
-        SemaphoreSlim methodsDictionarySemaphore = new SemaphoreSlim(1, 1);
-        readonly SemaphoreSlim receiveSemaphore = new SemaphoreSlim(1, 1);
-
-        volatile Dictionary<string, Tuple<MessageHandler, object>> receiveEventEndpoints;
-
-        volatile Tuple<MessageHandler, object> defaultEventCallback;
-
-        public const string ModuleTwinsPropertyName = "moduleTwins";
-        public const string MetadataName = "$metadata";
-
-        DeviceClientConnectionStatusManager connectionStatusManager = new DeviceClientConnectionStatusManager();
-
-        public const uint DefaultOperationTimeoutInMilliseconds = 4 * 60 * 1000;
-
-        /// <summary>
-        /// Stores the timeout used in the operation retries.
-        /// </summary>
-        // Codes_SRS_DEVICECLIENT_28_002: [This property shall be defaulted to 240000 (4 minutes).]
-        public uint OperationTimeoutInMilliseconds { get; set; } = DefaultOperationTimeoutInMilliseconds;
-
-        private ProductInfo productInfo = new ProductInfo();
-
-        /// <summary>
-        /// Stores custom product information that will be appended to the user agent string that is sent to IoT Hub.
-        /// </summary>
-        public string ProductInfo {
-            // We store DeviceClient.ProductInfo as a string property of an object (rather than directly as a string)
-            // so that updates will propagate down to the transport layer throughout the lifetime of the DeviceClient
-            // object instance.
-            get => productInfo.Extra;
-            set => productInfo.Extra = value;
-        }
-
-        /// <summary>
-        /// Stores the retry strategy used in the operation retries.
-        /// </summary>
-        // Codes_SRS_DEVICECLIENT_28_001: [This property shall be defaulted to the exponential retry strategy with backoff 
-        // parameters for calculating delay in between retries.]
-        [Obsolete("This method has been deprecated.  Please use Microsoft.Azure.Devices.Client.SetRetryPolicy(IRetryPolicy retryPolicy) instead.")]
-        public RetryPolicyType RetryPolicy { get; set; }
-
-        /// <summary>
-        /// Sets the retry policy used in the operation retries.
-        /// </summary>
-        /// <param name="retryPolicy">The retry policy. The default is new ExponentialBackoff(int.MaxValue, TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(100));</param>
-        // Codes_SRS_DEVICECLIENT_28_001: [This property shall be defaulted to the exponential retry strategy with backoff 
-        // parameters for calculating delay in between retries.]
-        public void SetRetryPolicy(IRetryPolicy retryPolicy)
-        {
-            var retryDelegatingHandler = GetDelegateHandler<RetryDelegatingHandler>();
-            if (retryDelegatingHandler == null)
-            {
-                throw new NotSupportedException();
-            }
-
-            retryDelegatingHandler.SetRetryPolicy(retryPolicy);
-        }
-
-
-        private T GetDelegateHandler<T>() where T: DefaultDelegatingHandler
-        {
-            var handler = this.InnerHandler as DefaultDelegatingHandler;
-            bool isFound = false;
-
-            while (!isFound || handler == null)
-            {
-                if (handler is T)
-                {
-                    isFound = true;
-                }
-                else
-                {
-                    handler = handler.InnerHandler as DefaultDelegatingHandler;
-                }
-            }
-
-            if (!isFound)
-            {
-                return default(T);
-            }
-
-            return (T) handler;
-        }
-
-        /// <summary>
-        /// Stores Methods supported by the client device and their associated delegate.
-        /// </summary>
-        volatile Dictionary<string, Tuple<MethodCallback, object>> deviceMethods;
-
-        volatile Tuple<MethodCallback, object> deviceDefaultMethodCallback;
-
-        volatile ConnectionStatusChangesHandler connectionStatusChangesHandler;
-
-        internal delegate Task OnMethodCalledDelegate(MethodRequestInternal methodRequestInternal);
-
-        internal delegate Task OnConnectionClosedDelegate(object sender, ConnectionEventArgs e);
-
-        internal delegate void OnConnectionOpenedDelegate(object sender, ConnectionEventArgs e);
-
-        internal delegate Task OnReceiveEventMessageCalledDelegate(string input, Message message);
-
         /// <summary>
         /// Callback to call whenever the twin's desired state is updated by the service
         /// </summary>
@@ -279,10 +102,23 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
 
         private int _currentMessageCount = 0;
 
-        DeviceClient(IotHubConnectionString iotHubConnectionString, ITransportSettings[] transportSettings, IDeviceClientPipelineBuilder pipelineBuilder)
-        {
-            this.iotHubConnectionString = iotHubConnectionString;
+        private ProductInfo productInfo = new ProductInfo();
 
+        /// <summary>
+        /// Stores custom product information that will be appended to the user agent string that is sent to IoT Hub.
+        /// </summary>
+        public string ProductInfo
+        {
+            // We store DeviceClient.ProductInfo as a string property of an object (rather than directly as a string)
+            // so that updates will propagate down to the transport layer throughout the lifetime of the DeviceClient
+            // object instance.
+            get => productInfo.Extra;
+            set => productInfo.Extra = value;
+        }
+
+        DeviceClient(IotHubConnectionString iotHubConnectionString, ITransportSettings[] transportSettings, IDeviceClientPipelineBuilder pipelineBuilder)
+            : base(iotHubConnectionString, transportSettings)
+        {
             var pipelineContext = new PipelineContext();
             pipelineContext.Set(transportSettings);
             pipelineContext.Set(iotHubConnectionString);
@@ -290,41 +126,10 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
             pipelineContext.Set<Action<TwinCollection>>(OnReportedStatePatchReceived);
             pipelineContext.Set<OnConnectionClosedDelegate>(OnConnectionClosed);
             pipelineContext.Set<OnConnectionOpenedDelegate>(OnConnectionOpened);
-            pipelineContext.Set<OnReceiveEventMessageCalledDelegate>(OnReceiveEventMessageCalled);
             pipelineContext.Set(this.productInfo);
 
             IDelegatingHandler innerHandler = pipelineBuilder.Build(pipelineContext);
-
             this.InnerHandler = innerHandler;
-            this.transportSettings = transportSettings;
-        }
-
-        DeviceClient(IotHubConnectionString iotHubConnectionString)
-        {
-            this.iotHubConnectionString = iotHubConnectionString;
-
-            var pipelineContext = new PipelineContext();
-            pipelineContext.Set(iotHubConnectionString);
-            pipelineContext.Set<ITransportSettings>(new Http1TransportSettings());
-
-            IDeviceClientPipelineBuilder pipelineBuilder = new DeviceClientPipelineBuilder()
-                .With(ctx => new GateKeeperDelegatingHandler(ctx))
-                .With(ctx => new ErrorDelegatingHandler(ctx))
-                .With(ctx => new HttpTransportHandler(ctx, ctx.Get<IotHubConnectionString>(), ctx.Get<ITransportSettings>() as Http1TransportSettings));
-
-            this.InnerHandler = pipelineBuilder.Build(pipelineContext);
-        }
-
-        static IDeviceClientPipelineBuilder BuildPipeline()
-        {
-            var transporthandlerFactory = new TransportHandlerFactory();
-            IDeviceClientPipelineBuilder pipelineBuilder = new DeviceClientPipelineBuilder()
-                .With(ctx => new GateKeeperDelegatingHandler(ctx))
-                .With(ctx => new RetryDelegatingHandler(ctx))
-                .With(ctx => new ErrorDelegatingHandler(ctx))
-                .With(ctx => new ProtocolRoutingDelegatingHandler(ctx))
-                .With(ctx => transporthandlerFactory.Create(ctx));
-            return pipelineBuilder;
         }
 
         internal Task SendMethodResponseAsync(MethodResponseInternal methodResponse)
@@ -578,60 +383,21 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
         internal static DeviceClient CreateFromConnectionString(
             string connectionString,
             IAuthenticationMethod authenticationMethod,
-            TransportType transportType, 
+            TransportType transportType,
             IDeviceClientPipelineBuilder pipelineBuilder)
         {
-            switch (transportType)
-            {
-                case TransportType.Amqp:
-                    return CreateFromConnectionString(
-                        connectionString, 
-                        authenticationMethod,
-                        new ITransportSettings[]
-                        {
-                            new AmqpTransportSettings(TransportType.Amqp_Tcp_Only),
-                            new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
-                        },
-                        pipelineBuilder);
-                case TransportType.Mqtt:
-                    return CreateFromConnectionString(
-                        connectionString,
-                        authenticationMethod,
-                        new ITransportSettings[]
-                        {
-                            new MqttTransportSettings(TransportType.Mqtt_Tcp_Only),
-                            new MqttTransportSettings(TransportType.Mqtt_WebSocket_Only)
-                        }, 
-                        pipelineBuilder);
-                case TransportType.Amqp_WebSocket_Only:
-                case TransportType.Amqp_Tcp_Only:
-                    return CreateFromConnectionString(
-                        connectionString,
-                        authenticationMethod,
-                        new ITransportSettings[] { new AmqpTransportSettings(transportType) }, 
-                        pipelineBuilder);
-                case TransportType.Mqtt_WebSocket_Only:
-                case TransportType.Mqtt_Tcp_Only:
-                    return CreateFromConnectionString(
-                        connectionString,
-                        authenticationMethod,
-                        new ITransportSettings[] { new MqttTransportSettings(transportType) }, 
-                        pipelineBuilder);
-                case TransportType.Http1:
-                    return CreateFromConnectionString(
-                        connectionString,
-                        authenticationMethod,
-                        new ITransportSettings[] { new Http1TransportSettings() }, 
-                        pipelineBuilder);
-                default:
-                    throw new InvalidOperationException("Unsupported Transport Type {0}".FormatInvariant(transportType));
-            }
+            ITransportSettings[] transportSettings = GetTransportSettings(transportType);
+            return CreateFromConnectionString(
+                connectionString,
+                authenticationMethod,
+                transportSettings,
+                pipelineBuilder);
         }
 
         internal static DeviceClient CreateFromConnectionString(
             string connectionString,
             IAuthenticationMethod authenticationMethod,
-            ITransportSettings[] transportSettings, 
+            ITransportSettings[] transportSettings,
             IDeviceClientPipelineBuilder pipelineBuilder)
         {
             if (connectionString == null)
@@ -650,68 +416,17 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
             }
 
             var builder = IotHubConnectionStringBuilder.CreateWithIAuthenticationOverride(
-                connectionString, 
+                connectionString,
                 authenticationMethod);
 
             IotHubConnectionString iotHubConnectionString = builder.ToIotHubConnectionString();
 
-            foreach (ITransportSettings transportSetting in transportSettings)
-            {
-                switch (transportSetting.GetTransportType())
-                {
-                    case TransportType.Amqp_WebSocket_Only:
-                    case TransportType.Amqp_Tcp_Only:
-                        if (!(transportSetting is AmqpTransportSettings))
-                        {
-                            throw new InvalidOperationException("Unknown implementation of ITransportSettings type");
-                        }
-                        break;
-                    case TransportType.Http1:
-                        if (!(transportSetting is Http1TransportSettings))
-                        {
-                            throw new InvalidOperationException("Unknown implementation of ITransportSettings type");
-                        }
-                        break;
-                    case TransportType.Mqtt_WebSocket_Only:
-                    case TransportType.Mqtt_Tcp_Only:
-                        if (!(transportSetting is MqttTransportSettings))
-                        {
-                            throw new InvalidOperationException("Unknown implementation of ITransportSettings type");
-                        }
-                        break;
-                    default:
-                        throw new InvalidOperationException("Unsupported Transport Type {0}".FormatInvariant(transportSetting.GetTransportType()));
-                }
-            }
+            ValidateTransportSettings(transportSettings);
 
             pipelineBuilder = pipelineBuilder ?? BuildPipeline();
 
             // Defer concrete DeviceClient creation to OpenAsync
             return new DeviceClient(iotHubConnectionString, transportSettings, pipelineBuilder);
-        }
-
-        CancellationTokenSource GetOperationTimeoutCancellationTokenSource()
-        {
-            return new CancellationTokenSource(TimeSpan.FromMilliseconds(OperationTimeoutInMilliseconds));
-        }
-
-        /// <summary>
-        /// Explicitly open the DeviceClient instance.
-        /// </summary>
-
-        public Task OpenAsync()
-        {
-            // Codes_SRS_DEVICECLIENT_28_007: [ The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable(authentication, quota exceed) error occurs.]
-            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.OpenAsync(true, operationTimeoutCancellationToken));
-        }
-
-        /// <summary>
-        /// Close the DeviceClient instance
-        /// </summary>
-        /// <returns></returns>
-        public Task CloseAsync()
-        {
-            return this.InnerHandler.CloseAsync();
         }
 
         /// <summary>
@@ -738,16 +453,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
         /// Deletes a received message from the device queue
         /// </summary>
         /// <returns>The lock identifier for the previously received message</returns>
-        public Task CompleteAsync(string lockToken)
-        {
-            if (string.IsNullOrEmpty(lockToken))
-            {
-                throw Fx.Exception.ArgumentNull("lockToken");
-            }
-
-            // Codes_SRS_DEVICECLIENT_28_013: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication, quota exceed) occurs.]
-            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.CompleteAsync(lockToken, operationTimeoutCancellationToken.Token));
-        }
+        public Task CompleteAsync(string lockToken) => this.CompleteInternalAsync(lockToken);
 
         /// <summary>
         /// Deletes a received message from the device queue
@@ -767,15 +473,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
         /// Puts a received message back onto the device queue
         /// </summary>
         /// <returns>The previously received message</returns>
-        public Task AbandonAsync(string lockToken)
-        {
-            if (string.IsNullOrEmpty(lockToken))
-            {
-                throw Fx.Exception.ArgumentNull("lockToken");
-            }
-            // Codes_SRS_DEVICECLIENT_28_015: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication, quota exceed) occurs.]
-            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.AbandonAsync(lockToken, operationTimeoutCancellationToken));
-        }
+        public Task AbandonAsync(string lockToken) => this.AbandonInternalAsync(lockToken);
 
         /// <summary>
         /// Puts a received message back onto the device queue
@@ -795,15 +493,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
         /// Deletes a received message from the device queue and indicates to the server that the message could not be processed.
         /// </summary>
         /// <returns>The previously received message</returns>
-        public Task RejectAsync(string lockToken)
-        {
-            if (string.IsNullOrEmpty(lockToken))
-            {
-                throw Fx.Exception.ArgumentNull("lockToken");
-            }
-
-            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.RejectAsync(lockToken, operationTimeoutCancellationToken));
-        }
+        public Task RejectAsync(string lockToken) => this.RejectInternalAsync(lockToken);
 
         /// <summary>
         /// Deletes a received message from the device queue and indicates to the server that the message could not be processed.
@@ -816,144 +506,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
                 throw Fx.Exception.ArgumentNull("message");
             }
             // Codes_SRS_DEVICECLIENT_28_017: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication, quota exceed) occurs.]
-            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.RejectAsync(message.LockToken, operationTimeoutCancellationToken));
-        }
-
-        /// <summary>
-        /// Sends an event to device hub
-        /// </summary>
-        /// <returns>The message containing the event</returns>
-        public Task SendEventAsync(Message message)
-        {
-            if (message == null)
-            {
-                throw Fx.Exception.ArgumentNull("message");
-            }
-
-            IoTHubClientDiagnostic.AddDiagnosticInfoIfNecessary(message, _diagnosticSamplingPercentage, ref _currentMessageCount);
-            // Codes_SRS_DEVICECLIENT_28_019: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication or quota exceed) occurs.]
-            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.SendEventAsync(message, operationTimeoutCancellationToken));
-        }
-
-        /// <summary>
-        /// Sends a batch of events to device hub
-        /// </summary>
-        /// <returns>The task containing the event</returns>
-        public Task SendEventBatchAsync(IEnumerable<Message> messages)
-        {
-            if (messages == null)
-            {
-                throw Fx.Exception.ArgumentNull("messages");
-            }
-
-            // Codes_SRS_DEVICECLIENT_28_019: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication or quota exceed) occurs.]
-            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.SendEventAsync(messages, operationTimeoutCancellationToken));
-        }
-        
-        Task ApplyTimeout(Func<CancellationTokenSource, Task> operation)
-        {
-            if (OperationTimeoutInMilliseconds == 0)
-            {
-                var cancellationTokenSource = new CancellationTokenSource();
-                return operation(cancellationTokenSource)
-                    .WithTimeout(TimeSpan.MaxValue, () => Resources.OperationTimeoutExpired, cancellationTokenSource.Token);
-            }
-
-            CancellationTokenSource operationTimeoutCancellationTokenSource = GetOperationTimeoutCancellationTokenSource();
-
-            var result = operation(operationTimeoutCancellationTokenSource)
-                .WithTimeout(TimeSpan.FromMilliseconds(OperationTimeoutInMilliseconds), () => Resources.OperationTimeoutExpired, operationTimeoutCancellationTokenSource.Token);
-            
-            return result.ContinueWith(t => {
-                
-                // operationTimeoutCancellationTokenSource will be disposed by GC. 
-                // Cannot dispose here since we don't know if both tasks created by WithTimeout ran to completion.
-                if (t.IsCanceled)
-                {
-                    throw new TimeoutException(Resources.OperationTimeoutExpired);
-                }
-
-                if (t.IsFaulted)
-                {
-                    throw t.Exception.InnerException;
-                }
-            });
-        }
-
-        Task ApplyTimeout(Func<CancellationToken, Task> operation)
-        {
-            if (OperationTimeoutInMilliseconds == 0)
-            {
-                return operation(CancellationToken.None)
-                    .WithTimeout(TimeSpan.MaxValue, () => Resources.OperationTimeoutExpired, CancellationToken.None);
-            }
-
-            CancellationTokenSource operationTimeoutCancellationTokenSource = GetOperationTimeoutCancellationTokenSource();
-
-            Debug.WriteLine(operationTimeoutCancellationTokenSource.Token.GetHashCode() + " DeviceClient.ApplyTimeout()");
-
-            var result = operation(operationTimeoutCancellationTokenSource.Token)
-                .WithTimeout(TimeSpan.FromMilliseconds(OperationTimeoutInMilliseconds), () => Resources.OperationTimeoutExpired, operationTimeoutCancellationTokenSource.Token);
-
-            return result.ContinueWith(t =>
-            {
-                // operationTimeoutCancellationTokenSource will be disposed by GC. 
-                // Cannot dispose here since we don't know if both tasks created by WithTimeout ran to completion.
-                if (t.IsFaulted)
-                {
-                    throw t.Exception.InnerException;
-                }
-            }, TaskContinuationOptions.NotOnCanceled);
-        }
-
-        Task<Message> ApplyTimeoutMessage(Func<CancellationToken, Task<Message>> operation)
-        {
-            if (OperationTimeoutInMilliseconds == 0)
-            {
-                return operation(CancellationToken.None)
-                    .WithTimeout(TimeSpan.MaxValue, () => Resources.OperationTimeoutExpired, CancellationToken.None);
-            }
-
-            CancellationTokenSource operationTimeoutCancellationTokenSource = GetOperationTimeoutCancellationTokenSource();
-
-            var result = operation(operationTimeoutCancellationTokenSource.Token)
-                .WithTimeout(TimeSpan.FromMilliseconds(OperationTimeoutInMilliseconds), () => Resources.OperationTimeoutExpired, operationTimeoutCancellationTokenSource.Token);
-
-            return result.ContinueWith(t =>
-            {
-                // operationTimeoutCancellationTokenSource will be disposed by GC. 
-                // Cannot dispose here since we don't know if both tasks created by WithTimeout ran to completion.
-                if (t.IsFaulted)
-                {
-                    throw t.Exception.InnerException;
-                }
-                return t.Result;
-            });
-        }
-
-        Task<Twin> ApplyTimeoutTwin(Func<CancellationToken, Task<Twin>> operation)
-        {
-            if (OperationTimeoutInMilliseconds == 0)
-            {
-                return operation(CancellationToken.None)
-                    .WithTimeout(TimeSpan.MaxValue, () => Resources.OperationTimeoutExpired, CancellationToken.None);
-            }
-
-            CancellationTokenSource operationTimeoutCancellationTokenSource = GetOperationTimeoutCancellationTokenSource();
-
-            var result = operation(operationTimeoutCancellationTokenSource.Token)
-                .WithTimeout(TimeSpan.FromMilliseconds(OperationTimeoutInMilliseconds), () => Resources.OperationTimeoutExpired, operationTimeoutCancellationTokenSource.Token);
-
-            return result.ContinueWith(t =>
-            {
-                // operationTimeoutCancellationTokenSource will be disposed by GC. 
-                // Cannot dispose here since we don't know if both tasks created by WithTimeout ran to completion.
-                if (t.IsFaulted)
-                {
-                    throw t.Exception.InnerException;
-                }
-                return t.Result;
-            });
+            return this.RejectAsync(message.LockToken);
         }
 
         /// <summary>
@@ -991,719 +544,13 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
             {
                 Http1TransportSettings transportSettings = new Http1TransportSettings();
                 transportSettings.ClientCertificate = this.Certificate;
-                httpTransport = new HttpTransportHandler(context, iotHubConnectionString, transportSettings);
+                httpTransport = new HttpTransportHandler(context, IotHubConnectionString, transportSettings);
             }
             else
             {
-                httpTransport = new HttpTransportHandler(context, iotHubConnectionString, new Http1TransportSettings());
+                httpTransport = new HttpTransportHandler(context, IotHubConnectionString, new Http1TransportSettings());
             }
             return httpTransport.UploadToBlobAsync(blobName, source);
         }
-
-        /// <summary>
-        /// Registers a new delegate for the named method. If a delegate is already associated with
-        /// the named method, it will be replaced with the new delegate.
-        /// <param name="methodName">The name of the method to associate with the delegate.</param>
-        /// <param name="methodHandler">The delegate to be used when a method with the given name is called by the cloud service.</param>
-        /// <param name="userContext">generic parameter to be interpreted by the client code.</param>
-        /// </summary>
-        public async Task SetMethodHandlerAsync(string methodName, MethodCallback methodHandler, object userContext)
-        {
-            try
-            {
-                await methodsDictionarySemaphore.WaitAsync().ConfigureAwait(false);
-
-                if (methodHandler != null)
-                {
-                    // codes_SRS_DEVICECLIENT_10_005: [ It shall EnableMethodsAsync when called for the first time. ]
-                    await this.EnableMethodAsync().ConfigureAwait(false);
-
-                    // codes_SRS_DEVICECLIENT_10_001: [ It shall lazy-initialize the deviceMethods property. ]
-                    if (this.deviceMethods == null)
-                    {
-                        this.deviceMethods = new Dictionary<string, Tuple<MethodCallback, object>>();
-                    }
-                    this.deviceMethods[methodName] = new Tuple<MethodCallback, object>(methodHandler, userContext);
-                }
-                else
-                {
-                    // codes_SRS_DEVICECLIENT_10_002: [ If the given methodName already has an associated delegate, the existing delegate shall be removed. ]
-                    // codes_SRS_DEVICECLIENT_10_003: [ The given delegate will only be added if it is not null. ]
-                    if (this.deviceMethods != null)
-                    {
-                        this.deviceMethods.Remove(methodName);
-
-                        if (this.deviceMethods.Count == 0)
-                        {
-                            // codes_SRS_DEVICECLIENT_10_004: [ The deviceMethods property shall be deleted if the last delegate has been removed. ]
-                            this.deviceMethods = null;
-                        }
-
-                        // codes_SRS_DEVICECLIENT_10_006: [ It shall DisableMethodsAsync when the last delegate has been removed. ]
-                        await this.DisableMethodAsync().ConfigureAwait(false);
-                    }
-                }
-            }
-            finally
-            {
-                methodsDictionarySemaphore.Release();
-            }
-        }
-
-        /// <summary>
-        /// Registers a new delegate that is called for a method that doesn't have a delegate registered for its name. 
-        /// If a default delegate is already registered it will replace with the new delegate.
-        /// </summary>
-        /// <param name="methodHandler">The delegate to be used when a method is called by the cloud service and there is no delegate registered for that method name.</param>
-        /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
-        public async Task SetMethodDefaultHandlerAsync(MethodCallback methodHandler, object userContext)
-        {
-            try
-            {
-                await methodsDictionarySemaphore.WaitAsync().ConfigureAwait(false);
-                if (methodHandler != null)
-                {
-                    // codes_SRS_DEVICECLIENT_10_005: [ It shall EnableMethodsAsync when called for the first time. ]
-                    await this.EnableMethodAsync().ConfigureAwait(false);
-
-                    // codes_SRS_DEVICECLIENT_24_001: [ If the default callback has already been set, it is replaced with the new callback. ]
-                    this.deviceDefaultMethodCallback = new Tuple<MethodCallback, object>(methodHandler, userContext);
-                }
-                else
-                {
-                    this.deviceDefaultMethodCallback = null;
-
-                    // codes_SRS_DEVICECLIENT_10_006: [ It shall DisableMethodsAsync when the last delegate has been removed. ]
-                    await this.DisableMethodAsync().ConfigureAwait(false);
-                }
-            }
-            finally
-            {
-                methodsDictionarySemaphore.Release();
-            }
-        }
-
-        /// <summary>
-        /// Registers a new delegate for the named method. If a delegate is already associated with
-        /// the named method, it will be replaced with the new delegate.
-        /// <param name="methodName">The name of the method to associate with the delegate.</param>
-        /// <param name="methodHandler">The delegate to be used when a method with the given name is called by the cloud service.</param>
-        /// <param name="userContext">generic parameter to be interpreted by the client code.</param>
-        /// </summary>
-
-        [Obsolete("Please use SetMethodHandlerAsync.")]
-        public void SetMethodHandler(string methodName, MethodCallback methodHandler, object userContext)
-        {
-            methodsDictionarySemaphore.Wait();
-
-            try
-            {
-                if (methodHandler != null)
-                {
-                    // codes_SRS_DEVICECLIENT_10_001: [ It shall lazy-initialize the deviceMethods property. ]
-                    if (this.deviceMethods == null)
-                    {
-                        this.deviceMethods = new Dictionary<string, Tuple<MethodCallback, object>>();
-
-                        // codes_SRS_DEVICECLIENT_10_005: [ It shall EnableMethodsAsync when called for the first time. ]
-                        ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.EnableMethodsAsync(operationTimeoutCancellationToken)).Wait();
-                    }
-                    this.deviceMethods[methodName] = new Tuple<MethodCallback, object>(methodHandler, userContext);
-                }
-                else
-                {
-                    // codes_SRS_DEVICECLIENT_10_002: [ If the given methodName already has an associated delegate, the existing delegate shall be removed. ]
-                    // codes_SRS_DEVICECLIENT_10_003: [ The given delegate will only be added if it is not null. ]
-                    if (this.deviceMethods != null)
-                    {
-                        this.deviceMethods.Remove(methodName);
-
-                        if (this.deviceMethods.Count == 0)
-                        {
-                            // codes_SRS_DEVICECLIENT_10_006: [ It shall DisableMethodsAsync when the last delegate has been removed. ]
-                            ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.DisableMethodsAsync(operationTimeoutCancellationToken)).Wait();
-
-                            // codes_SRS_DEVICECLIENT_10_004: [ The deviceMethods property shall be deleted if the last delegate has been removed. ]
-                            this.deviceMethods = null;
-                        }
-                    }
-                }
-            }
-            finally
-            {
-                methodsDictionarySemaphore.Release();
-            }
-        }
-
-        /// <summary>
-        /// Registers a new delegate for the connection status changed callback. If a delegate is already associated, 
-        /// it will be replaced with the new delegate.
-        /// <param name="statusChangesHandler">The name of the method to associate with the delegate.</param>
-        /// </summary>
-        public void SetConnectionStatusChangesHandler(ConnectionStatusChangesHandler statusChangesHandler)
-        {
-            // codes_SRS_DEVICECLIENT_28_025: [** `SetConnectionStatusChangesHandler` shall set connectionStatusChangesHandler **]**
-            // codes_SRS_DEVICECLIENT_28_026: [** `SetConnectionStatusChangesHandler` shall unset connectionStatusChangesHandler if `statusChangesHandler` is null **]**
-            this.connectionStatusChangesHandler = statusChangesHandler;
-        }
-
-        /// <summary>
-        /// The delegate for handling disrupted connection/links in the transport layer.
-        /// </summary>
-        internal void OnConnectionOpened(object sender, ConnectionEventArgs e)
-        {
-            ConnectionStatusChangeResult result = this.connectionStatusManager.ChangeTo(e.ConnectionType, ConnectionStatus.Connected);
-            if (result.IsClientStatusChanged && (connectionStatusChangesHandler != null))
-            {
-                // codes_SRS_DEVICECLIENT_28_024: [** `OnConnectionOpened` shall invoke the connectionStatusChangesHandler if ConnectionStatus is changed **]**  
-                this.connectionStatusChangesHandler(ConnectionStatus.Connected, e.ConnectionStatusChangeReason);
-            }
-        }
-
-        /// <summary>
-        /// The delegate for handling disrupted connection/links in the transport layer.
-        /// </summary>
-        internal async Task OnConnectionClosed(object sender, ConnectionEventArgs e)
-        {
-            ConnectionStatusChangeResult result = null;
-
-            // codes_SRS_DEVICECLIENT_28_023: [** `OnConnectionClosed` shall notify ConnectionStatusManager of the connection updates. **]**
-            if (e.ConnectionStatus == ConnectionStatus.Disconnected_Retrying)
-            {
-                try
-                {
-                    // codes_SRS_DEVICECLIENT_28_022: [** `OnConnectionClosed` shall invoke the RecoverConnections operation. **]**          
-                    await ApplyTimeout(async operationTimeoutCancellationTokenSource =>
-                    {
-                        result = this.connectionStatusManager.ChangeTo(e.ConnectionType, ConnectionStatus.Disconnected_Retrying, ConnectionStatus.Connected);
-                        if (result.IsClientStatusChanged && (connectionStatusChangesHandler != null))
-                        {
-                            this.connectionStatusChangesHandler(e.ConnectionStatus, e.ConnectionStatusChangeReason);
-                        }
-
-                        using (CancellationTokenSource linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(result.StatusChangeCancellationTokenSource.Token, operationTimeoutCancellationTokenSource.Token))
-                        {
-                            await this.InnerHandler.RecoverConnections(sender, e.ConnectionType, linkedTokenSource.Token).ConfigureAwait(false);
-                        }
-
-                    }).ConfigureAwait(false);
-                }
-                catch (Exception)
-                {
-                    // codes_SRS_DEVICECLIENT_28_027: [** `OnConnectionClosed` shall invoke the connectionStatusChangesHandler if RecoverConnections throw exception **]**
-                    result = this.connectionStatusManager.ChangeTo(e.ConnectionType, ConnectionStatus.Disconnected);
-                    if (result.IsClientStatusChanged && (connectionStatusChangesHandler != null))
-                    {
-                        this.connectionStatusChangesHandler(ConnectionStatus.Disconnected, ConnectionStatusChangeReason.Retry_Expired);
-                    }
-                }
-            }
-            else
-            {
-                result = this.connectionStatusManager.ChangeTo(e.ConnectionType, ConnectionStatus.Disabled);
-                if (result.IsClientStatusChanged && (connectionStatusChangesHandler != null))
-                {
-                    this.connectionStatusChangesHandler(ConnectionStatus.Disabled, e.ConnectionStatusChangeReason);
-                }
-            }
-        }
-
-        /// <summary>
-        /// The delegate for handling direct methods received from service.
-        /// </summary>
-        internal async Task OnMethodCalled(MethodRequestInternal methodRequestInternal)
-        {
-            Tuple<MethodCallback, object> m = null;
-
-            // codes_SRS_DEVICECLIENT_10_012: [ If the given methodRequestInternal argument is null, fail silently ]
-            if (methodRequestInternal != null)
-            {
-                MethodResponseInternal methodResponseInternal;
-                byte[] requestData = methodRequestInternal.GetBytes();
-
-                await methodsDictionarySemaphore.WaitAsync().ConfigureAwait(false);
-                try
-                {
-                    Utils.ValidateDataIsEmptyOrJson(requestData);                    
-                    this.deviceMethods?.TryGetValue(methodRequestInternal.Name, out m);
-                    if (m == null)
-                    {
-                        m = this.deviceDefaultMethodCallback;
-                    }
-                }
-                catch (Exception)
-                {
-                    // codes_SRS_DEVICECLIENT_28_020: [ If the given methodRequestInternal data is not valid json, respond with status code 400 (BAD REQUEST) ]
-                    methodResponseInternal = new MethodResponseInternal(methodRequestInternal.RequestId, (int)MethodResposeStatusCode.BadRequest);
-                    await this.SendMethodResponseAsync(methodResponseInternal).ConfigureAwait(false);
-                    return;
-                }
-                finally
-                {
-                    methodsDictionarySemaphore.Release();
-                }
-
-                if (m != null)
-                {
-                    try
-                    {
-                        // codes_SRS_DEVICECLIENT_10_011: [ The OnMethodCalled shall invoke the specified delegate. ]
-                        // codes_SRS_DEVICECLIENT_24_002: [ The OnMethodCalled shall invoke the default delegate if there is no specified delegate for that method. ]
-                        MethodResponse rv = await m.Item1(new MethodRequest(methodRequestInternal.Name, requestData), m.Item2).ConfigureAwait(false);
-
-                        // codes_SRS_DEVICECLIENT_03_012: [If the MethodResponse does not contain result, the MethodResponseInternal constructor shall be invoked with no results.]
-                        if (rv.Result == null)
-                        {
-                            methodResponseInternal = new MethodResponseInternal(methodRequestInternal.RequestId, rv.Status);
-                        }
-                        // codes_SRS_DEVICECLIENT_03_013: [Otherwise, the MethodResponseInternal constructor shall be invoked with the result supplied.]
-                        else
-                        {
-                            methodResponseInternal = new MethodResponseInternal(rv.Result, methodRequestInternal.RequestId, rv.Status);
-                        }
-                    }
-                    catch (Exception)
-                    {
-                        // codes_SRS_DEVICECLIENT_28_021: [ If the MethodResponse from the MethodHandler is not valid json, respond with status code 500 (USER CODE EXCEPTION) ]
-                        methodResponseInternal = new MethodResponseInternal(methodRequestInternal.RequestId, (int)MethodResposeStatusCode.UserCodeException);
-                    }
-                }
-                else
-                {
-                    // codes_SRS_DEVICECLIENT_10_013: [ If the given method does not have an associated delegate and no default delegate was registered, respond with status code 501 (METHOD NOT IMPLEMENTED) ]
-                    methodResponseInternal = new MethodResponseInternal(methodRequestInternal.RequestId, (int)MethodResposeStatusCode.MethodNotImplemented);
-                }
-                await this.SendMethodResponseAsync(methodResponseInternal).ConfigureAwait(false);
-            }
-        }
-
-        public void Dispose()
-        {
-            this.InnerHandler?.Dispose();
-        }
-
-        static ITransportSettings[] PopulateCertificateInTransportSettings(IotHubConnectionStringBuilder connectionStringBuilder, TransportType transportType)
-        {
-            switch (transportType)
-            {
-                case TransportType.Amqp:
-                    return new ITransportSettings[]
-                    {
-                        new AmqpTransportSettings(TransportType.Amqp_Tcp_Only)
-                        {
-                            ClientCertificate = connectionStringBuilder.Certificate
-                        },
-                        new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
-                        {
-                            ClientCertificate = connectionStringBuilder.Certificate
-                        }
-                    };
-                case TransportType.Amqp_Tcp_Only:
-                    return new ITransportSettings[]
-                    {
-                        new AmqpTransportSettings(TransportType.Amqp_Tcp_Only)
-                        {
-                            ClientCertificate = connectionStringBuilder.Certificate
-                        }
-                    };
-                case TransportType.Amqp_WebSocket_Only:
-                    return new ITransportSettings[]
-                    {
-                        new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
-                        {
-                            ClientCertificate = connectionStringBuilder.Certificate
-                        }
-                    };
-                case TransportType.Http1:
-                    return new ITransportSettings[]
-                    {
-                        new Http1TransportSettings()
-                        {
-                            ClientCertificate = connectionStringBuilder.Certificate
-                        }
-                    };
-                case TransportType.Mqtt:
-                    return new ITransportSettings[]
-                    {
-                        new MqttTransportSettings(TransportType.Mqtt_Tcp_Only)
-                        {
-                            ClientCertificate = connectionStringBuilder.Certificate
-                        },
-                        new MqttTransportSettings(TransportType.Mqtt_WebSocket_Only)
-                        {
-                            ClientCertificate = connectionStringBuilder.Certificate
-                        }
-                    };
-                case TransportType.Mqtt_Tcp_Only:
-                    return new ITransportSettings[]
-                    {
-                        new MqttTransportSettings(TransportType.Mqtt_Tcp_Only)
-                        {
-                            ClientCertificate = connectionStringBuilder.Certificate
-                        }
-                    };
-                case TransportType.Mqtt_WebSocket_Only:
-                    return new ITransportSettings[]
-                    {
-                        new MqttTransportSettings(TransportType.Mqtt_WebSocket_Only)
-                        {
-                            ClientCertificate = connectionStringBuilder.Certificate
-                        }
-                    };
-                default:
-                    throw new InvalidOperationException("Unsupported Transport {0}".FormatInvariant(transportType));
-            }
-        }
-
-        static ITransportSettings[] PopulateCertificateInTransportSettings(IotHubConnectionStringBuilder connectionStringBuilder, ITransportSettings[] transportSettings)
-        {
-            foreach (var transportSetting in  transportSettings)
-            {
-                switch (transportSetting.GetTransportType())
-                {
-                    case TransportType.Amqp_WebSocket_Only:
-                    case TransportType.Amqp_Tcp_Only:
-                        ((AmqpTransportSettings)transportSetting).ClientCertificate = connectionStringBuilder.Certificate;
-                        break;
-                    case TransportType.Http1:
-                        ((Http1TransportSettings)transportSetting).ClientCertificate = connectionStringBuilder.Certificate;
-                        break;
-                    case TransportType.Mqtt_WebSocket_Only:
-                    case TransportType.Mqtt_Tcp_Only:
-                        ((MqttTransportSettings)transportSetting).ClientCertificate = connectionStringBuilder.Certificate;
-                        break;
-                    default:
-                        throw new InvalidOperationException("Unsupported Transport {0}".FormatInvariant(transportSetting.GetTransportType()));
-                }
-            }
-
-            return transportSettings;
-        }
-
-        /// <summary>
-        /// Set a callback that will be called whenever the client receives a state update 
-        /// (desired or reported) from the service.  This has the side-effect of subscribing
-        /// to the PATCH topic on the service.
-        /// </summary>
-        /// <param name="callback">Callback to call after the state update has been received and applied</param>
-        /// <param name="userContext">Context object that will be passed into callback</param>
-        [Obsolete("Please use SetDesiredPropertyUpdateCallbackAsync.")]
-        public Task SetDesiredPropertyUpdateCallback(DesiredPropertyUpdateCallback callback, object userContext)
-        {
-            return SetDesiredPropertyUpdateCallbackAsync(callback, userContext);
-        }
-
-        /// <summary>
-        /// Set a callback that will be called whenever the client receives a state update 
-        /// (desired or reported) from the service.  This has the side-effect of subscribing
-        /// to the PATCH topic on the service.
-        /// </summary>
-        /// <param name="callback">Callback to call after the state update has been received and applied</param>
-        /// <param name="userContext">Context object that will be passed into callback</param>
-        public Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback callback, object userContext)
-        {
-            // Codes_SRS_DEVICECLIENT_18_007: `SetDesiredPropertyUpdateCallbackAsync` shall throw an `ArgumentNull` exception if `callback` is null
-            if (callback == null)
-            {
-                throw Fx.Exception.ArgumentNull("callback");
-            }
-
-            return ApplyTimeout(async operationTimeoutCancellationToken =>
-            {
-                // Codes_SRS_DEVICECLIENT_18_003: `SetDesiredPropertyUpdateCallbackAsync` shall call the transport to register for PATCHes on it's first call.
-                // Codes_SRS_DEVICECLIENT_18_004: `SetDesiredPropertyUpdateCallbackAsync` shall not call the transport to register for PATCHes on subsequent calls
-                if (!this.patchSubscribedWithService)
-                {
-                    await this.InnerHandler.EnableTwinPatchAsync(operationTimeoutCancellationToken).ConfigureAwait(false);
-                    patchSubscribedWithService = true;
-                }
-
-                this.desiredPropertyUpdateCallback = callback;
-                this.twinPatchCallbackContext = userContext;
-            });
-        }
-
-        /// <summary>
-        /// Retrieve a device twin object for the current device.
-        /// </summary>
-        /// <returns>The device twin object for the current device</returns>
-        public Task<Twin> GetTwinAsync()
-        {
-            return ApplyTimeoutTwin(async operationTimeoutCancellationToken =>
-            {
-                // Codes_SRS_DEVICECLIENT_18_001: `GetTwinAsync` shall call `SendTwinGetAsync` on the transport to get the twin state
-                return await this.InnerHandler.SendTwinGetAsync(operationTimeoutCancellationToken).ConfigureAwait(false);
-            });
-        }
-
-        /// <summary>
-        /// Push reported property changes up to the service.
-        /// </summary>
-        /// <param name="reportedProperties">Reported properties to push</param>
-        public Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties)
-        {
-            // Codes_SRS_DEVICECLIENT_18_006: `UpdateReportedPropertiesAsync` shall throw an `ArgumentNull` exception if `reportedProperties` is null
-            if (reportedProperties == null)
-            {
-                throw Fx.Exception.ArgumentNull("reportedProperties");
-            }
-            return ApplyTimeout(async operationTimeoutCancellationToken =>
-            {
-                // Codes_SRS_DEVICECLIENT_18_002: `UpdateReportedPropertiesAsync` shall call `SendTwinPatchAsync` on the transport to update the reported properties
-                 await this.InnerHandler.SendTwinPatchAsync(reportedProperties, operationTimeoutCancellationToken).ConfigureAwait(false);
-            });
-        }
-
-        //  Codes_SRS_DEVICECLIENT_18_005: When a patch is received from the service, the `callback` shall be called.
-        internal void OnReportedStatePatchReceived(TwinCollection patch)
-        {
-            if (this.desiredPropertyUpdateCallback != null)
-            {
-                this.desiredPropertyUpdateCallback(patch, this.twinPatchCallbackContext);
-            }
-        }
-
-        private async Task EnableMethodAsync()
-        {
-            if (this.deviceMethods == null && this.deviceDefaultMethodCallback == null)
-            {
-                await ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.EnableMethodsAsync(operationTimeoutCancellationToken)).ConfigureAwait(false);
-            }
-        }
-
-        private async Task DisableMethodAsync()
-        {
-            if (this.deviceMethods == null && this.deviceDefaultMethodCallback == null)
-            {
-                await ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.DisableMethodsAsync(operationTimeoutCancellationToken)).ConfigureAwait(false);
-            }
-        }
-
-        private bool IsE2EDiagnosticSupportedProtocol()
-        {
-            foreach (ITransportSettings transportSetting in this.transportSettings)
-            {
-                var transportType = transportSetting.GetTransportType();
-                if (!(transportType == TransportType.Amqp_WebSocket_Only || transportType == TransportType.Amqp_Tcp_Only
-                    || transportType == TransportType.Mqtt_WebSocket_Only || transportType == TransportType.Mqtt_Tcp_Only))
-                {
-                    throw new NotSupportedException($"{transportType} protocal doesn't support E2E diagnostic.");
-                }
-            }
-            return true;
-        }
-    
-        #region Module Specific API
-        /// <summary>
-        /// <param name="outputName">The output target for sending the given message</param>
-        /// <param name="message">The message to send</param>
-        /// <returns>The message containing the event</returns>
-        public Task SendEventAsync(string outputName, Message message)
-        {
-            ValidateModuleTransportHandler("SendEventAsync for a named output");
-
-            // Codes_SRS_DEVICECLIENT_10_012: [If `outputName` is `null` or empty, an `ArgumentNullException` shall be thrown.]
-            if (string.IsNullOrWhiteSpace(outputName))
-            {
-                throw new ArgumentException(nameof(outputName));
-            }
-
-            // Codes_SRS_DEVICECLIENT_10_013: [If `message` is `null` or empty, an `ArgumentNullException` shall be thrown.]
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
-
-            // Codes_SRS_DEVICECLIENT_10_015: [The `output` property of a given `message` shall be assigned the value `outputName` before submitting each request to the transport layer.]
-            message.SystemProperties.Add(MessageSystemPropertyNames.OutputName, outputName);
-
-            // Codes_SRS_DEVICECLIENT_10_011: [The `SendEventAsync` operation shall retry sending `message` until the `BaseClient::RetryStrategy` tiemspan expires or unrecoverable error(authentication or quota exceed) occurs.]
-            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.SendEventAsync(message, operationTimeoutCancellationToken));
-        }
-
-        /// <summary>
-        /// Sends a batch of events to device hub
-        /// <param name="outputName">The output target for sending the given message</param>
-        /// <param name="messages">A list of one or more messages to send</param>
-        /// </summary>
-        /// <returns>The task containing the event</returns>
-        public Task SendEventBatchAsync(string outputName, IEnumerable<Message> messages)
-        {
-            ValidateModuleTransportHandler("SendEventBatchAsync for a named output");
-
-            // Codes_SRS_DEVICECLIENT_10_012: [If `outputName` is `null` or empty, an `ArgumentNullException` shall be thrown.]
-            if (string.IsNullOrWhiteSpace(outputName))
-            {
-                throw new ArgumentException(nameof(outputName));
-            }
-
-            List<Message> messagesList = messages?.ToList();
-            // Codes_SRS_DEVICECLIENT_10_013: [If `message` is `null` or empty, an `ArgumentNullException` shall be thrown]
-            if (messagesList == null || messagesList.Count == 0)
-            {
-                throw new ArgumentNullException(nameof(messages));
-            }
-
-#if PCL
-            foreach(var m in messagesList)
-            {
-                m.SystemProperties.Add(MessageSystemPropertyNames.OutputName, outputName);
-            }
-#else
-            // Codes_SRS_DEVICECLIENT_10_015: [The `module-output` property of a given `message` shall be assigned the value `outputName` before submitting each request to the transport layer.]
-            messagesList.ForEach(m => m.SystemProperties.Add(MessageSystemPropertyNames.OutputName, outputName));
-#endif
-
-            // Codes_SRS_DEVICECLIENT_10_014: [The `SendEventBachAsync` operation shall retry sending `messages` until the `BaseClient::RetryStrategy` tiemspan expires or unrecoverable error(authentication or quota exceed) occurs.]
-            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.SendEventAsync(messagesList, operationTimeoutCancellationToken));
-        }
-
-        /// <summary>
-        /// Registers a new delgate for the particular input. If a delegate is already associated with
-        /// the input, it will be replaced with the new delegate.
-        /// <param name="inputName">The name of the input to associate with the delegate.</param>
-        /// <param name="messageHandler">The delegate to be used when a message is sent to the particular inputName.</param>
-        /// <param name="userContext">generic parameter to be interpreted by the client code.</param>
-        /// </summary>
-        /// <returns>The task containing the event</returns>
-        public async Task SetInputMessageHandlerAsync(string inputName, MessageHandler messageHandler, object userContext)
-        {
-            ValidateModuleTransportHandler("SetInputMessageHandlerAsync for a named output");
-            try
-            {
-                await this.receiveSemaphore.WaitAsync();
-
-                if (messageHandler != null)
-                {
-                    // codes_SRS_DEVICECLIENT_33_003: [ It shall EnableEventReceiveAsync when called for the first time. ]
-                    await this.EnableEventReceiveAsync();
-                    // codes_SRS_DEVICECLIENT_33_005: [ It shall lazy-initialize the receiveEventEndpoints property. ]
-                    if (this.receiveEventEndpoints == null)
-                    {
-                        this.receiveEventEndpoints = new Dictionary<string, Tuple<MessageHandler, object>>();
-                    }
-                    this.receiveEventEndpoints[inputName] = new Tuple<MessageHandler, object>(messageHandler, userContext);
-                }
-                else
-                {
-                    if (this.receiveEventEndpoints != null)
-                    {
-                        this.receiveEventEndpoints.Remove(inputName);
-                        if (this.receiveEventEndpoints.Count == 0)
-                        {
-                            this.receiveEventEndpoints = null;
-                        }
-                    }
-                    // codes_SRS_DEVICECLIENT_33_004: [ It shall call DisableEventReceiveAsync when the last delegate has been removed. ]
-                    await this.DisableEventReceiveAsync();
-                }
-            }
-            finally
-            {
-                this.receiveSemaphore.Release();
-            }
-        }
-
-        /// <summary>
-        /// Registers a new default delegate which applies to all endpoints. If a delegate is already associated with
-        /// the input, it will be called, else the default delegate will be called. If a default delegate was set previously,
-        /// it will be overwritten.
-        /// <param name="messageHandler">The delegate to be called when a message is sent to any input.</param>
-        /// <param name="userContext">generic parameter to be interpreted by the client code.</param>
-        /// </summary>
-        /// <returns>The task containing the event</returns>
-        public async Task SetMessageHandlerAsync(MessageHandler messageHandler, object userContext)
-        {
-            try
-            {
-                await this.receiveSemaphore.WaitAsync();
-                if (messageHandler != null)
-                {
-                    // codes_SRS_DEVICECLIENT_33_003: [ It shall EnableEventReceiveAsync when called for the first time. ]
-                    await this.EnableEventReceiveAsync();
-                    this.defaultEventCallback = new Tuple<MessageHandler, object>(messageHandler, userContext);
-                }
-                else
-                {
-                    this.defaultEventCallback = null;
-                    // codes_SRS_DEVICECLIENT_33_004: [ It shall DisableEventReceiveAsync when the last delegate has been removed. ]
-                    await this.DisableEventReceiveAsync();
-                }
-            }
-            finally
-            {
-                this.receiveSemaphore.Release();
-            }
-        }
-
-        private async Task EnableEventReceiveAsync()
-        {
-            if (this.receiveEventEndpoints == null && this.defaultEventCallback == null)
-            {
-                await ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.EnableEventReceiveAsync(operationTimeoutCancellationToken));
-            }
-        }
-
-        private async Task DisableEventReceiveAsync()
-        {
-            if (this.receiveEventEndpoints == null && this.defaultEventCallback == null)
-            {
-                await ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.DisableEventReceiveAsync(operationTimeoutCancellationToken));
-            }
-        }
-
-        /// <summary>
-        /// The delegate for handling event messages received
-        /// <param name="input">The input on which a message is received</param>
-        /// <param name="message">The message received</param>
-        /// </summary>
-        internal async Task OnReceiveEventMessageCalled(string input, Message message)
-        {
-            // codes_SRS_DEVICECLIENT_33_001: [ If the given eventMessageInternal argument is null, fail silently ]
-            if (message != null)
-            {
-                Tuple<MessageHandler, object> callback = null;
-                await this.receiveSemaphore.WaitAsync();
-                try
-                {
-                    // codes_SRS_DEVICECLIENT_33_006: [ The OnReceiveEventMessageCalled shall get the default delegate if a delegate has not been assigned. ]
-                    if (this.receiveEventEndpoints == null ||
-                        string.IsNullOrWhiteSpace(input) ||
-                        !this.receiveEventEndpoints.TryGetValue(input, out callback))
-                    {
-                        callback = this.defaultEventCallback;
-                    }
-                }
-                finally
-                {
-                    this.receiveSemaphore.Release();
-                }
-
-                // codes_SRS_DEVICECLIENT_33_002: [ The OnReceiveEventMessageCalled shall invoke the specified delegate. ]
-                MessageResponse response = await (callback?.Item1?.Invoke(message, callback.Item2) ?? Task.FromResult(MessageResponse.None));
-
-                switch (response)
-                {
-                    case MessageResponse.Completed:
-                        await this.CompleteAsync(message);
-                        break;
-                    case MessageResponse.Abandoned:
-                        await this.AbandonAsync(message);
-                        break;
-                    default:
-                        break;
-                }
-            }
-        }
-        
-        void ValidateModuleTransportHandler(string apiName)
-        {
-            if (string.IsNullOrEmpty(this.iotHubConnectionString.ModuleId))
-            {
-                throw new InvalidOperationException("{0} is available for Modules only.".FormatInvariant(apiName));
-            }
-        }
-
-        #endregion Module Specific API
     }
 }

--- a/iothub/device/src/Edge/EdgeModuleClientFactory.cs
+++ b/iothub/device/src/Edge/EdgeModuleClientFactory.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using Microsoft.Azure.Devices.Client.HsmAuthentication;
-
 namespace Microsoft.Azure.Devices.Client.Edge
 {
+    using System;
+    using System.Collections;
+    using Microsoft.Azure.Devices.Client.HsmAuthentication;
+
     /// <summary>
     /// Factory that creates ModuleClient based on the IoT Edge environment.
     /// </summary>
@@ -40,10 +40,10 @@ namespace Microsoft.Azure.Devices.Client.Edge
         /// <returns></returns>
         public ModuleClient Create()
         {
-            return this.CreateDeviceClientFromEnvironment();
+            return new ModuleClient(this.CreateInternalClientFromEnvironment());
         }
 
-        ModuleClient CreateDeviceClientFromEnvironment()
+        InternalClient CreateInternalClientFromEnvironment()
         {
             IDictionary envVariables = Environment.GetEnvironmentVariables();
 
@@ -52,15 +52,15 @@ namespace Microsoft.Azure.Devices.Client.Edge
             // First try to create from connection string and if env variable for connection string is not found try to create from edgedUri
             if (!string.IsNullOrWhiteSpace(connectionString))
             {
-                return this.CreateDeviceClientFromConnectionString(connectionString);
+                return this.CreateInternalClientFromConnectionString(connectionString);
             }
             else
             {
-                string edgedUri = this.GetValueFromEnvironment(envVariables, IotEdgedUriVariableName) ?? throw new InvalidOperationException($"Environement variable {IotEdgedUriVariableName} is required.");
-                string deviceId = this.GetValueFromEnvironment(envVariables, DeviceIdVariableName) ?? throw new InvalidOperationException($"Environement variable {DeviceIdVariableName} is required.");
-                string moduleId = this.GetValueFromEnvironment(envVariables, ModuleIdVariableName) ?? throw new InvalidOperationException($"Environement variable {ModuleIdVariableName} is required.");
-                string hostname = this.GetValueFromEnvironment(envVariables, IotHubHostnameVariableName) ?? throw new InvalidOperationException($"Environement variable {IotHubHostnameVariableName} is required.");
-                string authScheme = this.GetValueFromEnvironment(envVariables, AuthSchemeVariableName) ?? throw new InvalidOperationException($"Environement variable {AuthSchemeVariableName} is required.");
+                string edgedUri = this.GetValueFromEnvironment(envVariables, IotEdgedUriVariableName) ?? throw new InvalidOperationException($"Environment variable {IotEdgedUriVariableName} is required.");
+                string deviceId = this.GetValueFromEnvironment(envVariables, DeviceIdVariableName) ?? throw new InvalidOperationException($"Environment variable {DeviceIdVariableName} is required.");
+                string moduleId = this.GetValueFromEnvironment(envVariables, ModuleIdVariableName) ?? throw new InvalidOperationException($"Environment variable {ModuleIdVariableName} is required.");
+                string hostname = this.GetValueFromEnvironment(envVariables, IotHubHostnameVariableName) ?? throw new InvalidOperationException($"Environment variable {IotHubHostnameVariableName} is required.");
+                string authScheme = this.GetValueFromEnvironment(envVariables, AuthSchemeVariableName) ?? throw new InvalidOperationException($"Environment variable {AuthSchemeVariableName} is required.");
                 string gateway = this.GetValueFromEnvironment(envVariables, GatewayHostnameVariableName);
                 string apiVersion = this.GetValueFromEnvironment(envVariables, IotEdgedApiVersionVariableName);
 
@@ -74,18 +74,18 @@ namespace Microsoft.Azure.Devices.Client.Edge
                     : new HttpHsmSignatureProvider(edgedUri, apiVersion);
                 var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId);
 
-                return this.CreateDeviceClientFromAuthenticationMethod(hostname, gateway, authMethod);
+                return this.CreateInternalClientFromAuthenticationMethod(hostname, gateway, authMethod);
             }
         }
 
-        ModuleClient CreateDeviceClientFromConnectionString(string connectionString)
+        InternalClient CreateInternalClientFromConnectionString(string connectionString)
         {
-            return ModuleClient.CreateFromConnectionString(connectionString, this.transportSettings);
+            return ClientFactory.CreateFromConnectionString(connectionString, this.transportSettings);
         }
 
-        ModuleClient CreateDeviceClientFromAuthenticationMethod(string hostname, string gateway, IAuthenticationMethod authMethod)
+        InternalClient CreateInternalClientFromAuthenticationMethod(string hostname, string gateway, IAuthenticationMethod authMethod)
         {
-            return ModuleClient.Create(hostname, gateway, authMethod, this.transportSettings);
+            return ClientFactory.Create(hostname, gateway, authMethod, this.transportSettings);
         }
 
         string GetValueFromEnvironment(IDictionary envVariables, string variableName)

--- a/iothub/device/src/Edge/EdgeModuleClientFactory.cs
+++ b/iothub/device/src/Edge/EdgeModuleClientFactory.cs
@@ -8,9 +8,9 @@ using Microsoft.Azure.Devices.Client.HsmAuthentication;
 namespace Microsoft.Azure.Devices.Client.Edge
 {
     /// <summary>
-    /// Factory that creates DeviceClient based on the IoT Edge environment.
+    /// Factory that creates ModuleClient based on the IoT Edge environment.
     /// </summary>
-    public class DeviceClientFactory
+    internal class EdgeModuleClientFactory
     {
         const string IotEdgedUriVariableName = "IOTEDGE_IOTEDGEDURI";
         const string IotEdgedApiVersionVariableName = "IOTEDGE_IOTEDGEDVERSION";
@@ -23,44 +23,27 @@ namespace Microsoft.Azure.Devices.Client.Edge
         const string EdgehubConnectionstringVariableName = "EdgeHubConnectionString";
         const string IothubConnectionstringVariableName = "IotHubConnectionString";
 
-        readonly TransportType? transportType;
         readonly ITransportSettings[] transportSettings;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DeviceClientFactory"/> class.
-        /// </summary>
-        public DeviceClientFactory()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DeviceClientFactory"/> class with transport type.
-        /// </summary>
-        /// <param name="transportType">Specifies whether AMQP, MQTT or HTTP transport is used.</param>
-        public DeviceClientFactory(TransportType transportType)
-        {
-            this.transportType = transportType;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DeviceClientFactory"/> class with transport settings.
+        /// Initializes a new instance of the <see cref="EdgeModuleClientFactory"/> class with transport settings.
         /// </summary>
         /// <param name="transportSettings">Prioritized list of transportTypes and their settings.</param>
-        public DeviceClientFactory(ITransportSettings[] transportSettings)
+        public EdgeModuleClientFactory(ITransportSettings[] transportSettings)
         {
-            this.transportSettings = transportSettings;
+            this.transportSettings = transportSettings ?? throw new ArgumentNullException(nameof(transportSettings));
         }
 
         /// <summary>
-        /// Creates a DeviceClient instance based on environment.
+        /// Creates a ModuleClient instance based on environment.
         /// </summary>
         /// <returns></returns>
-        public DeviceClient Create()
+        public ModuleClient Create()
         {
             return this.CreateDeviceClientFromEnvironment();
         }
 
-        DeviceClient CreateDeviceClientFromEnvironment()
+        ModuleClient CreateDeviceClientFromEnvironment()
         {
             IDictionary envVariables = Environment.GetEnvironmentVariables();
 
@@ -95,34 +78,14 @@ namespace Microsoft.Azure.Devices.Client.Edge
             }
         }
 
-        DeviceClient CreateDeviceClientFromConnectionString(string connectionString)
+        ModuleClient CreateDeviceClientFromConnectionString(string connectionString)
         {
-            if (this.transportSettings != null)
-            {
-                return DeviceClient.CreateFromConnectionString(connectionString, this.transportSettings);
-            }
-
-            if (this.transportType.HasValue)
-            {
-                return DeviceClient.CreateFromConnectionString(connectionString, this.transportType.Value);
-            }
-
-            return DeviceClient.CreateFromConnectionString(connectionString);
+            return ModuleClient.CreateFromConnectionString(connectionString, this.transportSettings);
         }
 
-        DeviceClient CreateDeviceClientFromAuthenticationMethod(string hostname, string gateway, IAuthenticationMethod authMethod)
+        ModuleClient CreateDeviceClientFromAuthenticationMethod(string hostname, string gateway, IAuthenticationMethod authMethod)
         {
-            if (this.transportSettings != null)
-            {
-                return DeviceClient.Create(hostname, gateway, authMethod, this.transportSettings);
-            }
-
-            if (this.transportType.HasValue)
-            {
-                return DeviceClient.Create(hostname, gateway, authMethod, this.transportType.Value);
-            }
-
-            return DeviceClient.Create(hostname, gateway, authMethod);
+            return ModuleClient.Create(hostname, gateway, authMethod, this.transportSettings);
         }
 
         string GetValueFromEnvironment(IDictionary envVariables, string variableName)

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -230,6 +230,8 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
             });
         }
 
+        internal IotHubConnectionString IotHubConnectionString => this.iotHubConnectionString;
+
         /// <summary>
         /// Stores custom product information that will be appended to the user agent string that is sent to IoT Hub.
         /// </summary>

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -24,8 +24,7 @@ namespace Microsoft.Azure.Devices.Client
         {
             this.internalClient = internalClient ?? throw new ArgumentNullException(nameof(internalClient));
 
-            if (this.internalClient.IotHubConnectionString == null ||
-                string.IsNullOrWhiteSpace(this.internalClient.IotHubConnectionString.ModuleId))
+            if (string.IsNullOrWhiteSpace(this.internalClient.IotHubConnectionString?.ModuleId))
             {
                 throw new ArgumentException("A valid module ID should be specified to create a ModuleClient");
             }
@@ -144,9 +143,9 @@ namespace Microsoft.Azure.Devices.Client
         /// based on environment variables.
         /// </summary>
         /// <returns>ModuleClient instance</returns>
-        public static ModuleClient Create()
+        public static ModuleClient CreateFromEnvironment()
         {
-            return Create(TransportType.Amqp);
+            return CreateFromEnvironment(TransportType.Amqp);
         }
 
         /// <summary>
@@ -155,9 +154,9 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="transportType">Specifies whether Amqp or Http transport is used</param>
         /// <returns>ModuleClient instance</returns>
-        public static ModuleClient Create(TransportType transportType)
+        public static ModuleClient CreateFromEnvironment(TransportType transportType)
         {
-            return Create(ClientFactory.GetTransportSettings(transportType));
+            return CreateFromEnvironment(ClientFactory.GetTransportSettings(transportType));
         }
 
         /// <summary>
@@ -166,7 +165,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="transportSettings">Prioritized list of transports and their settings</param>
         /// <returns>ModuleClient instance</returns>
-        public static ModuleClient Create(ITransportSettings[] transportSettings)
+        public static ModuleClient CreateFromEnvironment(ITransportSettings[] transportSettings)
         {
             return new EdgeModuleClientFactory(transportSettings).Create();
         }

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -1,27 +1,18 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Azure.Devices.Client.Edge;
-
 namespace Microsoft.Azure.Devices.Client
 {
-    using Common;
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
 #if NETSTANDARD1_3
     using System.Net.Http;
 #endif
-    using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Devices.Client.Extensions;
-    using Microsoft.Azure.Devices.Client.Transport;
     using Microsoft.Azure.Devices.Shared;
-    using Newtonsoft.Json.Linq;
-    using Microsoft.Azure.Devices.Client.Transport.Mqtt;
-    using System.Security.Cryptography.X509Certificates;
+    using Microsoft.Azure.Devices.Client.Edge;
 
     /// <summary>
     ///    Status of handling a message. 
@@ -504,10 +495,10 @@ namespace Microsoft.Azure.Devices.Client
                 switch (response)
                 {
                     case MessageResponse.Completed:
-                        await this.CompleteInternalAsync(message.LockToken);
+                        await this.CompleteAsync(message);
                         break;
                     case MessageResponse.Abandoned:
-                        await this.AbandonInternalAsync(message.LockToken);
+                        await this.AbandonAsync(message);
                         break;
                     default:
                         break;

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -22,7 +22,13 @@ namespace Microsoft.Azure.Devices.Client
 
         internal ModuleClient(InternalClient internalClient)
         {
-            this.internalClient = internalClient;
+            this.internalClient = internalClient ?? throw new ArgumentNullException(nameof(internalClient));
+
+            if (this.internalClient.IotHubConnectionString == null ||
+                string.IsNullOrWhiteSpace(this.internalClient.IotHubConnectionString.ModuleId))
+            {
+                throw new ArgumentException("A valid module ID should be specified to create a ModuleClient");
+            }
         }
 
         /// <summary>

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="methodHandler">The delegate to be used when a method with the given name is called by the cloud service.</param>
         /// <param name="userContext">generic parameter to be interpreted by the client code.</param>
         /// </summary>
-        public async Task SetMethodHandlerAsync(string methodName, MethodCallback methodHandler, object userContext) =>
+        public Task SetMethodHandlerAsync(string methodName, MethodCallback methodHandler, object userContext) =>
             this.internalClient.SetMethodHandlerAsync(methodName, methodHandler, userContext);
 
         /// <summary>
@@ -282,7 +282,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="methodHandler">The delegate to be used when a method is called by the cloud service and there is no delegate registered for that method name.</param>
         /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
-        public async Task SetMethodDefaultHandlerAsync(MethodCallback methodHandler, object userContext) =>
+        public Task SetMethodDefaultHandlerAsync(MethodCallback methodHandler, object userContext) =>
             this.internalClient.SetMethodDefaultHandlerAsync(methodHandler, userContext);
 
         /// <summary>

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -1,0 +1,486 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Client
+{
+    using Common;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+#if NETSTANDARD1_3
+    using System.Net.Http;
+#endif
+    using System.Text.RegularExpressions;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Client.Extensions;
+    using Microsoft.Azure.Devices.Client.Transport;
+    using Microsoft.Azure.Devices.Shared;
+    using Newtonsoft.Json.Linq;
+    using Microsoft.Azure.Devices.Client.Transport.Mqtt;
+    using System.Security.Cryptography.X509Certificates;
+
+    /// <summary>
+    ///    Status of handling a message. 
+    ///    None - Means Device SDK won't send an ackowledge of receipt.
+    ///    Completed - Means Device SDK will Complete the event. Removing from the queue.
+    ///    Abandoned - Event will be Abandoned. 
+    /// </summary>
+    public enum MessageResponse { None, Completed, Abandoned };
+
+    /// <summary>
+    /// Delegate that gets called when a message is received on a particular input.
+    /// </summary>
+    /// <param name="message">The message received</param>
+    /// <param name="userContext">The context object passed in</param>
+    /// <returns>MessageResponse</returns>
+    public delegate Task<MessageResponse> MessageHandler(Message message, object userContext);
+
+    /// <summary>
+    /// Contains methods that a device can use to send messages to and receive from the service.
+    /// </summary>
+    public sealed class ModuleClient : BaseClient
+    {
+        volatile Dictionary<string, Tuple<MessageHandler, object>> receiveEventEndpoints;
+
+        readonly SemaphoreSlim receiveSemaphore = new SemaphoreSlim(1, 1);
+
+        volatile Tuple<MessageHandler, object> defaultEventCallback;
+
+        private ProductInfo productInfo = new ProductInfo();
+
+        /// <summary>
+        /// Stores custom product information that will be appended to the user agent string that is sent to IoT Hub.
+        /// </summary>
+        public string ProductInfo
+        {
+            // We store DeviceClient.ProductInfo as a string property of an object (rather than directly as a string)
+            // so that updates will propagate down to the transport layer throughout the lifetime of the DeviceClient
+            // object instance.
+            get => productInfo.Extra;
+            set => productInfo.Extra = value;
+        }
+
+        ModuleClient(IotHubConnectionString iotHubConnectionString, ITransportSettings[] transportSettings, IDeviceClientPipelineBuilder pipelineBuilder)
+            : base(iotHubConnectionString, transportSettings)
+        {
+            if (string.IsNullOrWhiteSpace(iotHubConnectionString.ModuleId))
+            {
+                throw new ArgumentException("ModuleId not present - ModuleClient can be used only with modules");
+            }
+
+            var pipelineContext = new PipelineContext();
+            pipelineContext.Set(transportSettings);
+            pipelineContext.Set(iotHubConnectionString);
+            pipelineContext.Set<OnMethodCalledDelegate>(OnMethodCalled);
+            pipelineContext.Set<Action<TwinCollection>>(OnReportedStatePatchReceived);
+            pipelineContext.Set<OnConnectionClosedDelegate>(OnConnectionClosed);
+            pipelineContext.Set<OnConnectionOpenedDelegate>(OnConnectionOpened);
+            pipelineContext.Set<OnReceiveEventMessageCalledDelegate>(OnReceiveEventMessageCalled);
+            pipelineContext.Set(this.productInfo);
+
+            IDelegatingHandler innerHandler = pipelineBuilder.Build(pipelineContext);
+            this.InnerHandler = innerHandler;
+        }
+
+        /// <summary>
+        /// Create an Amqp ModuleClient from individual parameters
+        /// </summary>
+        /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
+        /// <param name="authenticationMethod">The authentication method that is used</param>
+        /// <returns>ModuleClient</returns>
+        public static ModuleClient Create(string hostname, IAuthenticationMethod authenticationMethod)
+        {
+            return Create(hostname, authenticationMethod, TransportType.Amqp);
+        }
+
+        /// <summary>
+        /// Create an Amqp ModuleClient from individual parameters
+        /// </summary>
+        /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
+        /// <param name="authenticationMethod">The authentication method that is used</param>
+        /// <param name="gatewayHostname">The fully-qualified DNS hostname of Gateway</param>
+        /// <returns>ModuleClient</returns>
+        public static ModuleClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod)
+        {
+            return Create(hostname, gatewayHostname, authenticationMethod, TransportType.Amqp);
+        }
+
+        /// <summary>
+        /// Create a ModuleClient from individual parameters
+        /// </summary>
+        /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
+        /// <param name="authenticationMethod">The authentication method that is used</param>
+        /// <param name="transportType">The transportType used (Http1 or Amqp)</param>
+        /// <returns>ModuleClient</returns>
+        public static ModuleClient Create(string hostname, IAuthenticationMethod authenticationMethod, TransportType transportType)
+        {
+            return Create(hostname, null, authenticationMethod, transportType);
+        }
+
+        /// <summary>
+        /// Create a ModuleClient from individual parameters
+        /// </summary>
+        /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
+        /// <param name="gatewayHostname">The fully-qualified DNS hostname of Gateway</param>
+        /// <param name="authenticationMethod">The authentication method that is used</param>
+        /// <param name="transportType">The transportType used (Http1 or Amqp)</param>
+        /// <returns>ModuleClient</returns>
+        public static ModuleClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod, TransportType transportType)
+        {
+            if (hostname == null)
+            {
+                throw new ArgumentNullException(nameof(hostname));
+            }
+
+            if (authenticationMethod == null)
+            {
+                throw new ArgumentNullException(nameof(authenticationMethod));
+            }
+
+            IotHubConnectionStringBuilder connectionStringBuilder = IotHubConnectionStringBuilder.Create(hostname, gatewayHostname, authenticationMethod);
+
+#if !NETMF
+            if (authenticationMethod is DeviceAuthenticationWithX509Certificate)
+            {
+                throw new ArgumentException("Certificate authentication is not supported for modules");
+            }
+#endif
+
+            return CreateFromConnectionString(connectionStringBuilder.ToString(), authenticationMethod, transportType, null);
+        }
+
+        /// <summary>
+        /// Create a ModuleClient from individual parameters
+        /// </summary>
+        /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
+        /// <param name="authenticationMethod">The authentication method that is used</param>
+        /// <param name="transportSettings">Prioritized list of transportTypes and their settings</param>
+        /// <returns>ModuleClient</returns>
+        public static ModuleClient Create(string hostname, IAuthenticationMethod authenticationMethod,
+            ITransportSettings[] transportSettings)
+        {
+            return Create(hostname, null, authenticationMethod, transportSettings);
+        }
+
+        /// <summary>
+        /// Create a ModuleClient from individual parameters
+        /// </summary>
+        /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
+        /// <param name="gatewayHostname">The fully-qualified DNS hostname of Gateway</param>
+        /// <param name="authenticationMethod">The authentication method that is used</param>
+        /// <param name="transportSettings">Prioritized list of transportTypes and their settings</param>
+        /// <returns>ModuleClient</returns>
+        public static ModuleClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod,
+            ITransportSettings[] transportSettings)
+        {
+            if (hostname == null)
+            {
+                throw new ArgumentNullException("hostname");
+            }
+
+            if (authenticationMethod == null)
+            {
+                throw new ArgumentNullException("authenticationMethod");
+            }
+
+            var connectionStringBuilder = IotHubConnectionStringBuilder.Create(hostname, gatewayHostname, authenticationMethod);
+#if !NETMF
+            if (authenticationMethod is DeviceAuthenticationWithX509Certificate)
+            {
+                throw new ArgumentException("Certificate authentication is not supported for modules");
+            }
+#endif
+            return CreateFromConnectionString(connectionStringBuilder.ToString(), authenticationMethod, transportSettings, null);
+        }
+
+        /// <summary>
+        /// Create a ModuleClient using Amqp transport from the specified connection string
+        /// </summary>
+        /// <param name="connectionString">Connection string for the IoT hub (including DeviceId)</param>
+        /// <returns>ModuleClient</returns>
+        public static ModuleClient CreateFromConnectionString(string connectionString)
+        {
+            return CreateFromConnectionString(connectionString, TransportType.Amqp);
+        }
+
+        /// <summary>
+        /// Create ModuleClient from the specified connection string using the specified transport type
+        /// </summary>
+        /// <param name="connectionString">Connection string for the IoT hub (including DeviceId)</param>
+        /// <param name="transportType">Specifies whether Amqp or Http transport is used</param>
+        /// <returns>ModuleClient</returns>
+        public static ModuleClient CreateFromConnectionString(string connectionString, TransportType transportType)
+        {
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }
+
+            return CreateFromConnectionString(connectionString, null, transportType, null);
+        }
+
+        /// <summary>
+        /// Create ModuleClient from the specified connection string using a prioritized list of transports
+        /// </summary>
+        /// <param name="connectionString">Connection string for the IoT hub (with DeviceId)</param>
+        /// <param name="transportSettings">Prioritized list of transports and their settings</param>
+        /// <returns>ModuleClient</returns>
+        public static ModuleClient CreateFromConnectionString(string connectionString,
+            ITransportSettings[] transportSettings)
+        {
+            return CreateFromConnectionString(connectionString, null, transportSettings, null);
+        }
+
+        internal static ModuleClient CreateFromConnectionString(
+            string connectionString,
+            IAuthenticationMethod authenticationMethod,
+            TransportType transportType,
+            IDeviceClientPipelineBuilder pipelineBuilder)
+        {
+            ITransportSettings[] transportSettings = GetTransportSettings(transportType);
+            return CreateFromConnectionString(
+                connectionString,
+                authenticationMethod,
+                transportSettings,
+                pipelineBuilder);
+        }
+
+        internal static ModuleClient CreateFromConnectionString(
+            string connectionString,
+            IAuthenticationMethod authenticationMethod,
+            ITransportSettings[] transportSettings,
+            IDeviceClientPipelineBuilder pipelineBuilder)
+        {
+            if (connectionString == null)
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }
+
+            if (transportSettings == null)
+            {
+                throw new ArgumentNullException(nameof(transportSettings));
+            }
+
+            if (transportSettings.Length == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(connectionString), "Must specify at least one TransportSettings instance");
+            }
+
+            var builder = IotHubConnectionStringBuilder.CreateWithIAuthenticationOverride(
+                connectionString,
+                authenticationMethod);
+
+            IotHubConnectionString iotHubConnectionString = builder.ToIotHubConnectionString();
+
+            ValidateTransportSettings(transportSettings);
+
+            pipelineBuilder = pipelineBuilder ?? BuildPipeline();
+
+            // Defer concrete ModuleClient creation to OpenAsync
+            return new ModuleClient(iotHubConnectionString, transportSettings, pipelineBuilder);
+        }
+
+
+        #region Module Specific API
+        /// <summary>
+        /// <param name="outputName">The output target for sending the given message</param>
+        /// <param name="message">The message to send</param>
+        /// <returns>The message containing the event</returns>
+        public Task SendEventAsync(string outputName, Message message)
+        {
+            // Codes_SRS_DEVICECLIENT_10_012: [If `outputName` is `null` or empty, an `ArgumentNullException` shall be thrown.]
+            if (string.IsNullOrWhiteSpace(outputName))
+            {
+                throw new ArgumentException(nameof(outputName));
+            }
+
+            // Codes_SRS_DEVICECLIENT_10_013: [If `message` is `null` or empty, an `ArgumentNullException` shall be thrown.]
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            // Codes_SRS_DEVICECLIENT_10_015: [The `output` property of a given `message` shall be assigned the value `outputName` before submitting each request to the transport layer.]
+            message.SystemProperties.Add(MessageSystemPropertyNames.OutputName, outputName);
+
+            // Codes_SRS_DEVICECLIENT_10_011: [The `SendEventAsync` operation shall retry sending `message` until the `BaseClient::RetryStrategy` tiemspan expires or unrecoverable error(authentication or quota exceed) occurs.]
+            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.SendEventAsync(message, operationTimeoutCancellationToken));
+        }
+
+        /// <summary>
+        /// Sends a batch of events to device hub
+        /// <param name="outputName">The output target for sending the given message</param>
+        /// <param name="messages">A list of one or more messages to send</param>
+        /// </summary>
+        /// <returns>The task containing the event</returns>
+        public Task SendEventBatchAsync(string outputName, IEnumerable<Message> messages)
+        {
+            // Codes_SRS_DEVICECLIENT_10_012: [If `outputName` is `null` or empty, an `ArgumentNullException` shall be thrown.]
+            if (string.IsNullOrWhiteSpace(outputName))
+            {
+                throw new ArgumentException(nameof(outputName));
+            }
+
+            List<Message> messagesList = messages?.ToList();
+            // Codes_SRS_DEVICECLIENT_10_013: [If `message` is `null` or empty, an `ArgumentNullException` shall be thrown]
+            if (messagesList == null || messagesList.Count == 0)
+            {
+                throw new ArgumentNullException(nameof(messages));
+            }
+
+#if PCL
+            foreach(var m in messagesList)
+            {
+                m.SystemProperties.Add(MessageSystemPropertyNames.OutputName, outputName);
+            }
+#else
+            // Codes_SRS_DEVICECLIENT_10_015: [The `module-output` property of a given `message` shall be assigned the value `outputName` before submitting each request to the transport layer.]
+            messagesList.ForEach(m => m.SystemProperties.Add(MessageSystemPropertyNames.OutputName, outputName));
+#endif
+
+            // Codes_SRS_DEVICECLIENT_10_014: [The `SendEventBachAsync` operation shall retry sending `messages` until the `BaseClient::RetryStrategy` tiemspan expires or unrecoverable error(authentication or quota exceed) occurs.]
+            return ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.SendEventAsync(messagesList, operationTimeoutCancellationToken));
+        }
+
+        /// <summary>
+        /// Registers a new delgate for the particular input. If a delegate is already associated with
+        /// the input, it will be replaced with the new delegate.
+        /// <param name="inputName">The name of the input to associate with the delegate.</param>
+        /// <param name="messageHandler">The delegate to be used when a message is sent to the particular inputName.</param>
+        /// <param name="userContext">generic parameter to be interpreted by the client code.</param>
+        /// </summary>
+        /// <returns>The task containing the event</returns>
+        public async Task SetInputMessageHandlerAsync(string inputName, MessageHandler messageHandler, object userContext)
+        {
+            try
+            {
+                await this.receiveSemaphore.WaitAsync();
+
+                if (messageHandler != null)
+                {
+                    // codes_SRS_DEVICECLIENT_33_003: [ It shall EnableEventReceiveAsync when called for the first time. ]
+                    await this.EnableEventReceiveAsync();
+                    // codes_SRS_DEVICECLIENT_33_005: [ It shall lazy-initialize the receiveEventEndpoints property. ]
+                    if (this.receiveEventEndpoints == null)
+                    {
+                        this.receiveEventEndpoints = new Dictionary<string, Tuple<MessageHandler, object>>();
+                    }
+                    this.receiveEventEndpoints[inputName] = new Tuple<MessageHandler, object>(messageHandler, userContext);
+                }
+                else
+                {
+                    if (this.receiveEventEndpoints != null)
+                    {
+                        this.receiveEventEndpoints.Remove(inputName);
+                        if (this.receiveEventEndpoints.Count == 0)
+                        {
+                            this.receiveEventEndpoints = null;
+                        }
+                    }
+                    // codes_SRS_DEVICECLIENT_33_004: [ It shall call DisableEventReceiveAsync when the last delegate has been removed. ]
+                    await this.DisableEventReceiveAsync();
+                }
+            }
+            finally
+            {
+                this.receiveSemaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Registers a new default delegate which applies to all endpoints. If a delegate is already associated with
+        /// the input, it will be called, else the default delegate will be called. If a default delegate was set previously,
+        /// it will be overwritten.
+        /// <param name="messageHandler">The delegate to be called when a message is sent to any input.</param>
+        /// <param name="userContext">generic parameter to be interpreted by the client code.</param>
+        /// </summary>
+        /// <returns>The task containing the event</returns>
+        public async Task SetMessageHandlerAsync(MessageHandler messageHandler, object userContext)
+        {
+            try
+            {
+                await this.receiveSemaphore.WaitAsync();
+                if (messageHandler != null)
+                {
+                    // codes_SRS_DEVICECLIENT_33_003: [ It shall EnableEventReceiveAsync when called for the first time. ]
+                    await this.EnableEventReceiveAsync();
+                    this.defaultEventCallback = new Tuple<MessageHandler, object>(messageHandler, userContext);
+                }
+                else
+                {
+                    this.defaultEventCallback = null;
+                    // codes_SRS_DEVICECLIENT_33_004: [ It shall DisableEventReceiveAsync when the last delegate has been removed. ]
+                    await this.DisableEventReceiveAsync();
+                }
+            }
+            finally
+            {
+                this.receiveSemaphore.Release();
+            }
+        }
+
+        private async Task EnableEventReceiveAsync()
+        {
+            if (this.receiveEventEndpoints == null && this.defaultEventCallback == null)
+            {
+                await ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.EnableEventReceiveAsync(operationTimeoutCancellationToken));
+            }
+        }
+
+        private async Task DisableEventReceiveAsync()
+        {
+            if (this.receiveEventEndpoints == null && this.defaultEventCallback == null)
+            {
+                await ApplyTimeout(operationTimeoutCancellationToken => this.InnerHandler.DisableEventReceiveAsync(operationTimeoutCancellationToken));
+            }
+        }
+
+        /// <summary>
+        /// The delegate for handling event messages received
+        /// <param name="input">The input on which a message is received</param>
+        /// <param name="message">The message received</param>
+        /// </summary>
+        internal async Task OnReceiveEventMessageCalled(string input, Message message)
+        {
+            // codes_SRS_DEVICECLIENT_33_001: [ If the given eventMessageInternal argument is null, fail silently ]
+            if (message != null)
+            {
+                Tuple<MessageHandler, object> callback = null;
+                await this.receiveSemaphore.WaitAsync();
+                try
+                {
+                    // codes_SRS_DEVICECLIENT_33_006: [ The OnReceiveEventMessageCalled shall get the default delegate if a delegate has not been assigned. ]
+                    if (this.receiveEventEndpoints == null ||
+                        string.IsNullOrWhiteSpace(input) ||
+                        !this.receiveEventEndpoints.TryGetValue(input, out callback))
+                    {
+                        callback = this.defaultEventCallback;
+                    }
+                }
+                finally
+                {
+                    this.receiveSemaphore.Release();
+                }
+
+                // codes_SRS_DEVICECLIENT_33_002: [ The OnReceiveEventMessageCalled shall invoke the specified delegate. ]
+                MessageResponse response = await (callback?.Item1?.Invoke(message, callback.Item2) ?? Task.FromResult(MessageResponse.None));
+
+                switch (response)
+                {
+                    case MessageResponse.Completed:
+                        await this.CompleteInternalAsync(message.LockToken);
+                        break;
+                    case MessageResponse.Abandoned:
+                        await this.AbandonInternalAsync(message.LockToken);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        #endregion Module Specific API
+    }
+}

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Azure.Devices.Client.Edge;
+
 namespace Microsoft.Azure.Devices.Client
 {
     using Common;
@@ -282,6 +284,38 @@ namespace Microsoft.Azure.Devices.Client
             return new ModuleClient(iotHubConnectionString, transportSettings, pipelineBuilder);
         }
 
+        /// <summary>
+        /// Creates a ModuleClient instance in an IoT Edge deployment
+        /// based on environment variables.
+        /// </summary>
+        /// <returns>ModuleClient instance</returns>
+        public static ModuleClient Create()
+        {
+            return Create(TransportType.Amqp);
+        }
+
+
+        /// <summary>
+        /// Creates a ModuleClient instance in an IoT Edge deployment
+        /// based on environment variables.
+        /// </summary>
+        /// <param name="transportType">Specifies whether Amqp or Http transport is used</param>
+        /// <returns>ModuleClient instance</returns>
+        public static ModuleClient Create(TransportType transportType)
+        {
+            return Create(GetTransportSettings(transportType));
+        }
+
+        /// <summary>
+        /// Creates a ModuleClient instance in an IoT Edge deployment
+        /// based on environment variables.
+        /// </summary>
+        /// <param name="transportSettings">Prioritized list of transports and their settings</param>
+        /// <returns>ModuleClient instance</returns>
+        public static ModuleClient Create(ITransportSettings[] transportSettings)
+        {
+            return new EdgeModuleClientFactory(transportSettings).Create();
+        }
 
         #region Module Specific API
         /// <summary>

--- a/iothub/device/src/Transport/TransportHandlerFactory.cs
+++ b/iothub/device/src/Transport/TransportHandlerFactory.cs
@@ -17,11 +17,11 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             var connectionString = context.Get<IotHubConnectionString>();
             var transportSetting = context.Get<ITransportSettings[]>();
-            var onMethodCallback = context.Get<DeviceClient.OnMethodCalledDelegate>();
+            var onMethodCallback = context.Get<InternalClient.OnMethodCalledDelegate>();
             var onDesiredStatePatchReceived = context.Get<Action<TwinCollection>>();
-            var OnConnectionClosedCallback = context.Get<DeviceClient.OnConnectionClosedDelegate>();
-            var OnConnectionOpenedCallback = context.Get<DeviceClient.OnConnectionOpenedDelegate>();
-            var onReceiveCallback = context.Get<DeviceClient.OnReceiveEventMessageCalledDelegate>();
+            var OnConnectionClosedCallback = context.Get<InternalClient.OnConnectionClosedDelegate>();
+            var OnConnectionOpenedCallback = context.Get<InternalClient.OnConnectionOpenedDelegate>();
+            var onReceiveCallback = context.Get<InternalClient.OnReceiveEventMessageCalledDelegate>();
 
             switch (transportSetting[0].GetTransportType())
             {

--- a/iothub/device/tests/DeviceClientTests.cs
+++ b/iothub/device/tests/DeviceClientTests.cs
@@ -173,7 +173,7 @@
                 return Task.FromResult(new MethodResponse(Encoding.UTF8.GetBytes("{\"name\":\"ABC\"}"), 200));
             }, "custom data").ConfigureAwait(false);
 
-            await deviceClient.OnMethodCalled(null).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(null).ConfigureAwait(false);
             await innerHandler.Received(0).SendMethodResponseAsync(Arg.Any<MethodResponseInternal>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsFalse(isMethodHandlerCalled);
         }
@@ -195,7 +195,7 @@
 
             var methodRequestInternal = new MethodRequestInternal("TestMethodName", "4B810AFC-CF5B-4AE8-91EB-245F7C7751F9", new MemoryStream(Array.Empty<byte>()));
 
-            await deviceClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
             await innerHandler.Received().SendMethodResponseAsync(Arg.Any<MethodResponseInternal>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(isMethodHandlerCalled);
         }
@@ -217,7 +217,7 @@
 
             var methodRequestInternal = new MethodRequestInternal("TestMethodName", "4B810AFC-CF5B-4AE8-91EB-245F7C7751F9", new MemoryStream(Encoding.UTF8.GetBytes("{key")));
 
-            await deviceClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
             await innerHandler.Received().SendMethodResponseAsync(Arg.Is<MethodResponseInternal>(resp => resp.Status == 400), Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsFalse(isMethodHandlerCalled);
         }
@@ -239,7 +239,7 @@
 
             var methodRequestInternal = new MethodRequestInternal("TestMethodName", "4B810AFC-CF5B-4AE8-91EB-245F7C7751F9", new MemoryStream(Encoding.UTF8.GetBytes("{\"grade\":\"good\"}")));
 
-            await deviceClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
             await innerHandler.Received().SendMethodResponseAsync(Arg.Any<MethodResponseInternal>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(isMethodHandlerCalled);
         }
@@ -261,7 +261,7 @@
 
             var methodRequestInternal = new MethodRequestInternal("TestMethodName", "4B810AFC-CF5B-4AE8-91EB-245F7C7751F9", new MemoryStream(Encoding.UTF8.GetBytes("{\"grade\":\"good\"}")));
 
-            await deviceClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
             Assert.IsTrue(isMethodHandlerCalled);
             await innerHandler.Received().SendMethodResponseAsync(Arg.Is<MethodResponseInternal>(resp => resp.Status == 500), Arg.Any<CancellationToken>()).ConfigureAwait(false);
         }
@@ -282,7 +282,7 @@
                 return Task.FromResult(new MethodResponse(Encoding.UTF8.GetBytes("{\"name\":\"ABC\"}"), 200));
             }, "custom data");
 
-            await deviceClient.OnMethodCalled(null).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(null).ConfigureAwait(false);
             await innerHandler.Received(0).SendMethodResponseAsync(Arg.Any<MethodResponseInternal>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsFalse(isMethodHandlerCalled);
         }
@@ -304,7 +304,7 @@
 
             var methodRequestInternal = new MethodRequestInternal("TestMethodName", "4B810AFC-CF5B-4AE8-91EB-245F7C7751F9", new MemoryStream(Array.Empty<byte>()));
 
-            await deviceClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
             await innerHandler.Received().SendMethodResponseAsync(Arg.Any<MethodResponseInternal>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(isMethodHandlerCalled);
         }
@@ -327,7 +327,7 @@
 
             var methodRequestInternal = new MethodRequestInternal("TestMethodName", "4B810AFC-CF5B-4AE8-91EB-245F7C7751F9", new MemoryStream(Encoding.UTF8.GetBytes("{\"grade\":\"good\"}")));
 
-            await deviceClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
             await innerHandler.Received().SendMethodResponseAsync(Arg.Any<MethodResponseInternal>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(isMethodHandlerCalled);
         }
@@ -350,7 +350,7 @@
 
             var methodRequestInternal = new MethodRequestInternal("TestMethodName", "4B810AFC-CF5B-4AE8-91EB-245F7C7751F9", new MemoryStream(Encoding.UTF8.GetBytes("{\"grade\":\"good\"}")));
 
-            await deviceClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
             await innerHandler.Received().SendMethodResponseAsync(Arg.Any<MethodResponseInternal>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(isMethodDefaultHandlerCalled);
         }
@@ -379,7 +379,7 @@
 
             var methodRequestInternal = new MethodRequestInternal("TestMethodName", "4B810AFC-CF5B-4AE8-91EB-245F7C7751F9", new MemoryStream(Encoding.UTF8.GetBytes("{\"grade\":\"good\"}")));
 
-            await deviceClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
             await innerHandler.Received().SendMethodResponseAsync(Arg.Any<MethodResponseInternal>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsFalse(isMethodHandlerCalled);
             Assert.IsTrue(isMethodDefaultHandlerCalled);
@@ -409,7 +409,7 @@
 
             var methodRequestInternal = new MethodRequestInternal("TestMethodName", "4B810AFC-CF5B-4AE8-91EB-245F7C7751F9", new MemoryStream(Encoding.UTF8.GetBytes("{\"grade\":\"good\"}")));
 
-            await deviceClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
             await innerHandler.Received().SendMethodResponseAsync(Arg.Any<MethodResponseInternal>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(isMethodHandlerCalled);
             Assert.IsFalse(isMethodDefaultHandlerCalled);
@@ -433,7 +433,7 @@
 
             var methodRequestInternal = new MethodRequestInternal("TestMethodName", "4B810AFC-CF5B-4AE8-91EB-245F7C7751F9", new MemoryStream(Encoding.UTF8.GetBytes("{\"grade\":\"good\"}")));
 
-            await deviceClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
             await innerHandler.Received().SendMethodResponseAsync(Arg.Any<MethodResponseInternal>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(isMethodHandlerCalled);
         }
@@ -455,7 +455,7 @@
 
             var methodRequestInternal = new MethodRequestInternal("TestMethodName", "4B810AFC-CF5B-4AE8-91EB-245F7C7751F9", new MemoryStream(Encoding.UTF8.GetBytes("{\"grade\":\"good\"}")));
 
-            await deviceClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
             Assert.IsTrue(isMethodHandlerCalled);
             await innerHandler.Received().SendMethodResponseAsync(Arg.Is<MethodResponseInternal>(resp => resp.Status == 500), Arg.Any<CancellationToken>()).ConfigureAwait(false);
         }
@@ -471,7 +471,7 @@
             deviceClient.InnerHandler = innerHandler;
             var methodRequestInternal = new MethodRequestInternal("TestMethodName", "4B810AFC-CF5B-4AE8-91EB-245F7C7751F9", new MemoryStream(Encoding.UTF8.GetBytes("{\"grade\":\"good\"}")));
 
-            await deviceClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(methodRequestInternal).ConfigureAwait(false);
 
             await innerHandler.Received().SendMethodResponseAsync(Arg.Is<MethodResponseInternal>(resp => resp.Status == 501), Arg.Any<CancellationToken>()).ConfigureAwait(false);
         }
@@ -505,7 +505,7 @@
             string methodUserContext = "UserContext";
             string methodBody = "{\"grade\":\"good\"}";
             await deviceClient.SetMethodHandlerAsync(methodName, methodCallback, methodUserContext).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.Received().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -516,7 +516,7 @@
             innerHandler.ClearReceivedCalls();
             methodCallbackCalled = false;
             await deviceClient.SetMethodDefaultHandlerAsync(methodCallback, methodUserContext).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.DidNotReceive().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -554,7 +554,7 @@
             string methodUserContext = "UserContext";
             string methodBody = "{\"grade\":\"good\"}";
             await deviceClient.SetMethodDefaultHandlerAsync(methodCallback, methodUserContext).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.Received().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -565,7 +565,7 @@
             innerHandler.ClearReceivedCalls();
             methodCallbackCalled = false;
             await deviceClient.SetMethodHandlerAsync(methodName, methodCallback, methodUserContext).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.DidNotReceive().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -602,7 +602,7 @@
             string methodUserContext = "UserContext";
             string methodBody = "{\"grade\":\"good\"}";
             await deviceClient.SetMethodHandlerAsync(methodName, methodCallback, methodUserContext).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.Received().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -626,7 +626,7 @@
             string methodUserContext2 = "UserContext2";
             string methodBody2 = "{\"grade\":\"bad\"}";
             await deviceClient.SetMethodHandlerAsync(methodName, methodCallback2, methodUserContext2).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId2", new MemoryStream(Encoding.UTF8.GetBytes(methodBody2)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId2", new MemoryStream(Encoding.UTF8.GetBytes(methodBody2)))).ConfigureAwait(false);
 
             await innerHandler.Received().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled2);
@@ -663,7 +663,7 @@
             string methodUserContext = "UserContext";
             string methodBody = "{\"grade\":\"good\"}";
             await deviceClient.SetMethodDefaultHandlerAsync(methodCallback, methodUserContext).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.Received().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -687,7 +687,7 @@
             string methodUserContext2 = "UserContext2";
             string methodBody2 = "{\"grade\":\"bad\"}";
             await deviceClient.SetMethodDefaultHandlerAsync(methodCallback2, methodUserContext2).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId2", new MemoryStream(Encoding.UTF8.GetBytes(methodBody2)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId2", new MemoryStream(Encoding.UTF8.GetBytes(methodBody2)))).ConfigureAwait(false);
 
             await innerHandler.Received().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled2);
@@ -725,7 +725,7 @@
             string methodUserContext = "UserContext";
             string methodBody = "{\"grade\":\"good\"}";
             await deviceClient.SetMethodHandlerAsync(methodName, methodCallback, methodUserContext).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.Received().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -735,7 +735,7 @@
 
             methodCallbackCalled = false;
             await deviceClient.SetMethodHandlerAsync(methodName, null, null).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.Received().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsFalse(methodCallbackCalled);
@@ -770,7 +770,7 @@
             string methodUserContext = "UserContext";
             string methodBody = "{\"grade\":\"good\"}";
             await deviceClient.SetMethodHandlerAsync(methodName, methodCallback, methodUserContext).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.Received().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -781,7 +781,7 @@
             methodCallbackCalled = false;
             innerHandler.ClearReceivedCalls();
             await deviceClient.SetMethodDefaultHandlerAsync(methodCallback, methodUserContext).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.DidNotReceive().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -791,13 +791,13 @@
 
             methodCallbackCalled = false;
             await deviceClient.SetMethodDefaultHandlerAsync(null, null).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
             await innerHandler.DidNotReceive().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
 
             methodCallbackCalled = false;
             await deviceClient.SetMethodHandlerAsync(methodName, null, null).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.Received().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsFalse(methodCallbackCalled);
@@ -832,7 +832,7 @@
             string methodUserContext = "UserContext";
             string methodBody = "{\"grade\":\"good\"}";
             await deviceClient.SetMethodHandlerAsync(methodName, methodCallback, methodUserContext).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.Received().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -843,7 +843,7 @@
             methodCallbackCalled = false;
             innerHandler.ClearReceivedCalls();
             await deviceClient.SetMethodDefaultHandlerAsync(methodCallback, methodUserContext).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.DidNotReceive().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -853,13 +853,13 @@
 
             methodCallbackCalled = false;
             await deviceClient.SetMethodHandlerAsync(methodName, null, null).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
             await innerHandler.DidNotReceive().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
 
             methodCallbackCalled = false;
             await deviceClient.SetMethodDefaultHandlerAsync(null, null).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
             await innerHandler.Received().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsFalse(methodCallbackCalled);
         }
@@ -907,7 +907,7 @@
             string methodUserContext = "UserContext";
             string methodBody = "{\"grade\":\"good\"}";
             deviceClient.SetMethodHandler(methodName, methodCallback, methodUserContext);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.Received().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -944,7 +944,7 @@
             string methodUserContext = "UserContext";
             string methodBody = "{\"grade\":\"good\"}";
             deviceClient.SetMethodHandler(methodName, methodCallback, methodUserContext);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.Received().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -968,7 +968,7 @@
             string methodUserContext2 = "UserContext2";
             string methodBody2 = "{\"grade\":\"bad\"}";
             await deviceClient.SetMethodHandlerAsync(methodName, methodCallback2, methodUserContext2).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId2", new MemoryStream(Encoding.UTF8.GetBytes(methodBody2)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId2", new MemoryStream(Encoding.UTF8.GetBytes(methodBody2)))).ConfigureAwait(false);
 
             await innerHandler.Received().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled2);
@@ -1006,7 +1006,7 @@
             string methodUserContext = "UserContext";
             string methodBody = "{\"grade\":\"good\"}";
             deviceClient.SetMethodHandler(methodName, methodCallback, methodUserContext);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.Received().EnableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsTrue(methodCallbackCalled);
@@ -1016,7 +1016,7 @@
 
             methodCallbackCalled = false;
             await deviceClient.SetMethodHandlerAsync(methodName, null, null).ConfigureAwait(false);
-            await deviceClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
+            await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)))).ConfigureAwait(false);
 
             await innerHandler.Received().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsFalse(methodCallbackCalled);
@@ -1056,7 +1056,7 @@
             deviceClient.SetConnectionStatusChangesHandler(statusChangeHandler);
 
             // Connection status changes from disconnected to connected
-            deviceClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok});
+            deviceClient.InternalClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
 
             Assert.IsTrue(handlerCalled);
             Assert.AreEqual(ConnectionStatus.Connected, status);
@@ -1082,7 +1082,7 @@
             deviceClient.SetConnectionStatusChangesHandler(null);
 
             // Connection status changes from disconnected to connected
-            deviceClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok});
+            deviceClient.InternalClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
 
             Assert.IsFalse(handlerCalled);
         }
@@ -1104,14 +1104,14 @@
             };
             deviceClient.SetConnectionStatusChangesHandler(statusChangeHandler);
             // current status = disabled
-            deviceClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok});
+            deviceClient.InternalClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
             Assert.IsTrue(handlerCalled);
             Assert.AreEqual(ConnectionStatus.Connected, status);
             Assert.AreEqual(ConnectionStatusChangeReason.Connection_Ok, statusChangeReason);
             handlerCalled = false;
 
             // current status = connected
-            deviceClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok});
+            deviceClient.InternalClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
 
             Assert.IsFalse(handlerCalled);
         }
@@ -1137,15 +1137,15 @@
             };
             deviceClient.SetConnectionStatusChangesHandler(statusChangeHandler);
             // current status = disabled
-            deviceClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok});
+            deviceClient.InternalClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
             Assert.IsTrue(handlerCalled);
             Assert.AreEqual(ConnectionStatus.Connected, status);
             Assert.AreEqual(ConnectionStatusChangeReason.Connection_Ok, statusChangeReason);
             handlerCalled = false;
 
             // current status = connected
-            deviceClient.OnConnectionClosed(
-                sender, 
+            deviceClient.InternalClient.OnConnectionClosed(
+                sender,
                 new ConnectionEventArgs
                 {
                     ConnectionType = ConnectionType.MqttConnection,
@@ -1180,13 +1180,13 @@
             };
             deviceClient.SetConnectionStatusChangesHandler(statusChangeHandler);
             // current status = disabled
-            deviceClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok});
+            deviceClient.InternalClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
             Assert.AreEqual(handlerCalled, 1);
             Assert.AreEqual(ConnectionStatus.Connected, status);
             Assert.AreEqual(ConnectionStatusChangeReason.Connection_Ok, statusChangeReason);
 
             // current status = connected
-            deviceClient.OnConnectionClosed(
+            deviceClient.InternalClient.OnConnectionClosed(
                 sender,
                 new ConnectionEventArgs
                 {
@@ -1217,14 +1217,14 @@
             };
             deviceClient.SetConnectionStatusChangesHandler(statusChangeHandler);
             // current status = disabled
-            deviceClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok});
+            deviceClient.InternalClient.OnConnectionOpened(new object(), new ConnectionEventArgs { ConnectionType = ConnectionType.MqttConnection, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
             Assert.IsTrue(handlerCalled);
             Assert.AreEqual(ConnectionStatus.Connected, status);
             handlerCalled = false;
 
             // current status = connected
-            deviceClient.OnConnectionClosed(
-                new object(), 
+            deviceClient.InternalClient.OnConnectionClosed(
+                new object(),
                 new ConnectionEventArgs
                 {
                     ConnectionType = ConnectionType.MqttConnection,

--- a/iothub/device/tests/DeviceClientTests.cs
+++ b/iothub/device/tests/DeviceClientTests.cs
@@ -15,7 +15,16 @@
     [TestClass]
     public class DeviceClientTests
     {
-        static string fakeConnectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;SharedAccessKey=CQN2K33r45/0WeIjpqmErV5EIvX8JZrozt3NEHCEkG8=";
+        const string fakeConnectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;SharedAccessKey=CQN2K33r45/0WeIjpqmErV5EIvX8JZrozt3NEHCEkG8=";
+        const string fakeConnectionStringWithModuleId = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;SharedAccessKey=CQN2K33r45/0WeIjpqmErV5EIvX8JZrozt3NEHCEkG8=;ModuleId=mod1";
+
+        [TestMethod]
+        [TestCategory("ModuleClient")]
+        [ExpectedException(typeof(ArgumentException))]
+        public void DeviceClient_CreateFromConnectionString_WithModuleIdThrows()
+        {
+            DeviceClient.CreateFromConnectionString(fakeConnectionStringWithModuleId);
+        }
 
         /* Tests_SRS_DEVICECLIENT_28_002: [This property shall be defaulted to 240000 (4 minutes).] */
         [TestMethod]

--- a/iothub/device/tests/DeviceClientTwinApiTests.cs
+++ b/iothub/device/tests/DeviceClientTwinApiTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             await innerHandler.
                 Received(1).
                 EnableTwinPatchAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
-            Assert.AreEqual(client.desiredPropertyUpdateCallback, myCallback);
+            Assert.AreEqual(client.InternalClient.desiredPropertyUpdateCallback, myCallback);
         }
 
         // Tests_SRS_DEVICECLIENT_18_003: `SetDesiredPropertyUpdateCallbackAsync` shall call the transport to register for PATCHes on it's first call.
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             await innerHandler.
                 Received(1).
                 EnableTwinPatchAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
-            Assert.AreEqual(client.desiredPropertyUpdateCallback, myCallback);
+            Assert.AreEqual(client.InternalClient.desiredPropertyUpdateCallback, myCallback);
         }
 
         // Tests_SRS_DEVICECLIENT_18_004: `SetDesiredPropertyUpdateCallback` shall not call the transport to register for PATCHes on subsequent calls
@@ -197,7 +197,8 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             int callCount = 0;
             TwinCollection receivedPatch = null;
-            DesiredPropertyUpdateCallback myCallback = (p, c) => {
+            DesiredPropertyUpdateCallback myCallback = (p, c) =>
+            {
                 callCount++;
                 receivedPatch = p;
                 return TaskHelpers.CompletedTask;
@@ -205,7 +206,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             await client.SetDesiredPropertyUpdateCallback(myCallback, null).ConfigureAwait(false);
 
             // act
-            client.OnReportedStatePatchReceived(myPatch);
+            client.InternalClient.OnReportedStatePatchReceived(myPatch);
 
             //assert
             Assert.AreEqual(callCount, 1);
@@ -225,7 +226,8 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             int callCount = 0;
             TwinCollection receivedPatch = null;
-            DesiredPropertyUpdateCallback myCallback = (p, c) => {
+            DesiredPropertyUpdateCallback myCallback = (p, c) =>
+            {
                 callCount++;
                 receivedPatch = p;
                 return TaskHelpers.CompletedTask;
@@ -233,7 +235,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             await client.SetDesiredPropertyUpdateCallbackAsync(myCallback, null).ConfigureAwait(false);
 
             // act
-            client.OnReportedStatePatchReceived(myPatch);
+            client.InternalClient.OnReportedStatePatchReceived(myPatch);
 
             //assert
             Assert.AreEqual(callCount, 1);

--- a/iothub/device/tests/Edge/EdgeModuleClientFactoryTest.cs
+++ b/iothub/device/tests/Edge/EdgeModuleClientFactoryTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
 {
 
     [TestClass]
-    public class DeviceClientFactoryTest
+    public class EdgeModuleClientFactoryTest
     {
         readonly string serverUrl;
         readonly byte[] sasKey = System.Text.Encoding.UTF8.GetBytes("key");
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         const string ModuleIdVariableName = "IOTEDGE_MODULEID";
         const string AuthSchemeVariableName = "IOTEDGE_AUTHSCHEME";
 
-        public DeviceClientFactoryTest()
+        public EdgeModuleClientFactoryTest()
         {
             this.serverUrl = "localhost";
             this.iotHubConnectionString = "Hostname=iothub.test;DeviceId=device1;ModuleId=module1;SharedAccessKey=" + Convert.ToBase64String(this.sasKey);
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         public void TestCreate_FromConnectionStringEnvironment_ShouldCreateClient()
         {
             Environment.SetEnvironmentVariable(EdgehubConnectionstringVariableName, this.iotHubConnectionString);
-            DeviceClient dc = new DeviceClientFactory().Create();
+            ModuleClient dc = ModuleClient.Create();
 
             Assert.IsNotNull(dc);
 
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         public void TestCreate_FromConnectionStringEnvironment_SetTransportType_ShouldCreateClient()
         {
             Environment.SetEnvironmentVariable(EdgehubConnectionstringVariableName, this.iotHubConnectionString);
-            DeviceClient dc = new DeviceClientFactory(TransportType.Mqtt_Tcp_Only).Create();
+            ModuleClient dc = ModuleClient.Create(TransportType.Mqtt_Tcp_Only);
 
             Assert.IsNotNull(dc);
 
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         public void TestCreate_FromConnectionStringEnvironment_SetTransportSettings_ShouldCreateClient()
         {
             Environment.SetEnvironmentVariable(EdgehubConnectionstringVariableName, this.iotHubConnectionString);
-            DeviceClient dc = new DeviceClientFactory(new ITransportSettings[] { new MqttTransportSettings(TransportType.Mqtt_Tcp_Only) }).Create();
+            ModuleClient dc = ModuleClient.Create(new ITransportSettings[] { new MqttTransportSettings(TransportType.Mqtt_Tcp_Only) });
 
             Assert.IsNotNull(dc);
 
@@ -66,22 +66,22 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         [TestMethod]
         public void TestCreate_FromEnvironment_MissingVariable_ShouldThrow()
         {
-            TestAssert.Throws<InvalidOperationException>(() => new DeviceClientFactory().Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
 
             Environment.SetEnvironmentVariable(IotEdgedUriVariableName, this.serverUrl);
-            TestAssert.Throws<InvalidOperationException>(() => new DeviceClientFactory().Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
 
             Environment.SetEnvironmentVariable(IotHubHostnameVariableName, "iothub.test");
-            TestAssert.Throws<InvalidOperationException>(() => new DeviceClientFactory().Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
 
             Environment.SetEnvironmentVariable(GatewayHostnameVariableName, "localhost");
-            TestAssert.Throws<InvalidOperationException>(() => new DeviceClientFactory().Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
 
             Environment.SetEnvironmentVariable(DeviceIdVariableName, "device1");
-            TestAssert.Throws<InvalidOperationException>(() => new DeviceClientFactory().Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
 
             Environment.SetEnvironmentVariable(ModuleIdVariableName, "module1");
-            TestAssert.Throws<InvalidOperationException>(() => new DeviceClientFactory().Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
 
             Environment.SetEnvironmentVariable(IotEdgedUriVariableName, null);
             Environment.SetEnvironmentVariable(IotHubHostnameVariableName, null);
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             Environment.SetEnvironmentVariable(ModuleIdVariableName, "module1");
 
             Environment.SetEnvironmentVariable(AuthSchemeVariableName, "x509Cert");
-            TestAssert.Throws<InvalidOperationException>(() => new DeviceClientFactory().Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
 
             Environment.SetEnvironmentVariable(IotEdgedUriVariableName, null);
             Environment.SetEnvironmentVariable(IotHubHostnameVariableName, null);
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             Environment.SetEnvironmentVariable(ModuleIdVariableName, "module1");
             Environment.SetEnvironmentVariable(AuthSchemeVariableName, "sasToken");
 
-            DeviceClient dc = new DeviceClientFactory().Create();
+            ModuleClient dc = ModuleClient.Create();
 
             Assert.IsNotNull(dc);
 
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             Environment.SetEnvironmentVariable(ModuleIdVariableName, "module1");
             Environment.SetEnvironmentVariable(AuthSchemeVariableName, "sasToken");
 
-            DeviceClient dc = new DeviceClientFactory(TransportType.Mqtt_Tcp_Only).Create();
+            ModuleClient dc = ModuleClient.Create(TransportType.Mqtt_Tcp_Only);
 
             Assert.IsNotNull(dc);
 
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             Environment.SetEnvironmentVariable(ModuleIdVariableName, "module1");
             Environment.SetEnvironmentVariable(AuthSchemeVariableName, "sasToken");
 
-            DeviceClient dc = new DeviceClientFactory(new ITransportSettings[] { new MqttTransportSettings(TransportType.Mqtt_Tcp_Only) }).Create();
+            ModuleClient dc = new EdgeModuleClientFactory(new ITransportSettings[] { new MqttTransportSettings(TransportType.Mqtt_Tcp_Only) }).Create();
 
             Assert.IsNotNull(dc);
 

--- a/iothub/device/tests/Edge/EdgeModuleClientFactoryTest.cs
+++ b/iothub/device/tests/Edge/EdgeModuleClientFactoryTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         public void TestCreate_FromConnectionStringEnvironment_ShouldCreateClient()
         {
             Environment.SetEnvironmentVariable(EdgehubConnectionstringVariableName, this.iotHubConnectionString);
-            ModuleClient dc = ModuleClient.Create();
+            ModuleClient dc = ModuleClient.CreateFromEnvironment();
 
             Assert.IsNotNull(dc);
 
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         public void TestCreate_FromConnectionStringEnvironment_SetTransportType_ShouldCreateClient()
         {
             Environment.SetEnvironmentVariable(EdgehubConnectionstringVariableName, this.iotHubConnectionString);
-            ModuleClient dc = ModuleClient.Create(TransportType.Mqtt_Tcp_Only);
+            ModuleClient dc = ModuleClient.CreateFromEnvironment(TransportType.Mqtt_Tcp_Only);
 
             Assert.IsNotNull(dc);
 
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         public void TestCreate_FromConnectionStringEnvironment_SetTransportSettings_ShouldCreateClient()
         {
             Environment.SetEnvironmentVariable(EdgehubConnectionstringVariableName, this.iotHubConnectionString);
-            ModuleClient dc = ModuleClient.Create(new ITransportSettings[] { new MqttTransportSettings(TransportType.Mqtt_Tcp_Only) });
+            ModuleClient dc = ModuleClient.CreateFromEnvironment(new ITransportSettings[] { new MqttTransportSettings(TransportType.Mqtt_Tcp_Only) });
 
             Assert.IsNotNull(dc);
 
@@ -66,22 +66,22 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         [TestMethod]
         public void TestCreate_FromEnvironment_MissingVariable_ShouldThrow()
         {
-            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.CreateFromEnvironment());
 
             Environment.SetEnvironmentVariable(IotEdgedUriVariableName, this.serverUrl);
-            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.CreateFromEnvironment());
 
             Environment.SetEnvironmentVariable(IotHubHostnameVariableName, "iothub.test");
-            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.CreateFromEnvironment());
 
             Environment.SetEnvironmentVariable(GatewayHostnameVariableName, "localhost");
-            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.CreateFromEnvironment());
 
             Environment.SetEnvironmentVariable(DeviceIdVariableName, "device1");
-            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.CreateFromEnvironment());
 
             Environment.SetEnvironmentVariable(ModuleIdVariableName, "module1");
-            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.CreateFromEnvironment());
 
             Environment.SetEnvironmentVariable(IotEdgedUriVariableName, null);
             Environment.SetEnvironmentVariable(IotHubHostnameVariableName, null);
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             Environment.SetEnvironmentVariable(ModuleIdVariableName, "module1");
 
             Environment.SetEnvironmentVariable(AuthSchemeVariableName, "x509Cert");
-            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.Create());
+            TestAssert.Throws<InvalidOperationException>(() => ModuleClient.CreateFromEnvironment());
 
             Environment.SetEnvironmentVariable(IotEdgedUriVariableName, null);
             Environment.SetEnvironmentVariable(IotHubHostnameVariableName, null);
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             Environment.SetEnvironmentVariable(ModuleIdVariableName, "module1");
             Environment.SetEnvironmentVariable(AuthSchemeVariableName, "sasToken");
 
-            ModuleClient dc = ModuleClient.Create();
+            ModuleClient dc = ModuleClient.CreateFromEnvironment();
 
             Assert.IsNotNull(dc);
 
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             Environment.SetEnvironmentVariable(ModuleIdVariableName, "module1");
             Environment.SetEnvironmentVariable(AuthSchemeVariableName, "sasToken");
 
-            ModuleClient dc = ModuleClient.Create(TransportType.Mqtt_Tcp_Only);
+            ModuleClient dc = ModuleClient.CreateFromEnvironment(TransportType.Mqtt_Tcp_Only);
 
             Assert.IsNotNull(dc);
 

--- a/iothub/device/tests/ModuleClientTests.cs
+++ b/iothub/device/tests/ModuleClientTests.cs
@@ -60,6 +60,22 @@
 
         [TestMethod]
         [TestCategory("ModuleClient")]
+        public void ModuleClient_CreateFromConnectionString_WithModuleId()
+        {
+            ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(ConnectionStringWithModuleId);
+            Assert.IsNotNull(moduleClient);
+        }
+
+        [TestMethod]
+        [TestCategory("ModuleClient")]
+        [ExpectedException(typeof(ArgumentException))]
+        public void ModuleClient_CreateFromConnectionString_WithNoModuleId()
+        {
+            ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(ConnectionStringWithoutModuleId);
+        }
+
+        [TestMethod]
+        [TestCategory("ModuleClient")]
         public void ModuleClient_CreateFromConnectionString_NoTransportSettings()
         {
             ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);

--- a/iothub/device/tests/ModuleClientTests.cs
+++ b/iothub/device/tests/ModuleClientTests.cs
@@ -221,6 +221,6 @@
             await moduleClient.OnReceiveEventMessageCalled("endpoint2", testMessage);
             Assert.IsFalse(isDefaultCallbackCalled);
             Assert.IsTrue(isSpecificCallbackCalled);
-        }        
+        }
     }
 }

--- a/iothub/device/tests/ModuleClientTests.cs
+++ b/iothub/device/tests/ModuleClientTests.cs
@@ -156,7 +156,7 @@
                 return Task.FromResult(MessageResponse.Completed);
             }, "custom data");
 
-            await moduleClient.OnReceiveEventMessageCalled(null, null);
+            await moduleClient.InternalClient.OnReceiveEventMessageCalled(null, null);
             Assert.IsFalse(isMessageHandlerCalled);
         }
 
@@ -187,7 +187,7 @@
             Message testMessage = new Message();
             testMessage.LockToken = "AnyLockToken";
 
-            await moduleClient.OnReceiveEventMessageCalled("endpoint1", testMessage);
+            await moduleClient.InternalClient.OnReceiveEventMessageCalled("endpoint1", testMessage);
             Assert.IsTrue(isDefaultCallbackCalled);
             Assert.IsFalse(isSpecificCallbackCalled);
         }
@@ -218,7 +218,7 @@
             Message testMessage = new Message();
             testMessage.LockToken = "AnyLockToken";
 
-            await moduleClient.OnReceiveEventMessageCalled("endpoint2", testMessage);
+            await moduleClient.InternalClient.OnReceiveEventMessageCalled("endpoint2", testMessage);
             Assert.IsFalse(isDefaultCallbackCalled);
             Assert.IsTrue(isSpecificCallbackCalled);
         }

--- a/iothub/device/tests/ModuleClientTests.cs
+++ b/iothub/device/tests/ModuleClientTests.cs
@@ -50,28 +50,28 @@
         static string fakeConnectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;ModuleId=dummyModuleId;SharedAccessKey=CQN2K33r45/0WeIjpqmErV5EIvX8JZrozt3NEHCEkG8=";
 
         [TestMethod]
-        [TestCategory("DeviceClient")]
+        [TestCategory("ModuleClient")]
         [ExpectedException(typeof(ArgumentNullException))]
         // Tests_SRS_DEVICECLIENT_10_001: [** if `connectionString` is null, an `ArgumentNullException` shall be thrown. **]**
         public void ModuleClient_CreateFromConnectionString_NullConnectionString()
         {
-            DeviceClient moduleClient = DeviceClient.CreateFromConnectionString(null);
+            ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(null);
         }
 
         [TestMethod]
-        [TestCategory("DeviceClient")]
+        [TestCategory("ModuleClient")]
         public void ModuleClient_CreateFromConnectionString_NoTransportSettings()
         {
-            DeviceClient moduleClient = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
+            ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
             Assert.IsNotNull(moduleClient);
         }
 
         [TestMethod]
-        [TestCategory("DeviceClient")]
+        [TestCategory("ModuleClient")]
         // Tests_SRS_DEVICECLIENT_33_003: [** It shall EnableEventReceiveAsync when called for the first time. **]**
         public async Task ModuleClient_SetReceiveCallbackAsync_SetCallback()
         {
-            DeviceClient moduleClient = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
+            ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
             var innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -82,11 +82,11 @@
         }
 
         [TestMethod]
-        [TestCategory("DeviceClient")]
+        [TestCategory("ModuleClient")]
         // Tests_SRS_DEVICECLIENT_33_004: [** It shall call DisableEventReceiveAsync when the last delegate has been removed. **]**
         public async Task ModuleClient_SetReceiveCallbackAsync_RemoveCallback()
         {
-            DeviceClient moduleClient = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
+            ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
             var innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -106,11 +106,11 @@
         }
 
         [TestMethod]
-        [TestCategory("DeviceClient")]
+        [TestCategory("ModuleClient")]
         // Tests_SRS_DEVICECLIENT_33_003: [** It shall EnableEventReceiveAsync when called for the first time. **]**
         public async Task ModuleClient_SetDefaultReceiveCallbackAsync_SetCallback()
         {
-            DeviceClient moduleClient = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
+            ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
             var innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -121,11 +121,11 @@
         }
 
         [TestMethod]
-        [TestCategory("DeviceClient")]
+        [TestCategory("ModuleClient")]
         // Tests_SRS_DEVICECLIENT_33_004: [** It shall call DisableEventReceiveAsync when the last delegate has been removed. **]**
         public async Task ModuleClient_SetDefaultReceiveCallbackAsync_RemoveCallback()
         {
-            DeviceClient moduleClient = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
+            ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
             var innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -141,11 +141,11 @@
 
 
         [TestMethod]
-        [TestCategory("DeviceClient")]
+        [TestCategory("ModuleClient")]
         // Tests_SRS_DEVICECLIENT_33_001: [** If the given eventMessageInternal argument is null, fail silently **]**
         public async Task ModuleClient_OnReceiveEventMessageCalled_NullMessageRequest()
         {
-            DeviceClient moduleClient = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
+            ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
             var innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -161,12 +161,12 @@
         }
 
         [TestMethod]
-        [TestCategory("DeviceClient")]
+        [TestCategory("ModuleClient")]
         // Tests_SRS_DEVICECLIENT_33_006: [** The OnReceiveEventMessageCalled shall get the default delegate if a delegate has not been assigned. **]**
         // Tests_SRS_DEVICECLIENT_33_005: [** It shall lazy-initialize the receiveEventEndpoints property. **]**
         public async Task ModuleClient_OnReceiveEventMessageCalled_DefaultCallbackCalled()
         {
-            DeviceClient moduleClient = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
+            ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
             var innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -193,11 +193,11 @@
         }
 
         [TestMethod]
-        [TestCategory("DeviceClient")]
+        [TestCategory("ModuleClient")]
         // Tests_SRS_DEVICECLIENT_33_002: [** The OnReceiveEventMessageCalled shall invoke the specified delegate. **]**
         public async Task ModuleClient_OnReceiveEventMessageCalled_SpecifiedCallbackCalled()
         {
-            DeviceClient moduleClient = DeviceClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
+            ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(fakeConnectionString, TransportType.Mqtt_Tcp_Only);
             var innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 

--- a/iothub/device/tests/ModuleClientTests.cs
+++ b/iothub/device/tests/ModuleClientTests.cs
@@ -69,9 +69,9 @@
         [TestMethod]
         [TestCategory("ModuleClient")]
         [ExpectedException(typeof(ArgumentException))]
-        public void ModuleClient_CreateFromConnectionString_WithNoModuleId()
+        public void ModuleClient_CreateFromConnectionString_WithNoModuleIdThrows()
         {
-            ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(ConnectionStringWithoutModuleId);
+            ModuleClient.CreateFromConnectionString(ConnectionStringWithoutModuleId);
         }
 
         [TestMethod]


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `modules-preview` branch.

# Description of the changes
Split DeviceClient API into DeviceClient (for devices) and ModuleClient (for modules). Refactored shared code into a common base class. 
Also fixed the tests as necessary. 