### PR TITLE
Fix bug where DeviceClient amqp event links sent device id as correlation id

### DIFF
--- a/iothub/device/src/Transport/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/AmqpTransportHandler.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         string methodConnectionCorrelationId = Guid.NewGuid().ToString("N");
         string twinConnectionCorrelationId = Guid.NewGuid().ToString("N");
+        string eventConnectionCorrelationId = Guid.NewGuid().ToString("N");
 
         private string methodSendingLinkName;
         private string methodReceivingLinkName;
@@ -413,6 +414,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 {
                     if (this.eventReceivedListener != null)
                     {
+                        this.eventConnectionCorrelationId = Guid.NewGuid().ToString("N");
                         await this.GetEventReceivingLinkAsync(cancellationToken);
                         this.linkOpenedListener(
                             this.faultTolerantEventReceivingLink,
@@ -661,7 +663,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
             string correlationId = Guid.NewGuid().ToString();
             AmqpMessage response = null;
 
-
             try
             {
                 Outcome outcome;
@@ -884,7 +885,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             string path = this.BuildPath(CommonConstants.DeviceEventPathTemplate, CommonConstants.ModuleEventPathTemplate);
 
-            return await this.IotHubConnection.CreateSendingLinkAsync(path, this.iotHubConnectionString, this.deviceId, IotHubConnection.SendingLinkType.TelemetryEvents, timeout, this.productInfo, cancellationToken).ConfigureAwait(false);
+            return await this.IotHubConnection.CreateSendingLinkAsync(path, this.iotHubConnectionString, this.eventConnectionCorrelationId, IotHubConnection.SendingLinkType.TelemetryEvents, timeout, this.productInfo, cancellationToken).ConfigureAwait(false);
         }
 
         async Task<ReceivingAmqpLink> GetDeviceBoundReceivingLinkAsync(CancellationToken cancellationToken)
@@ -1077,7 +1078,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             string path = this.BuildPath(CommonConstants.DeviceEventPathTemplate, CommonConstants.ModuleEventPathTemplate);
 
-            ReceivingAmqpLink messageReceivingLink = await this.IotHubConnection.CreateReceivingLinkAsync(path, this.iotHubConnectionString, this.deviceId, IotHubConnection.ReceivingLinkType.Events, this.prefetchCount, timeout, this.productInfo, cancellationToken).ConfigureAwait(false);
+            ReceivingAmqpLink messageReceivingLink = await this.IotHubConnection.CreateReceivingLinkAsync(path, this.iotHubConnectionString, this.eventConnectionCorrelationId, IotHubConnection.ReceivingLinkType.Events, this.prefetchCount, timeout, this.productInfo, cancellationToken).ConfigureAwait(false);
             messageReceivingLink.RegisterMessageListener(amqpMessage => this.ProcessReceivedEventMessage(amqpMessage));
 
             MyStringCopy(messageReceivingLink.Name, out eventReceivingLinkName);


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
In the AmqpTransportHandler class used by the Device Client, the event links wrongly provide a device id as a correlation id. The service requires a unique string here instead so that it can better correlate request and receiving links during reconnection.

This commit also factors out some common logic when assigning properties to an amqp link

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
Fixes #618
