### PR TITLE
Fix trustbundle when gateway hostname is not set

### DIFF
--- a/iothub/device/src/Edge/EdgeModuleClientFactory.cs
+++ b/iothub/device/src/Edge/EdgeModuleClientFactory.cs
@@ -94,8 +94,13 @@ namespace Microsoft.Azure.Devices.Client.Edge
                 var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId, generationId);
 
                 Debug.WriteLine("EdgeModuleClientFactory setupTrustBundle from service");
-                IList<X509Certificate2> certs = await trustBundleProvider.GetTrustBundleAsync(new Uri(edgedUri), DefaultApiVersion).ConfigureAwait(false);
-                ICertificateValidator certificateValidator = this.GetCertificateValidator(certs);
+
+                ICertificateValidator certificateValidator = NullCertificateValidator.Instance;
+                if (!string.IsNullOrEmpty(gateway))
+                {
+                    IList<X509Certificate2> certs = await trustBundleProvider.GetTrustBundleAsync(new Uri(edgedUri), DefaultApiVersion).ConfigureAwait(false);
+                    certificateValidator = this.GetCertificateValidator(certs);
+                }
 
                 return new ModuleClient(this.CreateInternalClientFromAuthenticationMethod(hostname, gateway, authMethod), certificateValidator);
             }

--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.17.0-preview-011</Version>
+    <Version>1.17.0-preview-012</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/versions.csv
+++ b/versions.csv
@@ -1,5 +1,5 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.17.0-preview-011
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.17.0-preview-012
 iothub\service\src\Microsoft.Azure.Devices.csproj, 1.16.0-preview-006
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.15.0-preview-003
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.1.0


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

# Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

# Description of the changes
CreateFromEnvironmentAsync should not make a call to get the trustbundle when gateway hostname is not set
