### PR TITLE
Supporting timeouts when calling receive async

### DIFF
--- a/e2e/test/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/DeviceTokenRefreshE2ETests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 // and add a buffer for opening and sending on the deviceclient.
                 const int operationCompletionBufferTimeInSeconds = 10;
                 const int numberOfWaitForTokenCalls = 2;
-                var testRunTimeout = (numberOfWaitForTokenCalls * (ttl * (float)(1 + buffer / 100))) + operationCompletionBufferTimeInSeconds;
+                float testRunTimeout = (numberOfWaitForTokenCalls * (ttl * (float)(1 + buffer / 100))) + operationCompletionBufferTimeInSeconds;
 
                 using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(testRunTimeout)))
                 {

--- a/e2e/test/FaultInjection.cs
+++ b/e2e/test/FaultInjection.cs
@@ -190,14 +190,14 @@ namespace Microsoft.Azure.Devices.E2ETests
                         // 4 is the minimum notification count: connect, fault, reconnect, disable.
                         // There are cases where the retry must be timed out (i.e. very likely for MQTT where otherwise 
                         // we would attempt to send the fault injection forever.)
-                        Assert.IsTrue(setConnectionStatusChangesHandlerCount >= 4); 
+                        Assert.IsTrue(setConnectionStatusChangesHandlerCount >= 4, $"setConnectionStatusChangesHandlerCount is {setConnectionStatusChangesHandlerCount} expected is >= 4");
                     }
                     else
                     {
                         // 2 is the minimum notification count: connect, disable.
                         // We will monitor the test environment real network stability and switch to >=2 if necessary to 
                         // account for real network issues.
-                        Assert.IsTrue(setConnectionStatusChangesHandlerCount == 2); 
+                        Assert.AreEqual(2, setConnectionStatusChangesHandlerCount);
                     }
 
                     Assert.AreEqual(ConnectionStatus.Disabled, lastConnectionStatus);

--- a/e2e/test/MessageReceiveE2ETests.cs
+++ b/e2e/test/MessageReceiveE2ETests.cs
@@ -54,14 +54,14 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(OperationCanceledException))]
+        [ExpectedException(typeof(IotHubCommunicationException))]
         public async Task Message_DeviceReceive_Amqp_Validate_CancellationToken()
         {
             await ReceiveAsyncCancel(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(OperationCanceledException))]
+        [ExpectedException(typeof(IotHubCommunicationException))]
         public async Task Message_DeviceReceive_AmqpWs_Validate_CancellationToken()
         {
             await ReceiveAsyncCancel(TestDeviceType.Sasl, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
@@ -87,14 +87,14 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(OperationCanceledException))]
+        [ExpectedException(typeof(IotHubCommunicationException))]
         public async Task Message_DeviceReceive_Mqtt_Validate_CancellationToken()
         {
             await ReceiveAsyncCancel(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(OperationCanceledException))]
+        [ExpectedException(typeof(IotHubCommunicationException))]
         public async Task Message_DeviceReceive_MqttWs_Validate_CancellationToken()
         {
             await ReceiveAsyncCancel(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(OperationCanceledException))]
+        [ExpectedException(typeof(IotHubCommunicationException))]
         public async Task Message_DeviceReceive_Http_Validate_CancellationToken()
         {
             await ReceiveAsyncCancel(TestDeviceType.Sasl, Client.TransportType.Http1).ConfigureAwait(false);
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 {
                     using (var cts = new CancellationTokenSource())
                     {
-                        const int timeout = 1_000;
+                        const int timeout = 5_000;
 
                         var receiveTask = deviceClient.ReceiveAsync(cts.Token).ConfigureAwait(false);
 
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                             sw.Stop();
                             Assert.IsTrue(ex.InnerException is OperationCanceledException);
                             Assert.IsTrue(sw.ElapsedMilliseconds < 11_000, $"Expected timeout not met. Timeout fired after {sw.ElapsedMilliseconds}ms and requested was {timeout}ms");
-                            throw ex.InnerException;
+                            throw;
                         }
                     }
                 }

