### PR TITLE
added RemoteCertificateChainErrors flag

### DIFF
--- a/iothub/device/src/IotHubConnection.cs
+++ b/iothub/device/src/IotHubConnection.cs
@@ -471,7 +471,7 @@ namespace Microsoft.Azure.Devices.Client
                 return true;
             }
 
-            if (DisableServerCertificateValidation.Value && sslPolicyErrors == SslPolicyErrors.RemoteCertificateNameMismatch)
+            if (DisableServerCertificateValidation.Value && (sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateNameMismatch) || sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateChainErrors)))
             {
                 return true;
             }


### PR DESCRIPTION

## Checklist
- [x ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->

When the **DisableServerCertificateValidation** configuration flag is set to true and the server certificate has invalid **certificate chain**, then the server certificate validation is not disabled. 

Added **RemoteCertificateChainErrors** next to **RemoteCertificateNameMismatch** as two of the disabled validation server certificate errors.