### PR TITLE
Support the None attestation type.

### DIFF
--- a/provisioning/service/src/Config/AttestationMechanism.cs
+++ b/provisioning/service/src/Config/AttestationMechanism.cs
@@ -47,6 +47,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                                                         shall store the provided X509 certificates.] */
                 X509 = (X509Attestation)attestation;
             }
+            else if (attestation is NoneAttestation)
+            {
+                // No-op.
+            }
             else
             {
                 /* SRS_ATTESTATION_MECHANISM_21_005: [The constructor shall throw ArgumentException if the provided attestation is 
@@ -96,6 +100,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                                                     shall store the provided X509 attestation.] */
                     X509 = x509;
                     break;
+                case AttestationMechanismType.None:
+                    break;
                 default:
                     /* SRS_ATTESTATION_MECHANISM_21_017: [The constructor shall throw ProvisioningServiceClientException if the 
                                                     provided ProvisioningServiceClientException is not `TPM` or `X509`.] */
@@ -115,6 +121,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                     /* SRS_ATTESTATION_MECHANISM_21_011: [If the type is `X509`, the getAttestation shall return the 
                                                     stored X509Attestation.] */
                     return _x509;
+                case AttestationMechanismType.None:
+
+                    return s_none;
                 default:
                     /* SRS_ATTESTATION_MECHANISM_21_012: [If the type is not `X509` or `TPM`, the getAttestation shall 
                                                     throw ProvisioningServiceClientException.] */
@@ -177,5 +186,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             }
         }
         private X509Attestation _x509;
+
+        private class NoneAttestation : Attestation { }
+        private static NoneAttestation s_none = new NoneAttestation();
     }
 }


### PR DESCRIPTION
None is a valid attestation type for DPS. This change will allow the type which may be used by new attestation types.