### PR TITLE
Remove rethrowing of exception to preserve callstack.

### DIFF
--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -509,18 +509,8 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
                 Logging.Info(this, $"{operationTimeoutCancellationTokenSource.GetHashCode()}", nameof(ApplyTimeout));
             }
 
-            var result = operation(operationTimeoutCancellationTokenSource.Token)
+            return operation(operationTimeoutCancellationTokenSource.Token)
                 .WithTimeout(TimeSpan.FromMilliseconds(OperationTimeoutInMilliseconds), () => Resources.OperationTimeoutExpired, operationTimeoutCancellationTokenSource.Token);
-
-            return result.ContinueWith(t =>
-            {
-                // operationTimeoutCancellationTokenSource will be disposed by GC. 
-                // Cannot dispose here since we don't know if both tasks created by WithTimeout ran to completion.
-                if (t.IsFaulted)
-                {
-                    throw t.Exception.InnerException;
-                }
-            }, TaskContinuationOptions.NotOnCanceled);
         }
 
         Task<Message> ApplyTimeoutMessage(Func<CancellationToken, Task<Message>> operation)
@@ -533,19 +523,8 @@ TODO: revisit DefaultDelegatingHandler - it seems redundant as long as we have t
 
             CancellationTokenSource operationTimeoutCancellationTokenSource = GetOperationTimeoutCancellationTokenSource();
 
-            var result = operation(operationTimeoutCancellationTokenSource.Token)
+            return operation(operationTimeoutCancellationTokenSource.Token)
                 .WithTimeout(TimeSpan.FromMilliseconds(OperationTimeoutInMilliseconds), () => Resources.OperationTimeoutExpired, operationTimeoutCancellationTokenSource.Token);
-
-            return result.ContinueWith(t =>
-            {
-                // operationTimeoutCancellationTokenSource will be disposed by GC. 
-                // Cannot dispose here since we don't know if both tasks created by WithTimeout ran to completion.
-                if (t.IsFaulted)
-                {
-                    throw t.Exception.InnerException;
-                }
-                return t.Result;
-            });
         }
 
         Task<Twin> ApplyTimeoutTwin(Func<CancellationToken, Task<Twin>> operation)


### PR DESCRIPTION
## Checklist
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [X] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [X] This pull-request is submitted against the `master` branch.

## Description of the changes
ApplyTimeout methods in InternalClient rethrow exceptions coming from TransportHandlers. Because of this, we lose the callstack of where the exceptions are coming from, making the issues hard to debug. For example, we have seen NREs being thrown by the DeviceClient in some cases, but we have no idea which area of the code they are coming from, since the callstack is lost. 
It looks like the rethrow was unnecessary, so removing it to preserve the original callstack of the exception.