### PR TITLE
Implement connection status check with statistical results from multiple runs.

### DIFF
--- a/e2e/test/CombinedClientOperationsMultiplexingOverAmqpTests.cs
+++ b/e2e/test/CombinedClientOperationsMultiplexingOverAmqpTests.cs
@@ -115,7 +115,6 @@ namespace Microsoft.Azure.Devices.E2ETests
             ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
 
             // Message payload for C2D operation
-            string payload, messageId, p1Value;
             Dictionary<string, List<string>> messagesSent = new Dictionary<string, List<string>>();
 
             // Twin properties
@@ -127,7 +126,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 // Send C2D Message
                 _log.WriteLine($"{nameof(CombinedClientOperationsMultiplexingOverAmqpTests)}: Send C2D for device={testDevice.Id}");
-                Message msg = MessageReceiveE2ETests.ComposeC2DTestMessage(out payload, out messageId, out p1Value);
+                (Message msg, string messageId, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2DTestMessage();
                 messagesSent.Add(testDevice.Id, new List<string> { payload, p1Value });
                 var sendC2DMessage = serviceClient.SendAsync(testDevice.Id, msg);
                 initOperations.Add(sendC2DMessage);
@@ -161,8 +160,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                 // C2D Operation
                 _log.WriteLine($"{nameof(CombinedClientOperationsMultiplexingOverAmqpTests)}: Operation 2: Receive C2D for device={testDevice.Id}");
                 List<string> msgSent = messagesSent[testDevice.Id];
-                payload = msgSent[0];
-                p1Value = msgSent[1];
+                var payload = msgSent[0];
+                var p1Value = msgSent[1];
                 var verifyDeviceClientReceivesMessage = MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, payload, p1Value);
                 clientOperations.Add(verifyDeviceClientReceivesMessage);
 

--- a/e2e/test/CombinedClientOperationsMultiplexingOverAmqpTests.cs
+++ b/e2e/test/CombinedClientOperationsMultiplexingOverAmqpTests.cs
@@ -26,99 +26,90 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        public async Task Message_DeviceSak_DeviceCombinedClientOperations_MuxWithoutPooling_Amqp()
+        public async Task DeviceSak_DeviceCombinedClientOperations_MuxWithoutPooling_Amqp()
         {
             await DeviceCombinedClientOperations(
                 Client.TransportType.Amqp_Tcp_Only,
                 MultiplexingOverAmqp.MuxWithoutPoolingPoolSize,
                 MultiplexingOverAmqp.MuxWithoutPoolingDevicesCount,
-                ConnectionStringAuthScope.Device
-                ).ConfigureAwait(false);
+                ConnectionStringAuthScope.Device).ConfigureAwait(false);
         }
 
         [TestMethod]
-        public async Task Message_DeviceSak_DeviceCombinedClientOperations_MuxWithoutPooling_AmqpWs()
+        public async Task DeviceSak_DeviceCombinedClientOperations_MuxWithoutPooling_AmqpWs()
         {
             await DeviceCombinedClientOperations(
                 Client.TransportType.Amqp_WebSocket_Only,
                 MultiplexingOverAmqp.MuxWithoutPoolingPoolSize,
                 MultiplexingOverAmqp.MuxWithoutPoolingDevicesCount,
-                ConnectionStringAuthScope.Device
-                ).ConfigureAwait(false);
+                ConnectionStringAuthScope.Device).ConfigureAwait(false);
         }
 
         [TestMethod]
-        public async Task Message_DeviceSak_DeviceCombinedClientOperations_MuxWithPooling_Amqp()
+        public async Task DeviceSak_DeviceCombinedClientOperations_MuxWithPooling_Amqp()
         {
             await DeviceCombinedClientOperations(
                 Client.TransportType.Amqp_Tcp_Only,
                 MultiplexingOverAmqp.MuxWithPoolingPoolSize,
                 MultiplexingOverAmqp.MuxWithPoolingDevicesCount,
-                ConnectionStringAuthScope.Device
-                ).ConfigureAwait(false);
+                ConnectionStringAuthScope.Device).ConfigureAwait(false);
         }
 
         [TestMethod]
