### PR TITLE
Deprecating DeviceClient Timeout APIs, Doc changes

### DIFF
--- a/iothub/device/src/AmqpConnectionPoolSettings.cs
+++ b/iothub/device/src/AmqpConnectionPoolSettings.cs
@@ -1,41 +1,48 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
 
 namespace Microsoft.Azure.Devices.Client
 {
-    using System;
-
     /// <summary>
-    /// contains Amqp Connection Pool settings for DeviceClient
+    /// Configuration for the AMQP IoTHub Transport.
     /// </summary>
-
     public sealed class AmqpConnectionPoolSettings
     {
-        static readonly TimeSpan DefaultConnectionIdleTimeout = TimeSpan.FromMinutes(2);
-        static readonly TimeSpan MinConnectionIdleTimeout = TimeSpan.FromSeconds(5);
-        const uint DefaultPoolSize = 100; // This will allow upto 100000 devices
-        const uint MaxNumberOfPools = ushort.MaxValue;
-        internal const uint MaxDevicesPerConnection = 995; // IotHub allows upto 999 tokens per connection. Setting the threshold just below that.
+        private static readonly TimeSpan DefaultConnectionIdleTimeout = TimeSpan.FromMinutes(2);
+        private static readonly TimeSpan MinConnectionIdleTimeout = TimeSpan.FromSeconds(5);
+        private const uint DefaultPoolSize = 100;
+        private const uint MaxNumberOfPools = ushort.MaxValue;
 
-        uint maxPoolSize;
-        TimeSpan connectionIdleTimeout;
+        private uint _maxPoolSize;
+        private TimeSpan _connectionIdleTimeout;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AmqpConnectionPoolSettings"/> class.
+        /// </summary>
         public AmqpConnectionPoolSettings()
         {
-            this.maxPoolSize = DefaultPoolSize;
+            this._maxPoolSize = DefaultPoolSize;
             this.Pooling = false;
-            this.connectionIdleTimeout = DefaultConnectionIdleTimeout;
+            this._connectionIdleTimeout = DefaultConnectionIdleTimeout;
         }
 
+        /// <summary>
+        /// Gets or sets the maximum size of the pool.
+        /// </summary>
+        /// <value>
+        /// The maximum size of the pool.
+        /// </value>
+        /// <exception cref="ArgumentOutOfRangeException">value</exception>
         public uint MaxPoolSize
         {
-            get { return this.maxPoolSize; }
+            get { return this._maxPoolSize; }
 
             set
             {
                 if (value > 0 && value <= MaxNumberOfPools)
                 {
-                    this.maxPoolSize = value;
+                    this._maxPoolSize = value;
                 }
                 else
                 {
@@ -44,17 +51,23 @@ namespace Microsoft.Azure.Devices.Client
             }
         }
 
+        /// <summary>Gets or sets a value indicating whether this <see cref="AmqpConnectionPoolSettings"/> is pooling.</summary>
+        /// <value>
+        ///   <c>true</c> if pooling; otherwise, <c>false</c>.</value>
         public bool Pooling { get; set; }
 
+        /// <summary>Gets or sets the connection idle timeout.</summary>
+        /// <value>The connection idle timeout.</value>
+        /// <exception cref="ArgumentOutOfRangeException">value</exception>
         public TimeSpan ConnectionIdleTimeout
         {
-            get { return this.connectionIdleTimeout; }
+            get { return this._connectionIdleTimeout; }
 
             set
             {
                 if (value >= MinConnectionIdleTimeout)
                 {
-                    this.connectionIdleTimeout = value;
+                    this._connectionIdleTimeout = value;
                 }
                 else
                 {
@@ -63,6 +76,9 @@ namespace Microsoft.Azure.Devices.Client
             }
         }
 
+        /// <summary>Equalses the specified other.</summary>
+        /// <param name="other">The other.</param>
+        /// <returns></returns>
         public bool Equals(AmqpConnectionPoolSettings other)
         {
             if (other == null)

--- a/iothub/device/src/AmqpTransportSettings.cs
+++ b/iothub/device/src/AmqpTransportSettings.cs
@@ -1,29 +1,39 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Azure.Devices.Shared;
+using System;
+using System.Net;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
 namespace Microsoft.Azure.Devices.Client
 {
-    using Microsoft.Azure.Devices.Shared;
-    using System;
-    using System.Net;
-    using System.Net.Security;
-    using System.Security.Cryptography.X509Certificates;
-
-    /// <summary>
-    /// contains Amqp transport-specific settings for DeviceClient
-    /// </summary>
+    /// <summary>Contains advanced AMQP transport settings</summary>
+    /// <remarks>
+    ///   <para>
+    /// We recommend that default settings are used in most applications.</para>
+    ///   <para>If more granular control is required, advanced users can tweak this options with the following implications:</para>
+    ///   <list type="bullet">
+    ///     <item>Small timeouts (&lt;30 seconds) potentially consuming more CPU/battery as we will spin-wait on ReceiveAsync.</item>
+    ///     <item>Small timeouts can cause inconsistent states for messages being sent or received.</item>
+    ///     <item>
+    /// There are cases where some of the timeouts out can cause the AMQP stack to become unstable/unusable which could cause a disconnect or data loss.
+    /// </item>
+    ///   </list>
+    /// </remarks>
     public sealed class AmqpTransportSettings : ITransportSettings
     {
-        static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromMinutes(1);
-        static readonly TimeSpan DefaultOpenTimeout = TimeSpan.FromMinutes(1);
-        const uint DefaultPrefetchCount = 50;
+        private static readonly TimeSpan s_defaultOperationTimeout = TimeSpan.FromMinutes(1);
+        private static readonly TimeSpan s_defaultOpenTimeout = TimeSpan.FromMinutes(1);
+        private const uint DefaultPrefetchCount = 50;
 
-        readonly TransportType transportType;
-        TimeSpan operationTimeout;
-        TimeSpan openTimeout;
+        private readonly TransportType _transportType;
+        private TimeSpan _operationTimeout;
+        private TimeSpan _openTimeout;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AmqpTransportSettings" class./>
+        /// Initializes a new instance of the <see cref="AmqpTransportSettings"/> class./>
         /// </summary>
         /// <param name="transportType">The AMQP transport type.</param>
         public AmqpTransportSettings(TransportType transportType)
@@ -32,18 +42,28 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AmqpTransportSettings" class./>
+        /// Initializes a new instance of the <see cref="AmqpTransportSettings"/> class.
         /// </summary>
-        /// <param name="transportType">The AMQP transport type.</param>
+        /// <param name="transportType">Type of the transport.</param>
+        /// <param name="prefetchCount">The prefetch count (Total AMQP Link credit).</param>
         public AmqpTransportSettings(TransportType transportType, uint prefetchCount)
-            :this(transportType, prefetchCount, new AmqpConnectionPoolSettings())
+            : this(transportType, prefetchCount, new AmqpConnectionPoolSettings())
         {
         }
 
+        /// <summary>Initializes a new instance of the <see cref="AmqpTransportSettings"/> class.</summary>
+        /// <param name="transportType">Type of the transport.</param>
+        /// <param name="prefetchCount">The prefetch count (Total AMQP Link credit).</param>
+        /// <param name="amqpConnectionPoolSettings">The amqp connection pool settings.</param>
+        /// <exception cref="ArgumentOutOfRangeException">prefetchCount - Must be greater than zero
+        /// or
+        /// transportType - Must specify Amqp_WebSocket_Only or Amqp_Tcp_Only
+        /// or
+        /// transportType - null</exception>
         public AmqpTransportSettings(TransportType transportType, uint prefetchCount, AmqpConnectionPoolSettings amqpConnectionPoolSettings)
         {
-            this.operationTimeout = DefaultOperationTimeout;
-            this.openTimeout = DefaultOpenTimeout;
+            this._operationTimeout = s_defaultOperationTimeout;
+            this._openTimeout = s_defaultOpenTimeout;
 
             if (prefetchCount <= 0)
             {
@@ -54,10 +74,10 @@ namespace Microsoft.Azure.Devices.Client
             {
                 case TransportType.Amqp_WebSocket_Only:
                     this.Proxy = DefaultWebProxySettings.Instance;
-                    this.transportType = transportType;
+                    this._transportType = transportType;
                     break;
                 case TransportType.Amqp_Tcp_Only:
-                    this.transportType = transportType;
+                    this._transportType = transportType;
                     break;
                 case TransportType.Amqp:
                     throw new ArgumentOutOfRangeException(nameof(transportType), transportType, "Must specify Amqp_WebSocket_Only or Amqp_Tcp_Only");
@@ -69,34 +89,91 @@ namespace Microsoft.Azure.Devices.Client
             this.AmqpConnectionPoolSettings = amqpConnectionPoolSettings;
         }
 
+        /// <summary>
+        /// Returns the transport type of the TransportSettings object.
+        /// </summary>
+        /// <returns>
+        /// The TransportType
+        /// </returns>
         public TransportType GetTransportType()
         {
-            return this.transportType;
+            return this._transportType;
         }
 
-        public TimeSpan DefaultReceiveTimeout => this.operationTimeout;
+        /// <summary>
+        /// The default receive timeout.
+        /// </summary>
+        public TimeSpan DefaultReceiveTimeout => this._operationTimeout;
 
-        public TimeSpan OperationTimeout {
-            get { return this.operationTimeout; }
+        /// <summary>
+        /// Gets or sets the operation timeout.
+        /// </summary>
+        /// <value>
+        /// The operation timeout.
+        /// </value>
+        public TimeSpan OperationTimeout
+        {
+            get { return this._operationTimeout; }
             set { this.SetOperationTimeout(value); }
         }
 
+        /// <summary>
+        /// Gets or sets the open timeout.
+        /// </summary>
+        /// <value>
+        /// The open timeout.
+        /// </value>
         public TimeSpan OpenTimeout
         {
-            get { return this.openTimeout; }
+            get { return this._openTimeout; }
             set { this.SetOpenTimeout(value); }
         }
 
+        /// <summary>
+        /// Gets or sets the prefetch count. This is passed to the AMQP library as total link credit.
+        /// </summary>
+        /// <value>
+        /// The prefetch count.
+        /// </value>
         public uint PrefetchCount { get; set; }
 
+        /// <summary>
+        /// Gets or sets the client certificate.
+        /// </summary>
+        /// <value>
+        /// The client certificate.
+        /// </value>
         public X509Certificate2 ClientCertificate { get; set; }
 
+        /// <summary>
+        /// Gets or sets the proxy.
+        /// </summary>
+        /// <value>
+        /// The proxy.
+        /// </value>
         public IWebProxy Proxy { get; set; }
 
+        /// <summary>
+        /// Gets or sets the remote certificate validation callback.
+        /// </summary>
+        /// <value>
+        /// The remote certificate validation callback.
+        /// </value>
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 
+        /// <summary>
+        /// Gets or sets the AMQP connection pool settings.
+        /// </summary>
+        /// <value>
+        /// The AMQP connection pool settings.
+        /// </value>
         public AmqpConnectionPoolSettings AmqpConnectionPoolSettings { get; set; }
 
+        /// <summary>
+        /// Determines whether two objects have the same value.
+        /// </summary>
+        /// <param name="other">The other object.</param>
+        /// <returns>true if the object are equal</returns>
         public bool Equals(AmqpTransportSettings other)
         {
             if (other == null)
@@ -113,11 +190,11 @@ namespace Microsoft.Azure.Devices.Client
             return (this.PrefetchCount == other.PrefetchCount && this.OpenTimeout == other.OpenTimeout && this.OperationTimeout == other.OperationTimeout && this.AmqpConnectionPoolSettings.Equals(other.AmqpConnectionPoolSettings));
         }
 
-        void SetOperationTimeout(TimeSpan timeout)
+        private void SetOperationTimeout(TimeSpan timeout)
         {
             if (timeout > TimeSpan.Zero)
             {
-                this.operationTimeout = timeout;
+                this._operationTimeout = timeout;
             }
             else
             {
@@ -125,11 +202,11 @@ namespace Microsoft.Azure.Devices.Client
             }
         }
 
-        void SetOpenTimeout(TimeSpan timeout)
+        private void SetOpenTimeout(TimeSpan timeout)
         {
             if (timeout > TimeSpan.Zero)
             {
-                this.openTimeout = timeout;
+                this._openTimeout = timeout;
             }
             else
             {

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -279,18 +279,20 @@ namespace Microsoft.Azure.Devices.Client
         /// <returns>The receive message or null if there was no message until the default timeout</returns>
         public Task<Message> ReceiveAsync() => this.internalClient.ReceiveAsync();
 
-        /// <summary>
-        /// Receive a message from the device queue using the default timeout.
-        /// </summary>
+        /// <summary>Receive a message from the device queue using the default timeout.</summary>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>  
         /// <returns>The receive message or null if there was no message until the default timeout</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
+        /// <remarks>
+        /// Cancellation can be performed only when the AMQP protocol library returns control to the SDK. This is done every AmqpTransportSettings.OperationTimeout if the DeviceClient is already connected or before or after AmqpTransportSettings.OpenTimeout if the DeviceClient needs to reconnect.
+        /// </remarks>
         public Task<Message> ReceiveAsync(CancellationToken cancellationToken) => this.internalClient.ReceiveAsync(cancellationToken);
 
         /// <summary>
-        /// Receive a message from the device queue with the specified timeout
+        /// Receive a message from the device queue with the specified timeout.
         /// </summary>
         /// <returns>The receive message or null if there was no message until the specified time has elapsed</returns>
+        [Obsolete("This method has been deprecated. Please use ReceiveAsync(CancellationToken) instead.")]
         public Task<Message> ReceiveAsync(TimeSpan timeout) => this.internalClient.ReceiveAsync(timeout);
 
         /// <summary>


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [X] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
- Deprecating `ReceiveAsync(Timeout)`: we recommend using the CancellationToken APIs instead.
- Documenting `AmqpTransportSettings` and related classes.

PR reviewers: please ignore formatting (i.e. this._) for now. This is part of a work-in-progress change fixing all automation tool warnings and so these will be addressed in a future PR.

Fixes #1014