### PR TITLE
Added IModuleClient Interface for public sealed ModuleClient class.

### DIFF
--- a/iothub/device/src/IModuleClient.cs
+++ b/iothub/device/src/IModuleClient.cs
@@ -1,0 +1,61 @@
+﻿namespace Microsoft.Azure.Devices.Client
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Shared;
+
+    public interface IModuleClient
+    {
+        int DiagnosticSamplingPercentage { get; set; }
+
+        uint OperationTimeoutInMilliseconds { get; set; }
+
+        string ProductInfo { get; set; }
+
+        Task AbandonAsync(Message message);
+
+        Task AbandonAsync(string lockToken);
+
+        Task CloseAsync();
+
+        Task CompleteAsync(Message message);
+        
+        Task CompleteAsync(string lockToken);
+        
+        Task<Twin> GetTwinAsync();
+
+        Task<MethodResponse> InvokeMethodAsync(string deviceId, MethodRequest methodRequest);
+
+        Task<MethodResponse> InvokeMethodAsync(string deviceId, MethodRequest methodRequest, CancellationToken cancellationToken);
+
+        Task<MethodResponse> InvokeMethodAsync(string deviceId, string moduleId, MethodRequest methodRequest);
+
+        Task<MethodResponse> InvokeMethodAsync(string deviceId, string moduleId, MethodRequest methodRequest, CancellationToken cancellationToken);
+        Task OpenAsync();
+
+        Task SendEventAsync(Message message);
+
+        Task SendEventAsync(string outputName, Message message);
+
+        Task SendEventBatchAsync(IEnumerable<Message> messages);
+
+        Task SendEventBatchAsync(string outputName, IEnumerable<Message> messages);
+
+        void SetConnectionStatusChangesHandler(ConnectionStatusChangesHandler statusChangesHandler);
+        
+        Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback callback, object userContext);
+        
+        Task SetInputMessageHandlerAsync(string inputName, MessageHandler messageHandler, object userContext);
+        
+        Task SetMessageHandlerAsync(MessageHandler messageHandler, object userContext);
+
+        Task SetMethodDefaultHandlerAsync(MethodCallback methodHandler, object userContext);
+
+        Task SetMethodHandlerAsync(string methodName, MethodCallback methodHandler, object userContext);
+
+        void SetRetryPolicy(IRetryPolicy retryPolicy);
+
+        Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties);
+    }
+}

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -23,7 +23,7 @@ using System.Net.Http;
     /// <summary>
     /// Contains methods that a device can use to send messages to and receive from the service.
     /// </summary>
-    public sealed class ModuleClient : IDisposable
+    public sealed class ModuleClient : IModuleClient, IDisposable 
     {
         const string ModuleMethodUriFormat = "/twins/{0}/modules/{1}/methods?" + ClientApiVersionHelper.ApiVersionQueryString;
         const string DeviceMethodUriFormat = "/twins/{0}/methods?" + ClientApiVersionHelper.ApiVersionQueryString;


### PR DESCRIPTION
With the current sealed ModuleClient class it is hard to make custom IoT Edge modules unit testable.

By adding this IModuleClient, programmers are now able to inject their own ModuleClient implementation in their own custom module code for injection and unit test purposes. This makes custom IoT Edge modules unit testable for almost 100 percent.

I only added the interface description and implementated in in the existing ModuleClient class. 

Adding an interface does not affect the code coverage.