### PR TITLE
Fix InvalidCast Exception (DateTimeOffset to DateTime) deserializing …

### DIFF
--- a/iothub/service/tests/SerializationTests.cs
+++ b/iothub/service/tests/SerializationTests.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Azure.Devices.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices.Test
+{
+    [TestClass]
+    class SerializationTests
+    {
+        [TestMethod]
+        [TestCategory("CIT")]
+        [TestCategory("API")]
+        public async Task JsonDateParseHandlingTest()
+        {
+            var previousDefaultSettings = JsonConvert.DefaultSettings;
+
+            try
+            {
+                JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+                {
+                    DateParseHandling = DateParseHandling.DateTimeOffset
+                };
+
+                var now = DateTime.Now;
+
+                const string jsonString = @"
+{
+ ""deviceId"": ""test"",
+ ""etag"": ""AAAAAAAAAAM="",
+ ""version"": 5,
+ ""status"": ""enabled"",
+ ""statusUpdateTime"": ""2018-06-29T21:17:08.7759733"",
+ ""connectionState"": ""Connected"",
+ ""lastActivityTime"": ""2018-06-29T21:17:08.7759733"",
+},"; 
+
+                JsonConvert.DeserializeObject<Twin>(jsonString);
+            }
+            finally
+            {
+                JsonConvert.DefaultSettings = previousDefaultSettings;
+            }
+        }
+    }
+}

--- a/iothub/service/tests/SerializationTests.cs
+++ b/iothub/service/tests/SerializationTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Azure.Devices.Shared;
+﻿ // Copyright (c) Microsoft. All rights reserved.
+ // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Microsoft.Azure.Devices.Shared;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using System;

--- a/shared/src/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/src/Microsoft.Azure.Devices.Shared.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.15.0</Version>
+    <Version>1.15.1</Version>
     <Title>Microsoft Azure IoT Devices Shared</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/shared/src/TwinJsonConverter.cs
+++ b/shared/src/TwinJsonConverter.cs
@@ -186,16 +186,16 @@ namespace Microsoft.Azure.Devices.Shared
                     continue;
                 }
 
-                string propertyName = reader.Value as string;
+                string propertyName = reader.ReadAsString();
                 reader.Read();
 
                 switch (propertyName)
                 {
                     case DeviceIdJsonTag:
-                        twin.DeviceId = reader.Value as string;
+                        twin.DeviceId = reader.ReadAsString();
                         break;
                     case ModuleIdJsonTag:
-                        twin.ModuleId = reader.Value as string;
+                        twin.ModuleId = reader.ReadAsString();
                         break;
                     case ConfigurationsJsonTag:
                         twin.Configurations = serializer.Deserialize<Dictionary<string, ConfigurationInfo>>(reader);
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.Devices.Shared
                         };
                         break;
                     case ETagJsonTag:
-                        twin.ETag = reader.Value as string;
+                        twin.ETag = reader.ReadAsString();
                         break;
                     case TagsJsonTag:
                         if (reader.TokenType != JsonToken.StartObject)
@@ -224,27 +224,27 @@ namespace Microsoft.Azure.Devices.Shared
                         twin.Version = (long?)reader.Value;
                         break;
                     case StatusTag:
-                        string status = reader.Value as string;
+                        string status = reader.ReadAsString();
                         twin.Status = status?[0] == '\"' ? JsonConvert.DeserializeObject<DeviceStatus>(status) : serializer.Deserialize<DeviceStatus>(reader);
                         break;
                     case StatusReasonTag:
-                        twin.StatusReason = reader.Value as string;
+                        twin.StatusReason = reader.ReadAsString();
                         break;
                     case StatusUpdateTimeTag:
-                        twin.StatusUpdatedTime = (DateTime)reader.Value;
+                        twin.StatusUpdatedTime = reader.ReadAsDateTime();
                         break;
                     case ConnectionStateTag:
-                        string connectionState = reader.Value as string;
+                        string connectionState = reader.ReadAsString();
                         twin.ConnectionState = connectionState?[0] == '\"' ? JsonConvert.DeserializeObject<DeviceConnectionState>(connectionState) : serializer.Deserialize<DeviceConnectionState>(reader);
                         break;
                     case LastActivityTimeTag:
-                        twin.LastActivityTime = (DateTime)reader.Value;
+                        twin.LastActivityTime = reader.ReadAsDateTime();
                         break;
                     case CloudToDeviceMessageCountTag:
                         twin.CloudToDeviceMessageCount = serializer.Deserialize<int>(reader);
                         break;
                     case AuthenticationTypeTag:
-                        string authenticationType = reader.Value as string;
+                        string authenticationType = reader.ReadAsString();
                         twin.AuthenticationType = authenticationType?[0] == '\"' ? JsonConvert.DeserializeObject<AuthenticationType>(authenticationType) : serializer.Deserialize<AuthenticationType>(reader);
                         break;
                     case X509ThumbprintTag:
@@ -291,7 +291,7 @@ namespace Microsoft.Azure.Devices.Shared
                     break;
                 }
 
-                string propertyName = reader.Value as string;
+                string propertyName = reader.ReadAsString();
                 reader.Read();
 
                 if (reader.TokenType != JsonToken.StartObject)
@@ -328,7 +328,7 @@ namespace Microsoft.Azure.Devices.Shared
                     break;
                 }
 
-                string propertyName = reader.Value as string;
+                string propertyName = reader.ReadAsString();
                 reader.Read();
 
                 switch (propertyName)


### PR DESCRIPTION
…when JsonConvert.DefaultSettings returns a JsonSerializerSettings with DateParseHandling set to DateParseHandling.DateTimeOffset

Changed the JsonReader in TwinJsonConvert calls to avoid casting and use the ReadAs... where possible.