--- a/e2e/test/MessageReceiveFaultInjectionTests.cs
+++ b/e2e/test/MessageReceiveFaultInjectionTests.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                         transport == Client.TransportType.Mqtt_WebSocket_Only)
                     {
                         // Dummy ReceiveAsync to ensure mqtt subscription registration before SendAsync() is called on service client.
-                        await deviceClient.ReceiveAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                        await deviceClient.ReceiveAsync(TimeSpan.FromSeconds(60)).ConfigureAwait(false);
                     }
                 };
 

--- a/iothub/device/src/IDelegatingHandler.cs
+++ b/iothub/device/src/IDelegatingHandler.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Devices.Client
     {
         // Transport state.
         Task OpenAsync(CancellationToken cancellationToken);
+        Task OpenAsync(TimeSpan timeout);
         Task CloseAsync(CancellationToken cancellationToken);
         Task WaitForTransportClosedAsync();
         bool IsUsable { get; }
@@ -23,7 +24,7 @@ namespace Microsoft.Azure.Devices.Client
 
         // Telemetry downlink.
         Task<Message> ReceiveAsync(CancellationToken cancellationToken);
-        Task<Message> ReceiveAsync(TimeSpan timeout, CancellationToken cancellationToken);
+        Task<Message> ReceiveAsync(TimeSpan timeout);
         Task RejectAsync(string lockToken, CancellationToken cancellationToken);
         Task AbandonAsync(string lockToken, CancellationToken cancellationToken);
         Task CompleteAsync(string lockToken, CancellationToken cancellationToken);

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Azure.Devices.Client
             if (timeout == TimeSpan.MaxValue) return await ReceiveAsync(CancellationToken.None).ConfigureAwait(false);
             try
             {
-                return await InnerHandler.ReceiveAsync(timeout, CancellationToken.None).ConfigureAwait(false);
+                return await InnerHandler.ReceiveAsync(timeout).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -336,16 +336,13 @@ namespace Microsoft.Azure.Devices.Client
         public async Task<Message> ReceiveAsync(TimeSpan timeout)
         {
             if (timeout == TimeSpan.MaxValue) return await ReceiveAsync(CancellationToken.None).ConfigureAwait(false);
-            using (var cts = new CancellationTokenSource(timeout))
+            try
             {
-                try
-                {
-                    return await ReceiveAsync(cts.Token).ConfigureAwait(false);
-                }
-                catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
-                {
-                    return null;
-                }
+                return await InnerHandler.ReceiveAsync(timeout, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
+            {
+                return null;
             }
         }
 

--- a/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
@@ -162,16 +162,20 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
         public override async Task<Message> ReceiveAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled) Logging.Enter(this, timeout, cancellationToken, $"{nameof(ReceiveAsync)}");
+
             Message message = null;
+            var absoluteTimeout = DateTime.UtcNow + timeout;
+
             while (true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 message = await _amqpUnit.ReceiveMessageAsync(timeout).ConfigureAwait(false);
-                if (message != null)
+                if (message != null || DateTime.UtcNow >= absoluteTimeout)
                 {
                     break;
                 }
             }
+
             if (Logging.IsEnabled) Logging.Exit(this, timeout, cancellationToken, $"{nameof(ReceiveAsync)}");
             return message;
         }

--- a/iothub/device/src/Transport/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Transport/DefaultDelegatingHandler.cs
@@ -45,7 +45,13 @@ namespace Microsoft.Azure.Devices.Client.Transport
             ThrowIfDisposed();
             return InnerHandler?.OpenAsync(cancellationToken) ?? TaskHelpers.CompletedTask;
         }
-        
+
+        public virtual Task OpenAsync(TimeSpan timeout)
+        {
+            ThrowIfDisposed();
+            return InnerHandler?.OpenAsync(timeout) ?? TaskHelpers.CompletedTask;
+        }
+
         public virtual Task CloseAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
@@ -79,10 +85,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return InnerHandler?.ReceiveAsync(cancellationToken) ?? s_dummyResultObject;
         }
 
