### PR TITLE
Fix for github issue #992 and additional stress tests

### DIFF
--- a/e2e/stress/MemoryLeakTest/Program.cs
+++ b/e2e/stress/MemoryLeakTest/Program.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 catch (TimeoutException) { }
                 catch (SocketException) { }
                 catch (TaskCanceledException) { }
-                catch (IotHubCommunicationException) { }
+                catch (IotHubCommunicationException ex2) { Console.WriteLine(ex2); }
                 finally
                 {
                     foreach (Message m in msg)

--- a/e2e/stress/MemoryLeakTest/Program.cs
+++ b/e2e/stress/MemoryLeakTest/Program.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 catch (TimeoutException) { }
                 catch (SocketException) { }
                 catch (TaskCanceledException) { }
-                catch (IotHubCommunicationException ex2) { Console.WriteLine(ex2); }
+                catch (IotHubCommunicationException) { }
                 finally
                 {
                     foreach (Message m in msg)

--- a/e2e/stress/RaceConditionTest/Program.cs
+++ b/e2e/stress/RaceConditionTest/Program.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Run using the following:
+//  dotnet run --framework netcoreapp2.1 --configuration Release
+//  dotnet run --framework net47 --configuration Release
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Devices.Client;
+using System.Diagnostics;
+using System.Net.Sockets;
+using Microsoft.Azure.Devices.Client.Exceptions;
+using System.Threading;
+using System.Text;
+using System.IO;
+
+namespace Microsoft.Azure.Devices.E2ETests
+{
+    public class MessageRaceConditionTest
+    {
+        private string DeviceConnectionString;
+        private const int NumberOfParallelDeviceClientCalls = 10000;
+
+        public MessageRaceConditionTest(string deviceConnectionString)
+        {
+            DeviceConnectionString = deviceConnectionString;
+        }
+
+        public async Task<int> RunTest_SendTenThousandMessagesAsync(TransportType transportType)
+        {
+            const int MaxExecutionTimeMinutes = 10;
+            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(DeviceConnectionString, transportType);
+            deviceClient.OperationTimeoutInMilliseconds = 5;
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(MaxExecutionTimeMinutes));
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            deviceClient.RetryPolicy = RetryPolicyType.No_Retry;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            List<Task> tasks = new List<Task>();
+
+            try
+            {
+                for (int i = 0; i < NumberOfParallelDeviceClientCalls; i++)
+                {
+                    Message message = new Message(Encoding.ASCII.GetBytes("Test"));
+                    tasks.Add(deviceClient.SendEventAsync(message, cancellationTokenSource.Token));
+                }
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+                return 1;
+            }
+
+            Console.WriteLine("Test passed (" + transportType + ")");
+            return 0;
+        }
+
+        public async Task<int> RunTest_SendThousandsOfMessagesAndCancelAsync(TransportType transportType)
+        {
+            const int MaxExecutionTimeInSeconds = 10;
+            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(DeviceConnectionString, transportType);
+            deviceClient.OperationTimeoutInMilliseconds = 5;
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(MaxExecutionTimeInSeconds));
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            deviceClient.RetryPolicy = RetryPolicyType.No_Retry;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            List<Task> tasks = new List<Task>();
+
+            try
+            {
+                for (int i = 0; i < NumberOfParallelDeviceClientCalls; i++)
+                {
+                    Message message = new Message(Encoding.ASCII.GetBytes("Test"));
+                    tasks.Add(deviceClient.SendEventAsync(message, cancellationTokenSource.Token));
+                }
+
+                cancellationTokenSource.Cancel();
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+                return 1;
+            }
+
+            Console.WriteLine("Test passed (" + transportType + ")");
+            return 0;
+        }
+
+        public static int Main(string[] args)
+        {
+            string deviceConnectionString = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_CONN_STRING") ?? throw new Exception("Device Connection string not provided");
+
+            var messageRaceConditionTest = new MessageRaceConditionTest(deviceConnectionString);
+            TransportType[] transportTests =
+            {
+                TransportType.Http1,
+                TransportType.Amqp,
+                TransportType.Mqtt
+            };
+
+            foreach(TransportType t in transportTests)
+            {
+                int returnValue;
+
+                returnValue = messageRaceConditionTest.RunTest_SendTenThousandMessagesAsync(t).GetAwaiter().GetResult();
+
+                if (returnValue != 0)
+                {
+                    Console.WriteLine("Failed RunTest_SendTenThousandMessagesAsync");
+                    return returnValue;
+                }
+
+                returnValue = messageRaceConditionTest.RunTest_SendThousandsOfMessagesAndCancelAsync(t).GetAwaiter().GetResult();
+
+                if (returnValue != 0)
+                {
+                    Console.WriteLine("Failed RunTest_SendThousandsOfMessagesAndCancelAsync");
+                    return returnValue;
+                }
+            }
+
+            return 0;
+        }
+    }
+}

