### PR TITLE
Add proxy handling to HttpClientHelper.httpClientObjWithPerRequestTim…

### DIFF
--- a/common/src/service/HttpClientHelper.cs
+++ b/common/src/service/HttpClientHelper.cs
@@ -66,7 +66,18 @@ namespace Microsoft.Azure.Devices
             this.httpClientObj.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(CommonConstants.MediaTypeForDeviceManagementApis));
             this.httpClientObj.DefaultRequestHeaders.ExpectContinue = false;
 
-            this.httpClientObjWithPerRequestTimeout = new HttpClient();
+            if (customHttpProxy != DefaultWebProxySettings.Instance)
+            {
+                HttpClientHandler httpClientHandler = new HttpClientHandler();
+                httpClientHandler.UseProxy = (customHttpProxy != null);
+                httpClientHandler.Proxy = customHttpProxy;
+                this.httpClientObjWithPerRequestTimeout = new HttpClient(httpClientHandler);
+            }
+            else
+            {
+                this.httpClientObjWithPerRequestTimeout = new HttpClient();
+            }
+
             this.httpClientObjWithPerRequestTimeout.BaseAddress = this.baseAddress;
             this.httpClientObjWithPerRequestTimeout.Timeout = Timeout.InfiniteTimeSpan;
             this.httpClientObjWithPerRequestTimeout.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(CommonConstants.MediaTypeForDeviceManagementApis));

--- a/e2e/test/ServiceClientE2ETests.cs
+++ b/e2e/test/ServiceClientE2ETests.cs
@@ -44,21 +44,21 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        public async Task Service_InvokeMethodWithCustomTimeout_Amqp()
+        public async Task ServiceClient_InvokeMethodWithCustomTimeout_Amqp()
         {
-            await Service_InvokeMethodWithCustomTimeout(TransportType.Amqp).ConfigureAwait(false);
+            await ServiceClient_InvokeMethodWithCustomTimeout(TransportType.Amqp).ConfigureAwait(false);
         }
 
         [TestMethod]