-        public virtual Task<Message> ReceiveAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        public virtual Task<Message> ReceiveAsync(TimeSpan timeout)
         {
             ThrowIfDisposed();
-            return InnerHandler?.ReceiveAsync(timeout, cancellationToken) ?? s_dummyResultObject;
+            return InnerHandler?.ReceiveAsync(timeout) ?? s_dummyResultObject;
         }
 
         public virtual Task CompleteAsync(string lockToken, CancellationToken cancellationToken)

--- a/iothub/device/src/Transport/ErrorDelegatingHandler.cs
+++ b/iothub/device/src/Transport/ErrorDelegatingHandler.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             typeof(ClosedChannelException),
             typeof(TimeoutException),
             typeof(OperationCanceledException),
+            typeof(TaskCanceledException),
             typeof(HttpRequestException),
             typeof(WebException),
             typeof(WebSocketException),

--- a/iothub/device/src/Transport/ErrorDelegatingHandler.cs
+++ b/iothub/device/src/Transport/ErrorDelegatingHandler.cs
@@ -48,9 +48,9 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return ExecuteWithErrorHandlingAsync(() => base.ReceiveAsync(cancellationToken));
         }
 
-        public override Task<Message> ReceiveAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        public override Task<Message> ReceiveAsync(TimeSpan timeout)
         {
-            return ExecuteWithErrorHandlingAsync(() => base.ReceiveAsync(timeout, cancellationToken));
+            return ExecuteWithErrorHandlingAsync(() => base.ReceiveAsync(timeout));
         }
 
         public override Task EnableMethodsAsync(CancellationToken cancellationToken)

