### PR TITLE
[LTS_2018_01] Fixing UT broken by VSTest running in .NET Core 2.1 

### DIFF
--- a/provisioning/service/tests/Config/QueryResultTests.cs
+++ b/provisioning/service/tests/Config/QueryResultTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
                 "      \"attestation\": {\n" +
                 "        \"type\": \"tpm\",\n" +
                 "        \"tpm\": {\n" +
-                "          \"endorsementKey\": \"randonendorsementkeyfortest==\"\n" +
+                "          \"endorsementKey\": \"randonendorsementkeyfortest=\"\n" +
                 "        }\n" +
                 "      },\n" +
                 "      \"iotHubHostName\": \"ContosoIotHub.azure-devices.net\",\n" +
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
                 "      \"attestation\": {\n" +
                 "        \"type\": \"tpm\",\n" +
                 "        \"tpm\": {\n" +
-                "          \"endorsementKey\": \"randonendorsementkeyfortest==\"\n" +
+                "          \"endorsementKey\": \"randonendorsementkeyfortest=\"\n" +
                 "        }\n" +
                 "      },\n" +
                 "      \"iotHubHostName\": \"ContosoIotHub.azure-devices.net\",\n" +


### PR DESCRIPTION
This issue is caused by two separate issues:
1. [Convert.FromBase64String different behavior in .NET Core 2.1 vs 2.0](https://github.com/dotnet/corefx/issues/30793)
2. [Linux Test runner uses netcoreapp2.1 regardless of csproj TargetFramework of netcoreapp2.0](https://github.com/Microsoft/vstest/issues/1669) 

The fix is simply using another test Base64 string. 
As far as we can tell, this has no implications on the actual LTS SDK production code and is meant to allow our test automation to run against this branch and a .NET Core 2.1 Docker container.