### PR TITLE
Add Windows OS Product Type to User Agent string

### DIFF
--- a/iothub/device/src/NativeMethods.cs
+++ b/iothub/device/src/NativeMethods.cs
@@ -20,10 +20,17 @@ namespace Microsoft.Azure.Devices.Client
         public static int GetWindowsProductType()
         {
 #if !NETSTANDARD1_3
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-                GetProductInfo(Environment.OSVersion.Version.Major, Environment.OSVersion.Version.Minor, 0, 0, out int productType))
+            try
             {
-                return productType;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                    GetProductInfo(Environment.OSVersion.Version.Major, Environment.OSVersion.Version.Minor, 0, 0, out int productType))
+                {
+                    return productType;
+                }
+            }
+            catch (DllNotFoundException)
+            {
+                // Catch any DLL not found exceptions
             }
 #endif
             return 0;

--- a/iothub/device/src/NativeMethods.cs
+++ b/iothub/device/src/NativeMethods.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Azure.Devices.Shared;
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Azure.Devices.Client
@@ -28,9 +30,11 @@ namespace Microsoft.Azure.Devices.Client
                     return productType;
                 }
             }
-            catch (DllNotFoundException)
+            catch (DllNotFoundException ex)
             {
                 // Catch any DLL not found exceptions
+                Debug.Assert(false, ex.Message);
+                if (Logging.IsEnabled) Logging.Error(null, ex, nameof(NativeMethods));
             }
 #endif
             return 0;

--- a/iothub/device/src/NativeMethods.cs
+++ b/iothub/device/src/NativeMethods.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Azure.Devices.Client
         public static int GetWindowsProductType()
         {
 #if !NETSTANDARD1_3
-            if (GetProductInfo(Environment.OSVersion.Version.Major, Environment.OSVersion.Version.Minor, 0, 0, out int productType))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                GetProductInfo(Environment.OSVersion.Version.Major, Environment.OSVersion.Version.Minor, 0, 0, out int productType))
             {
                 return productType;
             }

--- a/iothub/device/src/NativeMethods.cs
+++ b/iothub/device/src/NativeMethods.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.Client
                 return productType;
             }
 #endif
-            return -1;
+            return 0;
         }
     }
 }

--- a/iothub/device/src/NativeMethods.cs
+++ b/iothub/device/src/NativeMethods.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Azure.Devices.Client
+{
+    internal static partial class NativeMethods
+    {
+        [DllImport("kernel32.dll", SetLastError = false)]
+        private static extern bool GetProductInfo(
+               int dwOSMajorVersion,
+               int dwOSMinorVersion,
+               int dwSpMajorVersion,
+               int dwSpMinorVersion,
+               out int pdwReturnedProductType
+           );
+
+        public static int GetWindowsProductType()
+        {
+#if !NETSTANDARD1_3
+            if (GetProductInfo(Environment.OSVersion.Version.Major, Environment.OSVersion.Version.Minor, 0, 0, out int productType))
+            {
+                return productType;
+            }
+#endif
+            return -1;
+        }
+    }
+}

