### PR TITLE
Fixed incorrect buffer length

### DIFF
--- a/security/tpm/src/SecurityProviderTpmHsm.cs
+++ b/security/tpm/src/SecurityProviderTpmHsm.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Security
             encryptedSecret = m.GetArray<byte>(encryptedSecret.Length, "encryptedSecret");
             TpmPrivate dupBlob = m.Get<TpmPrivate>();
             byte[] encWrapKey = new byte[m.Get<ushort>()];
-            encWrapKey = m.GetArray<byte>(encryptedSecret.Length, "encWrapKey");
+            encWrapKey = m.GetArray<byte>(encWrapKey.Length, "encWrapKey");
             UInt16 pubSize = m.Get<UInt16>();
             _idKeyPub = m.Get<TpmPublic>();
             byte[] cipherText = new byte[m.Get<ushort>()];


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

# Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

# Description of the changes
<!-- Itemized list of changes. -->

- Fixed Buffer length mismatch when parsing TPM key

# Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->

- Fixes #478 