### PR TITLE
Fix to close device and service WS clients (SGW clients) in parallel in Device Streaming e2e tests

### DIFF
--- a/e2e/test/DeviceStreamingE2ETests.cs
+++ b/e2e/test/DeviceStreamingE2ETests.cs
@@ -415,8 +415,10 @@ namespace Microsoft.Azure.Devices.E2ETests
                 }, TaskScheduler.Current)
             ).ConfigureAwait(false);
 
-            await deviceWSClient.CloseAsync(WebSocketCloseStatus.NormalClosure, "End of test", cts.Token).ConfigureAwait(false);
-            await serviceWSClient.CloseAsync(WebSocketCloseStatus.NormalClosure, "End of test", cts.Token).ConfigureAwait(false);
+            await Task.WhenAll(
+                deviceWSClient.CloseAsync(WebSocketCloseStatus.NormalClosure, "End of test", cts.Token),
+                serviceWSClient.CloseAsync(WebSocketCloseStatus.NormalClosure, "End of test", cts.Token)
+            ).ConfigureAwait(false);
 
             deviceWSClient.Dispose();
             serviceWSClient.Dispose();


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->
This is a change in preview branch only.

## Description of the changes
<!-- Itemized list of changes. -->

(This is being ported from DeviceStreaming branch, commit# 2d36a276213e15f1909bbd5bed31a12c62762dd4)

The Streaming Gateway was handling closure of websocket clients
incorrectly, waiting individually for the service-side client to close
first, then waiting for the device client-side to close, in this order.
Dmitry provided a fix that now makes it wait in parallel for both sides to close,
which is correct since there is no way to predict who will close the connection first.

The same fix had to be applied to the Device Streaming E2E tests as it
had similar behavior.


## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