-        public async Task Message_DeviceSak_DeviceCombinedClientOperations_MuxWithPooling_AmqpWs()
+        public async Task DeviceSak_DeviceCombinedClientOperations_MuxWithPooling_AmqpWs()
         {
             await DeviceCombinedClientOperations(
                 Client.TransportType.Amqp_WebSocket_Only,
                 MultiplexingOverAmqp.MuxWithPoolingPoolSize,
                 MultiplexingOverAmqp.MuxWithPoolingDevicesCount,
-                ConnectionStringAuthScope.Device
-                ).ConfigureAwait(false);
+                ConnectionStringAuthScope.Device).ConfigureAwait(false);
         }
 
         [TestMethod]
-        public async Task Message_IoTHubSak_DeviceCombinedClientOperations_MuxWithoutPooling_Amqp()
+        public async Task IoTHubSak_DeviceCombinedClientOperations_MuxWithoutPooling_Amqp()
         {
             await DeviceCombinedClientOperations(
                 Client.TransportType.Amqp_Tcp_Only,
                 MultiplexingOverAmqp.MuxWithoutPoolingPoolSize,
                 MultiplexingOverAmqp.MuxWithoutPoolingDevicesCount,
-                ConnectionStringAuthScope.IoTHub
-                ).ConfigureAwait(false);
+                ConnectionStringAuthScope.IoTHub).ConfigureAwait(false);
         }
 
         [TestMethod]
-        public async Task Message_IoTHubSak_DeviceCombinedClientOperations_MuxWithoutPooling_AmqpWs()
+        public async Task IoTHubSak_DeviceCombinedClientOperations_MuxWithoutPooling_AmqpWs()
         {
             await DeviceCombinedClientOperations(
                 Client.TransportType.Amqp_WebSocket_Only,
                 MultiplexingOverAmqp.MuxWithoutPoolingPoolSize,
                 MultiplexingOverAmqp.MuxWithoutPoolingDevicesCount,
-                ConnectionStringAuthScope.IoTHub
-                ).ConfigureAwait(false);
+                ConnectionStringAuthScope.IoTHub).ConfigureAwait(false);
         }
 
         [TestMethod]
-        public async Task Message_IoTHubSak_DeviceCombinedClientOperations_MuxWithPooling_Amqp()
+        public async Task IoTHubSak_DeviceCombinedClientOperations_MuxWithPooling_Amqp()
         {
             await DeviceCombinedClientOperations(
                 Client.TransportType.Amqp_Tcp_Only,
                 MultiplexingOverAmqp.MuxWithPoolingPoolSize,
                 MultiplexingOverAmqp.MuxWithPoolingDevicesCount,
-                ConnectionStringAuthScope.IoTHub
-                ).ConfigureAwait(false);
+                ConnectionStringAuthScope.IoTHub).ConfigureAwait(false);
         }
 
         [TestMethod]
-        public async Task Message_IoTHubSak_DeviceCombinedClientOperations_MuxWithPooling_AmqpWs()
+        public async Task IoTHubSak_DeviceCombinedClientOperations_MuxWithPooling_AmqpWs()
         {
             await DeviceCombinedClientOperations(
                 Client.TransportType.Amqp_WebSocket_Only,
                 MultiplexingOverAmqp.MuxWithPoolingPoolSize,
                 MultiplexingOverAmqp.MuxWithPoolingDevicesCount,
-                ConnectionStringAuthScope.IoTHub
-                ).ConfigureAwait(false);
+                ConnectionStringAuthScope.IoTHub).ConfigureAwait(false);
         }
 
         private async Task DeviceCombinedClientOperations(
             Client.TransportType transport,
             int poolSize,
             int devicesCount,
-            ConnectionStringAuthScope authScope
-            )
+            ConnectionStringAuthScope authScope)
         {
             // Initialize service client for service-side operations
             ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
@@ -215,8 +206,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 devicesCount,
                 initOperation,
                 testOperation,
-                cleanupOperation
-                ).ConfigureAwait(false);
+                cleanupOperation).ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/e2e/test/CombinedClientOperationsMultiplexingOverAmqpTests.cs
+++ b/e2e/test/CombinedClientOperationsMultiplexingOverAmqpTests.cs
@@ -197,6 +197,9 @@ namespace Microsoft.Azure.Devices.E2ETests
                 {
                     deviceClient.Dispose();
                 }
