### PR TITLE
Marking schema version as optional.

### DIFF
--- a/iothub/service/src/Configurations/Configuration.cs
+++ b/iothub/service/src/Configurations/Configuration.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Gets Schema version for the configuration
         /// </summary>
-        [JsonProperty(PropertyName = "schemaVersion", Required = Required.Always)]
+        [JsonProperty(PropertyName = "schemaVersion", NullValueHandling = NullValueHandling.Ignore)]
         public string SchemaVersion { get; internal set; }
 
         /// <summary>

--- a/iothub/service/tests/SerializationTests.cs
+++ b/iothub/service/tests/SerializationTests.cs
@@ -9,23 +9,13 @@ using System.Threading.Tasks;
 namespace Microsoft.Azure.Devices.Test
 {
     [TestClass]
-    class SerializationTests
+    public class SerializationTests
     {
         [TestMethod]
-        public async Task JsonDateParseHandlingTest()
+        public void Twin_JsonDateParse_Ok()
         {
-            var previousDefaultSettings = JsonConvert.DefaultSettings;
-
-            try
-            {
-                JsonConvert.DefaultSettings = () => new JsonSerializerSettings
-                {
-                    DateParseHandling = DateParseHandling.DateTimeOffset
-                };
-
-                var now = DateTime.Now;
-
-                const string jsonString = @"
+            var now = DateTime.Now;
+            const string jsonString = @"
 {
  ""deviceId"": ""test"",
  ""etag"": ""AAAAAAAAAAM="",
@@ -34,14 +24,49 @@ namespace Microsoft.Azure.Devices.Test
  ""statusUpdateTime"": ""2018-06-29T21:17:08.7759733"",
  ""connectionState"": ""Connected"",
  ""lastActivityTime"": ""2018-06-29T21:17:08.7759733"",
-},"; 
+}"; 
 
-                JsonConvert.DeserializeObject<Twin>(jsonString);
+            JsonConvert.DeserializeObject<Twin>(jsonString);
+        }
+
+        [TestMethod]
+        public void Configuration_TestWithSchema_Ok()
+        {
+            const string jsonString = @"
+{
+  ""id"": ""aa"",
+  ""schemaVersion"": ""1.0"",
+  ""content"": {
+    ""modulesContent"": {
+        ""$edgeAgent"": {
+            ""properties.desired"": {
+                ""schemaVersion"": ""1.0""
             }
-            finally
-            {
-                JsonConvert.DefaultSettings = previousDefaultSettings;
+        }
+    }
+  }
+}";
+
+            JsonConvert.DeserializeObject<Configuration>(jsonString);
+        }
+
+        [TestMethod]
+        public void Configuration_TestNullSchema_Ok()
+        {
+            const string jsonString = @"
+{
+  ""id"": ""aa"",
+  ""content"": {
+    ""modulesContent"": {
+        ""$edgeAgent"": {
+            ""properties.desired"": {
             }
+        }
+    }
+  }
+}";
+
+            JsonConvert.DeserializeObject<Configuration>(jsonString);
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [X] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [X] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
* ADM: marking the `schemaVersion` component as optional.
* Adding unit tests
* Enabling previously disabled serialization tests (test class was not marked as public).

## Reference/Link to the issue solved with this PR (if any)
Internal: 

> It appears that C# SDK has an requirement of “schemaVersion” to be non-null in Configuration object which is not a requirement from the service. Can we relax this in the next SDK release?
