### PR TITLE
AMQP should allow null AMQP app properties just like MQTT and HTTP. Properties with null value should not be dropped.

### DIFF
--- a/iothub/device/src/MessageConverter.cs
+++ b/iothub/device/src/MessageConverter.cs
@@ -222,10 +222,6 @@ namespace Microsoft.Azure.Devices.Client
         public static bool TryGetAmqpObjectFromNetObject(object netObject, MappingType mappingType, out object amqpObject)
         {
             amqpObject = null;
-            if (netObject == null)
-            {
-                return false;
-            }
 
             switch (SerializationUtilities.GetTypeId(netObject))
             {
@@ -288,6 +284,9 @@ namespace Microsoft.Azure.Devices.Client
                         amqpObject = new AmqpMap((IDictionary)netObject);
                     }
                     break;
+                case PropertyValueType.Null:
+                    amqpObject = string.Empty;
+                    break;
                 default:
                     break;
             }
@@ -298,10 +297,6 @@ namespace Microsoft.Azure.Devices.Client
         public static bool TryGetNetObjectFromAmqpObject(object amqpObject, MappingType mappingType, out object netObject)
         {
             netObject = null;
-            if (amqpObject == null)
-            {
-                return false;
-            }
 
             switch (SerializationUtilities.GetTypeId(amqpObject))
             {
@@ -381,6 +376,9 @@ namespace Microsoft.Azure.Devices.Client
                     {
                         netObject = amqpObject;
                     }
+                    break;
+                case PropertyValueType.Null:
+                    netObject = string.Empty;
                     break;
                 default:
                     break;

--- a/iothub/device/tests/MessageConverterTests.cs
+++ b/iothub/device/tests/MessageConverterTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             
                 amqpMessage.ApplicationProperties.Map["Prop1"] = "Value1";
                 amqpMessage.ApplicationProperties.Map["Prop2"] = "Value2";
+                amqpMessage.ApplicationProperties.Map["Prop3"] = null;
 
                 var message = new Message(bytes);
 
@@ -64,6 +65,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             
                 Assert.AreEqual("Value1", message.Properties["Prop1"]);
                 Assert.AreEqual("Value2", message.Properties["Prop2"]);
+                Assert.AreEqual(string.Empty, message.Properties["Prop3"]);
             }
         }
     }

--- a/iothub/service/src/MessageConverter.cs
+++ b/iothub/service/src/MessageConverter.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices
                     if (TryGetNetObjectFromAmqpObject(pair.Value, MappingType.ApplicationProperty, out netObject))
                     {
                         var stringObject = netObject as string;
-                        
+
                         if (stringObject != null)
                         {
                             switch (pair.Key.ToString())
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Devices
                             // TODO: RDBug 4093369 Handling of non-string property values in Amqp messages
                             // Drop non-string properties and log an error
                             Fx.Exception.TraceHandled(new InvalidDataException("IotHub does not accept non-string Amqp properties"), "MessageConverter.UpdateMessageHeaderAndProperties");
-                        }                        
+                        }
                     }
                 }
             }
@@ -195,10 +195,6 @@ namespace Microsoft.Azure.Devices
         public static bool TryGetAmqpObjectFromNetObject(object netObject, MappingType mappingType, out object amqpObject)
         {
             amqpObject = null;
-            if (netObject == null)
-            {
-                return false;
-            }
 
             switch (SerializationUtilities.GetTypeId(netObject))
             {
@@ -261,6 +257,9 @@ namespace Microsoft.Azure.Devices
                         amqpObject = new AmqpMap((IDictionary)netObject);
                     }
                     break;
+                case PropertyValueType.Null:
+                    amqpObject = string.Empty;
+                    break;
                 default:
                     break;
             }
@@ -271,10 +270,6 @@ namespace Microsoft.Azure.Devices
         public static bool TryGetNetObjectFromAmqpObject(object amqpObject, MappingType mappingType, out object netObject)
         {
             netObject = null;
-            if (amqpObject == null)
-            {
-                return false;
-            }
 
             switch (SerializationUtilities.GetTypeId(amqpObject))
             {
@@ -354,6 +349,9 @@ namespace Microsoft.Azure.Devices
                     {
                         netObject = amqpObject;
                     }
+                    break;
+                case PropertyValueType.Null:
+                    netObject = string.Empty;
                     break;
                 default:
                     break;


### PR DESCRIPTION
![AMQP](https://user-images.githubusercontent.com/4860052/55762284-3fa47180-5a17-11e9-9ff5-90a8d59c7339.png)
