### PR TITLE
Fixing AMQP SAS token double release issue.

### DIFF
--- a/common/test/Configuration.IoTHub.cs
+++ b/common/test/Configuration.IoTHub.cs
@@ -22,6 +22,53 @@ namespace Microsoft.Azure.Devices.E2ETests
             public static string ConnectionStringInvalidServiceCertificate => GetValue("IOTHUB_CONN_STRING_INVALIDCERT", string.Empty);
 
             public static string DeviceConnectionStringInvalidServiceCertificate => GetValue("IOTHUB_DEVICE_CONN_STRING_INVALIDCERT", string.Empty);
+
+            public static string DeviceConnectionString => GetValue("IOTHUB_DEVICE_CONN_STRING");
+
+            public class DeviceConnectionStringParser
+            {
+                public DeviceConnectionStringParser(string connectionString)
+                {
+                    string[] parts = connectionString.Split(';');
+                    foreach (string part in parts)
+                    {
+                        string[] tv = part.Split('=');
+    
+                        switch(tv[0].ToUpperInvariant())
+                        {
+                            case "HOSTNAME":
+                                IoTHub = tv[1];
+                                break;
+                            case "SHAREDACCESSKEY":
+                                SharedAccessKey = tv[1];
+                                break;
+                            case "DEVICEID":
+                                DeviceID = tv[1];
+                                break;
+                            default:
+                                throw new NotSupportedException("Unrecognized tag found in test ConnectionString.");
+                        }
+                    }
+                }
+
+                public string IoTHub
+                {
+                    get;
+                    private set;
+                }
+
+                public string DeviceID
+                {
+                    get;
+                    private set;
+                }
+
+                public string SharedAccessKey
+                {
+                    get;
+                    private set;
+                }
+            }
         }
     }
 }

--- a/e2e/test/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/DeviceTokenRefreshE2ETests.cs
@@ -4,7 +4,6 @@
 using Microsoft.Azure.Devices.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Text;
@@ -33,6 +32,48 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task DeviceClient_TokenIsRefreshed_Fails_Mqtt()
         {
             await DeviceClient_TokenIsRefreshed_Internal(Client.TransportType.Mqtt).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task DeviceClient_TokenConnectionDoubleRelease_Ok()
+        {
+            string deviceConnectionString = null;
+
+            try
+            {
+                 deviceConnectionString = Configuration.IoTHub.DeviceConnectionString;
+            }
+            catch (InvalidOperationException) { /* Invalid configuration. */ }
+
+            if (string.IsNullOrEmpty(deviceConnectionString))
+            {
+                Console.WriteLine("Device configuration not found. Test inconclusive.");
+                return;
+            }
+
+            var config = new Configuration.IoTHub.DeviceConnectionStringParser(deviceConnectionString);
+            string iotHub = config.IoTHub;
+            string deviceId = config.DeviceID;
+            string key = config.SharedAccessKey;
+
+            SharedAccessSignatureBuilder builder = new SharedAccessSignatureBuilder()
+            {
+                Key = "Lfc0z9UTENYRt0vEoFQjXeUkQV3ifk5f3qFN5N7vFlY=",
+                TimeToLive = new TimeSpan(0, 10, 0),
+                Target = $"{iotHub}/devices/{WebUtility.UrlEncode(deviceId)}",
+            };
+
+            DeviceAuthenticationWithToken auth = new DeviceAuthenticationWithToken(deviceId, builder.ToSignature());
+
+            using (DeviceClient iotClient = DeviceClient.Create(iotHub, auth, Client.TransportType.Amqp_Tcp_Only))
+            {
+                Console.WriteLine("DeviceClient OpenAsync.");
+                await iotClient.OpenAsync();
+                Console.WriteLine("DeviceClient SendEventAsync.");
+                await iotClient.SendEventAsync(new Client.Message(Encoding.UTF8.GetBytes("TestMessage")));
+                Console.WriteLine("DeviceClient CloseAsync.");
+                await iotClient.CloseAsync();   // First release
+            } // Second release
         }
 
         private async Task DeviceClient_TokenIsRefreshed_Internal(Client.TransportType transport)

--- a/iothub/device/src/IotHubSingleTokenConnection.cs
+++ b/iothub/device/src/IotHubSingleTokenConnection.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices.Client
 
     sealed class IotHubSingleTokenConnection : IotHubConnection
     {
-        readonly IotHubScopeConnectionPool iotHubScopeConnectionPool;
+        IotHubScopeConnectionPool iotHubScopeConnectionPool;
         IotHubTokenRefresher iotHubTokenRefresher;
 
         public IotHubSingleTokenConnection(IotHubScopeConnectionPool iotHubScopeConnectionPool, IotHubConnectionString connectionString, AmqpTransportSettings amqpTransportSettings)
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.Devices.Client
             if (this.iotHubScopeConnectionPool != null)
             {
                 this.iotHubScopeConnectionPool.RemoveRef();
+                this.iotHubScopeConnectionPool = null;
             }
             else
             {


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

# Checklist
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [X] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [X] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

# Description of the changes
The original `null` check within `IotHubSingleTokenConnection.cs` was never true because `iotHubScopeConnectionPool` was readonly.
Setting the property to null after release to ensure the code won't raise an assert on double release as described by #219 .

# Reference/Link to the issue solved with this PR (if any)
Fixes #219 
