### PR TITLE
Add support for Retry-After header to provisioning device client

### DIFF
--- a/common/src/device/provisioning/transport/RetryJitter.cs
+++ b/common/src/device/provisioning/transport/RetryJitter.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+using System.Diagnostics.CodeAnalysis;
+using System;
+
+namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
+{
+    /// <summary>
+    /// return the provided delay + extra jitter ranging from 0 seconds to 5 seconds
+    /// </summary>
+    internal class RetryJitter
+    {
+        private static int jitterMax = 5;
+        private static int jitterMin = 0;
+		
+        public static TimeSpan GenerateDelayWithJitterForRetry(TimeSpan defaultDelay)
+        {
+            Random random = new Random();
+            double jitterSeconds = random.NextDouble() * jitterMax + jitterMin;
+            TimeSpan defaultDelayWithJitter = defaultDelay.Add(TimeSpan.FromSeconds(jitterSeconds));
+            return defaultDelayWithJitter;
+        }
+    }
+}

--- a/provisioning/transport/amqp/src/DebugBuildConfiguration.cs
+++ b/provisioning/transport/amqp/src/DebugBuildConfiguration.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+#if (DEBUG)
+[assembly: InternalsVisibleTo("Microsoft.Azure.Devices.Provisioning.Transport.Amqp.UnitTests")]
+#endif

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -40,6 +40,9 @@
     <Compile Include="$(Common)\Logging.Common.cs">
       <Link>Common\Logging.Common.cs</Link>
     </Compile>
+    <Compile Include="$(Common)\device\provisioning\transport\RetryJitter.cs">
+      <Link>Common\device\provisioning\transport\RetryJitter.cs</Link>
+    </Compile>
     <Compile Include="$(Common)\Logging.ProvisioningTransport.Common.cs">
       <Link>Common\Logging.ProvisioningTransport.Common.cs</Link>
     </Compile>