-        public async Task Service_InvokeMethodWithCustomTimeout_AmqpWs()
+        public async Task ServiceClient_InvokeMethodWithCustomTimeout_AmqpWs()
         {
-            await Service_InvokeMethodWithCustomTimeout(TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
+            await ServiceClient_InvokeMethodWithCustomTimeout(TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
         }
 
         [TestMethod]
-        public async Task Service_InvokeMethodWithCustomTimeout_Amqp_WithProxy()
+        public async Task ServiceClient_InvokeMethodWithCustomTimeout_Amqp_WithProxy()
         {
-            await Service_InvokeMethodWithCustomTimeout(
+            await ServiceClient_InvokeMethodWithCustomTimeout(
                 TransportType.Amqp, 
                 new ServiceClientTransportSettings()
                 {
@@ -68,9 +68,9 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestMethod]
-        public async Task Service_InvokeMethodWithCustomTimeout_AmqpWs_WithProxy()
+        public async Task ServiceClient_InvokeMethodWithCustomTimeout_AmqpWs_WithProxy()
         {
-            await Service_InvokeMethodWithCustomTimeout(
+            await ServiceClient_InvokeMethodWithCustomTimeout(
                 TransportType.Amqp_WebSocket_Only,
                 new ServiceClientTransportSettings()
                 {
@@ -79,12 +79,12 @@ namespace Microsoft.Azure.Devices.E2ETests
                 }).ConfigureAwait(false);
         }
 
-        private async Task Service_InvokeMethodWithCustomTimeout(TransportType transportType)
+        private async Task ServiceClient_InvokeMethodWithCustomTimeout(TransportType transportType)
         {
-            await Service_InvokeMethodWithCustomTimeout(TransportType.Amqp_WebSocket_Only, new ServiceClientTransportSettings()).ConfigureAwait(false);
+            await ServiceClient_InvokeMethodWithCustomTimeout(TransportType.Amqp_WebSocket_Only, new ServiceClientTransportSettings()).ConfigureAwait(false);
         }
 
-        private async Task Service_InvokeMethodWithCustomTimeout(TransportType transportType, ServiceClientTransportSettings transportSettings)
+        private async Task ServiceClient_InvokeMethodWithCustomTimeout(TransportType transportType, ServiceClientTransportSettings transportSettings)
         {
             TestDevice device = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             DeviceClient deviceClient = device.CreateDeviceClient(Client.TransportType.Amqp);

--- a/e2e/test/ServiceClientE2ETests.cs
+++ b/e2e/test/ServiceClientE2ETests.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Azure.Devices.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -14,6 +16,10 @@ namespace Microsoft.Azure.Devices.E2ETests
     [TestCategory("IoTHub-E2E")]
     public class ServiceClientE2ETests : IDisposable
     {
+        private const string DeviceResponseJson = "{\"name\":\"e2e_test\"}";
+        private const string ServiceRequestJson = "{\"a\":123}";
+        private readonly string DirectMethodName = $"{nameof(ServiceClientE2ETests)}Method";
+        private TimeSpan CustomTimeout = TimeSpan.FromMinutes(5);
         private readonly string DevicePrefix = $"E2E_{nameof(ServiceClientE2ETests)}_";
         private static TestLogging _log = TestLogging.GetInstance();
 
@@ -35,6 +41,58 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task Message_NoTimeoutPassed()
         {
             await DefaultTimeout().ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Service_InvokeMethodWithCustomTimeout_Amqp()
+        {
+            await Service_InvokeMethodWithCustomTimeout(TransportType.Amqp).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Service_InvokeMethodWithCustomTimeout_AmqpWs()
+        {
+            await Service_InvokeMethodWithCustomTimeout(TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Service_InvokeMethodWithCustomTimeout_Amqp_WithProxy()
+        {
+            await Service_InvokeMethodWithCustomTimeout(
+                TransportType.Amqp, 
+                new ServiceClientTransportSettings()
+                {
+                    AmqpProxy = new WebProxy(Configuration.IoTHub.ProxyServerAddress),
+                    HttpProxy = new WebProxy(Configuration.IoTHub.ProxyServerAddress)
+                }).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Service_InvokeMethodWithCustomTimeout_AmqpWs_WithProxy()
+        {
+            await Service_InvokeMethodWithCustomTimeout(
+                TransportType.Amqp_WebSocket_Only,
+                new ServiceClientTransportSettings()
+                {
+                    AmqpProxy = new WebProxy(Configuration.IoTHub.ProxyServerAddress),
+                    HttpProxy = new WebProxy(Configuration.IoTHub.ProxyServerAddress)
+                }).ConfigureAwait(false);
+        }
+
+        private async Task Service_InvokeMethodWithCustomTimeout(TransportType transportType)
+        {
+            await Service_InvokeMethodWithCustomTimeout(TransportType.Amqp_WebSocket_Only, new ServiceClientTransportSettings()).ConfigureAwait(false);
+        }
+
+        private async Task Service_InvokeMethodWithCustomTimeout(TransportType transportType, ServiceClientTransportSettings transportSettings)
+        {
+            TestDevice device = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            DeviceClient deviceClient = device.CreateDeviceClient(Client.TransportType.Amqp);
+            await MethodE2ETests.SetDeviceReceiveMethod(deviceClient, DirectMethodName).ConfigureAwait(false);
+
+            var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString, transportType, transportSettings);
+            var result = await serviceClient.InvokeDeviceMethodAsync(device.Id, new CloudToDeviceMethod(DirectMethodName, CustomTimeout)).ConfigureAwait(false);
+            Assert.AreEqual(200, result.Status);
         }
 
         private async Task FastTimeout()


### PR DESCRIPTION
…eout

<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [X] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->
The change fixes proxy support for HTTP requests sent by service client or registry manager if custom operation timeout is specified and it is not equal to default operation timeout.

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
