### PR TITLE
Update AmqpTransportHandler.cs

### DIFF
--- a/iothub/device/src/Transport/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/AmqpTransportHandler.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         private string twinReceivingLinkName;
         private string eventReceivingLinkName;
 
-        const int ResponseTimeoutInSeconds = 10;
+        const int ResponseTimeoutInSeconds = 300;
 
         ConcurrentDictionary<string, TaskCompletionSource<AmqpMessage>> twinResponseCompletions = new ConcurrentDictionary<string, TaskCompletionSource<AmqpMessage>>();
 


### PR DESCRIPTION
Increase constant ResponseTimeoutInSeconds to 5 mins.  This is used in method RoundTripTwinMessage. We found that this method is timing out too soon in PROD deployments.

<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->
Changing time out value for Round trip twin messages
## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
