### PR TITLE
Fix message completion

### DIFF
--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1187,7 +1187,7 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
                 }
 
                 // codes_SRS_DEVICECLIENT_33_002: [ The OnReceiveEventMessageCalled shall invoke the specified delegate. ]
-                MessageResponse response = await (callback?.Item1?.Invoke(message, callback.Item2) ?? Task.FromResult(MessageResponse.None));
+                MessageResponse response = await (callback?.Item1?.Invoke(message, callback.Item2) ?? Task.FromResult(MessageResponse.Completed));
 
                 switch (response)
                 {


### PR DESCRIPTION
## Checklist
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [X] This pull-request is submitted against the `modules-preview` branch.

## Description of the changes
Complete all module messages if a matching callback is not found. This way, the server doesn't wait for the message to be completed. 