+
+                messagesSent.Clear();
+                twinPropertyMap.Clear();
             };
 
             await MultiplexingOverAmqp.TestMultiplexingOperationAsync(

--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -76,6 +76,8 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <!-- Note: 4.1.3 is the last ServiceBus release supporting net451. -->
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.3" />
+    <!-- .NET 4.5.1 requires the System.ValueTuple NuGet package to be referenced explicitly. -->
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <!-- NetCore and .NET 4.7 -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">

--- a/e2e/test/IoTHubServiceProxyE2ETests.cs
+++ b/e2e/test/IoTHubServiceProxyE2ETests.cs
@@ -68,9 +68,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             using (DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString))
             using (ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(ConnectionString, TransportType.Amqp, transportSettings))
             {
-                string payload;
-                string p1Value;
-                Message testMessage = ComposeD2CTestMessage(out payload, out p1Value);
+                (Message testMessage, string messageId, string payload, string p1Value) = ComposeD2CTestMessage();
                 await serviceClient.SendAsync(testDevice.Id, testMessage).ConfigureAwait(false);
 
                 await deviceClient.CloseAsync().ConfigureAwait(false);
@@ -105,17 +103,20 @@ namespace Microsoft.Azure.Devices.E2ETests
             }
         }
 
-       private Message ComposeD2CTestMessage(out string payload, out string p1Value)
+        private (Message message, string messageId, string payload, string p1Value) ComposeD2CTestMessage()
         {
-            payload = Guid.NewGuid().ToString();
-            p1Value = Guid.NewGuid().ToString();
+            var messageId = Guid.NewGuid().ToString();
+            var payload = Guid.NewGuid().ToString();
+            var p1Value = Guid.NewGuid().ToString();
 
-            _log.WriteLine($"{nameof(ComposeD2CTestMessage)}: payload='{payload}' p1Value='{p1Value}'");
-
-            return new Message(Encoding.UTF8.GetBytes(payload))
+            _log.WriteLine($"{nameof(ComposeD2CTestMessage)}: messageId='{messageId}' payload='{payload}' p1Value='{p1Value}'");
+            var message = new Message(Encoding.UTF8.GetBytes(payload))
             {
+                MessageId = messageId,
                 Properties = { ["property1"] = p1Value }
             };
+
+            return (message, messageId, payload, p1Value);
         }
 
         public void Dispose()

--- a/e2e/test/MessageReceiveE2EMultiplexingOverAmqpTests.cs
+++ b/e2e/test/MessageReceiveE2EMultiplexingOverAmqpTests.cs
@@ -124,11 +124,10 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // Initialize the service client
             ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
-            string payload, messageId, p1Value;
 
             Func<DeviceClient, TestDevice, Task> initOperation = async (deviceClient, testDevice) =>
             {
-                Message msg = MessageReceiveE2ETests.ComposeC2DTestMessage(out payload, out messageId, out p1Value);
+                (Message msg, string messageId, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2DTestMessage();
                 messagesSent.Add(testDevice.Id, new List<string> { payload, p1Value });
 
                 await serviceClient.SendAsync(testDevice.Id, msg).ConfigureAwait(false);
@@ -140,8 +139,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                 await deviceClient.OpenAsync().ConfigureAwait(false);
 
                 List<string> msgSent = messagesSent[testDevice.Id];
-                payload = msgSent[0];
-                p1Value = msgSent[1];
+                string payload = msgSent[0];
+                string p1Value = msgSent[1];
 
                 await MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, payload, p1Value).ConfigureAwait(false);
             };

--- a/e2e/test/MessageReceiveE2EMultiplexingOverAmqpTests.cs
+++ b/e2e/test/MessageReceiveE2EMultiplexingOverAmqpTests.cs
@@ -155,6 +155,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                 {
                     deviceClient.Dispose();
                 }
+
+                messagesSent.Clear();
             };
 
             await MultiplexingOverAmqp.TestMultiplexingOperationAsync(

--- a/e2e/test/MessageReceiveE2ETests.cs
+++ b/e2e/test/MessageReceiveE2ETests.cs
@@ -100,19 +100,20 @@ namespace Microsoft.Azure.Devices.E2ETests
             await ReceiveSingleMessage(TestDeviceType.X509, Client.TransportType.Http1).ConfigureAwait(false);
         }
 
