### PR TITLE
Mqtt Recovery issue

### DIFF
--- a/iothub/device/src/Transport/ErrorDelegatingHandler.cs
+++ b/iothub/device/src/Transport/ErrorDelegatingHandler.cs
@@ -15,6 +15,7 @@ using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using DotNetty.Transport.Channels;
 
 namespace Microsoft.Azure.Devices.Client.Transport
@@ -143,7 +144,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         private static bool IsNetwork(Exception singleException)
         {
-            return s_networkExceptions.Contains(singleException.GetType());
+            Type exceptionType = singleException.GetType();
+            return s_networkExceptions.Any(baseExceptionType => baseExceptionType.IsAssignableFrom(exceptionType));
         }
 
         private Task ExecuteWithErrorHandlingAsync(Func<Task> asyncOperation)

--- a/iothub/device/src/Transport/ErrorDelegatingHandler.cs
+++ b/iothub/device/src/Transport/ErrorDelegatingHandler.cs
@@ -144,8 +144,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         private static bool IsNetwork(Exception singleException)
         {
-            Type exceptionType = singleException.GetType();
-            return s_networkExceptions.Any(baseExceptionType => baseExceptionType.IsAssignableFrom(exceptionType));
+            return s_networkExceptions.Any(baseExceptionType => baseExceptionType.IsInstanceOfType(singleException));
         }
 
         private Task ExecuteWithErrorHandlingAsync(Func<Task> asyncOperation)

--- a/iothub/device/tests/ErrorDelegatingHandlerTests.cs
+++ b/iothub/device/tests/ErrorDelegatingHandlerTests.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Azure.Devices.Client.Test
                                                                 "Inner exception",
                                                                 new AuthenticationException()))
             },
+            { typeof(TestDerivedException), () => new TestDerivedException() },
         };
 
         private static readonly HashSet<Type> s_networkExceptions = new HashSet<Type>
@@ -76,7 +77,12 @@ namespace Microsoft.Azure.Devices.Client.Test
             typeof(WebException),
             typeof(IotHubCommunicationException),
             typeof(WebSocketException),
+            typeof(TestDerivedException),
         };
+
+        public class TestDerivedException : SocketException
+        {
+        }
 
         public class TestSecurityException : Exception
         {


### PR DESCRIPTION
Fix github issue#975; treat any exception as network exception if and only if its type is defined in network exception list in ErrorDelegatingHandler.cs or derived from that list.  For example, System.Net.Internals.SocketExceptionFactory+ExtendedSocketException is derived from SocketException.
