### PR TITLE
Extend the timeout for SendEventAsync to complete in ProvisioningE2ET…

### DIFF
--- a/e2e/test/netstandard20/ProvisioningE2ETests.cs
+++ b/e2e/test/netstandard20/ProvisioningE2ETests.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     await iotClient.OpenAsync().ConfigureAwait(false);
                     _log.WriteLine("DeviceClient SendEventAsync.");
                     await iotClient.SendEventAsync(
-                        new Client.Message(Encoding.UTF8.GetBytes("TestMessage"))).ConfigureAwait(false);
+                        new Client.Message(Encoding.UTF8.GetBytes("TestMessage")), cts.Token).ConfigureAwait(false);
                     _log.WriteLine("DeviceClient CloseAsync.");
                     await iotClient.CloseAsync().ConfigureAwait(false);
                 }


### PR DESCRIPTION
## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
This PR is ExtendDevProvE2ETestTimeout -> preview-update.


## Description of the changes

These two tests are failing due to timeout waiting for SendEventAsync to complete:
ProvisioningDeviceClient_ValidRegistrationId_Http_X509Group_RegisterOk
ProvisioningDeviceClient_ValidRegistrationId_Http_Tpm_RegisterOk

They are both failing in this location (ProvisioningE2ETests.cs:214):

at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)

   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)

   at Microsoft.Azure.Devices.Client.Transport.RetryDelegatingHandler.<SendEventAsync>d__17.MoveNext() in D:\a\1\s\iothub\device\src\Transport\RetryDelegatingHandler.cs:line 78

--- End of stack trace from previous location where exception was thrown ---

   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)

   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)

   at Microsoft.Azure.Devices.Client.InternalClient.<SendEventAsync>d__67.MoveNext() in D:\a\1\s\iothub\device\src\InternalClient.cs:line 617

--- End of inner exception stack trace ---

    at Microsoft.Azure.Devices.Client.InternalClient.<SendEventAsync>d__67.MoveNext() in D:\a\1\s\iothub\device\src\InternalClient.cs:line 623

--- End of stack trace from previous location where exception was thrown ---

   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)

   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)

   at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)

   at Microsoft.Azure.Devices.E2ETests.ProvisioningE2ETests.<ProvisioningDeviceClient_ValidRegistrationId_Register_Ok>d__30.MoveNext() in D:\a\1\s\e2e\test\netstandard20\ProvisioningE2ETests.cs:line 214

--- End of stack trace from previous location where exception was thrown ---

   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)

   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)

   at Microsoft.Azure.Devices.E2ETests.ProvisioningE2ETests.<ProvisioningDeviceClient_ValidRegistrationId_Http_Tpm_RegisterOk>d__11.MoveNext() in D:\a\1\s\e2e\test\netstandard20\ProvisioningE2ETests.cs:line 53

--- End of stack trace from previous location where exception was thrown ---

   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)

   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)

   at Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.ThreadOperations.Execut
   
   
Solution: extent the timeout for SendEventAsync (using already existing CancellationTokenSource in that test method).


## Reference/Link to the issue solved with this PR (if any)
None