-        public static Message ComposeC2DTestMessage(out string payload, out string messageId, out string p1Value)
+        public static (Message message, string messageId, string payload, string p1Value) ComposeC2DTestMessage()
         {
-            payload = Guid.NewGuid().ToString();
-            messageId = Guid.NewGuid().ToString();
-            p1Value = Guid.NewGuid().ToString();
+            var payload = Guid.NewGuid().ToString();
+            var messageId = Guid.NewGuid().ToString();
+            var p1Value = Guid.NewGuid().ToString();
 
-            _log.WriteLine($"{nameof(ComposeC2DTestMessage)}: payload='{payload}' messageId='{messageId}' p1Value='{p1Value}'");
-
-            return new Message(Encoding.UTF8.GetBytes(payload))
+            _log.WriteLine($"{nameof(ComposeC2DTestMessage)}: messageId='{messageId}' payload='{payload}' p1Value='{p1Value}'");
+            var message = new Message(Encoding.UTF8.GetBytes(payload))
             {
                 MessageId = messageId,
                 Properties = { ["property1"] = p1Value }
             };
+
+            return (message, messageId, payload, p1Value);
         }
 
         public static async Task VerifyReceivedC2DMessageAsync(Client.TransportType transport, DeviceClient dc, string payload, string p1Value)
@@ -167,10 +168,9 @@ namespace Microsoft.Azure.Devices.E2ETests
                     await deviceClient.ReceiveAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
                 }
 
-                string payload, messageId, p1Value;
                 await serviceClient.OpenAsync().ConfigureAwait(false);
 
-                Message msg = ComposeC2DTestMessage(out payload, out messageId, out p1Value);
+                (Message msg, string messageId, string payload, string p1Value) = ComposeC2DTestMessage();
                 await serviceClient.SendAsync(testDevice.Id, msg).ConfigureAwait(false);
                 await VerifyReceivedC2DMessageAsync(transport, deviceClient, payload, p1Value).ConfigureAwait(false);
 

