### PR TITLE
Throw exception when TopicName in MQTT packet is too long

### DIFF
--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
     using System.Diagnostics.Contracts;
     using System.Globalization;
     using System.IO;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -50,6 +51,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         private const string IotHubTrueString = "true";
         private const string SegmentSeparator = "/";
         private const int MaxPayloadSize = 0x3ffff;
+        private const int MaxTopicNameLength = 0xffff;
 
         private static readonly Action<object> PingServerCallback = PingServer;
         private static readonly Action<object> CheckConnAckTimeoutCallback = ShutdownIfNotReady;
@@ -1173,6 +1175,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             else
             {
                 msg = topicName;
+            }
+
+            if (Encoding.UTF8.GetByteCount(msg) > MaxTopicNameLength)
+            {
+                throw new MessageTooLargeException($"TopicName for MQTT packet cannot be larger than {MaxTopicNameLength} bytes, current length is {Encoding.UTF8.GetByteCount(msg)}. The probable cause is the list of message.Properties and/or message.systemProperties is too long. Please use AMQP or HTTP.");
             }
 
             return msg;


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [X] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [X] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
Fixes #853 