### PR TITLE
Proper naming for vsts test runs.

### DIFF
--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -100,9 +100,9 @@ phases:
     condition: always()
 
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: testresults'
+    displayName: 'Publish Artifact: testresults_linux'
     inputs:
-      ArtifactName: testresults
+      ArtifactName: testresults_linux
 
     condition: always()
 
@@ -110,7 +110,7 @@ phases:
     displayName: 'Publish Test Results **/*.trx'
     inputs:
       testRunner: VSTest
-
+      testRunTitle: 'Linux Tests'
       testResultsFiles: '**/*.trx'
 
     condition: always()
@@ -200,7 +200,7 @@ phases:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: testresults'
     inputs:
-      ArtifactName: testresults
+      ArtifactName: testresults_windows
 
     condition: always()
 
@@ -211,7 +211,7 @@ phases:
 
       testResultsFiles: '**/*.trx'
 
-      testRunTitle: 'Azure IoT C#'
+      testRunTitle: 'Windows Tests'
 
       platform: Windows
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [X] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->
Fixing VSTS test run naming to easily differentiate between Windows and Linux logs.

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
