### PR TITLE
Make the device explorer usable for very large IoT Hubs

### DIFF
--- a/tools/DeviceExplorer/DeviceExplorer/DeviceExplorer.csproj
+++ b/tools/DeviceExplorer/DeviceExplorer/DeviceExplorer.csproj
@@ -94,6 +94,7 @@
       <DependentUpon>SASTokenForm.cs</DependentUpon>
     </Compile>
     <Compile Include="SortableBindingList.cs" />
+    <Compile Include="ThreadUtil.cs" />
     <EmbeddedResource Include="CreateDeviceForm.resx">
       <DependentUpon>CreateDeviceForm.cs</DependentUpon>
     </EmbeddedResource>

--- a/tools/DeviceExplorer/DeviceExplorer/DevicesProcessor.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/DevicesProcessor.cs
@@ -30,6 +30,38 @@ namespace DeviceExplorer
         }
 
         /// <summary>
+        /// Receive an approximation of the devices in the IoT hub, up to the 
+        /// specified max.  This is not a definitive list, and seems to return
+        /// only up to around 1000 devices regardless of what you specify as 
+        /// the max.
+        /// </summary>
+        /// <remarks>
+        /// The GetDevicesAsync() method is currently marked as obsolete, but 
+        /// loading one thousand devices via this method is much, much faster
+        /// than doing so through the GetDeviceSample() method.  The reason for 
+        /// this is that that method makes one request to get the first page of
+        /// twins, and then another request for EVERY one of the devices in order
+        /// to get their keys and such (totaling 1001 requests for 1000 devices).  
+        /// If the call to FetchDeviceFromTwin() was removed from GetDevicesAsync(), 
+        /// it would be just as fast as GetDevicesAsync(), but it would not provide 
+        /// the device keys and other information to display in the table.
+        /// </remarks>
+        public async Task<List<DeviceEntity>> GetABunchOfDevices()
+        {
+            var listOfDevices = new List<DeviceEntity>();
+            IEnumerable<Device> devices = await registryManager.GetDevicesAsync(maxCountOfDevices);
+            if (devices == null) return listOfDevices;
+
+            foreach (Device device in devices)
+            {
+                DeviceEntity deviceEntity = MapDeviceToDeviceEntity(device);
+                listOfDevices.Add(deviceEntity);
+            }
+
+            return listOfDevices;
+        }
+
+        /// <summary>
         /// This method took well over an hour to load 120,000 devices
         /// </summary>
         /// <returns></returns>

--- a/tools/DeviceExplorer/DeviceExplorer/MainForm.Designer.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/MainForm.Designer.cs
@@ -57,7 +57,8 @@
             this.updateDeviceButton = new System.Windows.Forms.Button();
             this.deleteDeviceButton = new System.Windows.Forms.Button();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.filterDevicesTextBox = new System.Windows.Forms.TextBox();
+            this.deviceCountTextBox = new System.Windows.Forms.TextBox();
+            this.searchDevicesTextBox = new System.Windows.Forms.TextBox();
             this.filterDevicesLabel = new System.Windows.Forms.Label();
             this.totalLabel = new System.Windows.Forms.Label();
             this.devicesGridView = new System.Windows.Forms.DataGridView();
@@ -128,7 +129,6 @@
             this.label14 = new System.Windows.Forms.Label();
             this.label13 = new System.Windows.Forms.Label();
             this.ehStringToolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.deviceCountTextBox = new System.Windows.Forms.TextBox();
             this.tabCallDeviceMethod.SuspendLayout();
             this.tabPage2.SuspendLayout();
             this.groupBox5.SuspendLayout();
@@ -493,7 +493,7 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox2.Controls.Add(this.deviceCountTextBox);
-            this.groupBox2.Controls.Add(this.filterDevicesTextBox);
+            this.groupBox2.Controls.Add(this.searchDevicesTextBox);
             this.groupBox2.Controls.Add(this.filterDevicesLabel);
             this.groupBox2.Controls.Add(this.totalLabel);
             this.groupBox2.Controls.Add(this.devicesGridView);
@@ -504,23 +504,33 @@
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Devices";
             // 
-            // filterDevicesTextBox
+            // deviceCountTextBox
             // 