--- a/e2e/test/MessageReceiveFaultInjectionTests.cs
+++ b/e2e/test/MessageReceiveFaultInjectionTests.cs
@@ -182,19 +182,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
-        private Client.Message ComposeD2CTestMessage(out string payload, out string p1Value)
-        {
-            payload = Guid.NewGuid().ToString();
-            p1Value = Guid.NewGuid().ToString();
-
-            _log.WriteLine($"{nameof(ComposeD2CTestMessage)}: payload='{payload}' p1Value='{p1Value}'");
-
-            return new Client.Message(Encoding.UTF8.GetBytes(payload))
-            {
-                Properties = { ["property1"] = p1Value }
-            };
-        }
-
         private async Task ReceiveMessageRecovery(
             TestDeviceType type,
             Client.TransportType transport,
@@ -218,10 +205,8 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
                 {
-                    string payload, messageId, p1Value;
-                    await serviceClient.SendAsync(
-                        testDevice.Id,
-                        MessageReceiveE2ETests.ComposeC2DTestMessage(out payload, out messageId, out p1Value)).ConfigureAwait(false);
+                    (Message message, string messageId, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2DTestMessage();
+                    await serviceClient.SendAsync(testDevice.Id, message).ConfigureAwait(false);
                     await MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, payload, p1Value).ConfigureAwait(false);
                 };
 

--- a/e2e/test/MessageSendE2EMultiplexingOverAmqpTests.cs
+++ b/e2e/test/MessageSendE2EMultiplexingOverAmqpTests.cs
@@ -141,9 +141,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 _log.WriteLine($"{nameof(MessageSendE2EMultiplexingOverAmqpTests)}: Preparing to send message for device {testDevice.Id}");
                 await deviceClient.OpenAsync().ConfigureAwait(false);
 
-                string payload;
-                string p1Value;
-                Client.Message testMessage = MessageSendE2ETests.ComposeD2CTestMessage(out payload, out p1Value);
+                (Client.Message testMessage, string messageId, string payload, string p1Value) = MessageSendE2ETests.ComposeD2CTestMessage();
                 await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
 
                 EventHubTestListener testListener = eventHubListeners[testDevice.Id];

--- a/e2e/test/MessageSendE2EMultiplexingOverAmqpTests.cs
+++ b/e2e/test/MessageSendE2EMultiplexingOverAmqpTests.cs
@@ -157,11 +157,13 @@ namespace Microsoft.Azure.Devices.E2ETests
                 {
                     await listener.Value.CloseAsync().ConfigureAwait(false);
                 }
-                eventHubListeners.Clear();
+
                 foreach (DeviceClient deviceClient in deviceClients)
                 {
                     deviceClient.Dispose();
                 }
+
+                eventHubListeners.Clear();
             };
 
             await MultiplexingOverAmqp.TestMultiplexingOperationAsync(

--- a/e2e/test/MessageSendE2EMultiplexingOverAmqpTests.cs
+++ b/e2e/test/MessageSendE2EMultiplexingOverAmqpTests.cs
@@ -157,6 +157,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 {
                     await listener.Value.CloseAsync().ConfigureAwait(false);
                 }
+                eventHubListeners.Clear();
                 foreach (DeviceClient deviceClient in deviceClients)
                 {
                     deviceClient.Dispose();

--- a/e2e/test/MessageSendE2ETests.cs
+++ b/e2e/test/MessageSendE2ETests.cs
@@ -233,9 +233,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             try
             {
-                string payload;
-                string p1Value;
-                Client.Message testMessage = ComposeD2CTestMessage(out payload, out p1Value);
+                (Client.Message testMessage, string messageId, string payload, string p1Value) = ComposeD2CTestMessage();
                 await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
 
                 bool isReceived = await testListener.WaitForMessage(deviceId, payload, p1Value).ConfigureAwait(false);
@@ -253,9 +251,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             try
             {
-                string payload;
-                string p1Value;
-                Client.Message testMessage = ComposeD2CTestMessage(out payload, out p1Value);
+                (Client.Message testMessage, string messageId, string payload, string p1Value) = ComposeD2CTestMessage();
                 await moduleClient.SendEventAsync(testMessage).ConfigureAwait(false);
 
                 bool isReceived = await testListener.WaitForMessage(deviceId, payload, p1Value).ConfigureAwait(false);
@@ -267,17 +263,20 @@ namespace Microsoft.Azure.Devices.E2ETests
             }
         }
 
-        public static Client.Message ComposeD2CTestMessage(out string payload, out string p1Value)
+        public static (Client.Message message, string messageId, string payload, string p1Value) ComposeD2CTestMessage()
         {
-            payload = Guid.NewGuid().ToString();
-            p1Value = Guid.NewGuid().ToString();
+            var messageId = Guid.NewGuid().ToString();
+            var payload = Guid.NewGuid().ToString();
+            var p1Value = Guid.NewGuid().ToString();
 
-            _log.WriteLine($"{nameof(ComposeD2CTestMessage)}: payload='{payload}' p1Value='{p1Value}'");
-
-            return new Client.Message(Encoding.UTF8.GetBytes(payload))
+            _log.WriteLine($"{nameof(ComposeD2CTestMessage)}: messageId='{messageId}' payload='{payload}' p1Value='{p1Value}'");
+            var message = new Client.Message(Encoding.UTF8.GetBytes(payload))
             {
+                MessageId = messageId,
                 Properties = { ["property1"] = p1Value }
             };
+
+            return (message, messageId, payload, p1Value);
         }
 
         public void Dispose()

--- a/e2e/test/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/MessageSendFaultInjectionTests.cs
@@ -380,34 +380,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
-        private Client.Message ComposeD2CTestMessage(out string payload, out string p1Value)
-        {
-            payload = Guid.NewGuid().ToString();
-            p1Value = Guid.NewGuid().ToString();
-
-            _log.WriteLine($"{nameof(ComposeD2CTestMessage)}: payload='{payload}' p1Value='{p1Value}'");
-
-            return new Client.Message(Encoding.UTF8.GetBytes(payload))
-            {
-                Properties = { ["property1"] = p1Value }
-            };
-        }
-
-        private Message ComposeC2DTestMessage(out string payload, out string messageId, out string p1Value)
-        {
-            payload = Guid.NewGuid().ToString();
-            messageId = Guid.NewGuid().ToString();
-            p1Value = Guid.NewGuid().ToString();
-
-            _log.WriteLine($"{nameof(ComposeC2DTestMessage)}: payload='{payload}' messageId='{messageId}' p1Value='{p1Value}'");
-
-            return new Message(Encoding.UTF8.GetBytes(payload))
-            {
-                MessageId = messageId,
-                Properties = { ["property1"] = p1Value }
-            };
-        }
-
         internal async Task SendMessageRecovery(
             TestDeviceType type,
             Client.TransportType transport,
@@ -427,9 +399,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
             {
-                string payload, p1Value;
-
-                Client.Message testMessage = ComposeD2CTestMessage(out payload, out p1Value);
+                (Client.Message testMessage, string messageId, string payload, string p1Value) = MessageSendE2ETests.ComposeD2CTestMessage();
                 await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
 
                 bool isReceived = false;

--- a/e2e/test/MultiplexingOverAmqp.cs
+++ b/e2e/test/MultiplexingOverAmqp.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Azure.Devices.E2ETests
         public const int MuxWithoutPoolingPoolSize = 1; // For enabling multiplexing without pooling, the pool size needs to be set to 1
         public const int MuxWithPoolingDevicesCount = 4;
         public const int MuxWithPoolingPoolSize = 2;
+        public const int maxTestRunCount = 5;
+        public const float testSuccessRate = 0.8f; // 4 out of 5 test runs should pass (even after accounting for network instability issues).
 
         private static TestLogging s_log = TestLogging.GetInstance();
 
@@ -40,57 +42,81 @@ namespace Microsoft.Azure.Devices.E2ETests
                 }
             };
 
+            int totalRuns = 0;
+            int successfulRuns = 0;
+            bool reRunTest = false;
+
             IList<TestDevice> testDevices = new List<TestDevice>();
             IList<DeviceClient> deviceClients = new List<DeviceClient>();
             IList<AmqpConnectionStatusChange> amqpConnectionStatuses = new List<AmqpConnectionStatusChange>();
+            IList<Task> operations = new List<Task>();
 
-            // Arrange
-            // Initialize the test device client instances
-            // Set the device client connection status change handler
-            s_log.WriteLine($">>> {nameof(MultiplexingOverAmqp)} Initializing Device Clients for multiplexing test.");
-            for (int i = 0; i < devicesCount; i++)
+            do
             {
-                TestDevice testDevice = await TestDevice.GetTestDeviceAsync($"{devicePrefix}_{i}_").ConfigureAwait(false);
-                DeviceClient deviceClient = testDevice.CreateDeviceClient(transportSettings, authScope);
+                totalRuns++;
 
-                var amqpConnectionStatusChange = new AmqpConnectionStatusChange();
-                deviceClient.SetConnectionStatusChangesHandler(amqpConnectionStatusChange.ConnectionStatusChangesHandler);
-
-                testDevices.Add(testDevice);
-                deviceClients.Add(deviceClient);
-                amqpConnectionStatuses.Add(amqpConnectionStatusChange);
-
-                await initOperation(deviceClient, testDevice).ConfigureAwait(false);
-            }
-
-            try
-            {
-                // Act-Assert
-                // Perform the test operation and verify the operation is successful
-
+                // Arrange
+                // Initialize the test device client instances
+                // Set the device client connection status change handler
+                s_log.WriteLine($">>> {nameof(MultiplexingOverAmqp)} Initializing Device Clients for multiplexing test - Test run {totalRuns}");
                 for (int i = 0; i < devicesCount; i++)
                 {
-                    await testOperation(deviceClients[i], testDevices[i]).ConfigureAwait(false);
-                }
+                    TestDevice testDevice = await TestDevice.GetTestDeviceAsync($"{devicePrefix}_{i}_").ConfigureAwait(false);
+                    DeviceClient deviceClient = testDevice.CreateDeviceClient(transportSettings, authScope);
 
-                // Close the device client instances and verify the connection status change checks
-                for (int i = 0; i < devicesCount; i++)
+                    var amqpConnectionStatusChange = new AmqpConnectionStatusChange();
+                    deviceClient.SetConnectionStatusChangesHandler(amqpConnectionStatusChange.ConnectionStatusChangesHandler);
+
+                    testDevices.Add(testDevice);
+                    deviceClients.Add(deviceClient);
+                    amqpConnectionStatuses.Add(amqpConnectionStatusChange);
+
+                    operations.Add(initOperation(deviceClient, testDevice));
+                }
+                await Task.WhenAll(operations).ConfigureAwait(false);
+                operations.Clear();
+
+                try
                 {
-                    await deviceClients[i].CloseAsync().ConfigureAwait(false);
+                    for (int i = 0; i < devicesCount; i++)
+                    {
+                        operations.Add(testOperation(deviceClients[i], testDevices[i]));
+                    }
+                    await Task.WhenAll(operations).ConfigureAwait(false);
+                    operations.Clear();
 
-                    // The connection status change count should be 2: connect (open) and disabled (close)
-                    // The connection status should be "Disabled", with connection status change reason "Client_close"
-                    Assert.IsTrue(amqpConnectionStatuses[i].ConnectionStatusChangesHandlerCount == 2, $"The actual connection status change count is = {amqpConnectionStatuses[i].ConnectionStatusChangesHandlerCount}");
-                    Assert.AreEqual(ConnectionStatus.Disabled, amqpConnectionStatuses[i].LastConnectionStatus, $"The actual connection status is = {amqpConnectionStatuses[i].LastConnectionStatus}");
-                    Assert.AreEqual(ConnectionStatusChangeReason.Client_Close, amqpConnectionStatuses[i].LastConnectionStatusChangeReason, $"The actual connection status change reason is = {amqpConnectionStatuses[i].LastConnectionStatusChangeReason}");
+                    // Close the device client instances and verify the connection status change checks
+                    bool deviceConnectionStatusAsExpected = true;
+                    for (int i = 0; i < devicesCount; i++)
+                    {
+                        await deviceClients[i].CloseAsync().ConfigureAwait(false);
+
+                        // The connection status change count should be 2: connect (open) and disabled (close)
+                        if (amqpConnectionStatuses[i].ConnectionStatusChangesHandlerCount != 2)
+                        {
+                            deviceConnectionStatusAsExpected = false;
+                        }
+
+                        // The connection status should be "Disabled", with connection status change reason "Client_close"
+                        Assert.AreEqual(ConnectionStatus.Disabled, amqpConnectionStatuses[i].LastConnectionStatus, $"The actual connection status is = {amqpConnectionStatuses[i].LastConnectionStatus}");
+                        Assert.AreEqual(ConnectionStatusChangeReason.Client_Close, amqpConnectionStatuses[i].LastConnectionStatusChangeReason, $"The actual connection status change reason is = {amqpConnectionStatuses[i].LastConnectionStatusChangeReason}");
+                    }
+                    if (deviceConnectionStatusAsExpected) successfulRuns++;
+                    reRunTest = (successfulRuns / totalRuns) < testSuccessRate;
                 }
+                finally
+                {
+                    // Close the service-side components and dispose the device client instances.
+                    await cleanupOperation(deviceClients).ConfigureAwait(false);
 
-            }
-            finally
-            {
-                // Close the service-side components and dispose the device client instances.
-                await cleanupOperation(deviceClients).ConfigureAwait(false);
-            }
+                    // Clean up the local lists
+                    testDevices.Clear();
+                    deviceClients.Clear();
+                    amqpConnectionStatuses.Clear();
+                }
+            } while (reRunTest && totalRuns < maxTestRunCount);
+
+            Assert.IsFalse(reRunTest, $"Device client instances got disconnected in {totalRuns - successfulRuns} runs out of {totalRuns}.");
         }
 
         private class AmqpConnectionStatusChange

--- a/e2e/test/TwinE2EMultiplexingOverAmqpTests.cs
+++ b/e2e/test/TwinE2EMultiplexingOverAmqpTests.cs
@@ -283,6 +283,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                 {
                     deviceClient.Dispose();
                 }
+
+                twinPropertyMap.Clear();
                 await Task.FromResult<bool>(false).ConfigureAwait(false);
             };
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->
- Implement connection status check with results from multiple runs for the test (to account for network instability issues).
- Await on baseline/ test operation for all devices at once, instead of individually.

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