--- a/e2e/stress/RaceConditionTest/Program.cs
+++ b/e2e/stress/RaceConditionTest/Program.cs
@@ -88,6 +88,10 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 await Task.WhenAll(tasks).ConfigureAwait(false);
             }
+            catch (OperationCanceledException) { }
+            catch (IotHubCommunicationException iotHubEx) 
+                when (iotHubEx.InnerException is TaskCanceledException || iotHubEx.InnerException is OperationCanceledException)
+            { }
             catch (Exception ex)
             {
                 Console.WriteLine(ex);

--- a/e2e/stress/RaceConditionTest/RaceConditionText.csproj
+++ b/e2e/stress/RaceConditionTest/RaceConditionText.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.1;net47</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
+    <RootDir>$(MSBuildProjectDirectory)\..\..\..</RootDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <CommonTest>$(RootDir)\common\test</CommonTest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(CommonTest)\CodeAnalysisOverrides.cs">
+      <Link>Common\CodeAnalysisOverrides.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RootDir)\iothub\device\src\Microsoft.Azure.Devices.Client.csproj" />
+    <ProjectReference Include="$(RootDir)\shared\src\Microsoft.Azure.Devices.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/e2e/stress/stress.sln
+++ b/e2e/stress/stress.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.757
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.352
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MemoryLeakTest", "MemoryLeakTest\MemoryLeakTest.csproj", "{97445B7F-D060-4CDE-9B35-93746A526C02}"
 EndProject

--- a/e2e/stress/stress.sln
+++ b/e2e/stress/stress.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.352
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.757
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MemoryLeakTest", "MemoryLeakTest\MemoryLeakTest.csproj", "{97445B7F-D060-4CDE-9B35-93746A526C02}"
 EndProject
@@ -14,6 +14,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IoTClientPerf", "IoTClientPerf\IoTClientPerf.csproj", "{E8CC39DC-5C1E-4B8E-9916-6C7C72072B3F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Devices", "..\..\iothub\service\src\Microsoft.Azure.Devices.csproj", "{E3AB0D50-B2BC-4949-96CF-9D836B130F85}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RaceConditionText", "RaceConditionTest\RaceConditionText.csproj", "{D00E828D-860B-41FA-AA20-40695399626A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -85,6 +87,18 @@ Global
 		{E3AB0D50-B2BC-4949-96CF-9D836B130F85}.Release|x64.Build.0 = Release|Any CPU
 		{E3AB0D50-B2BC-4949-96CF-9D836B130F85}.Release|x86.ActiveCfg = Release|Any CPU
 		{E3AB0D50-B2BC-4949-96CF-9D836B130F85}.Release|x86.Build.0 = Release|Any CPU
+		{D00E828D-860B-41FA-AA20-40695399626A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D00E828D-860B-41FA-AA20-40695399626A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D00E828D-860B-41FA-AA20-40695399626A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D00E828D-860B-41FA-AA20-40695399626A}.Debug|x64.Build.0 = Debug|Any CPU
+		{D00E828D-860B-41FA-AA20-40695399626A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D00E828D-860B-41FA-AA20-40695399626A}.Debug|x86.Build.0 = Debug|Any CPU
+		{D00E828D-860B-41FA-AA20-40695399626A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D00E828D-860B-41FA-AA20-40695399626A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D00E828D-860B-41FA-AA20-40695399626A}.Release|x64.ActiveCfg = Release|Any CPU
+		{D00E828D-860B-41FA-AA20-40695399626A}.Release|x64.Build.0 = Release|Any CPU
+		{D00E828D-860B-41FA-AA20-40695399626A}.Release|x86.ActiveCfg = Release|Any CPU
+		{D00E828D-860B-41FA-AA20-40695399626A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/iothub/device/src/Transport/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Transport/RetryDelegatingHandler.cs
@@ -462,7 +462,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             if (Volatile.Read(ref _opened)) return;
 
-            await _handlerLock.WaitAsync().ConfigureAwait(false);
+            await _handlerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 if (!_opened)


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
Fix for GitHub issue https://github.com/Azure/azure-iot-sdk-csharp/issues/992

- Passed the cancellatoionToken to _handlerLock.WaitAsync;
- Added a stress test to verify no issues incur from the change.

## Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-csharp/issues/992
