### PR TITLE
AMQP token refresh timing, keeping method subscription active

### DIFF
--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1163,11 +1163,7 @@ namespace Microsoft.Azure.Devices.Client
 
         private Task DisableMethodAsync(CancellationToken cancellationToken)
         {
-            if (this.deviceMethods == null && this.deviceDefaultMethodCallback == null)
-            {
-                return InnerHandler.DisableMethodsAsync(cancellationToken);
-            }
-
+            // TODO # 890.
             return TaskHelpers.CompletedTask;
         }
 

--- a/iothub/device/src/IotHubConnectionString.Core.cs
+++ b/iothub/device/src/IotHubConnectionString.Core.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Devices.Client
                     if (Logging.IsEnabled && (TokenRefresher == null)) Logging.Fail(this, $"Cannot create SAS Token: no provider.", nameof(ICbsTokenProvider.GetTokenAsync));
                     Debug.Assert(TokenRefresher != null);
                     tokenValue = await this.TokenRefresher.GetTokenAsync(this.Audience).ConfigureAwait(false);
-                    expiresOn = this.TokenRefresher.ExpiresOn;
+                    expiresOn = this.TokenRefresher.RefreshesOn;
                 }
 
                 return new CbsToken(tokenValue, CbsConstants.IotHubSasTokenType, expiresOn);

--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.19.2-preview-amqp-002</Version>
+    <Version>1.19.2-preview-amqp-003</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/iothub/device/src/Transport/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Transport/RetryDelegatingHandler.cs
@@ -623,10 +623,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
             if (disposing)
             {
                 _handleDisconnectCts.Cancel();
-                base.Dispose(disposing);
             }
 
             _disposed = true;
+            base.Dispose(disposing);
         }
     }
 }

--- a/iothub/device/src/Transport/TransportHandler.cs
+++ b/iothub/device/src/Transport/TransportHandler.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
 
             _disposed = true;
+            base.Dispose(disposing);
         }
 
         protected void OnTransportClosedGracefully()

--- a/iothub/device/tests/DeviceClientTests.cs
+++ b/iothub/device/tests/DeviceClientTests.cs
@@ -718,7 +718,8 @@ namespace Microsoft.Azure.Devices.Client.Test
             await deviceClient.SetMethodHandlerAsync(methodName, null, null).ConfigureAwait(false);
             await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)), CancellationToken.None)).ConfigureAwait(false);
 
-            await innerHandler.Received().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
+            // TODO #890
+            await innerHandler.DidNotReceive().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsFalse(methodCallbackCalled);
         }
 
@@ -779,7 +780,8 @@ namespace Microsoft.Azure.Devices.Client.Test
             await deviceClient.SetMethodHandlerAsync(methodName, null, null).ConfigureAwait(false);
             await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)), CancellationToken.None)).ConfigureAwait(false);
 
-            await innerHandler.Received().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
+            // TODO #890
+            await innerHandler.DidNotReceive().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsFalse(methodCallbackCalled);
         }
 
@@ -839,7 +841,9 @@ namespace Microsoft.Azure.Devices.Client.Test
             methodCallbackCalled = false;
             await deviceClient.SetMethodDefaultHandlerAsync(null, null).ConfigureAwait(false);
             await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)), CancellationToken.None)).ConfigureAwait(false);
-            await innerHandler.Received().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
+
+            // TODO #890
+            await innerHandler.DidNotReceive().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsFalse(methodCallbackCalled);
         }
 
@@ -993,7 +997,8 @@ namespace Microsoft.Azure.Devices.Client.Test
             await deviceClient.SetMethodHandlerAsync(methodName, null, null).ConfigureAwait(false);
             await deviceClient.InternalClient.OnMethodCalled(new MethodRequestInternal(methodName, "fakeRequestId", new MemoryStream(Encoding.UTF8.GetBytes(methodBody)), CancellationToken.None)).ConfigureAwait(false);
 
-            await innerHandler.Received().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
+            //TODO #890
+            await innerHandler.DidNotReceive().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             Assert.IsFalse(methodCallbackCalled);
         }
 

--- a/versions.csv
+++ b/versions.csv
@@ -1,5 +1,5 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.19.2-preview-amqp-002
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.19.2-preview-amqp-003
 iothub\service\src\Microsoft.Azure.Devices.csproj, 1.17.2
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.15.2
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.2.2


### PR DESCRIPTION
1. AMQP token refresh timing fix; token refresh test enhancements
2. Keep method subscriptions active (similar to Twin, only if the application subscribed to methods at least once)
3. Increasing nuget version
