### PR TITLE
Mux e2e tests - telemetry, method and twin

### DIFF
--- a/e2e/test/FaultInjection.cs
+++ b/e2e/test/FaultInjection.cs
@@ -356,15 +356,15 @@ namespace Microsoft.Azure.Devices.E2ETests
                     Assert.Fail($"Exception expected for deviceId {testDevice.Id} with fault type {faultType}");
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!(ex is AssertFailedException))
             {
                 if (!faultShouldNotRecover)
                 {
-                    Assert.Fail($"Should recover for deviceId {testDevice.Id} fault type {faultType} but threw exception: {ex}");
+                    Assert.Fail($"Exception not expected for deviceId {testDevice.Id} with fault type {faultType} but threw exception: {ex}");
                 }
                 else if (!expectedExceptions.Contains(ex.GetType()))
                 {
-                    Assert.Fail($"Exception for {faultType} was thrown for deviceId {testDevice.Id} was not expected: {ex}");
+                    Assert.Fail($"Exception for {faultType} thrown for deviceId {testDevice.Id} was not expected: {ex}");
                 }
             }
         }

--- a/e2e/test/FaultInjection.cs
+++ b/e2e/test/FaultInjection.cs
@@ -255,6 +255,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     var testDevice = testDevices[i];
 
                     s_log.WriteLine($"{nameof(FaultInjection)}: Test baseline again deviceClient {TestLogging.GetHashCode(deviceClient)}");
+                    await initOperation(deviceClient, testDevice).ConfigureAwait(false);
                     await testOperation(deviceClient, testDevice).ConfigureAwait(false);
 
                     s_log.WriteLine($"{nameof(FaultInjection)}: Count {count} - Closing deviceClient {TestLogging.GetHashCode(deviceClient)}");

--- a/e2e/test/MessageReceiveFaultInjectionTests.cs
+++ b/e2e/test/MessageReceiveFaultInjectionTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.Azure.Devices.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Linq;
@@ -238,6 +239,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                     reason,
                     delayInSec,
                     FaultInjection.DefaultDurationInSec,
+                    false,
+                    new List<Type> { },
                     init,
                     testOperation,
                     cleanupOperation).ConfigureAwait(false);

--- a/e2e/test/MessageReceiveFaultInjectionTests.cs
+++ b/e2e/test/MessageReceiveFaultInjectionTests.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     return serviceClient.CloseAsync();
                 };
 
