### PR TITLE
Adding '?' prefix to MQTT username property bag and updating the clie…

### DIFF
--- a/iothub/device/src/Common/Api/ClientApiVersionHelper.cs
+++ b/iothub/device/src/Common/Api/ClientApiVersionHelper.cs
@@ -8,7 +8,15 @@ namespace Microsoft.Azure.Devices.Client
         const string ApiVersionQueryPrefix = "api-version=";
         const string ApiVersionNov2016 = "2016-11-14";
         const string ApiVersionJune2017 = "2017-06-30";
-        public const string ApiVersionString = ApiVersionJune2017;
+
+#if ENABLE_MODULES_SDK
+        const string ApiVersionEdgePublicPreview = "2017-11-08-preview";
+        const string ApiVersionLatest = ApiVersionEdgePublicPreview;
+#else
+        const string ApiVersionLatest = ApiVersionJune2017;
+#endif
+
+        public const string ApiVersionString = ApiVersionLatest;
 
         public const string ApiVersionQueryString = ApiVersionQueryPrefix + ApiVersionString;
     }

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 {
                     ClientId = id,
                     HasUsername = true,
-                    Username = $"{this.iotHubHostName}/{id}/api-version={ClientApiVersionHelper.ApiVersionString}&DeviceClientType={Uri.EscapeDataString(this.productInfo.ToString())}",
+                    Username = $"{this.iotHubHostName}/{id}/?api-version={ClientApiVersionHelper.ApiVersionString}&DeviceClientType={Uri.EscapeDataString(this.productInfo.ToString())}",
                     HasPassword = !string.IsNullOrEmpty(password),
                     Password = password,
                     KeepAliveInSeconds = this.mqttTransportSettings.KeepAliveInSeconds,


### PR DESCRIPTION
…nt API version.

<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

# Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.

This pull request is against the module-preview branch, since the fix is only required when modules support is available.

# Description of the changes
- Adding '?' prefix to MQTT username property bag, indicating the beginning of the property bag and making easier to identify if the MQTT username is referring to a device or module, by the # of segments before the property bag;
- Updating client API version to the edge preview version, since the service will only accept property bags under this new format starting on the edge preview version ("2017-11-08-preview");

# Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
