### PR TITLE
AMQP fixes

### DIFF
--- a/e2e/test/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/DeviceTokenRefreshE2ETests.cs
@@ -37,8 +37,6 @@ namespace Microsoft.Azure.Devices.E2ETests
             await DeviceClient_TokenIsRefreshed_Internal(Client.TransportType.Http1).ConfigureAwait(false);
         }
 
-        // TODO: #263 - Refactor AMQP token refresh test.
-        [Ignore]
         [TestMethod]
         public async Task DeviceClient_TokenIsRefreshed_Ok_Amqp()
         {
@@ -125,7 +123,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                         // Create the first Token.
                         Console.WriteLine($"[{DateTime.UtcNow}] OpenAsync");
                         await deviceClient.OpenAsync(cts.Token).ConfigureAwait(false);
-                        
+
                         Console.WriteLine($"[{DateTime.UtcNow}] SendEventAsync (1)");
                         await deviceClient.SendEventAsync(message, cts.Token).ConfigureAwait(false);
                         await refresher.WaitForTokenRefreshAsync(cts.Token).ConfigureAwait(false);
@@ -190,7 +188,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             private Stopwatch _stopwatch = new Stopwatch();
             private SemaphoreSlim _tokenRefreshSemaphore = new SemaphoreSlim(0);
             private int _counter;
-                       
+
             public TestTokenRefresher(string deviceId, string key) : base(deviceId)
             {
                 _key = key;

--- a/iothub/device/src/Message.cs
+++ b/iothub/device/src/Message.cs
@@ -615,20 +615,31 @@ namespace Microsoft.Azure.Devices.Client
         internal AmqpMessage ToAmqpMessage(bool setBodyCalled = true)
         {
             this.ThrowIfDisposed();
-            lock (this.messageLock)
+            if (this.serializedAmqpMessage == null)
             {
-                this.SetSizeInBytesCalled();
-                if (this.bodyStream == null)
+                lock (this.messageLock)
                 {
-                    this.serializedAmqpMessage = AmqpMessage.Create();
-                }
-                else
-                {
-                    this.serializedAmqpMessage = AmqpMessage.Create(this.bodyStream, false);
-                    if (!this.bodyStream.CanSeek) this.SetGetBodyCalled();
-                }
+                    if (this.serializedAmqpMessage == null)
+                    {
+                        // Interlocked exchange two variable does allow for a small period 
+                        // where one is set while the other is not. Not sure if it is worth
+                        // correct this gap. The intention of setting this two variable is
+                        // so that GetBody should not be called and all Properties are
+                        // readonly because the amqpMessage has been serialized.
 
-                this.serializedAmqpMessage = this.PopulateAmqpMessageForSend(this.serializedAmqpMessage);
+                        this.SetSizeInBytesCalled();
+                        if (this.bodyStream == null)
+                        {
+                            this.serializedAmqpMessage = AmqpMessage.Create();
+                        }
+                        else
+                        {
+                            this.serializedAmqpMessage = AmqpMessage.Create(this.bodyStream, false);
+                            this.SetGetBodyCalled();
+                        }
+                        this.serializedAmqpMessage = this.PopulateAmqpMessageForSend(this.serializedAmqpMessage);
+                    }
+                }
             }
 
             return this.serializedAmqpMessage;

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
         {
             if (Logging.IsEnabled) Logging.Enter(this, deviceIdentity, $"{nameof(RemoveDevice)}");
             bool removed = AmqpUnits.Remove(deviceIdentity);
-            if (removed && AmqpUnits.Count == 0)
+            if (removed && GetNumberOfUnits() == 0)
             {
                 // TODO #887: handle gracefulDisconnect
                 Shutdown();

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                 }
                 else if (AmqpConnection.IsClosing())
                 {
-                    throw new IotHubCommunicationException();
+                    throw new IotHubCommunicationException("AMQP connection is closing.");
                 }
                 else
                 {

--- a/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
@@ -575,11 +575,12 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
         {
             if (_disposed) return;
 
+            base.Dispose(disposing);
             if (disposing)
             {
                 _amqpUnit?.Dispose();
             }
-            base.Dispose(disposing);
+
         }
         #endregion
 

--- a/iothub/device/src/Transport/Amqp/AmqpUnit.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnit.cs
@@ -541,6 +541,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                 {
                     OnUnitDisconnected?.Invoke(false, EventArgs.Empty);
                 }
+
                 _amqpSession?.Abort();
                 if (Logging.IsEnabled) Logging.Exit(this, disposing, $"{nameof(Dispose)}");
             }

--- a/iothub/device/src/Transport/Amqp/AmqpUnit.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnit.cs
@@ -121,6 +121,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                     OnUnitDisconnected?.Invoke(false, EventArgs.Empty);
                 }
 
+                throw;
             }
             finally
             {

--- a/iothub/device/src/Transport/Amqp/AmqpUnit.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnit.cs
@@ -114,6 +114,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
                 if (Logging.IsEnabled) Logging.Associate(this, _messageSendingLink, $"{nameof(_messageSendingLink)}");
             }
+            catch (Exception ex) when (!ex.IsFatal())
+            {
+                if (SetNotUsable() == 0)
+                {
+                    OnUnitDisconnected?.Invoke(false, EventArgs.Empty);
+                }
+
+            }
             finally
             {
                 if (Logging.IsEnabled) Logging.Exit(this, timeout, $"{nameof(OpenAsync)}");
@@ -523,7 +531,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
         #endregion
 
         #region IDisposable
-        
+
         public void Dispose()
         {
             Dispose(true);

--- a/iothub/device/src/Transport/HttpTransportHandler.cs
+++ b/iothub/device/src/Transport/HttpTransportHandler.cs
@@ -120,16 +120,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         protected override void Dispose(bool disposing)
         {
-            try
+            if (_disposed) return;
+
+            base.Dispose(disposing);
+            if (disposing)
             {
-                if (disposing)
-                {
-                    this.httpClientHelper?.Dispose();
-                }
-            }
-            finally
-            {
-                base.Dispose(disposing);
+                this.httpClientHelper?.Dispose();
             }
         }
 

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -307,19 +307,15 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         protected override void Dispose(bool disposing)
         {
-            try
+            if (_disposed) return;
+
+            base.Dispose(disposing);
+            if (disposing)
             {
-                if (disposing)
+                if (this.TryStop())
                 {
-                    if (this.TryStop())
-                    {
-                        this.Cleanup();
-                    }
+                    this.Cleanup();
                 }
-            }
-            finally
-            {
-                base.Dispose(disposing);
             }
         }
 

--- a/iothub/device/src/Transport/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Transport/RetryDelegatingHandler.cs
@@ -620,11 +620,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             if (_disposed) return;
 
+            base.Dispose(disposing);
             if (disposing)
             {
                 _handleDisconnectCts.Cancel();
             }
-            base.Dispose(disposing);
+
         }
     }
 }

--- a/iothub/device/src/Transport/TransportHandler.cs
+++ b/iothub/device/src/Transport/TransportHandler.cs
@@ -32,12 +32,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             if (_disposed) return;
 
+            base.Dispose(disposing);
             if (disposing)
             {
                 OnTransportClosedGracefully();
             }
 
-            base.Dispose(disposing);
         }
 
         protected void OnTransportClosedGracefully()


### PR DESCRIPTION
1. Cherry-pick fix from the amqp branch.
2. Enable AMQP token test (accidentally disabled during merge).
3. Fix for AMQP OpenAsync session open bug that may cause retry to reuse a dropped `AmqpConnection`.
4. Fix for `AmqpMessage` reuse after it was sent to the Amqp library.