-                await FaultInjection.TestErrorInjectionAsync(
+                await FaultInjection.TestErrorInjectionSingleDeviceAsync(
                     DevicePrefix,
                     type,
                     transport,

--- a/e2e/test/MessageSendE2EMultiplexingTests.cs
+++ b/e2e/test/MessageSendE2EMultiplexingTests.cs
@@ -1,0 +1,261 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices.E2ETests
+{
+    [TestClass]
+    [TestCategory("IoTHub-E2E")]
+    [TestCategory("ConnectionPooling_AMQP_E2E")]
+    public class MessageSendE2EMultiplexingTests : IDisposable
+    {
+        private readonly string DevicePrefix = $"E2E_{nameof(MessageSendE2EMultiplexingTests)}_";
+        private readonly int MuxWithoutPoolingDevicesCount = 2;
+        // For enabling multiplexing without pooling, the pool size needs to be set to 1
+        private readonly int MuxWithoutPoolingPoolSize = 1;
+        // These values are configurable
+        private readonly int MuxWithPoolingDevicesCount = 4;
+        private readonly int MuxWithPoolingPoolSize = 2;
+
+        // TODO: Implement proxy and mux tests
+        private static string ProxyServerAddress = Configuration.IoTHub.ProxyServerAddress;
+        private static TestLogging _log = TestLogging.GetInstance();
+
+        private readonly ConsoleEventListener _listener;
+
+        public MessageSendE2EMultiplexingTests()
+        {
+            _listener = TestConfig.StartEventListener();
+        }
+
+        [TestMethod]
+        public async Task Message_DeviceSak_DeviceSendSingleMessage_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.Device,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_DeviceSak_DeviceSendSingleMessage_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.Device,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_IoTHubSak_DeviceSendSingleMessage_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_IoTHubSak_DeviceSendSingleMessage_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_X509_DeviceSendSingleMessage_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageMuxedOverAmqp(
+                TestDeviceType.X509,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_X509_DeviceSendSingleMessage_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageMuxedOverAmqp(
+                TestDeviceType.X509,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_DeviceSak_DeviceSendSingleMessage_MuxWithPooling_Amqp()
+        {
+            await SendMessageMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.Device,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_DeviceSak_DeviceSendSingleMessage_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.Device,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_IoTHubSak_DeviceSendSingleMessage_MuxWithPooling_Amqp()
+        {
+            await SendMessageMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_IoTHubSak_DeviceSendSingleMessage_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_X509_DeviceSendSingleMessage_MuxWithPooling_Amqp()
+        {
+            await SendMessageMuxedOverAmqp(
+                TestDeviceType.X509,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_X509_DeviceSendSingleMessage_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageMuxedOverAmqp(
+                TestDeviceType.X509,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        //[TestMethod]
+        //public async Task Message_DeviceSak_DeviceSendSingleMessage_MuxWithoutPoolingInParallel_Amqp()
+        //{
+        //    await SendMessageMuxedOverAmqpInParallel(
+        //        TestDeviceType.Sasl,
+        //        ConnectionStringAuthScope.Device,
+        //        Client.TransportType.Amqp_Tcp_Only,
+        //        MuxWithoutPoolingPoolSize,
+        //        MuxDevicesCount
+        //        ).ConfigureAwait(false);
+        //}
+
+        private async Task SendMessageMuxedOverAmqp(
+            TestDeviceType type, 
+            ConnectionStringAuthScope authScope, 
+            Client.TransportType transport, 
+            int poolSize, 
+            int devicesCount)
+        {
+            var transportSettings = new ITransportSettings[]
+            {
+                new AmqpTransportSettings(transport)
+                {
+                    AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings()
+                    {
+                        MaxPoolSize = unchecked((uint)poolSize),
+                        Pooling = true
+                    }
+                }
+            };
+
+            ICollection<DeviceClient> deviceClients = new List<DeviceClient>();
+
+            try
+            {
+                _log.WriteLine($"{nameof(MessageSendE2ETests)}: Starting the test execution for {devicesCount} devices");
+
+                for (int i = 0; i < devicesCount; i++)
+                {
+                    DeviceClient deviceClient = null;
+                    TestDevice testDevice = await TestDevice.GetTestDeviceAsync($"{DevicePrefix}_{i}_", type).ConfigureAwait(false);
+
+                    if (type == TestDeviceType.Sasl)
+                    {
+                        deviceClient = testDevice.CreateDeviceClient(transportSettings, authScope);
+                    }
+                    else
+                    {
+                        deviceClient = testDevice.CreateDeviceClient(transportSettings);
+                    }
+                    deviceClients.Add(deviceClient);
+
+                    _log.WriteLine($"{nameof(MessageSendE2ETests)}: Preparing to send message for device {i}");
+                    await deviceClient.OpenAsync().ConfigureAwait(false);
+                    await MessageSendUtil.SendSingleMessage(deviceClient, testDevice.Id).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                // Close and dispose all of the device client instances here
+                foreach (DeviceClient deviceClient in deviceClients)
+                {
+                    await deviceClient.CloseAsync().ConfigureAwait(false);
+                    _log.WriteLine($"{nameof(MessageSendE2ETests)}: Disposing deviceClient {TestLogging.GetHashCode(deviceClient)}");
+                    deviceClient.Dispose();
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+    }
+}

--- a/e2e/test/MessageSendE2EMultiplexingTests.cs
+++ b/e2e/test/MessageSendE2EMultiplexingTests.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                     _log.WriteLine($"{nameof(MessageSendE2ETests)}: Preparing to send message for device {i}");
                     await deviceClient.OpenAsync().ConfigureAwait(false);
-                    await MessageSendUtil.SendSingleMessage(deviceClient, testDevice.Id).ConfigureAwait(false);
+                    await MessageSendUtil.SendSingleMessageAndVerify(deviceClient, testDevice.Id).ConfigureAwait(false);
                 }
             }
             finally

--- a/e2e/test/MessageSendE2ETests.cs
+++ b/e2e/test/MessageSendE2ETests.cs
@@ -2,12 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Azure.Devices.Client;
-using Microsoft.Azure.Devices.Client.Exceptions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -194,73 +191,21 @@ namespace Microsoft.Azure.Devices.E2ETests
                 await sender.SendAsync(testDevice.Id, new Message(Encoding.ASCII.GetBytes("Dummy Message")), timeout).ConfigureAwait(false);
             }
         }
-
-        private Client.Message ComposeD2CTestMessage(out string payload, out string p1Value)
-        {
-            payload = Guid.NewGuid().ToString();
-            p1Value = Guid.NewGuid().ToString();
-
-            _log.WriteLine($"{nameof(ComposeD2CTestMessage)}: payload='{payload}' p1Value='{p1Value}'");
-
-            return new Client.Message(Encoding.UTF8.GetBytes(payload))
-            {
-                Properties = { ["property1"] = p1Value }
-            };
-        }
-
-        private Message ComposeC2DTestMessage(out string payload, out string messageId, out string p1Value)
-        {
-            payload = Guid.NewGuid().ToString();
-            messageId = Guid.NewGuid().ToString();
-            p1Value = Guid.NewGuid().ToString();
-
-            _log.WriteLine($"{nameof(ComposeC2DTestMessage)}: payload='{payload}' messageId='{messageId}' p1Value='{p1Value}'");
-
-            return new Message(Encoding.UTF8.GetBytes(payload))
-            {
-                MessageId = messageId,
-                Properties = { ["property1"] = p1Value }
-            };
-        }
-
         private async Task SendSingleMessage(TestDeviceType type, Client.TransportType transport)
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix, type).ConfigureAwait(false);
-            using (DeviceClient deviceClient = testDevice.CreateDeviceClient(transport))
-            {
-                await SendSingleMessage(deviceClient, testDevice.Id).ConfigureAwait(false);
-            }
+            ITransportSettings[] transportSettings = TestDevice.GetTransportSettings(transport);
+            await SendSingleMessage(type, transportSettings).ConfigureAwait(false);
         }
 
         private async Task SendSingleMessage(TestDeviceType type, ITransportSettings[] transportSettings)
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
-            using (DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transportSettings))
-            {
-                await SendSingleMessage(deviceClient, testDevice.Id).ConfigureAwait(false);
-            }
-        }
-        
-        private async Task SendSingleMessage(DeviceClient deviceClient, string deviceId)
-        {
-            EventHubTestListener testListener = await EventHubTestListener.CreateListener(deviceId).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix, type).ConfigureAwait(false);
 
-            try
+            using (DeviceClient deviceClient = testDevice.CreateDeviceClient(transportSettings))
             {
                 await deviceClient.OpenAsync().ConfigureAwait(false);
-
-                string payload;
-                string p1Value;
-                Client.Message testMessage = ComposeD2CTestMessage(out payload, out p1Value);
-                await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
-
-                bool isReceived = await testListener.WaitForMessage(deviceId, payload, p1Value).ConfigureAwait(false);
-                Assert.IsTrue(isReceived, "Message is not received.");
-            }
-            finally
-            {
+                await MessageSendUtil.SendSingleMessage(deviceClient, testDevice.Id).ConfigureAwait(false);
                 await deviceClient.CloseAsync().ConfigureAwait(false);
-                await testListener.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -273,7 +218,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 string payload;
                 string p1Value;
-                Client.Message testMessage = ComposeD2CTestMessage(out payload, out p1Value);
+                Client.Message testMessage = MessageSendUtil.ComposeD2CTestMessage(out payload, out p1Value);
                 await moduleClient.SendEventAsync(testMessage).ConfigureAwait(false);
                 await moduleClient.CloseAsync().ConfigureAwait(false);
             }

--- a/e2e/test/MessageSendE2ETests.cs
+++ b/e2e/test/MessageSendE2ETests.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             using (DeviceClient deviceClient = testDevice.CreateDeviceClient(transportSettings))
             {
                 await deviceClient.OpenAsync().ConfigureAwait(false);
-                await MessageSendUtil.SendSingleMessage(deviceClient, testDevice.Id).ConfigureAwait(false);
+                await MessageSendUtil.SendSingleMessageAndVerify(deviceClient, testDevice.Id).ConfigureAwait(false);
                 await deviceClient.CloseAsync().ConfigureAwait(false);
             }
         }

--- a/e2e/test/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/MessageSendFaultInjectionTests.cs
@@ -1633,16 +1633,27 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
             {
-                EventHubTestListener testListener = await EventHubTestListener.CreateListener(testDevice.Id).ConfigureAwait(false);
+                EventHubTestListener testListener = null;
+
                 string payload, p1Value;
+                try
+                {
+                    testListener = await EventHubTestListener.CreateListener(testDevice.Id).ConfigureAwait(false);
 
-                Client.Message testMessage = ComposeD2CTestMessage(out payload, out p1Value);
-                await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
+                    Client.Message testMessage = ComposeD2CTestMessage(out payload, out p1Value);
+                    await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
 
-                bool isReceived = false;
-                isReceived = await testListener.WaitForMessage(testDevice.Id, payload, p1Value).ConfigureAwait(false);
-                Assert.IsTrue(isReceived);
-                await testListener.CloseAsync().ConfigureAwait(false);
+                    bool isReceived = false;
+                    isReceived = await testListener.WaitForMessage(testDevice.Id, payload, p1Value).ConfigureAwait(false);
+                    Assert.IsTrue(isReceived);
+                }
+                finally
+                {
+                    if (testListener != null)
+                    {
+                        await testListener.CloseAsync().ConfigureAwait(false);
+                    }
+                }
             };
 
             Func<Task> cleanupOperation = () =>
@@ -1687,16 +1698,27 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
             {
-                EventHubTestListener testListener = await EventHubTestListener.CreateListener(testDevice.Id).ConfigureAwait(false);
+                EventHubTestListener testListener = null;
+
                 string payload, p1Value;
+                try
+                {
+                    testListener = await EventHubTestListener.CreateListener(testDevice.Id).ConfigureAwait(false);
 
-                Client.Message testMessage = ComposeD2CTestMessage(out payload, out p1Value);
-                await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
+                    Client.Message testMessage = ComposeD2CTestMessage(out payload, out p1Value);
+                    await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
 
-                bool isReceived = false;
-                isReceived = await testListener.WaitForMessage(testDevice.Id, payload, p1Value).ConfigureAwait(false);
-                Assert.IsTrue(isReceived);
-                await testListener.CloseAsync().ConfigureAwait(false);
+                    bool isReceived = false;
+                    isReceived = await testListener.WaitForMessage(testDevice.Id, payload, p1Value).ConfigureAwait(false);
+                    Assert.IsTrue(isReceived);
+                }
+                finally
+                {
+                    if (testListener != null)
+                    {
+                        await testListener.CloseAsync().ConfigureAwait(false);
+                    }
+                }
             };
 
             Func<Task> cleanupOperation = () =>

--- a/e2e/test/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/MessageSendFaultInjectionTests.cs
@@ -60,126 +60,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("ConnectionPoolingE2ETests")]
-        public async Task Message_DeviceSak_TcpConnectionLossSendRecovery_MuxedWithoutPooling_Amqp()
-        {
-            await SendMessageRecoveryMuxedOverAmqp(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_Tcp_Only,
-                MuxWithoutPoolingPoolSize,
-                MuxWithoutPoolingDevicesCount,
-                ConnectionStringAuthScope.Device,
-                FaultInjection.FaultType_Tcp,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        [TestCategory("ConnectionPoolingE2ETests")]
-        public async Task Message_DeviceSak_TcpConnectionLossSendRecovery_MuxedWithoutPooling_AmqpWs()
-        {
-            await SendMessageRecoveryMuxedOverAmqp(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_WebSocket_Only,
-                MuxWithoutPoolingPoolSize,
-                MuxWithoutPoolingDevicesCount,
-                ConnectionStringAuthScope.Device,
-                FaultInjection.FaultType_Tcp,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        [TestCategory("ConnectionPoolingE2ETests")]
-        public async Task Message_DeviceSak_TcpConnectionLossSendRecovery_MuxedWithPooling_Amqp()
-        {
-            await SendMessageRecoveryMuxedOverAmqp(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_Tcp_Only,
-                MuxWithPoolingPoolSize,
-                MuxWithPoolingDevicesCount,
-                ConnectionStringAuthScope.Device,
-                FaultInjection.FaultType_Tcp,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        [TestCategory("ConnectionPoolingE2ETests")]
-        public async Task Message_DeviceSak_TcpConnectionLossSendRecovery_MuxedWithPooling_AmqpWs()
-        {
-            await SendMessageRecoveryMuxedOverAmqp(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_WebSocket_Only,
-                MuxWithPoolingPoolSize,
-                MuxWithPoolingDevicesCount,
-                ConnectionStringAuthScope.Device,
-                FaultInjection.FaultType_Tcp,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        [TestCategory("ConnectionPoolingE2ETests")]
-        public async Task Message_IoTHubSak_TcpConnectionLossSendRecovery_MuxedWithoutPooling_Amqp()
-        {
-            await SendMessageRecoveryMuxedOverAmqp(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_Tcp_Only,
-                MuxWithoutPoolingPoolSize,
-                MuxWithoutPoolingDevicesCount,
-                ConnectionStringAuthScope.IoTHub,
-                FaultInjection.FaultType_Tcp,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        [TestCategory("ConnectionPoolingE2ETests")]
-        public async Task Message_IoTHubSak_TcpConnectionLossSendRecovery_MuxedWithoutPooling_AmqpWs()
-        {
-            await SendMessageRecoveryMuxedOverAmqp(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_WebSocket_Only,
-                MuxWithoutPoolingPoolSize,
-                MuxWithoutPoolingDevicesCount,
-                ConnectionStringAuthScope.IoTHub,
-                FaultInjection.FaultType_Tcp,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        [TestCategory("ConnectionPoolingE2ETests")]
-        public async Task Message_IoTHubSak_TcpConnectionLossSendRecovery_MuxedWithPooling_Amqp()
-        {
-            await SendMessageRecoveryMuxedOverAmqp(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_Tcp_Only,
-                MuxWithPoolingPoolSize,
-                MuxWithPoolingDevicesCount,
-                ConnectionStringAuthScope.IoTHub,
-                FaultInjection.FaultType_Tcp,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        [TestCategory("ConnectionPoolingE2ETests")]
-        public async Task Message_IoTHubSak_TcpConnectionLossSendRecovery_MuxedWithPooling_AmqpWs()
-        {
-            await SendMessageRecoveryMuxedOverAmqp(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_WebSocket_Only,
-                MuxWithPoolingPoolSize,
-                MuxWithPoolingDevicesCount,
-                ConnectionStringAuthScope.IoTHub,
-                FaultInjection.FaultType_Tcp,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
         public async Task Message_TcpConnectionLossSendRecovery_Mqtt()
         {
             await SendMessageRecovery(
@@ -220,6 +100,369 @@ namespace Microsoft.Azure.Devices.E2ETests
                 Client.TransportType.Amqp_WebSocket_Only,
                 FaultInjection.FaultType_AmqpConn,
                 "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_AmqpSessionLossSendRecovery_Amqp()
+        {
+            await SendMessageRecovery(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                FaultInjection.FaultType_AmqpSess,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_AmqpSessionLossSendRecovery_AmqpWs()
+        {
+            await SendMessageRecovery(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                FaultInjection.FaultType_AmqpSess,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_AmqpD2CLinkDropSendRecovery_Amqp()
+        {
+            await SendMessageRecovery(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                FaultInjection.FaultType_AmqpD2C,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_AmqpD2CLinkDropSendRecovery_AmqpWs()
+        {
+            await SendMessageRecovery(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                FaultInjection.FaultType_AmqpD2C,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        // WIP: Exception handling
+        [TestMethod]
+        public async Task Message_ThrottledConnectionRecovery_Amqp()
+        {
+            await SendMessageRecovery(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // WIP: Exception handling
+        [TestMethod]
+        public async Task Message_ThrottledConnectionRecovery_AmqpWs()
+        {
+            await SendMessageRecovery(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // WIP: Exception handling
+        [TestMethod]
+        public async Task Message_ThrottledConnectionLongTimeNoRecovery_Amqp()
+        {
+            await SendMessageRecovery(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
+        }
+
+        // WIP: Exception handling
+        [TestMethod]
+        public async Task Message_ThrottledConnectionLongTimeNoRecovery_AmqpWs()
+        {
+            await SendMessageRecovery(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
+        }
+
+        // WIP: Exception handling
+        [TestMethod]
+        public async Task Message_ThrottledConnectionLongTimeNoRecovery_Http()
+        {
+            await SendMessageRecovery(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Http1,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        // WIP: Exception handling
+        public async Task Message_QuotaExceededNoRecovery_Amqp()
+        {
+            await SendMessageRecovery(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                FaultInjection.FaultType_QuotaExceeded,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        // WIP: Exception handling
+        public async Task Message_QuotaExceededNoRecovery_AmqpWs()
+        {
+            await SendMessageRecovery(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                FaultInjection.FaultType_QuotaExceeded,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // WIP: Exception handling
+        [TestMethod]
+        public async Task Message_QuotaExceededRecovery_Http()
+        {
+            await SendMessageRecovery(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Http1,
+                    FaultInjection.FaultType_QuotaExceeded,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        // WIP: Exception handling
+        public async Task Message_AuthenticationErrorNoRecovery_Amqp()
+        {
+            await SendMessageRecovery(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                FaultInjection.FaultType_Auth,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        // WIP: Exception handling
+        public async Task Message_AuthenticationErrorNoRecovery_AmqpWs()
+        {
+            await SendMessageRecovery(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                FaultInjection.FaultType_Auth,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        // WIP: Exception handling
+        public async Task Message_AuthenticationErrorNoRecover_Http()
+        {
+            await SendMessageRecovery(
+                TestDeviceType.Sasl,
+                Client.TransportType.Http1,
+                FaultInjection.FaultType_Auth,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_GracefulShutdownSendRecovery_Amqp()
+        {
+            await SendMessageRecovery(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_GracefulShutdownSendRecovery_AmqpWs()
+        {
+            await SendMessageRecovery(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_GracefulShutdownSendRecovery_Mqtt()
+        {
+            await SendMessageRecovery(
+                TestDeviceType.Sasl,
+                Client.TransportType.Mqtt_Tcp_Only,
+                FaultInjection.FaultType_GracefulShutdownMqtt,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Message_GracefulShutdownSendRecovery_MqttWs()
+        {
+            await SendMessageRecovery(
+                TestDeviceType.Sasl,
+                Client.TransportType.Mqtt_WebSocket_Only,
+                FaultInjection.FaultType_GracefulShutdownMqtt,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_TcpConnectionLossSendRecovery_MuxedWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_TcpConnectionLossSendRecovery_MuxedWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_TcpConnectionLossSendRecovery_MuxedWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_TcpConnectionLossSendRecovery_MuxedWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_TcpConnectionLossSendRecovery_MuxedWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_TcpConnectionLossSendRecovery_MuxedWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_TcpConnectionLossSendRecovery_MuxedWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_TcpConnectionLossSendRecovery_MuxedWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
@@ -347,28 +590,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 MuxWithPoolingDevicesCount,
                 ConnectionStringAuthScope.IoTHub,
                 FaultInjection.FaultType_AmqpConn,
-                "",
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Message_AmqpSessionLossSendRecovery_Amqp()
-        {
-            await SendMessageRecovery(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_Tcp_Only,
-                FaultInjection.FaultType_AmqpSess,
-                "",
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Message_AmqpSessionLossSendRecovery_AmqpWs()
-        {
-            await SendMessageRecovery(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_WebSocket_Only,
-                FaultInjection.FaultType_AmqpSess,
                 "",
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
@@ -501,28 +722,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
-        [TestMethod]
-        public async Task Message_AmqpD2CLinkDropSendRecovery_Amqp()
-        {
-            await SendMessageRecovery(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_Tcp_Only,
-                FaultInjection.FaultType_AmqpD2C,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Message_AmqpD2CLinkDropSendRecovery_AmqpWs()
-        {
-            await SendMessageRecovery(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_WebSocket_Only,
-                FaultInjection.FaultType_AmqpD2C,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
         [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
@@ -649,32 +848,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.FaultType_AmqpD2C,
                 FaultInjection.FaultCloseReason_Boom,
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        // WIP: Exception handling
-        [TestMethod]
-        public async Task Message_ThrottledConnectionRecovery_Amqp()
-        {
-            await SendMessageRecovery(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    FaultInjection.FaultType_Throttle,
-                    FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
-                    FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
-        }
-
-        // WIP: Exception handling
-        [TestMethod]
-        public async Task Message_ThrottledConnectionRecovery_AmqpWs()
-        {
-            await SendMessageRecovery(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    FaultInjection.FaultType_Throttle,
-                    FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
-                    FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
         }
 
         [Ignore]
@@ -819,34 +992,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                     FaultInjection.FaultCloseReason_Boom,
                     FaultInjection.DefaultDelayInSec,
                     FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
-        }
-
-        // WIP: Exception handling
-        [TestMethod]
-        public async Task Message_ThrottledConnectionLongTimeNoRecovery_Amqp()
-        {
-            await SendMessageRecovery(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    FaultInjection.FaultType_Throttle,
-                    FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
-                    FaultInjection.DefaultDurationInSec,
-                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
-        }
-
-        // WIP: Exception handling
-        [TestMethod]
-        public async Task Message_ThrottledConnectionLongTimeNoRecovery_AmqpWs()
-        {
-            await SendMessageRecovery(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    FaultInjection.FaultType_Throttle,
-                    FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
-                    FaultInjection.DefaultDurationInSec,
-                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
         }
 
         // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
@@ -1010,46 +1155,6 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         }
 
-        // WIP: Exception handling
-        [TestMethod]
-        public async Task Message_ThrottledConnectionLongTimeNoRecovery_Http()
-        {
-            await SendMessageRecovery(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Http1,
-                    FaultInjection.FaultType_Throttle,
-                    FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
-                    FaultInjection.DefaultDurationInSec,
-                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        // WIP: Exception handling
-        public async Task Message_QuotaExceededNoRecovery_Amqp()
-        {
-            await SendMessageRecovery(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_Tcp_Only,
-                FaultInjection.FaultType_QuotaExceeded,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec,
-                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        // WIP: Exception handling
-        public async Task Message_QuotaExceededNoRecovery_AmqpWs()
-        {
-            await SendMessageRecovery(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_WebSocket_Only,
-                FaultInjection.FaultType_QuotaExceeded,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec,
-                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
-        }
-
         // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
         [Ignore]
         [TestMethod]
@@ -1197,46 +1302,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 MuxWithPoolingDevicesCount,
                 ConnectionStringAuthScope.IoTHub,
                 FaultInjection.FaultType_QuotaExceeded,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec,
-                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
-        }
-
-        // WIP: Exception handling
-        [TestMethod]
-        public async Task Message_QuotaExceededRecovery_Http()
-        {
-            await SendMessageRecovery(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Http1,
-                    FaultInjection.FaultType_QuotaExceeded,
-                    FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
-                    FaultInjection.DefaultDurationInSec,
-                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        // WIP: Exception handling
-        public async Task Message_AuthenticationErrorNoRecovery_Amqp()
-        {
-            await SendMessageRecovery(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_Tcp_Only,
-                FaultInjection.FaultType_Auth,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec,
-                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        // WIP: Exception handling
-        public async Task Message_AuthenticationErrorNoRecovery_AmqpWs()
-        {
-            await SendMessageRecovery(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_WebSocket_Only,
-                FaultInjection.FaultType_Auth,
                 FaultInjection.FaultCloseReason_Boom,
                 FaultInjection.DefaultDelayInSec,
                 FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
@@ -1394,41 +1459,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
         }
 
-        [TestMethod]
-        // WIP: Exception handling
-        public async Task Message_AuthenticationErrorNoRecover_Http()
-        {
-            await SendMessageRecovery(
-                TestDeviceType.Sasl,
-                Client.TransportType.Http1,
-                FaultInjection.FaultType_Auth,
-                FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec,
-                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Message_GracefulShutdownSendRecovery_Amqp()
-        {
-            await SendMessageRecovery(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_Tcp_Only,
-                FaultInjection.FaultType_GracefulShutdownAmqp,
-                FaultInjection.FaultCloseReason_Bye,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Message_GracefulShutdownSendRecovery_AmqpWs()
-        {
-            await SendMessageRecovery(
-                TestDeviceType.Sasl,
-                Client.TransportType.Amqp_WebSocket_Only,
-                FaultInjection.FaultType_GracefulShutdownAmqp,
-                FaultInjection.FaultCloseReason_Bye,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
         [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
@@ -1553,28 +1583,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 MuxWithPoolingDevicesCount,
                 ConnectionStringAuthScope.IoTHub,
                 FaultInjection.FaultType_GracefulShutdownAmqp,
-                FaultInjection.FaultCloseReason_Bye,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Message_GracefulShutdownSendRecovery_Mqtt()
-        {
-            await SendMessageRecovery(
-                TestDeviceType.Sasl,
-                Client.TransportType.Mqtt_Tcp_Only,
-                FaultInjection.FaultType_GracefulShutdownMqtt,
-                FaultInjection.FaultCloseReason_Bye,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Message_GracefulShutdownSendRecovery_MqttWs()
-        {
-            await SendMessageRecovery(
-                TestDeviceType.Sasl,
-                Client.TransportType.Mqtt_WebSocket_Only,
-                FaultInjection.FaultType_GracefulShutdownMqtt,
                 FaultInjection.FaultCloseReason_Bye,
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }

--- a/e2e/test/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/MessageSendFaultInjectionTests.cs
@@ -222,6 +222,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_AmqpConnectionLossSendRecovery_MuxWithoutPooling_Amqp()
@@ -237,6 +238,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_AmqpConnectionLossSendRecovery_MuxWithoutPooling_AmqpWs()
@@ -252,6 +254,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_AmqpConnectionLossSendRecovery_MuxWithPooling_Amqp()
@@ -267,6 +270,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_AmqpConnectionLossSendRecovery_MuxWithPooling_AmqpWs()
@@ -282,6 +286,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_AmqpConnectionLossSendRecovery_MuxWithoutPooling_Amqp()
@@ -297,6 +302,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_AmqpConnectionLossSendRecovery_MuxWithoutPooling_AmqpWs()
@@ -312,6 +318,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_AmqpConnectionLossSendRecovery_MuxWithPooling_Amqp()
@@ -327,6 +334,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_AmqpConnectionLossSendRecovery_MuxWithPooling_AmqpWs()
@@ -364,6 +372,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_AmqpSessionLossSendRecovery_MuxWithoutPooling_Amqp()
@@ -379,6 +388,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_AmqpSessionLossSendRecovery_MuxWithoutPooling_AmqpWs()
@@ -394,6 +404,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_AmqpSessionLossSendRecovery_MuxWithPooling_Amqp()
@@ -409,6 +420,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_AmqpSessionLossSendRecovery_MuxWithPooling_AmqpWs()
@@ -424,6 +436,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_AmqpSessionLossSendRecovery_MuxWithoutPooling_Amqp()
@@ -439,6 +452,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_AmqpSessionLossSendRecovery_MuxWithoutPooling_AmqpWs()
@@ -454,6 +468,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_AmqpSessionLossSendRecovery_MuxWithPooling_Amqp()
@@ -469,6 +484,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_AmqpSessionLossSendRecovery_MuxWithPooling_AmqpWs()
@@ -506,6 +522,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_AmqpD2CLinkDropSendRecovery_MuxWithoutPooling_Amqp()
@@ -521,6 +538,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_AmqpD2CLinkDropSendRecovery_MuxWithoutPooling_AmqpWs()
@@ -536,6 +554,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_AmqpD2CLinkDropSendRecovery_MuxWithPooling_Amqp()
@@ -551,6 +570,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_AmqpD2CLinkDropSendRecovery_MuxWithPooling_AmqpWs()
@@ -566,6 +586,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_AmqpD2CLinkDropSendRecovery_MuxWithoutPooling_Amqp()
@@ -581,6 +602,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_AmqpD2CLinkDropSendRecovery_MuxWithoutPooling_AmqpWs()
@@ -596,6 +618,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_AmqpD2CLinkDropSendRecovery_MuxWithPooling_Amqp()
@@ -611,6 +634,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_AmqpD2CLinkDropSendRecovery_MuxWithPooling_AmqpWs()
@@ -652,6 +676,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         // WIP: Exception handling
@@ -669,6 +694,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         // WIP: Exception handling
@@ -686,6 +712,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         // WIP: Exception handling
@@ -703,6 +730,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         // WIP: Exception handling
@@ -720,6 +748,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         // WIP: Exception handling
@@ -737,6 +766,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         // WIP: Exception handling
@@ -754,6 +784,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         // WIP: Exception handling
@@ -771,6 +802,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         // WIP: Exception handling
@@ -1396,6 +1428,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_GracefulShutdownSendRecovery_MuxWithoutPooling_Amqp()
@@ -1411,6 +1444,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_GracefulShutdownSendRecovery_MuxWithoutPooling_AmqpWs()
@@ -1426,6 +1460,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_GracefulShutdownSendRecovery_MuxWithPooling_Amqp()
@@ -1441,6 +1476,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_DeviceSak_GracefulShutdownSendRecovery_MuxWithPooling_AmqpWs()
@@ -1456,6 +1492,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IotHubSak_GracefulShutdownSendRecovery_MuxWithoutPooling_Amqp()
@@ -1471,6 +1508,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_GracefulShutdownSendRecovery_MuxWithoutPooling_AmqpWs()
@@ -1486,6 +1524,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_GracefulShutdownSendRecovery_MuxWithPooling_Amqp()
@@ -1501,6 +1540,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Message_IoTHubSak_GracefulShutdownSendRecovery_MuxWithPooling_AmqpWs()

--- a/e2e/test/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/MessageSendFaultInjectionTests.cs
@@ -18,6 +18,14 @@ namespace Microsoft.Azure.Devices.E2ETests
     {
         private readonly string DevicePrefix = $"E2E_{nameof(MessageSendFaultInjectionTests)}_";
         private readonly string ModulePrefix = $"E2E_{nameof(MessageSendFaultInjectionTests)}_";
+
+        private readonly int MuxWithoutPoolingDevicesCount = 2;
+        // For enabling multiplexing without pooling, the pool size needs to be set to 1
+        private readonly int MuxWithoutPoolingPoolSize = 1;
+        // These values are configurable
+        private readonly int MuxWithPoolingDevicesCount = 4;
+        private readonly int MuxWithPoolingPoolSize = 2;
+
         private static string ProxyServerAddress = Configuration.IoTHub.ProxyServerAddress;
         private static TestLogging _log = TestLogging.GetInstance();
 
@@ -45,6 +53,126 @@ namespace Microsoft.Azure.Devices.E2ETests
             await SendMessageRecovery(
                 TestDeviceType.Sasl,
                 Client.TransportType.Amqp_WebSocket_Only,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_TcpConnectionLossSendRecovery_MuxedWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_TcpConnectionLossSendRecovery_MuxedWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_TcpConnectionLossSendRecovery_MuxedWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_TcpConnectionLossSendRecovery_MuxedWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_TcpConnectionLossSendRecovery_MuxedWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_TcpConnectionLossSendRecovery_MuxedWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_TcpConnectionLossSendRecovery_MuxedWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_TcpConnectionLossSendRecovery_MuxedWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
                 FaultInjection.FaultType_Tcp,
                 FaultInjection.FaultCloseReason_Boom,
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
@@ -95,6 +223,126 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_AmqpConnectionLossSendRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpConn,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_AmqpConnectionLossSendRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpConn,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_AmqpConnectionLossSendRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpConn,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_AmqpConnectionLossSendRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpConn,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_AmqpConnectionLossSendRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpConn,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_AmqpConnectionLossSendRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpConn,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_AmqpConnectionLossSendRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpConn,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_AmqpConnectionLossSendRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpConn,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
         public async Task Message_AmqpSessionLossSendRecovery_Amqp()
         {
             await SendMessageRecovery(
@@ -111,6 +359,126 @@ namespace Microsoft.Azure.Devices.E2ETests
             await SendMessageRecovery(
                 TestDeviceType.Sasl,
                 Client.TransportType.Amqp_WebSocket_Only,
+                FaultInjection.FaultType_AmqpSess,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_AmqpSessionLossSendRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpSess,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_AmqpSessionLossSendRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpSess,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_AmqpSessionLossSendRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpSess,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_AmqpSessionLossSendRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpSess,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_AmqpSessionLossSendRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpSess,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_AmqpSessionLossSendRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpSess,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_AmqpSessionLossSendRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpSess,
+                "",
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_AmqpSessionLossSendRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
                 FaultInjection.FaultType_AmqpSess,
                 "",
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
@@ -139,49 +507,292 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_AmqpD2CLinkDropSendRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpD2C,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_AmqpD2CLinkDropSendRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpD2C,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_AmqpD2CLinkDropSendRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpD2C,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_AmqpD2CLinkDropSendRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpD2C,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_AmqpD2CLinkDropSendRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpD2C,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_AmqpD2CLinkDropSendRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpD2C,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_AmqpD2CLinkDropSendRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpD2C,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_AmqpD2CLinkDropSendRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpD2C,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        // WIP: Exception handling
+        [TestMethod]
         public async Task Message_ThrottledConnectionRecovery_Amqp()
         {
-            try
-            {
-                await SendMessageRecovery(
+            await SendMessageRecovery(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_Throttle,
                     FaultInjection.FaultCloseReason_Boom,
                     FaultInjection.DefaultDelayInSec,
                     FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
-            }
-            catch (IotHubException ex)
-            {
-                Assert.IsInstanceOfType(ex, typeof(IotHubThrottledException));
-            }
         }
 
+        // WIP: Exception handling
         [TestMethod]
         public async Task Message_ThrottledConnectionRecovery_AmqpWs()
         {
-            try
-            {
-                await SendMessageRecovery(
+            await SendMessageRecovery(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_Throttle,
                     FaultInjection.FaultCloseReason_Boom,
                     FaultInjection.DefaultDelayInSec,
                     FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
-            }
-            catch (IotHubException ex)
-            {
-                Assert.IsInstanceOfType(ex, typeof(IotHubThrottledException));
-            }
         }
 
         [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_ThrottledConnectionRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    MuxWithoutPoolingPoolSize,
+                    MuxWithoutPoolingDevicesCount,
+                    ConnectionStringAuthScope.Device,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_ThrottledConnectionRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    MuxWithoutPoolingPoolSize,
+                    MuxWithoutPoolingDevicesCount,
+                    ConnectionStringAuthScope.Device,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_ThrottledConnectionRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    MuxWithPoolingPoolSize,
+                    MuxWithPoolingDevicesCount,
+                    ConnectionStringAuthScope.Device,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_ThrottledConnectionRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    MuxWithPoolingPoolSize,
+                    MuxWithPoolingDevicesCount,
+                    ConnectionStringAuthScope.Device,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_ThrottledConnectionRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    MuxWithoutPoolingPoolSize,
+                    MuxWithoutPoolingDevicesCount,
+                    ConnectionStringAuthScope.IoTHub,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_ThrottledConnectionRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    MuxWithoutPoolingPoolSize,
+                    MuxWithoutPoolingDevicesCount,
+                    ConnectionStringAuthScope.IoTHub,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_ThrottledConnectionRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    MuxWithPoolingPoolSize,
+                    MuxWithPoolingDevicesCount,
+                    ConnectionStringAuthScope.IoTHub,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_ThrottledConnectionRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    MuxWithPoolingPoolSize,
+                    MuxWithPoolingDevicesCount,
+                    ConnectionStringAuthScope.IoTHub,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // WIP: Exception handling
+        [TestMethod]
         public async Task Message_ThrottledConnectionLongTimeNoRecovery_Amqp()
         {
-            try
-            {
-                await SendMessageRecovery(
+            await SendMessageRecovery(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_Throttle,
@@ -189,23 +800,13 @@ namespace Microsoft.Azure.Devices.E2ETests
                     FaultInjection.DefaultDelayInSec,
                     FaultInjection.DefaultDurationInSec,
                     FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
-
-                Assert.Fail("None of the expected exceptions were thrown.");
-            }
-            catch (IotHubThrottledException) { }
-            catch (IotHubCommunicationException ex)
-            {
-                Assert.IsInstanceOfType(ex.InnerException, typeof(OperationCanceledException));
-            }
-            catch (TimeoutException) { }
         }
 
+        // WIP: Exception handling
         [TestMethod]
         public async Task Message_ThrottledConnectionLongTimeNoRecovery_AmqpWs()
         {
-            try
-            {
-                await SendMessageRecovery(
+            await SendMessageRecovery(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_Throttle,
@@ -213,22 +814,174 @@ namespace Microsoft.Azure.Devices.E2ETests
                     FaultInjection.DefaultDelayInSec,
                     FaultInjection.DefaultDurationInSec,
                     FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
-                Assert.Fail("None of the expected exceptions were thrown.");
-            }
-            catch (IotHubThrottledException) { }
-            catch (IotHubCommunicationException ex)
-            {
-                Assert.IsInstanceOfType(ex.InnerException, typeof(OperationCanceledException));
-            }
-            catch (TimeoutException) { }
         }
 
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_ThrottledConnectionLongTimeNoRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    MuxWithoutPoolingPoolSize,
+                    MuxWithoutPoolingDevicesCount,
+                    ConnectionStringAuthScope.Device,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_ThrottledConnectionLongTimeNoRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    MuxWithoutPoolingPoolSize,
+                    MuxWithoutPoolingDevicesCount,
+                    ConnectionStringAuthScope.Device,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_ThrottledConnectionLongTimeNoRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    MuxWithPoolingPoolSize,
+                    MuxWithPoolingDevicesCount,
+                    ConnectionStringAuthScope.Device,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_ThrottledConnectionLongTimeNoRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    MuxWithPoolingPoolSize,
+                    MuxWithPoolingDevicesCount,
+                    ConnectionStringAuthScope.Device,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_ThrottledConnectionLongTimeNoRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    MuxWithoutPoolingPoolSize,
+                    MuxWithoutPoolingDevicesCount,
+                    ConnectionStringAuthScope.IoTHub,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_ThrottledConnectionLongTimeNoRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    MuxWithoutPoolingPoolSize,
+                    MuxWithoutPoolingDevicesCount,
+                    ConnectionStringAuthScope.IoTHub,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_ThrottledConnectionLongTimeNoRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    MuxWithPoolingPoolSize,
+                    MuxWithPoolingDevicesCount,
+                    ConnectionStringAuthScope.IoTHub,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_ThrottledConnectionLongTimeNoRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    MuxWithPoolingPoolSize,
+                    MuxWithPoolingDevicesCount,
+                    ConnectionStringAuthScope.IoTHub,
+                    FaultInjection.FaultType_Throttle,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
+
+        }
+
+        // WIP: Exception handling
         [TestMethod]
         public async Task Message_ThrottledConnectionLongTimeNoRecovery_Http()
         {
-            try
-            {
-                await SendMessageRecovery(
+            await SendMessageRecovery(
                     TestDeviceType.Sasl,
                     Client.TransportType.Http1,
                     FaultInjection.FaultType_Throttle,
@@ -236,20 +989,11 @@ namespace Microsoft.Azure.Devices.E2ETests
                     FaultInjection.DefaultDelayInSec,
                     FaultInjection.DefaultDurationInSec,
                     FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
-
-                Assert.Fail("None of the expected exceptions were thrown.");
-            }
-            catch (IotHubThrottledException) { }
-            catch (IotHubCommunicationException ex)
-            {
-                Assert.IsInstanceOfType(ex.InnerException, typeof(OperationCanceledException));
-            }
-            catch (TimeoutException) { }
         }
 
         [TestMethod]
-        [ExpectedException(typeof(DeviceMaximumQueueDepthExceededException))]
-        public async Task Message_QuotaExceededRecovery_Amqp()
+        // WIP: Exception handling
+        public async Task Message_QuotaExceededNoRecovery_Amqp()
         {
             await SendMessageRecovery(
                 TestDeviceType.Sasl,
@@ -261,8 +1005,8 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(DeviceMaximumQueueDepthExceededException))]
-        public async Task Message_QuotaExceededRecovery_AmqpWs()
+        // WIP: Exception handling
+        public async Task Message_QuotaExceededNoRecovery_AmqpWs()
         {
             await SendMessageRecovery(
                 TestDeviceType.Sasl,
@@ -273,12 +1017,163 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
         }
 
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_QuotaExceededNoRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_QuotaExceeded,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_QuotaExceededNoRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_QuotaExceeded,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_QuotaExceededNoRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_QuotaExceeded,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_QuotaExceededNoRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_QuotaExceeded,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_QuotaExceededNoRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_QuotaExceeded,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_QuotaExceededNoRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_QuotaExceeded,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_QuotaExceededNoRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_QuotaExceeded,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_QuotaExceededNoRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_QuotaExceeded,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // WIP: Exception handling
         [TestMethod]
         public async Task Message_QuotaExceededRecovery_Http()
         {
-            try
-            {
-                await SendMessageRecovery(
+            await SendMessageRecovery(
                     TestDeviceType.Sasl,
                     Client.TransportType.Http1,
                     FaultInjection.FaultType_QuotaExceeded,
@@ -286,20 +1181,11 @@ namespace Microsoft.Azure.Devices.E2ETests
                     FaultInjection.DefaultDelayInSec,
                     FaultInjection.DefaultDurationInSec,
                     FaultInjection.ShortRetryInMilliSec).ConfigureAwait(false);
-
-                Assert.Fail("None of the expected exceptions were thrown.");
-            }
-            catch (QuotaExceededException) { }
-            catch (IotHubCommunicationException ex)
-            {
-                Assert.IsInstanceOfType(ex.InnerException, typeof(OperationCanceledException));
-            }
-            catch (TimeoutException) { }
         }
 
         [TestMethod]
-        [ExpectedException(typeof(UnauthorizedException))]
-        public async Task Message_AuthenticationRecovery_Amqp()
+        // WIP: Exception handling
+        public async Task Message_AuthenticationErrorNoRecovery_Amqp()
         {
             await SendMessageRecovery(
                 TestDeviceType.Sasl,
@@ -311,8 +1197,8 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(UnauthorizedException))]
-        public async Task Message_AuthenticationRecovery_AmqpWs()
+        // WIP: Exception handling
+        public async Task Message_AuthenticationErrorNoRecovery_AmqpWs()
         {
             await SendMessageRecovery(
                 TestDeviceType.Sasl,
@@ -323,9 +1209,161 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
         }
 
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
         [TestMethod]
-        [ExpectedException(typeof(UnauthorizedException))]
-        public async Task Message_AuthenticationWontRecover_Http()
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_AuthenticationErrorNoRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Auth,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_AuthenticationErrorNoRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Auth,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_AuthenticationErrorNoRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Auth,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_DeviceSak_AuthenticationErrorNoRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Auth,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_AuthenticationErrorNoRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Auth,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_AuthenticationErrorNoRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Auth,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_AuthenticationErrorNoRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Auth,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        // TODO: #839 - Disabling fault injection tests which expect an exception ( for multiplexed devices)
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        // WIP: Exception handling
+        public async Task Message_IoTHubSak_AuthenticationErrorNoRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Auth,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec,
+                FaultInjection.DefaultDurationInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        // WIP: Exception handling
+        public async Task Message_AuthenticationErrorNoRecover_Http()
         {
             await SendMessageRecovery(
                 TestDeviceType.Sasl,
@@ -353,6 +1391,126 @@ namespace Microsoft.Azure.Devices.E2ETests
             await SendMessageRecovery(
                 TestDeviceType.Sasl,
                 Client.TransportType.Amqp_WebSocket_Only,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_GracefulShutdownSendRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_GracefulShutdownSendRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_GracefulShutdownSendRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_DeviceSak_GracefulShutdownSendRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IotHubSak_GracefulShutdownSendRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_GracefulShutdownSendRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_GracefulShutdownSendRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Message_IoTHubSak_GracefulShutdownSendRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMessageRecoveryMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
                 FaultInjection.FaultType_GracefulShutdownAmqp,
                 FaultInjection.FaultCloseReason_Bye,
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
@@ -417,16 +1575,16 @@ namespace Microsoft.Azure.Devices.E2ETests
             int durationInSec = FaultInjection.DefaultDurationInSec,
             int retryDurationInMilliSec = FaultInjection.RecoveryTimeMilliseconds)
         {
-            EventHubTestListener testListener = null;
+            
 
             Func<DeviceClient, TestDevice, Task> init = async (deviceClient, testDevice) =>
             {
-                testListener = await EventHubTestListener.CreateListener(testDevice.Id).ConfigureAwait(false);
                 deviceClient.OperationTimeoutInMilliseconds = (uint)retryDurationInMilliSec;
             };
 
             Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
             {
+                EventHubTestListener testListener = await EventHubTestListener.CreateListener(testDevice.Id).ConfigureAwait(false);
                 string payload, p1Value;
 
                 Client.Message testMessage = ComposeD2CTestMessage(out payload, out p1Value);
@@ -435,24 +1593,70 @@ namespace Microsoft.Azure.Devices.E2ETests
                 bool isReceived = false;
                 isReceived = await testListener.WaitForMessage(testDevice.Id, payload, p1Value).ConfigureAwait(false);
                 Assert.IsTrue(isReceived);
+                await testListener.CloseAsync().ConfigureAwait(false);
             };
 
             Func<Task> cleanupOperation = () =>
             {
-                if (testListener != null)
-                {
-                    return testListener.CloseAsync();
-                }
-                else
-                {
-                    return Task.FromResult(false);
-                }
+                return Task.FromResult(false);
             };
 
-            await FaultInjection.TestErrorInjectionAsync(
+            await FaultInjection.TestErrorInjectionSingleDeviceAsync(
                 DevicePrefix,
                 type,
                 transport,
+                faultType,
+                reason,
+                delayInSec,
+                durationInSec,
+                init,
+                testOperation,
+                cleanupOperation).ConfigureAwait(false);
+        }
+
+        internal async Task SendMessageRecoveryMuxedOverAmqp(
+            TestDeviceType type,
+            Client.TransportType transport,
+            int poolSize,
+            int devicesCount,
+            ConnectionStringAuthScope authScope,
+            string faultType,
+            string reason,
+            int delayInSec,
+            int durationInSec = FaultInjection.DefaultDurationInSec,
+            int retryDurationInMilliSec = FaultInjection.RecoveryTimeMilliseconds)
+        {
+            Func<DeviceClient, TestDevice, Task> init = async (deviceClient, testDevice) =>
+            {
+                deviceClient.OperationTimeoutInMilliseconds = (uint)retryDurationInMilliSec;
+            };
+
+            Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
+            {
+                EventHubTestListener testListener = await EventHubTestListener.CreateListener(testDevice.Id).ConfigureAwait(false);
+                string payload, p1Value;
+
+                Client.Message testMessage = ComposeD2CTestMessage(out payload, out p1Value);
+                await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
+
+                bool isReceived = false;
+                isReceived = await testListener.WaitForMessage(testDevice.Id, payload, p1Value).ConfigureAwait(false);
+                Assert.IsTrue(isReceived);
+                await testListener.CloseAsync().ConfigureAwait(false);
+            };
+
+            Func<Task> cleanupOperation = () =>
+            {
+                return Task.FromResult(false);
+            };
+
+            await FaultInjection.TestErrorInjectionMuxedOverAmqpAsync(
+                DevicePrefix,
+                authScope,
+                type,
+                transport,
+                poolSize,
+                devicesCount,
                 faultType,
                 reason,
                 delayInSec,

--- a/e2e/test/MessageSendUtil.cs
+++ b/e2e/test/MessageSendUtil.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             };
         }
 
-        public static async Task SendSingleMessage(DeviceClient deviceClient, string deviceId)
+        public static async Task SendSingleMessageAndVerify(DeviceClient deviceClient, string deviceId)
         {
             EventHubTestListener testListener = await EventHubTestListener.CreateListener(deviceId).ConfigureAwait(false);
 

--- a/e2e/test/MessageSendUtil.cs
+++ b/e2e/test/MessageSendUtil.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices.E2ETests
+{
+    public static class MessageSendUtil
+    {
+        private static TestLogging s_log = TestLogging.GetInstance();
+
+        public static Client.Message ComposeD2CTestMessage(out string payload, out string p1Value)
+        {
+            payload = Guid.NewGuid().ToString();
+            p1Value = Guid.NewGuid().ToString();
+
+            s_log.WriteLine($"{nameof(ComposeD2CTestMessage)}: payload='{payload}' p1Value='{p1Value}'");
+
+            return new Client.Message(Encoding.UTF8.GetBytes(payload))
+            {
+                Properties = { ["property1"] = p1Value }
+            };
+        }
+
+        public static async Task SendSingleMessage(DeviceClient deviceClient, string deviceId)
+        {
+            EventHubTestListener testListener = await EventHubTestListener.CreateListener(deviceId).ConfigureAwait(false);
+
+            try
+            {
+                string payload;
+                string p1Value;
+                Client.Message testMessage = ComposeD2CTestMessage(out payload, out p1Value);
+                await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
+
+                bool isReceived = await testListener.WaitForMessage(deviceId, payload, p1Value).ConfigureAwait(false);
+                Assert.IsTrue(isReceived, "Message is not received.");
+            }
+            finally
+            {
+                await testListener.CloseAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/e2e/test/MethodE2EMultiplexingTests.cs
+++ b/e2e/test/MethodE2EMultiplexingTests.cs
@@ -1,0 +1,198 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices.E2ETests
+{
+    [TestClass]
+    [TestCategory("IoTHub-E2E")]
+    [TestCategory("ConnectionPooling_AMQP_E2E")]
+    public class MethodE2EMultiplexingTests : IDisposable
+    {
+        private readonly string DevicePrefix = $"E2E_{nameof(MethodE2EMultiplexingTests)}_";
+        private readonly int MuxWithoutPoolingDevicesCount = 2;
+        // For enabling multiplexing without pooling, the pool size needs to be set to 1
+        private readonly int MuxWithoutPoolingPoolSize = 1;
+        // These values are configurable
+        private readonly int MuxWithPoolingDevicesCount = 4;
+        private readonly int MuxWithPoolingPoolSize = 2;
+
+        private static TestLogging _log = TestLogging.GetInstance();
+        private readonly ConsoleEventListener _listener;
+
+        public MethodE2EMultiplexingTests()
+        {
+            _listener = TestConfig.StartEventListener();
+        }
+
+        [TestMethod]
+        public async Task Method_DeviceSak_DeviceReceivesMethodAndResponse_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.Device,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                MethodUtil.SetDeviceReceiveMethod
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Method_DeviceSak_DeviceReceivesMethodAndResponse_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.Device,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                MethodUtil.SetDeviceReceiveMethod
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Method_IoTHubSak_DeviceReceivesMethodAndResponse_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                MethodUtil.SetDeviceReceiveMethod
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Method_IoTHubSak_DeviceReceivesMethodAndResponse_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                MethodUtil.SetDeviceReceiveMethod
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Method_DeviceSak_DeviceReceivesMethodAndResponse_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.Device,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize, 
+                MuxWithPoolingDevicesCount,
+                MethodUtil.SetDeviceReceiveMethod
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Method_DeviceSak_DeviceReceivesMethodAndResponse_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.Device,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                MethodUtil.SetDeviceReceiveMethod
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Method_IoTHubSak_DeviceReceivesMethodAndResponse_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                MethodUtil.SetDeviceReceiveMethod
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Method_IoTHubSak_DeviceReceivesMethodAndResponse_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                MethodUtil.SetDeviceReceiveMethod
+                ).ConfigureAwait(false);
+        }
+
+        private async Task SendMethodAndRespondMuxedOverAmqp(
+            TestDeviceType type,
+            ConnectionStringAuthScope authScope,
+            Client.TransportType transport,
+            int poolSize,
+            int devicesCount,
+            Func<DeviceClient, Task<Task>> setDeviceReceiveMethod
+            )
+        {
+            var transportSettings = new ITransportSettings[]
+            {
+                new AmqpTransportSettings(transport)
+                {
+                    AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings()
+                    {
+                        MaxPoolSize = unchecked((uint)poolSize),
+                        Pooling = true
+                    }
+                }
+            };
+
+            ICollection<DeviceClient> deviceClients = new List<DeviceClient>();
+
+            try
+            {
+                for (int i = 0; i < devicesCount; i++)
+                {
+                    TestDevice testDevice = await TestDevice.GetTestDeviceAsync($"{DevicePrefix}_{i}_", type).ConfigureAwait(false);
+                    DeviceClient deviceClient = testDevice.CreateDeviceClient(transportSettings, authScope);
+                    deviceClients.Add(deviceClient);
+
+                    Task methodReceivedTask = await setDeviceReceiveMethod(deviceClient).ConfigureAwait(false);
+                    await Task.WhenAll(
+                        MethodUtil.ServiceSendMethodAndVerifyResponse(testDevice.Id),
+                        methodReceivedTask).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                // Close and dispose all of the device client instances here
+                foreach (DeviceClient deviceClient in deviceClients)
+                {
+                    await deviceClient.CloseAsync().ConfigureAwait(false);
+                    _log.WriteLine($"{nameof(MethodE2ETests)}: Disposing deviceClient {TestLogging.GetHashCode(deviceClient)}");
+                    deviceClient.Dispose();
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+    }
+}

--- a/e2e/test/MethodE2ETests.cs
+++ b/e2e/test/MethodE2ETests.cs
@@ -17,9 +17,6 @@ namespace Microsoft.Azure.Devices.E2ETests
     public class MethodE2ETests : IDisposable
     {
         private readonly string DevicePrefix = $"E2E_{nameof(MethodE2ETests)}_";
-        private const string DeviceResponseJson = "{\"name\":\"e2e_test\"}";
-        private const string ServiceRequestJson = "{\"a\":123}";
-        private const string MethodName = "MethodE2ETest";
         private static TestLogging _log = TestLogging.GetInstance();
 
         private readonly ConsoleEventListener _listener;
@@ -32,176 +29,73 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         public async Task Method_DeviceReceivesMethodAndResponse_Mqtt()
         {
-            await SendMethodAndRespond(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethod).ConfigureAwait(false);
+            await SendMethodAndRespond(Client.TransportType.Mqtt_Tcp_Only, MethodUtil.SetDeviceReceiveMethod).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Method_DeviceReceivesMethodAndResponse_MqttWs()
         {
-            await SendMethodAndRespond(Client.TransportType.Mqtt_WebSocket_Only, SetDeviceReceiveMethod).ConfigureAwait(false);
+            await SendMethodAndRespond(Client.TransportType.Mqtt_WebSocket_Only, MethodUtil.SetDeviceReceiveMethod).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Method_DeviceReceivesMethodAndResponseWithObseletedSetMethodHandler_Mqtt()
         {
-            await SendMethodAndRespond(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethodObsoleteHandler).ConfigureAwait(false);
+            await SendMethodAndRespond(Client.TransportType.Mqtt_Tcp_Only, MethodUtil.SetDeviceReceiveMethodObsoleteHandler).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Method_DeviceReceivesMethodAndResponseWithObseletedSetMethodHandler_MqttWs()
         {
-            await SendMethodAndRespond(Client.TransportType.Mqtt_WebSocket_Only, SetDeviceReceiveMethodObsoleteHandler).ConfigureAwait(false);
+            await SendMethodAndRespond(Client.TransportType.Mqtt_WebSocket_Only, MethodUtil.SetDeviceReceiveMethodObsoleteHandler).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Method_DeviceReceivesMethodAndResponseWithDefaultMethodHandler_Mqtt()
         {
-            await SendMethodAndRespond(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethodDefaultHandler).ConfigureAwait(false);
+            await SendMethodAndRespond(Client.TransportType.Mqtt_Tcp_Only, MethodUtil.SetDeviceReceiveMethodDefaultHandler).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Method_DeviceReceivesMethodAndResponseWithDefaultMethodHandler_MqttWs()
         {
-            await SendMethodAndRespond(Client.TransportType.Mqtt_WebSocket_Only, SetDeviceReceiveMethodDefaultHandler).ConfigureAwait(false);
+            await SendMethodAndRespond(Client.TransportType.Mqtt_WebSocket_Only, MethodUtil.SetDeviceReceiveMethodDefaultHandler).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Method_DeviceReceivesMethodAndResponse_Amqp()
         {
-            await SendMethodAndRespond(Client.TransportType.Amqp_Tcp_Only, SetDeviceReceiveMethod).ConfigureAwait(false);
+            await SendMethodAndRespond(Client.TransportType.Amqp_Tcp_Only, MethodUtil.SetDeviceReceiveMethod).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Method_DeviceReceivesMethodAndResponse_AmqpWs()
         {
-            await SendMethodAndRespond(Client.TransportType.Amqp_WebSocket_Only, SetDeviceReceiveMethod).ConfigureAwait(false);
+            await SendMethodAndRespond(Client.TransportType.Amqp_WebSocket_Only, MethodUtil.SetDeviceReceiveMethod).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Method_DeviceReceivesMethodAndResponseWithObseletedSetMethodHandler_Amqp()
         {
-            await SendMethodAndRespond(Client.TransportType.Amqp_Tcp_Only, SetDeviceReceiveMethodObsoleteHandler).ConfigureAwait(false);
+            await SendMethodAndRespond(Client.TransportType.Amqp_Tcp_Only, MethodUtil.SetDeviceReceiveMethodObsoleteHandler).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Method_DeviceReceivesMethodAndResponseWithObseletedSetMethodHandler_AmqpWs()
         {
-            await SendMethodAndRespond(Client.TransportType.Amqp_WebSocket_Only, SetDeviceReceiveMethodObsoleteHandler).ConfigureAwait(false);
+            await SendMethodAndRespond(Client.TransportType.Amqp_WebSocket_Only, MethodUtil.SetDeviceReceiveMethodObsoleteHandler).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Method_DeviceReceivesMethodAndResponseWithDefaultMethodHandler_Amqp()
         {
-            await SendMethodAndRespond(Client.TransportType.Amqp_Tcp_Only, SetDeviceReceiveMethodDefaultHandler).ConfigureAwait(false);
+            await SendMethodAndRespond(Client.TransportType.Amqp_Tcp_Only, MethodUtil.SetDeviceReceiveMethodDefaultHandler).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Method_DeviceReceivesMethodAndResponseWithDefaultMethodHandler_AmqpWs()
         {
-            await SendMethodAndRespond(Client.TransportType.Amqp_WebSocket_Only, SetDeviceReceiveMethodDefaultHandler).ConfigureAwait(false);
-        }
-
-        private async Task ServiceSendMethodAndVerifyResponse(string deviceName, string methodName, string respJson, string reqJson)
-        {
-            using (ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString))
-            {
-                _log.WriteLine($"{nameof(ServiceSendMethodAndVerifyResponse)}: Invoke method {methodName}.");
-                CloudToDeviceMethodResult response =
-                    await serviceClient.InvokeDeviceMethodAsync(
-                        deviceName,
-                        new CloudToDeviceMethod(methodName, TimeSpan.FromMinutes(5)).SetPayloadJson(reqJson)).ConfigureAwait(false);
-
-                _log.WriteLine($"{nameof(ServiceSendMethodAndVerifyResponse)}: Method status: {response.Status}.");
-                Assert.AreEqual(200, response.Status);
-                Assert.AreEqual(respJson, response.GetPayloadAsJson());
-
-                await serviceClient.CloseAsync().ConfigureAwait(false);
-            }
-        }
-
-        private async Task<Task> SetDeviceReceiveMethod(DeviceClient deviceClient)
-        {
-            var methodCallReceived = new TaskCompletionSource<bool>();
-
-            await deviceClient.SetMethodHandlerAsync(MethodName,
-                (request, context) =>
-                {
-                    _log.WriteLine($"{nameof(SetDeviceReceiveMethod)}: DeviceClient method: {request.Name} {request.ResponseTimeout}.");
-
-                    try
-                    {
-                        Assert.AreEqual(MethodName, request.Name);
-                        Assert.AreEqual(ServiceRequestJson, request.DataAsJson);
-
-                        methodCallReceived.SetResult(true);
-                    }
-                    catch (Exception ex)
-                    {
-                        methodCallReceived.SetException(ex);
-                    }
-                    
-                    return Task.FromResult(new MethodResponse(Encoding.UTF8.GetBytes(DeviceResponseJson), 200));
-                },
-                null).ConfigureAwait(false);
-            
-            // Return the task that tells us we have received the callback.
-            return methodCallReceived.Task;
-        }
-
-        private async Task<Task> SetDeviceReceiveMethodDefaultHandler(DeviceClient deviceClient)
-        {
-            var methodCallReceived = new TaskCompletionSource<bool>();
-
-            await deviceClient.SetMethodDefaultHandlerAsync(
-                (request, context) =>
-                {
-                    _log.WriteLine($"{nameof(SetDeviceReceiveMethodDefaultHandler)}: DeviceClient method: {request.Name} {request.ResponseTimeout}.");
-
-                    try
-                    {
-                        Assert.AreEqual(MethodName, request.Name);
-                        Assert.AreEqual(ServiceRequestJson, request.DataAsJson);
-
-                        methodCallReceived.SetResult(true);
-                    }
-                    catch (Exception ex)
-                    {
-                        methodCallReceived.SetException(ex);
-                    }
-
-                    return Task.FromResult(new MethodResponse(Encoding.UTF8.GetBytes(DeviceResponseJson), 200));
-                },
-                null).ConfigureAwait(false);
-
-            return methodCallReceived.Task;
-        }
-
-        private Task<Task> SetDeviceReceiveMethodObsoleteHandler(DeviceClient deviceClient)
-        {
-            var methodCallReceived = new TaskCompletionSource<bool>();
-
-#pragma warning disable CS0618
-            deviceClient.SetMethodHandler(MethodName, (request, context) =>
-            {
-                _log.WriteLine($"{nameof(SetDeviceReceiveMethodObsoleteHandler)}: DeviceClient method: {request.Name} {request.ResponseTimeout}.");
-
-                try
-                {
-                    Assert.AreEqual(MethodName, request.Name);
-                    Assert.AreEqual(ServiceRequestJson, request.DataAsJson);
-
-                    methodCallReceived.SetResult(true);
-                }
-                catch (Exception ex)
-                {
-                    methodCallReceived.SetException(ex);
-                }
-
-                return Task.FromResult(new MethodResponse(Encoding.UTF8.GetBytes(DeviceResponseJson), 200));
-            }, null);
-#pragma warning restore CS0618
-
-            return Task.FromResult<Task>(methodCallReceived.Task);
+            await SendMethodAndRespond(Client.TransportType.Amqp_WebSocket_Only, MethodUtil.SetDeviceReceiveMethodDefaultHandler).ConfigureAwait(false);
         }
 
         private async Task SendMethodAndRespond(Client.TransportType transport, Func<DeviceClient, Task<Task>> setDeviceReceiveMethod)
@@ -213,7 +107,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 Task methodReceivedTask = await setDeviceReceiveMethod(deviceClient).ConfigureAwait(false);
 
                 await Task.WhenAll(
-                    ServiceSendMethodAndVerifyResponse(testDevice.Id, MethodName, DeviceResponseJson, ServiceRequestJson),
+                    MethodUtil.ServiceSendMethodAndVerifyResponse(testDevice.Id),
                     methodReceivedTask).ConfigureAwait(false);
 
                 await deviceClient.CloseAsync().ConfigureAwait(false);

--- a/e2e/test/MethodFaultInjectionTests.cs
+++ b/e2e/test/MethodFaultInjectionTests.cs
@@ -21,6 +21,14 @@ namespace Microsoft.Azure.Devices.E2ETests
     public class MethodFaultInjectionTests : IDisposable
     {
         private readonly string DevicePrefix = $"E2E_{nameof(MethodFaultInjectionTests)}_";
+
+        private readonly int MuxWithoutPoolingDevicesCount = 2;
+        // For enabling multiplexing without pooling, the pool size needs to be set to 1
+        private readonly int MuxWithoutPoolingPoolSize = 1;
+        // These values are configurable
+        private readonly int MuxWithPoolingDevicesCount = 4;
+        private readonly int MuxWithPoolingPoolSize = 2;
+
         private const string DeviceResponseJson = "{\"name\":\"e2e_test\"}";
         private const string ServiceRequestJson = "{\"a\":123}";
         private const string MethodName = "MethodE2ETest";
@@ -177,6 +185,630 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodTcpConnRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodTcpConnRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodTcpConnRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodTcpConnRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodTcpConnRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodTcpConnRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodTcpConnRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodTcpConnRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodAmqpConnLostRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpConn,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodAmqpConnLostRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpConn,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodAmqpConnLostRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpConn,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodAmqpConnLostRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpConn,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodAmqpConnLostRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpConn,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodAmqpConnLostRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpConn,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodAmqpConnLostRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpConn,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodAmqpConnLostRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpConn,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodSessionLostRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpSess,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodSessionLostRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpSess,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodSessionLostRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpSess,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodSessionLostRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpSess,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodSessionLostRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpSess,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodSessionLostRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpSess,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodSessionLostRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpSess,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodSessionLostRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpSess,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodReqLinkDropRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpMethodReq,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodReqLinkDropRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpMethodReq,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodReqLinkDropRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpMethodReq,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodReqLinkDropRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpMethodReq,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodReqLinkDropRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpMethodReq,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodReqLinkDropRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpMethodReq,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodReqLinkDropRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpMethodReq,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodReqLinkDropRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpMethodReq,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodRespLinkDropRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpMethodResp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodRespLinkDropRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpMethodResp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodRespLinkDropRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpMethodResp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodRespLinkDropRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_AmqpMethodResp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodRespLinkDropRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpMethodResp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodRespLinkDropRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpMethodResp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodRespLinkDropRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpMethodResp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodRespLinkDropRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_AmqpMethodResp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodGracefulShutdownRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodGracefulShutdownRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodGracefulShutdownRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_DeviceSak_DeviceMethodGracefulShutdownRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodGracefulShutdownRecovery_MuxWithoutPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodGracefulShutdownRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodGracefulShutdownRecovery_MuxWithPooling_Amqp()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Method_IoTHubSak_DeviceMethodGracefulShutdownRecovery_MuxWithPooling_AmqpWs()
+        {
+            await SendMethodAndRespondRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
         private async Task ServiceSendMethodAndVerifyResponse(string deviceName, string methodName, string respJson, string reqJson)
         {
             var sw = new Stopwatch();
@@ -248,10 +880,63 @@ namespace Microsoft.Azure.Devices.E2ETests
                 }
             };
 
-            await FaultInjection.TestErrorInjectionAsync(
+            await FaultInjection.TestErrorInjectionSingleDeviceAsync(
                 DevicePrefix,
                 TestDeviceType.Sasl,
                 transport,
+                faultType,
+                reason,
+                delayInSec,
+                FaultInjection.DefaultDelayInSec,
+                initOperation,
+                testOperation,
+                () => { return Task.FromResult<bool>(false); }).ConfigureAwait(false);
+        }
+
+        private async Task SendMethodAndRespondRecoveryMuxedOverAmqp(
+            Client.TransportType transport,
+            int poolSize,
+            int devicesCount,
+            ConnectionStringAuthScope ConnectionStringAuthScope,
+            string faultType,
+            string reason,
+            int delayInSec
+            )
+        {
+            TestDeviceCallbackHandler testDeviceCallbackHandler = null;
+            var cts = new CancellationTokenSource(FaultInjection.RecoveryTimeMilliseconds);
+
+            // Configure the callback and start accepting method calls.
+            Func<DeviceClient, TestDevice, Task> initOperation = async (deviceClient, testDevice) =>
+            {
+                testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient);
+                await testDeviceCallbackHandler.SetDeviceReceiveMethodAsync(MethodName, DeviceResponseJson, ServiceRequestJson).ConfigureAwait(false);
+            };
+
+            // Call the method from the service side and verify the device received the call.
+            Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
+            {
+                s_log.WriteLine($"{nameof(FaultInjection)}: Testing the direct methods.");
+
+                Task serviceSendTask = ServiceSendMethodAndVerifyResponse(testDevice.Id, MethodName, DeviceResponseJson, ServiceRequestJson);
+                Task methodReceivedTask = testDeviceCallbackHandler.WaitForMethodCallbackAsync(cts.Token);
+
+                var tasks = new List<Task>() { serviceSendTask, methodReceivedTask };
+                while (tasks.Count > 0)
+                {
+                    Task completedTask = await Task.WhenAny(tasks).ConfigureAwait(false);
+                    completedTask.GetAwaiter().GetResult();
+                    tasks.Remove(completedTask);
+                }
+            };
+
+            await FaultInjection.TestErrorInjectionMuxedOverAmqpAsync(
+                DevicePrefix,
+                ConnectionStringAuthScope,
+                TestDeviceType.Sasl,
+                transport,
+                poolSize,
+                devicesCount,
                 faultType,
                 reason,
                 delayInSec,

--- a/e2e/test/MethodFaultInjectionTests.cs
+++ b/e2e/test/MethodFaultInjectionTests.cs
@@ -936,6 +936,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                 reason,
                 delayInSec,
                 FaultInjection.DefaultDelayInSec,
+                false,
+                new List<Type> { },
                 initOperation,
                 testOperation,
                 () => { return Task.FromResult<bool>(false); }).ConfigureAwait(false);
@@ -989,6 +991,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                 reason,
                 delayInSec,
                 FaultInjection.DefaultDelayInSec,
+                false,
+                new List<Type> { },
                 initOperation,
                 testOperation,
                 () => { return Task.FromResult<bool>(false); }).ConfigureAwait(false);

--- a/e2e/test/MethodFaultInjectionTests.cs
+++ b/e2e/test/MethodFaultInjectionTests.cs
@@ -185,6 +185,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodTcpConnRecovery_MuxWithoutPooling_Amqp()
@@ -198,6 +199,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodTcpConnRecovery_MuxWithoutPooling_AmqpWs()
@@ -211,6 +213,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodTcpConnRecovery_MuxWithPooling_Amqp()
@@ -224,6 +227,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodTcpConnRecovery_MuxWithPooling_AmqpWs()
@@ -237,6 +241,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodTcpConnRecovery_MuxWithoutPooling_Amqp()
@@ -250,6 +255,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodTcpConnRecovery_MuxWithoutPooling_AmqpWs()
@@ -263,6 +269,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodTcpConnRecovery_MuxWithPooling_Amqp()
@@ -276,6 +283,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodTcpConnRecovery_MuxWithPooling_AmqpWs()
@@ -289,6 +297,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodAmqpConnLostRecovery_MuxWithoutPooling_Amqp()
@@ -302,6 +311,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodAmqpConnLostRecovery_MuxWithoutPooling_AmqpWs()
@@ -315,6 +325,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodAmqpConnLostRecovery_MuxWithPooling_Amqp()
@@ -328,6 +339,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodAmqpConnLostRecovery_MuxWithPooling_AmqpWs()
@@ -341,6 +353,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodAmqpConnLostRecovery_MuxWithoutPooling_Amqp()
@@ -354,6 +367,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodAmqpConnLostRecovery_MuxWithoutPooling_AmqpWs()
@@ -367,6 +381,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodAmqpConnLostRecovery_MuxWithPooling_Amqp()
@@ -380,6 +395,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodAmqpConnLostRecovery_MuxWithPooling_AmqpWs()
@@ -393,6 +409,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodSessionLostRecovery_MuxWithoutPooling_Amqp()
@@ -406,6 +423,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodSessionLostRecovery_MuxWithoutPooling_AmqpWs()
@@ -419,6 +437,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodSessionLostRecovery_MuxWithPooling_Amqp()
@@ -432,6 +451,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodSessionLostRecovery_MuxWithPooling_AmqpWs()
@@ -445,6 +465,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodSessionLostRecovery_MuxWithoutPooling_Amqp()
@@ -458,6 +479,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodSessionLostRecovery_MuxWithoutPooling_AmqpWs()
@@ -471,6 +493,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodSessionLostRecovery_MuxWithPooling_Amqp()
@@ -484,6 +507,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodSessionLostRecovery_MuxWithPooling_AmqpWs()
@@ -497,6 +521,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodReqLinkDropRecovery_MuxWithoutPooling_Amqp()
@@ -510,6 +535,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodReqLinkDropRecovery_MuxWithoutPooling_AmqpWs()
@@ -523,6 +549,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodReqLinkDropRecovery_MuxWithPooling_Amqp()
@@ -536,6 +563,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodReqLinkDropRecovery_MuxWithPooling_AmqpWs()
@@ -549,6 +577,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodReqLinkDropRecovery_MuxWithoutPooling_Amqp()
@@ -562,6 +591,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodReqLinkDropRecovery_MuxWithoutPooling_AmqpWs()
@@ -575,6 +605,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodReqLinkDropRecovery_MuxWithPooling_Amqp()
@@ -588,6 +619,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodReqLinkDropRecovery_MuxWithPooling_AmqpWs()
@@ -601,6 +633,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodRespLinkDropRecovery_MuxWithoutPooling_Amqp()
@@ -614,6 +647,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodRespLinkDropRecovery_MuxWithoutPooling_AmqpWs()
@@ -627,6 +661,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodRespLinkDropRecovery_MuxWithPooling_Amqp()
@@ -640,6 +675,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodRespLinkDropRecovery_MuxWithPooling_AmqpWs()
@@ -653,6 +689,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodRespLinkDropRecovery_MuxWithoutPooling_Amqp()
@@ -666,6 +703,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodRespLinkDropRecovery_MuxWithoutPooling_AmqpWs()
@@ -679,6 +717,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodRespLinkDropRecovery_MuxWithPooling_Amqp()
@@ -692,6 +731,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodRespLinkDropRecovery_MuxWithPooling_AmqpWs()
@@ -705,6 +745,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodGracefulShutdownRecovery_MuxWithoutPooling_Amqp()
@@ -718,6 +759,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodGracefulShutdownRecovery_MuxWithoutPooling_AmqpWs()
@@ -731,6 +773,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodGracefulShutdownRecovery_MuxWithPooling_Amqp()
@@ -744,6 +787,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_DeviceSak_DeviceMethodGracefulShutdownRecovery_MuxWithPooling_AmqpWs()
@@ -757,6 +801,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodGracefulShutdownRecovery_MuxWithoutPooling_Amqp()
@@ -770,6 +815,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodGracefulShutdownRecovery_MuxWithoutPooling_AmqpWs()
@@ -783,6 +829,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodGracefulShutdownRecovery_MuxWithPooling_Amqp()
@@ -796,6 +843,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [TestCategory("ConnectionPoolingE2ETests")]
         public async Task Method_IoTHubSak_DeviceMethodGracefulShutdownRecovery_MuxWithPooling_AmqpWs()

--- a/e2e/test/MethodUtil.cs
+++ b/e2e/test/MethodUtil.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices.E2ETests
+{
+    public static class MethodUtil
+    {
+        private const string DeviceResponseJson = "{\"name\":\"e2e_test\"}";
+        private const string ServiceRequestJson = "{\"a\":123}";
+        private const string MethodName = "MethodE2ETest";
+        private static TestLogging s_log = TestLogging.GetInstance();
+
+        public static async Task ServiceSendMethodAndVerifyResponse(string deviceName)
+        {
+            using (ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString))
+            {
+                s_log.WriteLine($"{nameof(ServiceSendMethodAndVerifyResponse)}: Invoke method {MethodName}.");
+                CloudToDeviceMethodResult response =
+                    await serviceClient.InvokeDeviceMethodAsync(
+                        deviceName,
+                        new CloudToDeviceMethod(MethodName, TimeSpan.FromMinutes(5)).SetPayloadJson(ServiceRequestJson)).ConfigureAwait(false);
+
+                s_log.WriteLine($"{nameof(ServiceSendMethodAndVerifyResponse)}: Method status: {response.Status}.");
+                Assert.AreEqual(200, response.Status);
+                Assert.AreEqual(DeviceResponseJson, response.GetPayloadAsJson());
+
+                await serviceClient.CloseAsync().ConfigureAwait(false);
+            }
+        }
+
+        public static async Task<Task> SetDeviceReceiveMethod(DeviceClient deviceClient)
+        {
+            var methodCallReceived = new TaskCompletionSource<bool>();
+
+            await deviceClient.SetMethodHandlerAsync(MethodName,
+                (request, context) =>
+                {
+                    s_log.WriteLine($"{nameof(SetDeviceReceiveMethod)}: DeviceClient method: {request.Name} {request.ResponseTimeout}.");
+
+                    try
+                    {
+                        Assert.AreEqual(MethodName, request.Name);
+                        Assert.AreEqual(ServiceRequestJson, request.DataAsJson);
+
+                        methodCallReceived.SetResult(true);
+                    }
+                    catch (Exception ex)
+                    {
+                        methodCallReceived.SetException(ex);
+                    }
+
+                    return Task.FromResult(new MethodResponse(Encoding.UTF8.GetBytes(DeviceResponseJson), 200));
+                },
+                null).ConfigureAwait(false);
+
+            // Return the task that tells us we have received the callback.
+            return methodCallReceived.Task;
+        }
+
+        public static async Task<Task> SetDeviceReceiveMethodDefaultHandler(DeviceClient deviceClient)
+        {
+            var methodCallReceived = new TaskCompletionSource<bool>();
+
+            await deviceClient.SetMethodDefaultHandlerAsync(
+                (request, context) =>
+                {
+                    s_log.WriteLine($"{nameof(SetDeviceReceiveMethodDefaultHandler)}: DeviceClient method: {request.Name} {request.ResponseTimeout}.");
+
+                    try
+                    {
+                        Assert.AreEqual(MethodName, request.Name);
+                        Assert.AreEqual(ServiceRequestJson, request.DataAsJson);
+
+                        methodCallReceived.SetResult(true);
+                    }
+                    catch (Exception ex)
+                    {
+                        methodCallReceived.SetException(ex);
+                    }
+
+                    return Task.FromResult(new MethodResponse(Encoding.UTF8.GetBytes(DeviceResponseJson), 200));
+                },
+                null).ConfigureAwait(false);
+
+            return methodCallReceived.Task;
+        }
+
+        public static Task<Task> SetDeviceReceiveMethodObsoleteHandler(DeviceClient deviceClient)
+        {
+            var methodCallReceived = new TaskCompletionSource<bool>();
+
+#pragma warning disable CS0618
+            deviceClient.SetMethodHandler(MethodName, (request, context) =>
+            {
+                s_log.WriteLine($"{nameof(SetDeviceReceiveMethodObsoleteHandler)}: DeviceClient method: {request.Name} {request.ResponseTimeout}.");
+
+                try
+                {
+                    Assert.AreEqual(MethodName, request.Name);
+                    Assert.AreEqual(ServiceRequestJson, request.DataAsJson);
+
+                    methodCallReceived.SetResult(true);
+                }
+                catch (Exception ex)
+                {
+                    methodCallReceived.SetException(ex);
+                }
+
+                return Task.FromResult(new MethodResponse(Encoding.UTF8.GetBytes(DeviceResponseJson), 200));
+            }, null);
+#pragma warning restore CS0618
+
+            return Task.FromResult<Task>(methodCallReceived.Task);
+        }
+    }
+}

--- a/e2e/test/TestConfig.cs
+++ b/e2e/test/TestConfig.cs
@@ -4,7 +4,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Diagnostics.Tracing;
 
-[assembly: Parallelize(Workers = 32, Scope = ExecutionScope.ClassLevel)]
+[assembly: Parallelize(Workers = 1, Scope = ExecutionScope.ClassLevel)]
 
 namespace Microsoft.Azure.Devices.E2ETests
 {

--- a/e2e/test/TestConfig.cs
+++ b/e2e/test/TestConfig.cs
@@ -4,7 +4,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Diagnostics.Tracing;
 
-[assembly: Parallelize(Workers = 1, Scope = ExecutionScope.ClassLevel)]
+[assembly: Parallelize(Workers = 32, Scope = ExecutionScope.ClassLevel)]
 
 namespace Microsoft.Azure.Devices.E2ETests
 {

--- a/e2e/test/TwinE2EMultiplexingTests.cs
+++ b/e2e/test/TwinE2EMultiplexingTests.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices.E2ETests
+{
+    [TestClass]
+    [TestCategory("IoTHub-E2E")]
+    [TestCategory("ConnectionPooling_AMQP_E2E")]
+    public class TwinE2EMultiplexingTests : IDisposable
+    {
+        private readonly string DevicePrefix = $"E2E_{nameof(TwinE2EMultiplexingTests)}_";
+        private readonly int MuxWithoutPoolingDevicesCount = 2;
+        // For enabling multiplexing without pooling, the pool size needs to be set to 1
+        private readonly int MuxWithoutPoolingPoolSize = 1;
+        // These values are configurable
+        private readonly int MuxWithPoolingDevicesCount = 4;
+        private readonly int MuxWithPoolingPoolSize = 2;
+
+        // TODO: Implement proxy and mux tests
+        private static string ProxyServerAddress = Configuration.IoTHub.ProxyServerAddress;
+        private static TestLogging _log = TestLogging.GetInstance();
+
+        private readonly ConsoleEventListener _listener;
+
+        public TwinE2EMultiplexingTests()
+        {
+            _listener = TestConfig.StartEventListener();
+        }
+
+        [TestMethod]
+        public async Task Twin_DeviceSak_DeviceSetsReportedPropertyAndGetsItBack_MuxWithoutPooling_Amqp()
+        {
+            await Twin_DeviceSetsReportedPropertyAndGetsItBackMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.Device,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Twin_DeviceSak_DeviceSetsReportedPropertyAndGetsItBack_MuxWithoutPooling_AmqpWs()
+        {
+            await Twin_DeviceSetsReportedPropertyAndGetsItBackMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.Device,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Twin_IoTHubSak_DeviceSetsReportedPropertyAndGetsItBack_MuxWithoutPooling_Amqp()
+        {
+            await Twin_DeviceSetsReportedPropertyAndGetsItBackMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Twin_IotHubSak_DeviceSetsReportedPropertyAndGetsItBack_MuxWithoutPooling_AmqpWs()
+        {
+            await Twin_DeviceSetsReportedPropertyAndGetsItBackMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Twin_DeviceSak_DeviceSetsReportedPropertyAndGetsItBack_MuxWithPooling_AmqpWs()
+        {
+            await Twin_DeviceSetsReportedPropertyAndGetsItBackMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.Device,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Twin_IoTHubSak_DeviceSetsReportedPropertyAndGetsItBack_MuxWithPooling_Amqp()
+        {
+            await Twin_DeviceSetsReportedPropertyAndGetsItBackMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Twin_IotHubSak_DeviceSetsReportedPropertyAndGetsItBack_MuxWithPooling_AmqpWs()
+        {
+            await Twin_DeviceSetsReportedPropertyAndGetsItBackMuxedOverAmqp(
+                TestDeviceType.Sasl,
+                ConnectionStringAuthScope.IoTHub,
+                Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount
+                ).ConfigureAwait(false);
+        }
+
+        private async Task Twin_DeviceSetsReportedPropertyAndGetsItBackMuxedOverAmqp(
+            TestDeviceType type,
+            ConnectionStringAuthScope authScope,
+            Client.TransportType transport,
+            int poolSize,
+            int devicesCount)
+        {
+            var transportSettings = new ITransportSettings[]
+            {
+                new AmqpTransportSettings(transport)
+                {
+                    AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings()
+                    {
+                        MaxPoolSize = unchecked((uint)poolSize),
+                        Pooling = true
+                    }
+                }
+            };
+
+            ICollection<DeviceClient> deviceClients = new List<DeviceClient>();
+
+            try
+            {
+                _log.WriteLine($"{nameof(MessageSendE2ETests)}: Starting the test execution for {devicesCount} devices");
+
+                for (int i = 0; i < devicesCount; i++)
+                {
+                    DeviceClient deviceClient = null;
+                    TestDevice testDevice = await TestDevice.GetTestDeviceAsync($"{DevicePrefix}_{i}_", type).ConfigureAwait(false);
+
+                    if (type == TestDeviceType.Sasl)
+                    {
+                        deviceClient = testDevice.CreateDeviceClient(transportSettings, authScope);
+                    }
+                    else
+                    {
+                        deviceClient = testDevice.CreateDeviceClient(transportSettings);
+                    }
+                    deviceClients.Add(deviceClient);
+
+                    await TwinUtil.Twin_DeviceSetsReportedPropertyAndGetsItBack(deviceClient).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                // Close and dispose all of the device client instances here
+                foreach (DeviceClient deviceClient in deviceClients)
+                {
+                    await deviceClient.CloseAsync().ConfigureAwait(false);
+                    _log.WriteLine($"{nameof(MessageSendE2ETests)}: Disposing deviceClient {TestLogging.GetHashCode(deviceClient)}");
+                    deviceClient.Dispose();
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+    }
+}

--- a/e2e/test/TwinE2ETests.cs
+++ b/e2e/test/TwinE2ETests.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.Shared;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,25 +29,25 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         public async Task Twin_DeviceSetsReportedPropertyAndGetsItBack_Mqtt()
         {
-            await Twin_DeviceSetsReportedPropertyAndGetsItBack(Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
+            await Twin_DeviceSetsReportedPropertyAndGetsItBackSingleDevice(Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Twin_DeviceSetsReportedPropertyAndGetsItBack_MqttWs()
         {
-            await Twin_DeviceSetsReportedPropertyAndGetsItBack(Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
+            await Twin_DeviceSetsReportedPropertyAndGetsItBackSingleDevice(Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Twin_DeviceSetsReportedPropertyAndGetsItBack_Amqp()
         {
-            await Twin_DeviceSetsReportedPropertyAndGetsItBack(Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
+            await Twin_DeviceSetsReportedPropertyAndGetsItBackSingleDevice(Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task Twin_DeviceSetsReportedPropertyAndGetsItBack_AmqpWs()
         {
-            await Twin_DeviceSetsReportedPropertyAndGetsItBack(Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
+            await Twin_DeviceSetsReportedPropertyAndGetsItBackSingleDevice(Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -200,21 +201,12 @@ namespace Microsoft.Azure.Devices.E2ETests
             await Twin_ClientHandlesRejectionInvalidPropertyName(Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
         }
 
-        private async Task Twin_DeviceSetsReportedPropertyAndGetsItBack(Client.TransportType transport)
+        private async Task Twin_DeviceSetsReportedPropertyAndGetsItBackSingleDevice(Client.TransportType transport)
         {
-            var propName = Guid.NewGuid().ToString();
-            var propValue = Guid.NewGuid().ToString();
-
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             using (DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport))
             {
-                TwinCollection props = new TwinCollection();
-                props[propName] = propValue;
-                await deviceClient.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
-
-                Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
-                Assert.AreEqual<String>(deviceTwin.Properties.Reported[propName].ToString(), propValue);
-
+                await TwinUtil.Twin_DeviceSetsReportedPropertyAndGetsItBack(deviceClient).ConfigureAwait(false);
                 await deviceClient.CloseAsync().ConfigureAwait(false);
             }
         }

--- a/e2e/test/TwinFaultInjectionTests.cs
+++ b/e2e/test/TwinFaultInjectionTests.cs
@@ -15,9 +15,18 @@ namespace Microsoft.Azure.Devices.E2ETests
 {
     [TestClass]
     [TestCategory("IoTHub-E2E")]
+    [TestCategory("IoTHub-FaultInjection")]
     public class TwinFaultInjectionTests : IDisposable
     {
         private readonly string DevicePrefix = $"E2E_{nameof(TwinFaultInjectionTests)}_";
+
+        private readonly int MuxWithoutPoolingDevicesCount = 2;
+        // For enabling multiplexing without pooling, the pool size needs to be set to 1
+        private readonly int MuxWithoutPoolingPoolSize = 1;
+        // These values are configurable
+        private readonly int MuxWithPoolingDevicesCount = 4;
+        private readonly int MuxWithPoolingPoolSize = 2;
+
         private static TestLogging s_log = TestLogging.GetInstance();
 
         private readonly ConsoleEventListener _listener;
@@ -28,7 +37,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceReportedPropertiesTcpConnRecovery_Mqtt()
         {
             await Twin_DeviceReportedPropertiesRecovery(Client.TransportType.Mqtt_Tcp_Only,
@@ -38,7 +46,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceReportedPropertiesTcpConnRecovery_MqttWs()
         {
             await Twin_DeviceReportedPropertiesRecovery(Client.TransportType.Mqtt_WebSocket_Only,
@@ -48,7 +55,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceReportedPropertiesTcpConnRecovery_Amqp()
         {
             await Twin_DeviceReportedPropertiesRecovery(Client.TransportType.Amqp_Tcp_Only,
@@ -58,7 +64,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceReportedPropertiesTcpConnRecovery_AmqpWs()
         {
             await Twin_DeviceReportedPropertiesRecovery(Client.TransportType.Amqp_WebSocket_Only,
@@ -68,7 +73,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceReportedPropertiesGracefulShutdownRecovery_Mqtt()
         {
             await Twin_DeviceReportedPropertiesRecovery(Client.TransportType.Mqtt_Tcp_Only,
@@ -78,7 +82,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceReportedPropertiesGracefulShutdownRecovery_MqttWs()
         {
             await Twin_DeviceReportedPropertiesRecovery(Client.TransportType.Mqtt_WebSocket_Only,
@@ -88,7 +91,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceReportedPropertiesGracefulShutdownRecovery_Amqp()
         {
             await Twin_DeviceReportedPropertiesRecovery(Client.TransportType.Amqp_Tcp_Only,
@@ -98,7 +100,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceReportedPropertiesGracefulShutdownRecovery_AmqpWs()
         {
             await Twin_DeviceReportedPropertiesRecovery(Client.TransportType.Amqp_WebSocket_Only,
@@ -108,7 +109,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceDesiredPropertyUpdateTcpConnRecovery_Mqtt()
         {
             await Twin_DeviceDesiredPropertyUpdateRecovery(Client.TransportType.Mqtt_Tcp_Only,
@@ -118,7 +118,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceDesiredPropertyUpdateTcpConnRecovery_MqttWs()
         {
             await Twin_DeviceDesiredPropertyUpdateRecovery(Client.TransportType.Mqtt_WebSocket_Only,
@@ -128,7 +127,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceDesiredPropertyUpdateTcpConnRecovery_Amqp()
         {
             await Twin_DeviceDesiredPropertyUpdateRecovery(Client.TransportType.Amqp_Tcp_Only,
@@ -138,7 +136,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceDesiredPropertyUpdateTcpConnRecovery_AmqpWs()
         {
             await Twin_DeviceDesiredPropertyUpdateRecovery(Client.TransportType.Amqp_WebSocket_Only,
@@ -148,7 +145,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
         
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceDesiredPropertyUpdateGracefulShutdownRecovery_Mqtt()
         {
             await Twin_DeviceDesiredPropertyUpdateRecovery(Client.TransportType.Mqtt_Tcp_Only,
@@ -158,7 +154,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceDesiredPropertyUpdateGracefulShutdownRecovery_MqttWs()
         {
             await Twin_DeviceDesiredPropertyUpdateRecovery(Client.TransportType.Mqtt_WebSocket_Only,
@@ -168,7 +163,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceDesiredPropertyUpdateGracefulShutdownRecovery_Amqp()
         {
             await Twin_DeviceDesiredPropertyUpdateRecovery(Client.TransportType.Amqp_Tcp_Only,
@@ -178,10 +172,457 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [TestCategory("IoTHub-FaultInjection")]
         public async Task Twin_DeviceDesiredPropertyUpdateGracefulShutdownRecovery_AmqpWs()
         {
             await Twin_DeviceDesiredPropertyUpdateRecovery(Client.TransportType.Amqp_WebSocket_Only,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceReportedPropertiesTcpConnRecovery_MuxWithoutPooling_Amqp()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceReportedPropertiesTcpConnRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceReportedPropertiesTcpConnRecovery_MuxWithPooling_Amqp()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceReportedPropertiesTcpConnRecovery_MuxWithPooling_AmqpWs()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceReportedPropertiesTcpConnRecovery_MuxWithoutPooling_Amqp()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceReportedPropertiesTcpConnRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceReportedPropertiesTcpConnRecovery_MuxWithPooling_Amqp()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceReportedPropertiesTcpConnRecovery_MuxWithPooling_AmqpWs()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceReportedPropertiesGracefulShutdownRecovery_MuxWithoutPooling_Amqp()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceReportedPropertiesGracefulShutdownRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceReportedPropertiesGracefulShutdownRecovery_MuxWithPooling_Amqp()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceReportedPropertiesGracefulShutdownRecovery_MuxWithPooling_AmqpWs()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceReportedPropertiesGracefulShutdownRecovery_MuxWithoutPooling_Amqp()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceReportedPropertiesGracefulShutdownRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceReportedPropertiesGracefulShutdownRecovery_MuxWithPooling_Amqp()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceReportedPropertiesGracefulShutdownRecovery_MuxWithPooling_AmqpWs()
+        {
+            await Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceDesiredPropertyUpdateTcpConnRecovery_MuxWithoutPooling_Amqp()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceDesiredPropertyUpdateTcpConnRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceDesiredPropertyUpdateTcpConnRecovery_MuxWithPooling_Amqp()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceDesiredPropertyUpdateTcpConnRecovery_MuxWithPooling_AmqpWs()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceDesiredPropertyUpdateTcpConnRecovery_MuxWithoutPooling_Amqp()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceDesiredPropertyUpdateTcpConnRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceDesiredPropertyUpdateTcpConnRecovery_MuxWithPooling_Amqp()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceDesiredPropertyUpdateTcpConnRecovery_MuxWithPooling_AmqpWs()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_Tcp,
+                FaultInjection.FaultCloseReason_Boom,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceDesiredPropertyUpdateGracefulShutdownRecovery_MuxWithoutPooling_Amqp()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceDesiredPropertyUpdateGracefulShutdownRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceDesiredPropertyUpdateGracefulShutdownRecovery_MuxWithPooling_Amqp()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_DeviceSak_DeviceDesiredPropertyUpdateGracefulShutdownRecovery_MuxWithPooling_AmqpWs()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.Device,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceDesiredPropertyUpdateGracefulShutdownRecovery_MuxWithoutPooling_Amqp()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceDesiredPropertyUpdateGracefulShutdownRecovery_MuxWithoutPooling_AmqpWs()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithoutPoolingPoolSize,
+                MuxWithoutPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceDesiredPropertyUpdateGracefulShutdownRecovery_MuxWithPooling_Amqp()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_Tcp_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
+                FaultInjection.FaultType_GracefulShutdownAmqp,
+                FaultInjection.FaultCloseReason_Bye,
+                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [TestMethod]
+        [TestCategory("ConnectionPoolingE2ETests")]
+        public async Task Twin_IoTHubSak_DeviceDesiredPropertyUpdateGracefulShutdownRecovery_MuxWithPooling_AmqpWs()
+        {
+            await Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType.Amqp_WebSocket_Only,
+                MuxWithPoolingPoolSize,
+                MuxWithPoolingDevicesCount,
+                ConnectionStringAuthScope.IoTHub,
                 FaultInjection.FaultType_GracefulShutdownAmqp,
                 FaultInjection.FaultCloseReason_Bye,
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
@@ -261,20 +702,111 @@ namespace Microsoft.Azure.Devices.E2ETests
                 Task serviceSendTask = RegistryManagerUpdateDesiredPropertyAsync(testDevice.Id, propName, propValue);
                 Task twinReceivedTask = testDeviceCallbackHandler.WaitForTwinCallbackAsync(cts.Token);
 
-                // var tasks = new List<Task>() { serviceSendTask, twinReceivedTask };
-                await Task.WhenAll(serviceSendTask, twinReceivedTask).ConfigureAwait(false);
-                //while (tasks.Count > 0)
-                //{
-                //    Task completedTask = await Task.WhenAny(tasks).ConfigureAwait(false);
-                //    completedTask.GetAwaiter().GetResult();
-                //    tasks.Remove(completedTask);
-                //}
+                var tasks = new List<Task>() { serviceSendTask, twinReceivedTask };
+                while (tasks.Count > 0)
+                {
+                    Task completedTask = await Task.WhenAny(tasks).ConfigureAwait(false);
+                    completedTask.GetAwaiter().GetResult();
+                    tasks.Remove(completedTask);
+                }
             };
 
             await FaultInjection.TestErrorInjectionSingleDeviceAsync(
                 DevicePrefix,
                 TestDeviceType.Sasl,
                 transport,
+                faultType,
+                reason,
+                delayInSec,
+                FaultInjection.DefaultDurationInSec,
+                false,
+                new List<Type> { },
+                initOperation,
+                testOperation,
+                () => { return Task.FromResult<bool>(false); }).ConfigureAwait(false);
+        }
+
+        private async Task Twin_DeviceReportedPropertiesRecoveryMuxedOverAmqp(Client.TransportType transport, int poolSize, int devicesCount, ConnectionStringAuthScope ConnectionStringAuthScope, string faultType, string reason, int delayInSec)
+        {
+            var propName = Guid.NewGuid().ToString();
+            var props = new TwinCollection();
+
+            Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
+            {
+                var propValue = Guid.NewGuid().ToString();
+                props[propName] = propValue;
+
+                await deviceClient.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
+
+                Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+                Assert.IsNotNull(deviceTwin, $"{nameof(deviceTwin)} is null");
+                Assert.IsNotNull(deviceTwin.Properties, $"{nameof(deviceTwin)}.Properties is null");
+                Assert.IsNotNull(deviceTwin.Properties.Reported, $"{nameof(deviceTwin)}.Properties.Reported is null");
+                Assert.IsNotNull(deviceTwin.Properties.Reported[propName], $"{nameof(deviceTwin)}.Properties.Reported[{nameof(propName)}] is null");
+                Assert.AreEqual<String>(deviceTwin.Properties.Reported[propName].ToString(), propValue);
+            };
+
+            await FaultInjection.TestErrorInjectionMuxedOverAmqpAsync(
+                DevicePrefix,
+                ConnectionStringAuthScope,
+                TestDeviceType.Sasl,
+                transport,
+                poolSize,
+                devicesCount,
+                faultType,
+                reason,
+                delayInSec,
+                FaultInjection.DefaultDurationInSec,
+                false,
+                new List<Type> { },
+                (d, t) => { return Task.FromResult<bool>(false); },
+                testOperation,
+                () => { return Task.FromResult<bool>(false); }).ConfigureAwait(false);
+        }
+
+        private async Task Twin_DeviceDesiredPropertyUpdateRecoveryMuxedOverAmqp(Client.TransportType transport, int poolSize, int devicesCount, ConnectionStringAuthScope ConnectionStringAuthScope, string faultType, string reason, int delayInSec)
+        {
+            TestDeviceCallbackHandler testDeviceCallbackHandler = null;
+            RegistryManager registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            var cts = new CancellationTokenSource(FaultInjection.RecoveryTimeMilliseconds);
+
+            var propName = Guid.NewGuid().ToString();
+            var props = new TwinCollection();
+
+            // Configure the callback and start accepting twin changes.
+            Func<DeviceClient, TestDevice, Task> initOperation = async (deviceClient, testDevice) =>
+            {
+                testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient);
+                await testDeviceCallbackHandler.SetTwinPropertyUpdateCallbackHandlerAsync(propName).ConfigureAwait(false);
+            };
+
+            // Change the twin from the service side and verify the device received it.
+            Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
+            {
+                var propValue = Guid.NewGuid().ToString();
+                testDeviceCallbackHandler.ExpectedTwinPropertyValue = propValue;
+
+                s_log.WriteLine($"{nameof(Twin_DeviceDesiredPropertyUpdateRecovery)}: name={propName}, value={propValue}");
+
+                Task serviceSendTask = RegistryManagerUpdateDesiredPropertyAsync(testDevice.Id, propName, propValue);
+                Task twinReceivedTask = testDeviceCallbackHandler.WaitForTwinCallbackAsync(cts.Token);
+
+                var tasks = new List<Task>() { serviceSendTask, twinReceivedTask };
+                while (tasks.Count > 0)
+                {
+                    Task completedTask = await Task.WhenAny(tasks).ConfigureAwait(false);
+                    completedTask.GetAwaiter().GetResult();
+                    tasks.Remove(completedTask);
+                }
+            };
+
+            await FaultInjection.TestErrorInjectionMuxedOverAmqpAsync(
+                DevicePrefix,
+                ConnectionStringAuthScope,
+                TestDeviceType.Sasl,
+                transport,
+                poolSize,
+                devicesCount,
                 faultType,
                 reason,
                 delayInSec,

--- a/e2e/test/TwinFaultInjectionTests.cs
+++ b/e2e/test/TwinFaultInjectionTests.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 Assert.AreEqual<String>(deviceTwin.Properties.Reported[propName].ToString(), propValue);
             };
 
-            await FaultInjection.TestErrorInjectionAsync(
+            await FaultInjection.TestErrorInjectionSingleDeviceAsync(
                 DevicePrefix,
                 TestDeviceType.Sasl,
                 transport,
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 }
             };
 
-            await FaultInjection.TestErrorInjectionAsync(
+            await FaultInjection.TestErrorInjectionSingleDeviceAsync(
                 DevicePrefix,
                 TestDeviceType.Sasl,
                 transport,

--- a/e2e/test/TwinFaultInjectionTests.cs
+++ b/e2e/test/TwinFaultInjectionTests.cs
@@ -215,6 +215,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                 reason,
                 delayInSec,
                 FaultInjection.DefaultDurationInSec,
+                false,
+                new List<Type> { },
                 (d, t) => { return Task.FromResult<bool>(false); },
                 testOperation,
                 () => { return Task.FromResult<bool>(false); }).ConfigureAwait(false);
@@ -258,14 +260,15 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 Task serviceSendTask = RegistryManagerUpdateDesiredPropertyAsync(testDevice.Id, propName, propValue);
                 Task twinReceivedTask = testDeviceCallbackHandler.WaitForTwinCallbackAsync(cts.Token);
-                
-                var tasks = new List<Task>() { serviceSendTask, twinReceivedTask };
-                while (tasks.Count > 0)
-                {
-                    Task completedTask = await Task.WhenAny(tasks).ConfigureAwait(false);
-                    completedTask.GetAwaiter().GetResult();
-                    tasks.Remove(completedTask);
-                }
+
+                // var tasks = new List<Task>() { serviceSendTask, twinReceivedTask };
+                await Task.WhenAll(serviceSendTask, twinReceivedTask).ConfigureAwait(false);
+                //while (tasks.Count > 0)
+                //{
+                //    Task completedTask = await Task.WhenAny(tasks).ConfigureAwait(false);
+                //    completedTask.GetAwaiter().GetResult();
+                //    tasks.Remove(completedTask);
+                //}
             };
 
             await FaultInjection.TestErrorInjectionSingleDeviceAsync(
@@ -276,6 +279,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                 reason,
                 delayInSec,
                 FaultInjection.DefaultDurationInSec,
+                false,
+                new List<Type> { },
                 initOperation,
                 testOperation,
                 () => { return Task.FromResult<bool>(false); }).ConfigureAwait(false);

--- a/e2e/test/TwinUtil.cs
+++ b/e2e/test/TwinUtil.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices.E2ETests
+{
+    public static class TwinUtil
+    {
+        public static async Task Twin_DeviceSetsReportedPropertyAndGetsItBack(DeviceClient deviceClient)
+        {
+            var propName = Guid.NewGuid().ToString();
+            var propValue = Guid.NewGuid().ToString();
+
+            TwinCollection props = new TwinCollection();
+            props[propName] = propValue;
+            await deviceClient.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
+
+            Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+            Assert.AreEqual<String>(deviceTwin.Properties.Reported[propName].ToString(), propValue);
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->
Multiplexing E2E tests: 

Basic scenario tests:
- [x] Telemetry

- [x] Methods

- [x] Twin

Fault injection tests:
- [ ] Telemetry

- [ ] Methods

- [ ] Twin

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
