### PR TITLE
Fix one character spelling issue in provisioning\device\samples\ProvisioningDeviceClientX509\readme.md

### DIFF
--- a/provisioning/device/samples/ProvisioningDeviceClientX509/readme.md
+++ b/provisioning/device/samples/ProvisioningDeviceClientX509/readme.md
@@ -29,7 +29,7 @@ Continue by following the instructions presented by the sample.
 
 ## Using your certificates
 
-The SDK requires an [X509Certificate2](https://msdn.microsoft.com/en-us/library/system.security.cryptography.x509certificates.x509certificate2(v=vs.110).aspx) object with private key ([HasPrivateKey](https://msdn.microsoft.com/en-us/library/system.security.cryptography.x509certificates.x509certificate2.hasprivatekey(v=vs.110).aspx)==true) and, optionally, the certificate chain within an [X509Certificate2Colection](https://msdn.microsoft.com/en-us/library/system.security.cryptography.x509certificates.x509certificate2collection(v=vs.110).aspx) object.
+The SDK requires an [X509Certificate2](https://msdn.microsoft.com/en-us/library/system.security.cryptography.x509certificates.x509certificate2(v=vs.110).aspx) object with private key ([HasPrivateKey](https://msdn.microsoft.com/en-us/library/system.security.cryptography.x509certificates.x509certificate2.hasprivatekey(v=vs.110).aspx)==true) and, optionally, the certificate chain within an [X509Certificate2Collection](https://msdn.microsoft.com/en-us/library/system.security.cryptography.x509certificates.x509certificate2collection(v=vs.110).aspx) object.
 
 This can be achieved by changing the following line:
 


### PR DESCRIPTION
…an incorrect spelling for 'X509CertificateCollection'; it is missing the double 'l' and has 'Colection'.

<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ N/A; doc change] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->
Inside the 'Using your certificates' section for readme.md, there is an incorrect spelling for 'X509CertificateCollection'; it is missing the double 'l' and has 'Colection'.

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