--- a/iothub/device/src/ProductInfo.cs
+++ b/iothub/device/src/ProductInfo.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices.Client
     {
         public string Extra { get; set; } = "";
 
-        private Lazy<int> _productType = new Lazy<int>(() => NativeMethods.GetWindowsProductType());
+        private readonly Lazy<int> _productType = new Lazy<int>(() => NativeMethods.GetWindowsProductType());
 
         public override string ToString()
         {

--- a/iothub/device/src/ProductInfo.cs
+++ b/iothub/device/src/ProductInfo.cs
@@ -20,13 +20,9 @@ namespace Microsoft.Azure.Devices.Client
             string runtime = RuntimeInformation.FrameworkDescription.Trim();
             string operatingSystem = RuntimeInformation.OSDescription.Trim();
             string processorArchitecture = RuntimeInformation.ProcessArchitecture.ToString().Trim();
+            string productType = (_productType.Value != 0) ? $" WindowsProduct:0x{_productType.Value:X8}" : string.Empty;
 
-            string userAgent = $"{Name}/{version} ({runtime}; {operatingSystem}; {processorArchitecture})";
-
-            if (_productType.Value != 0)
-            {
-                userAgent += $" WindowsProduct:0x{_productType.Value:X8}";
-            }
+            string userAgent = $"{Name}/{version} ({runtime}; {operatingSystem}{productType}; {processorArchitecture})";
 
             if (!String.IsNullOrWhiteSpace(this.Extra))
             {

--- a/iothub/device/src/ProductInfo.cs
+++ b/iothub/device/src/ProductInfo.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Azure.Devices.Client
     {
         public string Extra { get; set; } = "";
 
+        private Lazy<int> _productType = new Lazy<int>(() => NativeMethods.GetWindowsProductType());
+
         public override string ToString()
         {
             const string Name = "Microsoft.Azure.Devices.Client";
@@ -20,6 +22,11 @@ namespace Microsoft.Azure.Devices.Client
             string processorArchitecture = RuntimeInformation.ProcessArchitecture.ToString().Trim();
 
             string userAgent = $"{Name}/{version} ({runtime}; {operatingSystem}; {processorArchitecture})";
+
+            if (_productType.Value != -1)
+            {
+                userAgent += $" WindowsProduct:0x{_productType.Value:X8}";
+            }
 
             if (!String.IsNullOrWhiteSpace(this.Extra))
             {

--- a/iothub/device/src/ProductInfo.cs
+++ b/iothub/device/src/ProductInfo.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Client
 
             string userAgent = $"{Name}/{version} ({runtime}; {operatingSystem}; {processorArchitecture})";
 
-            if (_productType.Value != -1)
+            if (_productType.Value != 0)
             {
                 userAgent += $" WindowsProduct:0x{_productType.Value:X8}";
             }

--- a/iothub/device/tests/ProductInfoTests.cs
+++ b/iothub/device/tests/ProductInfoTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             string processorArchitecture = RuntimeInformation.ProcessArchitecture.ToString().Trim();
 
             var productType = NativeMethods.GetWindowsProductType();
-            var productTypeString = (productType != -1) ? $" WindowsProduct:0x{productType:X8}" : string.Empty;
+            var productTypeString = (productType != 0) ? $" WindowsProduct:0x{productType:X8}" : string.Empty;
 
             return $"Microsoft.Azure.Devices.Client/{version} ({runtime}; {operatingSystem}; {processorArchitecture}){productTypeString}";
         }

--- a/iothub/device/tests/ProductInfoTests.cs
+++ b/iothub/device/tests/ProductInfoTests.cs
@@ -19,7 +19,10 @@ namespace Microsoft.Azure.Devices.Client.Test
             string operatingSystem = RuntimeInformation.OSDescription.Trim();
             string processorArchitecture = RuntimeInformation.ProcessArchitecture.ToString().Trim();
 
-            return $"Microsoft.Azure.Devices.Client/{version} ({runtime}; {operatingSystem}; {processorArchitecture})";
+            var productType = NativeMethods.GetWindowsProductType();
+            var productTypeString = (productType != -1) ? $" WindowsProduct:0x{productType:X8}" : string.Empty;
+
+            return $"Microsoft.Azure.Devices.Client/{version} ({runtime}; {operatingSystem}; {processorArchitecture}){productTypeString}";
         }
 
         [TestMethod]

--- a/iothub/device/tests/ProductInfoTests.cs
+++ b/iothub/device/tests/ProductInfoTests.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.Devices.Client.Test
 {
@@ -22,7 +23,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var productType = NativeMethods.GetWindowsProductType();
             var productTypeString = (productType != 0) ? $" WindowsProduct:0x{productType:X8}" : string.Empty;
 
-            return $"Microsoft.Azure.Devices.Client/{version} ({runtime}; {operatingSystem}; {processorArchitecture}){productTypeString}";
+            return $"Microsoft.Azure.Devices.Client/{version} ({runtime}; {operatingSystem}{productTypeString}; {processorArchitecture})";
         }
 
         [TestMethod]
@@ -75,6 +76,13 @@ namespace Microsoft.Azure.Devices.Client.Test
             info.Extra = extra;
 
             Assert.AreEqual($"{ExpectedUserAgentString()} {extra.Trim()}", info.ToString());
+        }
+
+        [TestMethod]
+        public void ToString_IsValidHttpHeaderFormat()
+        {
+            var httpRequestMessage = new HttpRequestMessage();
+            Assert.IsTrue(httpRequestMessage.Headers.UserAgent.TryParseAdd((new ProductInfo()).ToString()));
         }
     }
 }


### PR DESCRIPTION
Add Windows OS Product Type to User Agent string

<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [X] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [X] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
- Add Windows OS product type to user agent string to differentiate/identify Windows SKUs in telemetry
- Update existing user agent test to include product type

## Reference/Link to the issue solved with this PR (if any)
Addresses internal task/request for Windows OS SKU information to be included in user agent