-            this.filterDevicesTextBox.AccessibleName = "Filter devices list";
-            this.filterDevicesTextBox.Location = new System.Drawing.Point(58, 49);
-            this.filterDevicesTextBox.Name = "filterDevicesTextBox";
-            this.filterDevicesTextBox.Size = new System.Drawing.Size(676, 22);
-            this.filterDevicesTextBox.TabIndex = 12;
-            this.filterDevicesTextBox.TextChanged += new System.EventHandler(this.filterDevicesTextBox_TextChanged);
+            this.deviceCountTextBox.AccessibleName = "Total device count";
+            this.deviceCountTextBox.Location = new System.Drawing.Point(68, 19);
+            this.deviceCountTextBox.Name = "deviceCountTextBox";
+            this.deviceCountTextBox.ReadOnly = true;
+            this.deviceCountTextBox.Size = new System.Drawing.Size(100, 22);
+            this.deviceCountTextBox.TabIndex = 10;
+            this.deviceCountTextBox.Text = "0";
+            // 
+            // searchDevicesTextBox
+            // 
+            this.searchDevicesTextBox.AccessibleName = "Filter devices list";
+            this.searchDevicesTextBox.Location = new System.Drawing.Point(67, 49);
+            this.searchDevicesTextBox.Name = "searchDevicesTextBox";
+            this.searchDevicesTextBox.Size = new System.Drawing.Size(667, 22);
+            this.searchDevicesTextBox.TabIndex = 12;
+            this.searchDevicesTextBox.TextChanged += new System.EventHandler(this.filterDevicesTextBox_TextChanged);
             // 
             // filterDevicesLabel
             // 
             this.filterDevicesLabel.AutoSize = true;
             this.filterDevicesLabel.Location = new System.Drawing.Point(7, 52);
             this.filterDevicesLabel.Name = "filterDevicesLabel";
-            this.filterDevicesLabel.Size = new System.Drawing.Size(40, 16);
+            this.filterDevicesLabel.Size = new System.Drawing.Size(54, 16);
             this.filterDevicesLabel.TabIndex = 11;
-            this.filterDevicesLabel.Text = "Filter:";
+            this.filterDevicesLabel.Text = "Search:";
             // 
             // totalLabel
             // 
@@ -1293,16 +1303,6 @@
             this.label13.TabIndex = 0;
             this.label13.Text = "Call Method on Device";
             // 
-            // deviceCountTextBox
-            // 
-            this.deviceCountTextBox.AccessibleName = "Total device count";
-            this.deviceCountTextBox.Location = new System.Drawing.Point(58, 19);
-            this.deviceCountTextBox.Name = "deviceCountTextBox";
-            this.deviceCountTextBox.ReadOnly = true;
-            this.deviceCountTextBox.Size = new System.Drawing.Size(100, 22);
-            this.deviceCountTextBox.TabIndex = 10;
-            this.deviceCountTextBox.Text = "0";
-            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1445,7 +1445,7 @@
         private System.Windows.Forms.DataGridView messageSystemPropertiesGrid;
         private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn1;
         private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn2;
-        private System.Windows.Forms.TextBox filterDevicesTextBox;
+        private System.Windows.Forms.TextBox searchDevicesTextBox;
         private System.Windows.Forms.Label filterDevicesLabel;
         private System.Windows.Forms.RichTextBox messagesTextBox;
         private System.Windows.Forms.TextBox deviceCountTextBox;