--- a/provisioning/transport/amqp/src/ProvisioningErrorDetailsAmqp.cs
+++ b/provisioning/transport/amqp/src/ProvisioningErrorDetailsAmqp.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Amqp;
+using Microsoft.Azure.Amqp.Framing;
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
+{
+    [SuppressMessage("Microsoft.Performance", "CA1812", Justification = "Is instantiated by json convertor")]
+    internal class ProvisioningErrorDetailsAmqp : ProvisioningErrorDetails
+    {
+        /// <summary>
+        /// The time to wait before trying again if this error is transient
+        /// </summary>
+        internal TimeSpan? RetryAfter { get; set; }
+
+        public const string RetryAfterKey = "Retry-After";
+
+        public static TimeSpan? GetRetryAfterFromApplicationProperties(AmqpMessage amqpResponse, TimeSpan defaultInterval)
+        {
+            object retryAfter;
+            if (amqpResponse.ApplicationProperties != null && amqpResponse.ApplicationProperties.Map.TryGetValue(RetryAfterKey, out retryAfter))
+            {
+                int secondsToWait;
+                if (int.TryParse(retryAfter.ToString(), out secondsToWait))
+                {
+                    TimeSpan serviceRecommendedDelay = TimeSpan.FromSeconds(secondsToWait);
+
+                    if (serviceRecommendedDelay.TotalSeconds < defaultInterval.TotalSeconds)
+                    {
+                        return defaultInterval;
+                    }
+                    else
+                    {
+                        return serviceRecommendedDelay;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public static TimeSpan? GetRetryAfterFromRejection(Rejected rejected, TimeSpan defaultInterval)
+        {
+            if (rejected.Error != null && rejected.Error.Info != null)
+            {
+                object retryAfter;
+                if (rejected.Error.Info.TryGetValue(RetryAfterKey, out retryAfter))
+                {
+                    int secondsToWait = 0;
+                    if (int.TryParse(retryAfter.ToString(), out secondsToWait))
+                    {
+                        if (secondsToWait < defaultInterval.Seconds)
+                        {
+                            return defaultInterval;
+                        }
+                        else
+                        {
+                            return TimeSpan.FromSeconds(secondsToWait);
+                        }
+                    }
+                }
+                
+            }
+
+            return null;
+        }
+    }
+}

--- a/provisioning/transport/amqp/tests/ProvisioningErrorDetailsAmqpTests.cs
+++ b/provisioning/transport/amqp/tests/ProvisioningErrorDetailsAmqpTests.cs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Amqp;
+using Microsoft.Azure.Amqp.Encoding;
+using Microsoft.Azure.Amqp.Framing;
+using Microsoft.Azure.Devices.Provisioning.Client.Transport;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.Devices.Provisioning.Transport.Amqp.UnitTests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class ProvisioningErrorDetailsAmqpTests
+    {
+        private static TimeSpan defaultInterval = TimeSpan.FromSeconds(2);
+
+        [TestMethod]
+        public void GetRetryFromRejectedSuccess()
+        {
+            int expectedSeconds = 32;
+            Rejected Rejected = new Rejected();
+            Rejected.Error = new Error();
+            Rejected.Error.Info = new Fields();
+            Rejected.Error.Info.Add(new AmqpSymbol("Retry-After"), expectedSeconds);
+
+            TimeSpan? actual = ProvisioningErrorDetailsAmqp.GetRetryAfterFromRejection(Rejected, defaultInterval);
+
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(actual?.Seconds, expectedSeconds);
+        }
+
+        [TestMethod]
+        public void GetRetryFromRejectedFallsBackToDefaultIfNegativeRetryAfterProvided()
+        {
+            int expectedSeconds = -1;
+            Rejected rejected = new Rejected();
+            rejected.Error = new Error();
+            rejected.Error.Info = new Fields();
+            rejected.Error.Info.Add(new Azure.Amqp.Encoding.AmqpSymbol("Retry-After"), expectedSeconds);
+
+            TimeSpan? actual = ProvisioningErrorDetailsAmqp.GetRetryAfterFromRejection(rejected, defaultInterval);
+
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(actual?.Seconds, defaultInterval.Seconds);
+        }
+
+        [TestMethod]
+        public void GetRetryFromRejectedFallsBackToDefaultIfRetryAfterProvidedIs0()
+        {
+            int expectedSeconds = 0;
+            Rejected rejected = new Rejected();
+            rejected.Error = new Error();
+            rejected.Error.Info = new Fields();
+            rejected.Error.Info.Add(new Azure.Amqp.Encoding.AmqpSymbol("Retry-After"), expectedSeconds);
+
+            TimeSpan? actual = ProvisioningErrorDetailsAmqp.GetRetryAfterFromRejection(rejected, defaultInterval);
+
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(actual?.Seconds, defaultInterval.Seconds);
+        }
+
+        [TestMethod]
+        public void GetRetryFromRejectedReturnsNullIfNoErrorInfoEntries()
+        {
+            Rejected rejected = new Rejected();
+            rejected.Error = new Error();
+            rejected.Error.Info = new Fields();
+
+            TimeSpan? actual = ProvisioningErrorDetailsAmqp.GetRetryAfterFromRejection(rejected, defaultInterval);
+
+            Assert.IsNull(actual);
+        }
+
+        [TestMethod]
+        public void GetRetryFromRejectedReturnsNullIfNoErrorInfo()
+        {
+            Rejected rejected = new Rejected();
+            rejected.Error = new Error();
+
+            TimeSpan? actual = ProvisioningErrorDetailsAmqp.GetRetryAfterFromRejection(rejected, defaultInterval);
+
+            Assert.IsNull(actual);
+        }
+
+        [TestMethod]
+        public void GetRetryFromRejectedReturnsNullIfNoError()
+        {
+            Rejected rejected = new Rejected();
+
+            TimeSpan? actual = ProvisioningErrorDetailsAmqp.GetRetryAfterFromRejection(rejected, defaultInterval);
+
+            Assert.IsNull(actual);
+        }
+
+        [TestMethod]
+        public void GetRetryAfterFromApplicationPropertiesSuccess()
+        {
+            int expectedRetryAfter = 42;
+            AmqpMessage amqpResponse = AmqpMessage.Create();
+            amqpResponse.ApplicationProperties = new ApplicationProperties();
+            amqpResponse.ApplicationProperties.Map.Add(new MapKey("Retry-After"), expectedRetryAfter);
+            TimeSpan? actual = ProvisioningErrorDetailsAmqp.GetRetryAfterFromApplicationProperties(amqpResponse, defaultInterval);
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(expectedRetryAfter, actual?.Seconds);
+        }
+
+        [TestMethod]
+        public void GetRetryAfterFromApplicationPropertiesReturnsDefaultIfRetryAfterValueIsNegative()
+        {
+            int expectedRetryAfter = -1;
+            AmqpMessage amqpResponse = AmqpMessage.Create();
+            amqpResponse.ApplicationProperties = new ApplicationProperties();
+            amqpResponse.ApplicationProperties.Map.Add(new MapKey("Retry-After"), expectedRetryAfter);
+            TimeSpan? actual = ProvisioningErrorDetailsAmqp.GetRetryAfterFromApplicationProperties(amqpResponse, defaultInterval);
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(defaultInterval.Seconds, actual?.Seconds);
+        }
+
+        [TestMethod]
+        public void GetRetryAfterFromApplicationPropertiesReturnsDefaultIfRetryAfterValueIsZero()
+        {
+            int expectedRetryAfter = 0;
+            AmqpMessage amqpResponse = AmqpMessage.Create();
+            amqpResponse.ApplicationProperties = new ApplicationProperties();
+            amqpResponse.ApplicationProperties.Map.Add(new MapKey("Retry-After"), expectedRetryAfter);
+            TimeSpan? actual = ProvisioningErrorDetailsAmqp.GetRetryAfterFromApplicationProperties(amqpResponse, defaultInterval);
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(defaultInterval.Seconds, actual?.Seconds);
+        }
+
+        [TestMethod]
+        public void GetRetryAfterFromApplicationPropertiesReturnsNullIfNoRetryAfterApplicationProperty()
+        {
+            AmqpMessage amqpResponse = AmqpMessage.Create();
+            amqpResponse.ApplicationProperties = new ApplicationProperties();
+            TimeSpan? actual = ProvisioningErrorDetailsAmqp.GetRetryAfterFromApplicationProperties(amqpResponse, defaultInterval);
+            Assert.IsNull(actual);
+        }
+
+        [TestMethod]
+        public void GetRetryAfterFromApplicationPropertiesReturnsNullIfNoApplicationProperties()
+        {
+            AmqpMessage amqpResponse = AmqpMessage.Create();
+            TimeSpan? actual = ProvisioningErrorDetailsAmqp.GetRetryAfterFromApplicationProperties(amqpResponse, defaultInterval);
+            Assert.IsNull(actual);
+        }
+    }
+}

--- a/provisioning/transport/amqp/tests/RetryJitterTests.cs
+++ b/provisioning/transport/amqp/tests/RetryJitterTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Provisioning.Client.Transport;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Microsoft.Azure.Devices.Provisioning.Transport.Amqp.UnitTests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class RetryJitterTests
+    {
+        [TestMethod]
+        public void RetryJitterGeneratedDelayLargerOrEqualToDefaultDelay()
+        {
+            int expectedMinimumDelay = 2;
+            TimeSpan DefaultDelay = TimeSpan.FromSeconds(expectedMinimumDelay);
+            TimeSpan GeneratedDelay = RetryJitter.GenerateDelayWithJitterForRetry(DefaultDelay);
+            Assert.IsNotNull(GeneratedDelay);
+            Assert.IsTrue(GeneratedDelay.Seconds >= DefaultDelay.Seconds);
+        }
+
+        [TestMethod]
+        public void RetryJitterGeneratedDelayNoLargerThanFiveSeconds()
+        {
+            //current maximum jitter delay is 5 seconds, may change in the future
+            int expectedMinimumDelay = 0;
+            TimeSpan DefaultDelay = TimeSpan.FromSeconds(expectedMinimumDelay);
+            TimeSpan GeneratedDelay = RetryJitter.GenerateDelayWithJitterForRetry(DefaultDelay);
+            Assert.IsNotNull(GeneratedDelay);
+            Assert.IsTrue(GeneratedDelay.Seconds <= 5);
+        }
+    }
+}

--- a/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
+++ b/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
@@ -40,6 +40,9 @@
     <Compile Include="$(Common)\Logging.Common.cs">
       <Link>Common\Logging.Common.cs</Link>
     </Compile>
+    <Compile Include="$(Common)\device\provisioning\transport\RetryJitter.cs">
+      <Link>Common\device\provisioning\transport\RetryJitter.cs</Link>
+    </Compile>
     <Compile Include="$(Common)\Logging.ProvisioningTransport.Common.cs">
       <Link>Common\Logging.ProvisioningTransport.Common.cs</Link>
     </Compile>  

--- a/provisioning/transport/http/src/ProvisioningErrorDetailsHttp.cs
+++ b/provisioning/transport/http/src/ProvisioningErrorDetailsHttp.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
+{
+    [SuppressMessage("Microsoft.Performance", "CA1812", Justification = "Is instantiated by json convertor")]
+    internal class ProvisioningErrorDetailsHttp : ProvisioningErrorDetails
+    {
+        /// <summary>
+        /// The time to wait before trying again if this error is transient
+        /// </summary>
+        internal TimeSpan? RetryAfter { get; set; }
+    }
+}

--- a/provisioning/transport/mqtt/src/DebugBuildConfiguration.cs
+++ b/provisioning/transport/mqtt/src/DebugBuildConfiguration.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+#if (DEBUG)
+[assembly: InternalsVisibleTo("Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.UnitTests")]
+#endif

--- a/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
+++ b/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
@@ -40,6 +40,9 @@
     <Compile Include="$(Common)\Logging.Common.cs">
       <Link>Common\Logging.Common.cs</Link>
     </Compile>
+    <Compile Include="$(Common)\device\provisioning\transport\RetryJitter.cs">
+      <Link>Common\device\provisioning\transport\RetryJitter.cs</Link>
+    </Compile>
     <Compile Include="$(Common)\Logging.ProvisioningTransport.Common.cs">
       <Link>Common\Logging.ProvisioningTransport.Common.cs</Link>
     </Compile>

--- a/provisioning/transport/mqtt/src/ProvisioningChannelHandlerAdapter.cs
+++ b/provisioning/transport/mqtt/src/ProvisioningChannelHandlerAdapter.cs
@@ -9,12 +9,10 @@ using Microsoft.Azure.Devices.Shared;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Net;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -37,7 +35,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
         private const string RegisterTopic = "$dps/registrations/PUT/iotdps-register/?$rid={0}";
         private const string GetOperationsTopic = "$dps/registrations/GET/iotdps-get-operationstatus/?$rid={0}&operationId={1}";
         private static readonly Regex RegistrationStatusTopicRegex = new Regex("^\\$dps/registrations/res/(.*?)/\\?\\$rid=(.*?)$", RegexOptions.Compiled);
-        private static readonly TimeSpan s_defaultOperationPoolingIntervalMilliseconds = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan s_defaultOperationPoolingInterval = TimeSpan.FromSeconds(2);
 
         private const string Registration = "registration";
 
@@ -323,9 +321,15 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 {
                     if (statusCode >= HttpStatusCode.BadRequest)
                     {
-                        var errorDetails = JsonConvert.DeserializeObject<ProvisioningErrorDetails>(jsonData);
+                        var errorDetails = JsonConvert.DeserializeObject<ProvisioningErrorDetailsMqtt>(jsonData);
 
                         bool isTransient = statusCode >= HttpStatusCode.InternalServerError || (int)statusCode == 429;
+
+                        if (isTransient)
+                        {
+                            errorDetails.RetryAfter = ProvisioningErrorDetailsMqtt.GetRetryAfterFromTopic(topicName, s_defaultOperationPoolingInterval);
+                        }
+
                         await FailWithExceptionAsync(
                              context,
                              new ProvisioningTransportException(
@@ -356,11 +360,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 //"{\"operationId\":\"0.indcertdevice1.e50c0fa7-8b9b-4b3d-8374-02d71377886f\",\"status\":\"assigning\"}"
                 var operation = JsonConvert.DeserializeObject<RegistrationOperationStatus>(jsonData);
                 operationId = operation.OperationId;
+                operation.RetryAfter = ProvisioningErrorDetailsMqtt.GetRetryAfterFromTopic(packet.TopicName, s_defaultOperationPoolingInterval);
 
                 if (string.CompareOrdinal(operation.Status, RegistrationOperationStatus.OperationStatusAssigning) == 0 ||
                     string.CompareOrdinal(operation.Status, RegistrationOperationStatus.OperationStatusUnassigned) == 0)
                 {
-                    await Task.Delay(s_defaultOperationPoolingIntervalMilliseconds).ConfigureAwait(true);
+                    await Task.Delay(operation.RetryAfter ?? RetryJitter.GenerateDelayWithJitterForRetry(s_defaultOperationPoolingInterval)).ConfigureAwait(true);
                     ChangeState(State.WaitForStatus, State.WaitForPubAck);
                     await PublishGetOperationAsync(context, operationId).ConfigureAwait(true);
                 }

--- a/provisioning/transport/mqtt/src/ProvisioningErrorDetailsMqtt.cs
+++ b/provisioning/transport/mqtt/src/ProvisioningErrorDetailsMqtt.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
+{
+    [SuppressMessage("Microsoft.Performance", "CA1812", Justification = "Is instantiated by json convertor")]
+    internal class ProvisioningErrorDetailsMqtt : ProvisioningErrorDetails
+    {
+        private const string RetryAfterHeader = "Retry-After";
+
+        /// <summary>
+        /// The time to wait before trying again if this error is transient
+        /// </summary>
+        internal TimeSpan? RetryAfter { get; set; }
+
+        public static TimeSpan? GetRetryAfterFromTopic(string topic, TimeSpan defaultPoolingInterval)
+        {
+            string[] topicAndQueryString = topic.Split('?');
+            if (topicAndQueryString.Length > 1)
+            {
+                string[] queryPairs = topicAndQueryString[1].Split('&');
+                for (int queryPairIndex = 0; queryPairIndex < queryPairs.Length; queryPairIndex++)
+                {
+                    string[] queryKeyAndValue = queryPairs[queryPairIndex].Split('=');
+                    if (queryKeyAndValue.Length == 2 && queryKeyAndValue[0].Equals(RetryAfterHeader, StringComparison.OrdinalIgnoreCase))
+                    {
+                        int secondsToWait;
+                        if (int.TryParse(queryKeyAndValue[1], out secondsToWait))
+                        {
+                            TimeSpan serviceRecommendedDelay = TimeSpan.FromSeconds(secondsToWait);
+
+                            if (serviceRecommendedDelay.TotalSeconds < defaultPoolingInterval.TotalSeconds)
+                            {
+                                return defaultPoolingInterval;
+                            }
+                            else
+                            {
+                                return serviceRecommendedDelay;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/provisioning/transport/mqtt/tests/ProvisioningErrorDetailsMqttTests.cs
+++ b/provisioning/transport/mqtt/tests/ProvisioningErrorDetailsMqttTests.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Provisioning.Client.Transport;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.UnitTests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class ProvisioningErrorDetailsMqttTests
+    {
+        private static double? throttledDelay = 32;
+        private static string validTopicNameThrottled = $"$dps/registrations/res/429/?$rid=9&Retry-After={throttledDelay}";
+
+        private static double? acceptedDelay = 23;
+        private static string validTopicNameAccepted = $"$dps/registrations/res/202/?$rid=9&Retry-After={acceptedDelay}";
+
+        private TimeSpan defaultInterval = TimeSpan.FromSeconds(2);
+
+        [TestMethod]
+        public void testRetryAfterValidThrottled()
+        {
+            TimeSpan? actual = ProvisioningErrorDetailsMqtt.GetRetryAfterFromTopic(validTopicNameThrottled, defaultInterval);
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(throttledDelay, actual?.Seconds);
+        }
+
+        [TestMethod]
+        public void testRetryAfterValidAccepted()
+        {
+            TimeSpan? actual = ProvisioningErrorDetailsMqtt.GetRetryAfterFromTopic(validTopicNameAccepted, defaultInterval);
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(acceptedDelay, actual?.Seconds);
+        }
+
+        [TestMethod]
+        public void testRetryAfterWithNoRetryAfterValue()
+        {
+            string invalidTopic = "$dps/registrations/res/429/?$rid=9&Retry-After=";
+            TimeSpan? actual = ProvisioningErrorDetailsMqtt.GetRetryAfterFromTopic(invalidTopic, defaultInterval);
+            Assert.IsNull(actual);
+        }
+
+        [TestMethod]
+        public void testRetryAfterWithNoRetryAfterQueryKeyOrValue()
+        {
+            string invalidTopic = "$dps/registrations/res/429/?$rid=9";
+            TimeSpan? actual = ProvisioningErrorDetailsMqtt.GetRetryAfterFromTopic(invalidTopic, defaultInterval);
+            Assert.IsNull(actual);
+        }
+
+        [TestMethod]
+        public void testRetryAfterWithNoQueryString()
+        {
+            string invalidTopic = "$dps/registrations/res/429/";
+            TimeSpan? actual = ProvisioningErrorDetailsMqtt.GetRetryAfterFromTopic(invalidTopic, defaultInterval);
+            Assert.IsNull(actual);
+        }
+
+        [TestMethod]
+        public void testRetryAfterWithNoTopicString()
+        {
+            string invalidTopic = "";
+            TimeSpan? actual = ProvisioningErrorDetailsMqtt.GetRetryAfterFromTopic(invalidTopic, defaultInterval);
+            Assert.IsNull(actual);
+        }
+
+        [TestMethod]
+        public void testRetryAfterWithTooSmallOfDelayChoosesDefault()
+        {
+            string invalidTopic = "$dps/registrations/res/429/?$rid=9&Retry-After=0";
+            TimeSpan? actual = ProvisioningErrorDetailsMqtt.GetRetryAfterFromTopic(invalidTopic, defaultInterval);
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(defaultInterval.Seconds, actual?.Seconds);
+        }
+
+        [TestMethod]
+        public void testRetryAfterWithNegativeDelayChoosesDefault()
+        {
+            string invalidTopic = "$dps/registrations/res/429/?$rid=9&Retry-After=-1";
+            TimeSpan? actual = ProvisioningErrorDetailsMqtt.GetRetryAfterFromTopic(invalidTopic, defaultInterval);
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(defaultInterval.Seconds, actual?.Seconds);
+        }
+    }
+}


### PR DESCRIPTION
Http handled the header already, but added support to amqp and mqtt.

DPS has added a new header to DeviceRegistrationOperation responses that should dictate how long to wait before retrying. When this value is not provided, the SDK defaults to 2 seconds between operations.