### PR TITLE
Serialize empty method invoke body

### DIFF
--- a/iothub/device/src/MethodInvokeRequest.cs
+++ b/iothub/device/src/MethodInvokeRequest.cs
@@ -23,7 +23,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <exception cref="ArgumentException">If <b>methodName</b> is null or whitespace</exception>
         public MethodInvokeRequest(string methodName, string payload, TimeSpan? responseTimeout, TimeSpan? connectionTimeout)
         {
-            ValidatePayloadIsJson(payload);
+            if (!string.IsNullOrEmpty(payload))
+            {
+                ValidatePayloadIsJson(payload);
+                this.Payload = new JRaw(payload);
+            }
             if (string.IsNullOrWhiteSpace(methodName))
             {
                 throw new ArgumentException("Canot be empty", nameof(methodName));
@@ -31,8 +35,7 @@ namespace Microsoft.Azure.Devices.Client
 
             this.MethodName = methodName;
             this.ResponseTimeout = responseTimeout;
-            this.ConnectionTimeout = connectionTimeout;
-            this.Payload = new JRaw(payload);
+            this.ConnectionTimeout = connectionTimeout; 
         }
 
         /// <summary>
@@ -65,7 +68,7 @@ namespace Microsoft.Azure.Devices.Client
         [JsonProperty("connectTimeoutInSeconds", NullValueHandling = NullValueHandling.Ignore)]
         internal int? ConnectionTimeoutInSeconds => !this.ConnectionTimeout.HasValue || this.ConnectionTimeout <= TimeSpan.Zero ? (int?)null : (int)this.ConnectionTimeout.Value.TotalSeconds;
 
-        [JsonProperty("payload")]
+        [JsonProperty("payload", NullValueHandling = NullValueHandling.Include)]
         internal JRaw Payload { get; set; }
 
         private void ValidatePayloadIsJson(string json)

--- a/iothub/device/src/MethodInvokeRequest.cs
+++ b/iothub/device/src/MethodInvokeRequest.cs
@@ -23,17 +23,18 @@ namespace Microsoft.Azure.Devices.Client
         /// <exception cref="ArgumentException">If <b>methodName</b> is null or whitespace</exception>
         public MethodInvokeRequest(string methodName, string payload, TimeSpan? responseTimeout, TimeSpan? connectionTimeout)
         {
+            if (string.IsNullOrWhiteSpace(methodName))
+            {
+                throw new ArgumentNullException(nameof(methodName));
+            }
+            this.MethodName = methodName;
+
             if (!string.IsNullOrEmpty(payload))
             {
                 ValidatePayloadIsJson(payload);
                 this.Payload = new JRaw(payload);
             }
-            if (string.IsNullOrWhiteSpace(methodName))
-            {
-                throw new ArgumentException("Canot be empty", nameof(methodName));
-            }
 
-            this.MethodName = methodName;
             this.ResponseTimeout = responseTimeout;
             this.ConnectionTimeout = connectionTimeout; 
         }

--- a/iothub/device/tests/ModuleClientTests.cs
+++ b/iothub/device/tests/ModuleClientTests.cs
@@ -238,5 +238,14 @@
             Assert.IsFalse(isDefaultCallbackCalled);
             Assert.IsTrue(isSpecificCallbackCalled);
         }
+
+        [TestMethod]
+        [TestCategory("ModuleClient")]
+        public async Task ModuleClient_InvokeMethodAsyncWithoutBody()
+        {
+            var request = new MethodRequest("test");
+            var invokeRequest = new MethodInvokeRequest(request.Name, request.DataAsJson, request.ResponseTimeout, request.ConnectionTimeout);
+            Assert.IsTrue(invokeRequest != null);
+        }
     }
 }


### PR DESCRIPTION
This change allows us to invoke a method from a module with an empty body. That behavior is currently broken in Edge and the invoking module gets back an error indicating that the body must not be null.


