### PR TITLE
Don't subscribe to C2D messages for modules over AMQP

### DIFF
--- a/iothub/device/src/Transport/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/AmqpTransportHandler.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                          this.faultTolerantEventSendingLink,
                          new ConnectionEventArgs { ConnectionType = ConnectionType.AmqpTelemetry, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
 
-                     if (!string.IsNullOrWhiteSpace(this.moduleId))
+                     if (string.IsNullOrWhiteSpace(this.moduleId))
                      {
                          await this.faultTolerantDeviceBoundReceivingLink.OpenAsync(this.openTimeout, cancellationToken).ConfigureAwait(false);
                          this.linkOpenedListener(

--- a/iothub/device/src/Transport/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/AmqpTransportHandler.cs
@@ -990,7 +990,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             string path = this.BuildPath(CommonConstants.DeviceEventPathTemplate, CommonConstants.ModuleEventPathTemplate);
 
-            ReceivingAmqpLink messageReceivingLink = await this.IotHubConnection.CreateReceivingLinkAsync(path, this.iotHubConnectionString, $"{this.deviceId}/{this.moduleId}", IotHubConnection.ReceivingLinkType.Events, this.prefetchCount, timeout, this.productInfo, cancellationToken);
+            ReceivingAmqpLink messageReceivingLink = await this.IotHubConnection.CreateReceivingLinkAsync(path, this.iotHubConnectionString, this.deviceId, IotHubConnection.ReceivingLinkType.Events, this.prefetchCount, timeout, this.productInfo, cancellationToken).ConfigureAwait(false);
             messageReceivingLink.RegisterMessageListener(amqpMessage => this.ProcessReceivedEventMessage(amqpMessage));
 
             MyStringCopy(messageReceivingLink.Name, out eventReceivingLinkName);

--- a/iothub/device/src/Transport/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/AmqpTransportHandler.cs
@@ -121,15 +121,18 @@ namespace Microsoft.Azure.Devices.Client.Transport
              {
                  try
                  {
-                     await Task.WhenAll(
-                         this.faultTolerantEventSendingLink.OpenAsync(this.openTimeout, cancellationToken),
-                         this.faultTolerantDeviceBoundReceivingLink.OpenAsync(this.openTimeout, cancellationToken)).ConfigureAwait(false);
+                     await this.faultTolerantEventSendingLink.OpenAsync(this.openTimeout, cancellationToken).ConfigureAwait(false);
                      this.linkOpenedListener(
                          this.faultTolerantEventSendingLink,
                          new ConnectionEventArgs { ConnectionType = ConnectionType.AmqpTelemetry, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
-                     this.linkOpenedListener(
-                         this.faultTolerantDeviceBoundReceivingLink,
-                         new ConnectionEventArgs { ConnectionType = ConnectionType.AmqpMessaging, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
+
+                     if (!string.IsNullOrWhiteSpace(this.moduleId))
+                     {
+                         await this.faultTolerantDeviceBoundReceivingLink.OpenAsync(this.openTimeout, cancellationToken).ConfigureAwait(false);
+                         this.linkOpenedListener(
+                             this.faultTolerantDeviceBoundReceivingLink,
+                             new ConnectionEventArgs { ConnectionType = ConnectionType.AmqpMessaging, ConnectionStatus = ConnectionStatus.Connected, ConnectionStatusChangeReason = ConnectionStatusChangeReason.Connection_Ok });
+                     }
                  }
                  catch (Exception exception)
                  {
@@ -987,7 +990,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             string path = this.BuildPath(CommonConstants.DeviceEventPathTemplate, CommonConstants.ModuleEventPathTemplate);
 
-            ReceivingAmqpLink messageReceivingLink = await this.IotHubConnection.CreateReceivingLinkAsync(path, this.iotHubConnectionString, this.deviceId, IotHubConnection.ReceivingLinkType.Events, this.prefetchCount, timeout, this.productInfo, cancellationToken);
+            ReceivingAmqpLink messageReceivingLink = await this.IotHubConnection.CreateReceivingLinkAsync(path, this.iotHubConnectionString, $"{this.deviceId}/{this.moduleId}", IotHubConnection.ReceivingLinkType.Events, this.prefetchCount, timeout, this.productInfo, cancellationToken);
             messageReceivingLink.RegisterMessageListener(amqpMessage => this.ProcessReceivedEventMessage(amqpMessage));
 
             MyStringCopy(messageReceivingLink.Name, out eventReceivingLinkName);


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `modules-preview` branch.

# Description of the changes
C2D is not supported for modules. So, don't subscribe to C2D messages for modules, over AMQP.