--- a/iothub/device/src/Transport/HttpTransportHandler.cs
+++ b/iothub/device/src/Transport/HttpTransportHandler.cs
@@ -209,28 +209,43 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task<Message> ReceiveAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {
-            // Long-polling is not supported
+            CancellationTokenSource cts = null;
+
             if (!TimeSpan.Zero.Equals(timeout))
             {
-                throw new ArgumentOutOfRangeException(nameof(timeout), "Http Protocol does not support a non-zero receive timeout");
+                if (cancellationToken == CancellationToken.None)
+                {
+                    cts = new CancellationTokenSource((int)timeout.TotalMilliseconds);
+                    cancellationToken = cts.Token;
+                }
+                else
+                {
+                    // Long-polling is not supported
+                    throw new ArgumentOutOfRangeException(nameof(timeout), "Http Protocol does not support a non-zero receive timeout");
+                }
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
+            HttpResponseMessage responseMessage = null;
 
-            IDictionary<string, string> customHeaders = PrepareCustomHeaders(CommonConstants.DeviceBoundPathTemplate.FormatInvariant(this.deviceId), null, CommonConstants.CloudToDeviceOperation);
-            IDictionary<string, string> queryValueDictionary =
-                new Dictionary<string, string>() { { CustomHeaderConstants.MessageLockTimeout, DefaultOperationTimeout.TotalSeconds.ToString(CultureInfo.InvariantCulture) } };
-
-            HttpResponseMessage responseMessage = await this.httpClientHelper.GetAsync<HttpResponseMessage>(
-                GetRequestUri(this.deviceId, CommonConstants.DeviceBoundPathTemplate, queryValueDictionary),
-                ExceptionHandlingHelper.GetDefaultErrorMapping(),
-                customHeaders,
-                true,
-                cancellationToken).ConfigureAwait(false);
-
-            if (responseMessage == null || responseMessage.StatusCode == HttpStatusCode.NoContent)
+            using (cts)
             {
-                return null;
+                cancellationToken.ThrowIfCancellationRequested();
+
+                IDictionary<string, string> customHeaders = PrepareCustomHeaders(CommonConstants.DeviceBoundPathTemplate.FormatInvariant(this.deviceId), null, CommonConstants.CloudToDeviceOperation);
+                IDictionary<string, string> queryValueDictionary =
+                    new Dictionary<string, string>() { { CustomHeaderConstants.MessageLockTimeout, DefaultOperationTimeout.TotalSeconds.ToString(CultureInfo.InvariantCulture) } };
+
+                responseMessage = await this.httpClientHelper.GetAsync<HttpResponseMessage>(
+                    GetRequestUri(this.deviceId, CommonConstants.DeviceBoundPathTemplate, queryValueDictionary),
+                    ExceptionHandlingHelper.GetDefaultErrorMapping(),
+                    customHeaders,
+                    true,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (responseMessage == null || responseMessage.StatusCode == HttpStatusCode.NoContent)
+                {
+                    return null;
+                }
             }
 
             IEnumerable<string> messageId;

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
         }
 
-        public override async Task<Message> ReceiveAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        public override async Task<Message> ReceiveAsync(CancellationToken cancellationToken)
         {
             Message message = null;
 
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 await this.SubscribeAsync().ConfigureAwait(true);
             }
 
-            bool hasMessage = await this.ReceiveMessageArrivalAsync(timeout, cancellationToken).ConfigureAwait(true);
+            bool hasMessage = await this.ReceiveMessageArrivalAsync(cancellationToken).ConfigureAwait(true);
 
             if (hasMessage)
             {
@@ -236,18 +236,17 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             return message;
         }
 
-        async Task<bool> ReceiveMessageArrivalAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        async Task<bool> ReceiveMessageArrivalAsync(CancellationToken cancellationToken)
         {
-            bool hasMessage = false;
             cancellationToken.ThrowIfCancellationRequested();
             this.EnsureValidState();
 
             using (CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, this.disconnectAwaitersCancellationSource.Token))
             {
-                hasMessage = await this.receivingSemaphore.WaitAsync(timeout, linkedCts.Token).ConfigureAwait(true);
+                await this.receivingSemaphore.WaitAsync(linkedCts.Token).ConfigureAwait(true);
             }
 
-            return hasMessage;
+            return true;
         }
 
         public override async Task CompleteAsync(string lockToken, CancellationToken cancellationToken)

--- a/iothub/device/tests/AmqpTransportHandlerTests.cs
+++ b/iothub/device/tests/AmqpTransportHandlerTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
         [TestMethod]
         public async Task AmqpTransportHandlerReceiveAsyncTokenCancellationRequested()
         {
-            await TestOperationCanceledByToken(token => CreateFromConnectionString().ReceiveAsync(new TimeSpan(0, 10, 0), token)).ConfigureAwait(false);
+            await TestOperationCanceledByToken(token => CreateFromConnectionString().ReceiveAsync(token)).ConfigureAwait(false);
         }
 
         [TestMethod]

--- a/iothub/device/tests/ErrorDelegatingHandlerTests.cs
+++ b/iothub/device/tests/ErrorDelegatingHandlerTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             { typeof(SocketException), () => new SocketException(1) },
             { typeof(HttpRequestException), () => new HttpRequestException() },
             { typeof(WebException), () => new WebException() },
-            { typeof(AmqpException), () => new AmqpException(new Amqp.Framing.Error()) },
+            { typeof(AmqpException), () => new AmqpException(new Microsoft.Azure.Amqp.Framing.Error()) },
             { typeof(WebSocketException), () => new WebSocketException() },
             { typeof(TestSecurityException), () => new Exception(
                                                             "Test top level",
@@ -181,9 +181,9 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             TimeSpan timeout = TimeSpan.FromSeconds(1);
             await OperationAsync_ExceptionThrownAndThenSucceed_OperationSuccessfullyCompleted(
-                di => di.ReceiveAsync(Arg.Is(timeout), Arg.Any<CancellationToken>()),
-                di => di.ReceiveAsync(timeout, cancellationToken),
-                di => di.Received(2).ReceiveAsync(Arg.Is(timeout), Arg.Any<CancellationToken>()),
+                di => di.ReceiveAsync(Arg.Is(timeout)),
+                di => di.ReceiveAsync(timeout),
+                di => di.Received(2).ReceiveAsync(Arg.Is(timeout)),
                 thrownExceptionType, expectedExceptionType).ConfigureAwait(false);
 
             await OperationAsync_ExceptionThrownAndThenSucceed_OperationSuccessfullyCompleted(

--- a/iothub/device/tests/HttpTransportHandlerTests.cs
+++ b/iothub/device/tests/HttpTransportHandlerTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
         [TestMethod]
         public async Task HttpTransportHandler_ReceiveAsync_TokenCancellationRequested()
         {
-            await TestOperationCanceledByToken(token => CreateFromConnectionString().ReceiveAsync(new TimeSpan(0, 0, 0), token)).ConfigureAwait(false);
+            await TestOperationCanceledByToken(token => CreateFromConnectionString().ReceiveAsync(token)).ConfigureAwait(false);
         }
 
         [TestMethod]

--- a/iothub/device/tests/MqttTransportHandlerTests.cs
+++ b/iothub/device/tests/MqttTransportHandlerTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
         [TestMethod]
         public async Task MqttTransportHandlerReceiveAsyncTokenCancellationRequested()
         {
-            await TestOperationCanceledByToken(token => CreateFromConnectionString().ReceiveAsync(new TimeSpan(0, 10, 0), token)).ConfigureAwait(false);
+            await TestOperationCanceledByToken(token => CreateFromConnectionString().ReceiveAsync(token)).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -582,7 +582,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
 
             transport.OnConnected();
             await transport.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-            await transport.ReceiveAsync(new TimeSpan(0, 0, 0, 0, 5), CancellationToken.None).ConfigureAwait(false);
+            await transport.ReceiveAsync(new TimeSpan(0, 0, 0, 0, 5)).ConfigureAwait(false);
 
             // act
             transport.OnError(new ApplicationException("Testing"));

--- a/iothub/device/tests/RetryDelegatingHandlerImplicitOpenTests.cs
+++ b/iothub/device/tests/RetryDelegatingHandlerImplicitOpenTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             innerHandlerMock.SendEventAsync(Arg.Any<Message>(), Arg.Any<CancellationToken>()).Returns(t => Task.CompletedTask);
             innerHandlerMock.SendEventAsync(Arg.Any<IEnumerable<Message>>(), Arg.Any<CancellationToken>()).Returns(t => Task.CompletedTask);
             innerHandlerMock.ReceiveAsync(Arg.Any<CancellationToken>()).Returns(t => Task.FromResult(new Message()));
-            innerHandlerMock.ReceiveAsync(Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>()).Returns(t => Task.FromResult(new Message()));
+            innerHandlerMock.ReceiveAsync(Arg.Any<TimeSpan>()).Returns(t => Task.FromResult(new Message()));
             innerHandlerMock.AbandonAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(t => Task.CompletedTask);
             innerHandlerMock.CompleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(t => Task.CompletedTask);
             innerHandlerMock.RejectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(t => Task.CompletedTask);
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Devices.Client.Test
                 sut => sut.SendEventAsync(new Message(), cancellationToken),
                 sut => sut.SendEventAsync(new[] { new Message() }, cancellationToken),
                 sut => sut.ReceiveAsync(cancellationToken),
-                sut => sut.ReceiveAsync(TimeSpan.FromSeconds(1), cancellationToken),
+                sut => sut.ReceiveAsync(TimeSpan.FromSeconds(1)),
                 sut => sut.AbandonAsync(string.Empty, cancellationToken),
                 sut => sut.CompleteAsync(string.Empty, cancellationToken),
                 sut => sut.RejectAsync(string.Empty, cancellationToken),
@@ -63,7 +63,10 @@ namespace Microsoft.Azure.Devices.Client.Test
                 await action(sut).ConfigureAwait(false);
             }
 
-            await innerHandlerMock.Received(actions.Length).OpenAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
+            await innerHandlerMock.Received(actions.Length - 1).OpenAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
+            
+            // ReceiveAsync(TimeSpan)
+            await innerHandlerMock.Received(1).OpenAsync(Arg.Any<TimeSpan>()).ConfigureAwait(false);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
When calling ReceiveAsync on the DeviceClient the timeout nor the cancellation token are effective in aborting the request when using AmqpTransport. There are 2 issues we found: 
1. The AmqpTransportHandler does have an endless while(true) and won't exit until a message was received, or the operation timed out. 
2. The actual timeout being supplied to the method is not reaching the AmqpTransportHandler because it is wrapped in the CancellationToken that has no effect on the AmqpTransportHandler level.

@fbeltrao 

## Reference/Link to the issue solved with this PR (if any)
Fixes:  #1003 