--- a/tools/DeviceExplorer/DeviceExplorer/MainForm.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/MainForm.cs
@@ -348,7 +348,7 @@ namespace DeviceExplorer
         private async Task updateDevicesGridView()
         {
             var devicesProcessor = new DevicesProcessor(activeIoTHubConnectionString, MAX_COUNT_OF_DEVICES, protocolGatewayHost.Text);
-            var devicesList = await devicesProcessor.GetDevices();
+            var devicesList = await devicesProcessor.GetAllDevicesExtremelySlowly();
             devicesList.Sort();
             allDevices = new SortableBindingList<DeviceEntity>(devicesList);
 

--- a/tools/DeviceExplorer/DeviceExplorer/MainForm.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/MainForm.cs
@@ -347,8 +347,14 @@ namespace DeviceExplorer
         #region ManagementTab
         private async Task updateDevicesGridView()
         {
-            var devicesProcessor = new DevicesProcessor(activeIoTHubConnectionString, MAX_COUNT_OF_DEVICES, protocolGatewayHost.Text);
-            var devicesList = await devicesProcessor.GetAllDevicesExtremelySlowly();
+            var devicesProcessor = new DevicesProcessor(
+                activeIoTHubConnectionString,
+                MAX_COUNT_OF_DEVICES,
+                protocolGatewayHost.Text);
+
+            const int sampleSize = 100;
+            var devicesList = await devicesProcessor.GetDeviceSample(sampleSize);
+
             devicesList.Sort();
             allDevices = new SortableBindingList<DeviceEntity>(devicesList);
 

--- a/tools/DeviceExplorer/DeviceExplorer/MainForm.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/MainForm.cs
@@ -363,10 +363,8 @@ namespace DeviceExplorer
                 .ContinueWith(t => numDevicesInIotHub = t.Result)
                 .FireAndForget();
 
-            int sampleSize = 100;
             allLoadedDevices = new SortableBindingList<DeviceEntity>();
             devicesGridView.DataSource = allLoadedDevices;
-            allLoadedDevices.ListChanged += (sender, args) => updateDeviceCountLabel();
 
             // Save the device ID currently selected on the grid.
             string deviceCurrentlySelected = null;
@@ -374,11 +372,12 @@ namespace DeviceExplorer
             {
                 deviceCurrentlySelected = (string)devicesGridView.SelectedRows[0].Cells[0].Value;
             }
-
-            // Kick off the fetching of devices
-            devicesProcessor
-                .GetDeviceSample(sampleSize, allLoadedDevices)
-                .FireAndForget();
+            
+            // Fetch the priliminary set of devices to display
+            List<DeviceEntity> devices = await devicesProcessor.GetABunchOfDevices();
+            devices.Sort();
+            allLoadedDevices = new SortableBindingList<DeviceEntity>(devices);
+            updateDeviceCountLabel();
 
             // Re-select the device ID previously selected before the update.
             // This avoids the super-annoying need to scroll down every time the management grid gets updated.

--- a/tools/DeviceExplorer/DeviceExplorer/MainForm.resx
+++ b/tools/DeviceExplorer/DeviceExplorer/MainForm.resx
@@ -126,18 +126,6 @@
   <metadata name="ValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="KeyColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="dataGridViewTextBoxColumn1.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="dataGridViewTextBoxColumn2.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="dataGridViewTextBoxColumn1.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>

--- a/tools/DeviceExplorer/DeviceExplorer/ThreadUtil.cs
+++ b/tools/DeviceExplorer/DeviceExplorer/ThreadUtil.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DeviceExplorer
+{
+    internal static class ThreadUtil
+    {
+        /// <summary>
+        ///     Fire off a task that can complete whenever it pleases.  This method
+        ///     is mostly to improve the semantics of calling an async method from
+        ///     a synchronous method when we don't care about the exact time table
+        ///     or return value.
+        /// </summary>
+        /// <remarks>
+        ///     Copied from https://stackoverflow.com/a/22864616/2517147
+        /// </remarks>
+        /// <param name="task"></param>
+        /// <param name="acceptableExceptions"></param>
+        public static async void FireAndForget(
+            this Task task,
+            params Type[] acceptableExceptions)
+        {
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // TODO: consider whether derived types are also acceptable.
+                if (!acceptableExceptions.Contains(ex.GetType()))
+                    throw;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes

Currently, with IoT Hubs with a very large number of devices, the Device Explorer tool is basically unusable.  It makes an individual web request for every single device in the IoT Hub, which can take hours.  I have taken a number of different steps in this pull request to improve that performance.

I am of the opinion that for IoT Hubs with more than a thousand devices, no one needs to look at all the info for all those devices at the same time.  Their goal with this tool is almost certainly to make modifications to a single device.  So we (in a single web request) populate the first thousand devices, and then allow them to search for the particular device that they're concerned about.

- Add the ability to request a subset of all the devices in the IoT Hub
- Display to the user how many devices they have loaded out of the entirety of the devices in the IoT Hub
- Allow the search box to be used to load additional devices
- Populate the first thousand devices in the IoT Hub very quickly

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
