### PR TITLE
Change Module messages mode to AtLeastOnce

### DIFF
--- a/iothub/device/src/IotHubConnection.cs
+++ b/iothub/device/src/IotHubConnection.cs
@@ -37,13 +37,15 @@ namespace Microsoft.Azure.Devices.Client
 
         readonly string twinConnectionCorrelationId = Guid.NewGuid().ToString("N");
 
-        public enum SendingLinkType {
+        public enum SendingLinkType
+        {
             TelemetryEvents,
             Methods,
             Twin
         };
 
-        public enum ReceivingLinkType {
+        public enum ReceivingLinkType
+        {
             C2DMessages,
             Methods,
             Twin,
@@ -86,7 +88,7 @@ namespace Microsoft.Azure.Devices.Client
             {
                 Role = false,
                 InitialDeliveryCount = 0,
-                Target = new Target() {Address = linkAddress.AbsoluteUri},
+                Target = new Target() { Address = linkAddress.AbsoluteUri },
                 LinkName = Guid.NewGuid().ToString("N") // Use a human readable link name to help with debugging
             };
 
@@ -145,17 +147,25 @@ namespace Microsoft.Azure.Devices.Client
                 Role = true,
                 TotalLinkCredit = prefetchCount,
                 AutoSendFlow = prefetchCount > 0,
-                Source = new Source() {Address = linkAddress.AbsoluteUri},
+                Source = new Source() { Address = linkAddress.AbsoluteUri },
                 LinkName = Guid.NewGuid().ToString("N") // Use a human readable link name to help with debuggin
             };
 
             switch (linkType)
             {
+                // Exactly once
                 case ReceivingLinkType.C2DMessages:
-                case ReceivingLinkType.Events:
                     linkSettings.SndSettleMode = null; // SenderSettleMode.Unsettled (null as it is the default and to avoid bytes on the wire)
                     linkSettings.RcvSettleMode = (byte)ReceiverSettleMode.Second;
                     break;
+
+                // At least once
+                case ReceivingLinkType.Events:
+                    linkSettings.SndSettleMode = null; // SenderSettleMode.Unsettled (null as it is the default and to avoid bytes on the wire)
+                    linkSettings.RcvSettleMode = (byte)ReceiverSettleMode.First;
+                    break;
+
+                // At most once
                 case ReceivingLinkType.Methods:
                 case ReceivingLinkType.Twin:
                     linkSettings.SndSettleMode = (byte)SenderSettleMode.Settled;
@@ -175,7 +185,7 @@ namespace Microsoft.Azure.Devices.Client
 
             var link = new ReceivingAmqpLink(linkSettings);
             link.AttachTo(session);
- 
+
             var audience = this.BuildAudience(connectionString, path);
             await this.OpenLinkAsync(link, connectionString, audience, timeoutHelper.RemainingTime(), cancellationToken).ConfigureAwait(false);
 
@@ -193,7 +203,7 @@ namespace Microsoft.Azure.Devices.Client
 
                 Fx.Assert(session != null, "Amqp Session cannot be null.");
                 if (session.State != AmqpObjectState.Opened)
-                {                    
+                {
                     if (session.State == AmqpObjectState.End)
                     {
                         this.FaultTolerantSession.TryRemove();


### PR DESCRIPTION
## Checklist
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [X] This pull-request is submitted against the `modules-preview` branch.

## Description of the changes
Modules receiving messages should have at least once semantics. So Changing the module messages link to use that instead of Exactly once semantics like C2D. 