### PR TITLE
Fix bug where Singleton Amqp links were being disposed upon closing the device client (#620)

### DIFF
--- a/common/test/TestDevice.cs
+++ b/common/test/TestDevice.cs
@@ -31,6 +31,11 @@ namespace Microsoft.Azure.Devices.E2ETests
             _authenticationMethod = authenticationMethod;
         }
 
+        public Device getDevice()
+        {
+            return _device;
+        }
+
         /// <summary>
         /// Factory method.
         /// IMPORTANT: Not thread safe!
@@ -155,7 +160,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             return deviceClient;
         }
 
-        private static string GetHostName(string iotHubConnectionString)
+        public static string GetHostName(string iotHubConnectionString)
         {
             Regex regex = new Regex("HostName=([^;]+)", RegexOptions.None);
             return regex.Match(iotHubConnectionString).Groups[1].Value;

--- a/iothub/device/src/Common/Singleton.cs
+++ b/iothub/device/src/Common/Singleton.cs
@@ -45,14 +45,22 @@ namespace Microsoft.Azure.Devices.Client
 
         public Task CloseAsync()
         {
-            this.Dispose();
+            var thisTaskCompletionSource = this.taskCompletionSource;
+            if (thisTaskCompletionSource != null && thisTaskCompletionSource.Task.Status == TaskStatus.RanToCompletion)
+            {
+                OnSafeClose(thisTaskCompletionSource.Task.Result);
+            }
 
             return TaskHelpers.CompletedTask;
         }
 
         public void Close()
         {
-            this.Dispose();
+            var thisTaskCompletionSource = this.taskCompletionSource;
+            if (thisTaskCompletionSource != null && thisTaskCompletionSource.Task.Status == TaskStatus.RanToCompletion)
+            {
+                OnSafeClose(thisTaskCompletionSource.Task.Result);
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
Issue #620

<!--
Thank you for helping us improve the Azure IoT C# SDK!

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
Singleton class now maintains a distinction between closing, and disposing. This PR fixes  FaultTolerantAmqpObject to be closed, not disposed, when a device client is closed.

Previously, when you closed any device client, the singleton instance of the FaultTolerantAmqpObject would become unusable, and this would cause any subsequently opened AMQP device client to fail to create the links needed to communicate.

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
Fixes #620 
