### PR TITLE
Amqp link recovery fix

### DIFF
--- a/iothub/device/src/Transport/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/AmqpTransportHandler.cs
@@ -252,9 +252,9 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
             // disconnected link belongs to the current sets
             if (((connectionType == ConnectionType.AmqpMethodSending) &&
-                 ((link as SendingAmqpLink).Name == methodSendingLinkName)) ||
+                 (this.methodSendingLinkName == null || (link as SendingAmqpLink).Name == methodSendingLinkName)) ||
                 ((connectionType == ConnectionType.AmqpMethodReceiving) &&
-                 ((link as ReceivingAmqpLink).Name == methodReceivingLinkName)))
+                 (this.methodReceivingLinkName == null || (link as ReceivingAmqpLink).Name == methodReceivingLinkName)))
             {
                 methodSendingLinkName = null;
                 methodReceivingLinkName = null;
@@ -262,9 +262,9 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
 
             if (((connectionType == ConnectionType.AmqpTwinSending) &&
-                 ((link as SendingAmqpLink).Name == twinSendingLinkName)) ||
+                 (this.twinSendingLinkName == null || (link as SendingAmqpLink).Name == this.twinSendingLinkName)) ||
                 ((connectionType == ConnectionType.AmqpTwinReceiving) &&
-                 ((link as ReceivingAmqpLink).Name == twinReceivingLinkName)))
+                 (this.twinReceivingLinkName == null || (link as ReceivingAmqpLink).Name == this.twinReceivingLinkName)))
             {
                 twinSendingLinkName = null;
                 twinReceivingLinkName = null;
@@ -272,7 +272,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
 
             if (connectionType == ConnectionType.AmqpMessaging &&
-                (link as ReceivingAmqpLink).Name == eventReceivingLinkName)
+                (this.eventReceivingLinkName == null || (link as ReceivingAmqpLink).Name == this.eventReceivingLinkName))
             {
                 eventReceivingLinkName = null;
                 needEventReceivingLinkRecovery = true;


### PR DESCRIPTION
## Checklist
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [X] This pull-request is submitted against the `master` branch.

## Description of the changes
Issue: Over AMQP, the link recovery callbacks don't retry multiple times. Because of this, if the server is not available when the first retry happens, the link goes silent. This affects receiving links - receiving messages, method invocations and twin updates. In particular, I was investigating this for the receiving messages link.

Underlying cause: The error delegating handler cleans up all connections if an exception is thrown. This causes the links to get closed entirely, and the retry gets cancelled. This works for MQTT, since it expects the connection to be closed, and re-opened in the next retry. On the other hand, for AMQP, each link is treated separately, and as such, the connection (and all its links) should not be closed if the recovery fails once. So added code to reset the connection only for MQTT.
I spent significant time trying other options and somehow "unifying" the approach for both AMQP and MQTT, but because of the way the 2 protocols are written and expected to behave, this was not possible, without a significant refactor of the codebase.
The proposed fix works for both cases.

Tests: I will work with @CIPop to add E2E tests for these scenarios.

## Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-csharp/issues/571
