### PR TITLE
Amqp Stack exception handling

### DIFF
--- a/e2e/stress/IoTClientPerf/Program.cs
+++ b/e2e/stress/IoTClientPerf/Program.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             int n = 1;
             string a = "sas";
             int c = -1;
-            string i = Guid.NewGuid().ToString();
+            string i = null;
             string f = null;
 
             while (param_counter + 1 < args.Length)
@@ -183,6 +183,11 @@ namespace Microsoft.Azure.Devices.E2ETests
                 Console.Error.WriteLine("Missing -f <scenario> parameter.");
                 Help();
                 return -1;
+            }
+
+            if (i == null)
+            {
+                i = $"{DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffZ")}_dotNet_{f}";
             }
 
             Tuple<string, Func<PerfScenarioConfig, PerfScenario>> scenario;

--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -41,7 +41,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetty.Codecs.Mqtt" Version="0.6.0" />
     <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />
   </ItemGroup>

--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.20.2</Version>
+    <Version>1.20.3</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             {
                 amqpIoTCbsLink?.Close();
                 amqpAuthenticationRefresher?.StopLoop();
-                amqpIoTConnection?.SafeClose();
+                amqpIoTConnection?.Abort();
                 throw;
             }
             finally

--- a/iothub/device/src/Transport/Amqp/AmqpConnector.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnector.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
         #region Authentication
         private static bool InitializeDisableServerCertificateValidation()
         {
-#if NETSTANDARD1_3 // No System.Configuration.ConfigurationManager in NetStandard1.3
+#if !NET451
             bool flag;
             if (!AppContext.TryGetSwitch("DisableServerCertificateValidationKeyName", out flag))
             {

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTCbsLink.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTCbsLink.cs
@@ -25,9 +25,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             {
                 return await _amqpCbsLink.SendTokenAsync(tokenProvider, namespaceAddress, audience, resource, requiredClaims, timeout).ConfigureAwait(false);
             }
-            catch (AmqpException ex)
+            catch (Exception ex)
             {
-                throw new IotHubCommunicationException("AmqpIoTCbsLink.SendTokenAsync error", ex.InnerException);
+                AmqpIoTExceptionAdapter.HandleAmqpException(ex, "Cannot send CBS token.");
+                throw;
             }
             finally
             {
@@ -42,9 +43,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             {
                 _amqpCbsLink.Close();
             }
-            catch (AmqpException ex)
+            catch (Exception ex)
             {
-                throw new IotHubCommunicationException("AmqpIoTCbsLink.Close error", ex.InnerException);
+                AmqpIoTExceptionAdapter.HandleAmqpException(ex, "Cannot close CBS link.");
+                throw;
             }
             finally
             {

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTErrorAdapter.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTErrorAdapter.cs
@@ -10,7 +10,7 @@ using Microsoft.Azure.Amqp.Framing;
 
 namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
 {
-    static class AmqpIoTErrorAdapter
+    internal static class AmqpIoTErrorAdapter
     {
         public static readonly AmqpSymbol TimeoutName = AmqpIoTConstants.Vendor + ":timeout";
         public static readonly AmqpSymbol StackTraceName = AmqpIoTConstants.Vendor + ":stack-trace";
@@ -34,12 +34,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
         public static readonly AmqpSymbol ApiVersion = AmqpIoTConstants.Vendor + ":api-version";
         public static readonly AmqpSymbol ChannelCorrelationId = AmqpIoTConstants.Vendor + ":channel-correlation-id";
 
-        const int MaxSizeInInfoMap = 32 * 1024;
-
-        public static AmqpException ToAmqpException(Exception exception, string gatewayId)
-        {
-            return ToAmqpException(exception, gatewayId, false);
-        }
+        private const int MaxSizeInInfoMap = 32 * 1024;
 
         public static AmqpException ToAmqpException(Exception exception, string gatewayId, bool includeStackTrace)
         {

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTExceptionAdapter.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTExceptionAdapter.cs
@@ -4,11 +4,52 @@
 using System;
 using Microsoft.Azure.Devices.Client.Exceptions;
 using Microsoft.Azure.Amqp;
+using Microsoft.Azure.Devices.Shared;
+using System.Security.Authentication;
 
 namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
 {
     internal class AmqpIoTExceptionAdapter
     {
+        public static bool HandleAmqpException(Exception ex, string newMessage)
+        {
+            if (ex is ObjectDisposedException ||
+                ex is InvalidOperationException ||
+                ex is TimeoutException)
+            {
+                throw new IotHubCommunicationException(newMessage, ex);
+            }
+
+            if (ex is AmqpException)
+            {
+                var amqpEx = (AmqpException)ex;
+                if (amqpEx.Error.Condition.Equals(AmqpErrorCode.HandleInUse))
+                {
+                    if (Logging.IsEnabled) Logging.Fail(ex, $"AMQP protocol exception: {nameof(AmqpErrorCode.HandleInUse)}");
+                    throw new IotHubException(newMessage, ex);
+                }
+                else if (amqpEx.Error.Condition.Equals(AmqpErrorCode.UnattachedHandle))
+                {
+                    if (Logging.IsEnabled) Logging.Fail(ex, $"AMQP protocol exception: {nameof(AmqpErrorCode.UnattachedHandle)}");
+                    throw new IotHubException(newMessage, ex);
+                }
+                else if (amqpEx.Error.Condition.Equals(AmqpErrorCode.UnauthorizedAccess))
+                {
+                    throw new AuthenticationException(newMessage, ex);
+                }
+                else if (amqpEx.Error.Condition.Equals(AmqpErrorCode.MessageSizeExceeded))
+                {
+                    throw new MessageTooLargeException(newMessage, ex);
+                }
+                else
+                {
+                    throw new IotHubCommunicationException(newMessage, ex);
+                }
+            }
+
+            return false;
+        }
+
         public static Exception ConvertToIoTHubException(Exception exception)
         {
             if (exception is TimeoutException)

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTMessageConverter.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTMessageConverter.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
         private const string MethodName = "IoThub-methodname";
         private const string Status = "IoThub-status";
 
-#region AmqpMessage <--> Message
+        #region AmqpMessage <--> Message
         public static Message AmqpMessageToMessage(AmqpMessage amqpMessage)
         {
             if (amqpMessage == null)

--- a/iothub/device/tests/Microsoft.Azure.Devices.Client.Test.csproj
+++ b/iothub/device/tests/Microsoft.Azure.Devices.Client.Test.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="DotNetty.Codecs.Mqtt" Version="0.6.0" />
     <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -106,7 +106,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.18.0</Version>
+    <Version>1.18.1</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/iothub/service/tests/Microsoft.Azure.Devices.Test.csproj
+++ b/iothub/service/tests/Microsoft.Azure.Devices.Test.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.2" />
     <PackageReference Include="Moq" Version="4.8.2" />
   </ItemGroup>
 

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -82,7 +82,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.2" />
     <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
   </ItemGroup>
 </Project>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.1.8</Version>
+    <Version>1.1.9</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client AMQP Transport</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/readme.md
+++ b/readme.md
@@ -31,9 +31,8 @@ Due to security considerations, build logs are not publicly available.
 
 | Service Environment      | Status |
 | ---                      | ---    |
-| WestUS                   | [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/csharp/csharp-westus1?branchName=master)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=44)|
-| Canary                   | [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/csharp/csharp-canary1?branchName=master)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=43)|
-| Dogfood                  | [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/csharp/csharp-df1?branchName=master)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=36)|
+| Master                   | [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/csharp/csharp-westus1?branchName=master)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=44)|
+| Preview                   | [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/csharp/csharp-canary1?branchName=preview)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=43)|
 
 ## OS platforms and hardware compatibility
 The IoT Hub device SDK for .NET can be used with a broad range of OS platforms and devices.

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ Due to security considerations, build logs are not publicly available.
 
 | Service Environment      | Status |
 | ---                      | ---    |
-| Master                   | [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/csharp/csharp-westus1?branchName=master)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=44)|
-| Preview                   | [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/csharp/csharp-canary1?branchName=preview)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=43)|
+| Master                   | [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/csharp/csharp-westus1?branchName=master)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build?definitionId=44&_a=summary&repositoryFilter=9&branchFilter=23)|
+| Preview                   | [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/csharp/csharp-canary1?branchName=preview)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build?definitionId=43&_a=summary&repositoryFilter=9&branchFilter=72)|
 
 ## OS platforms and hardware compatibility
 The IoT Hub device SDK for .NET can be used with a broad range of OS platforms and devices.

--- a/versions.csv
+++ b/versions.csv
@@ -1,9 +1,9 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.20.2
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.18.0
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.20.3
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.18.1
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.16.0
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.4.0
-provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.1.8
+provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.1.9
 provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.1.6
 provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.1.8
 security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.1.6


### PR DESCRIPTION
- Add better exception handling within the AmqpIoT types
- Upgrade AMQP lib to latest (TCP signaling)
- Better RunID for Stress/Perf testing (helps with run filtering during analysis)
- Fixing NS2.0 regression on UWP and Xamarin (using AppContext instead of Config)

Fixes #949 
