### PR TITLE
Add SQM ID to UserAgent string

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -124,4 +124,16 @@
     <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="Microsoft.Win32.Registry">
+      <Version>4.5.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Win32.Registry">
+      <Version>4.5.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/iothub/device/src/ProductInfo.cs
+++ b/iothub/device/src/ProductInfo.cs
@@ -17,6 +17,28 @@ namespace Microsoft.Azure.Devices.Client
 
         public override string ToString()
         {
+            return ToString(UserAgentFormats.Default);
+        }
+
+        internal string ToString(UserAgentFormats format)
+        {
+            switch (format)
+            {
+                case UserAgentFormats.Http:
+                    return ToString("{runtime}; {operatingSystem}; {architecture}");
+                default:
+                    return ToString(null);
+            }
+        }
+
+        /// <summary>
+        /// <para>Specify the format of the content in the parentheses of the UserAgent string</para>
+        /// <para>Example: "{runtime}; {operatingSystem}; {architecture}; {deviceId}"</para>
+        /// </summary>
+        /// <param name="format"></param>
+        /// <returns></returns>
+        private string ToString(string format)
+        {
             const string Name = ".NET";
             string version = typeof(DeviceClient).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
             string runtime = RuntimeInformation.FrameworkDescription.Trim();
@@ -25,17 +47,33 @@ namespace Microsoft.Azure.Devices.Client
             string productType = (_productType.Value != 0) ? $" WindowsProduct:0x{_productType.Value:X8}" : string.Empty;
             string deviceId = (!string.IsNullOrWhiteSpace(_sqmId.Value)) ? _sqmId.Value : string.Empty;
 
-            string[] agentInfoParts =
-            {
-                runtime,
-                operatingSystem + productType,
-                processorArchitecture,
-                deviceId,
-            };
+            string userAgent = string.Empty;
+            string infoParts = string.Empty;
 
-            string userAgent = $"{Name}/{version} ({string.Join("; ", agentInfoParts.Where(x => !string.IsNullOrEmpty(x)))})";
-            
-            if (!String.IsNullOrWhiteSpace(this.Extra))
+            if (!string.IsNullOrWhiteSpace(format))
+            {
+                infoParts =
+                    format.Replace("{runtime}", runtime)
+                    .Replace("{operatingSystem}", operatingSystem + productType)
+                    .Replace("{architecture}", processorArchitecture)
+                    .Replace("{deviceId}", deviceId);
+            }
+            else
+            {
+                string[] agentInfoParts =
+                {
+                    runtime,
+                    operatingSystem + productType,
+                    processorArchitecture,
+                    deviceId,
+                };
+
+                infoParts = string.Join("; ", agentInfoParts.Where(x => !string.IsNullOrEmpty(x)));
+            }
+
+            userAgent = $"{Name}/{version} ({infoParts})";
+
+            if (!string.IsNullOrWhiteSpace(this.Extra))
             {
                 userAgent += $" {this.Extra.Trim()}";
             }
@@ -43,4 +81,10 @@ namespace Microsoft.Azure.Devices.Client
             return userAgent;
         }
     }
+
+    internal enum UserAgentFormats
+    {
+        Default,
+        Http,
+    };
 }

--- a/iothub/device/src/TelemetryMethods.cs
+++ b/iothub/device/src/TelemetryMethods.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Shared;
+using Microsoft.Win32;
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Azure.Devices.Client
+{
+    internal static partial class TelemetryMethods
+    {
+        public static string GetSqmMachineId()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                try
+                {
+                    var key = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\SQMClient");
+                    if (key != null)
+                    {
+                        return key.GetValue("MachineId") as string;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.Assert(false, ex.Message);
+                    if (Logging.IsEnabled) Logging.Error(null, ex, nameof(TelemetryMethods));
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/iothub/device/src/Transport/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/HttpClientHelper.cs
@@ -435,7 +435,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     msg.Headers.Add(HttpRequestHeader.Authorization.ToString(), authHeader);
                 }
 
-                msg.Headers.UserAgent.ParseAdd(this.productInfo.ToString());
+                msg.Headers.UserAgent.ParseAdd(this.productInfo.ToString(UserAgentFormats.Http));
 
                 if (modifyRequestMessageAsync != null) await modifyRequestMessageAsync(msg, cancellationToken).ConfigureAwait(false);
 

--- a/iothub/device/tests/ProductInfoTests.cs
+++ b/iothub/device/tests/ProductInfoTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -22,8 +23,17 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             var productType = NativeMethods.GetWindowsProductType();
             var productTypeString = (productType != 0) ? $" WindowsProduct:0x{productType:X8}" : string.Empty;
+            var deviceId = TelemetryMethods.GetSqmMachineId() ?? string.Empty;
 
-            return $".NET/{version} ({runtime}; {operatingSystem}{productTypeString}; {processorArchitecture})";
+            string[] agentInfoParts =
+            {
+                runtime,
+                operatingSystem + productTypeString,
+                processorArchitecture,
+                deviceId,
+            };
+
+            return $".NET/{version} ({string.Join("; ", agentInfoParts.Where(x => !string.IsNullOrEmpty(x)))})";
         }
 
         [TestMethod]

--- a/iothub/device/tests/TelemetryMethodsTests.cs
+++ b/iothub/device/tests/TelemetryMethodsTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Win32;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Azure.Devices.Client.Test
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class TelemetryMethodsTests
+    {
+        [TestMethod]
+        public void GetSqmMachineId_ReturnsExpectedValue()
+        {
+            var actualValue = TelemetryMethods.GetSqmMachineId();
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                string expectedValue = null;
+
+                // Get SQM ID from Registry if exists
+                var key = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\SQMClient");
+                if (key != null)
+                {
+                    expectedValue = key.GetValue("MachineId") as string;
+                }
+
+                Assert.AreEqual(expectedValue, actualValue);
+            }
+            else
+            {
+                // GetSqmMachineId() should always return null for all other platforms
+                Assert.IsNull(actualValue);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
Added SQM ID from Windows to UserAgent string 

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
