### PR TITLE
Deprecating support for .NET MicroFramework.

### DIFF
--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -47,7 +47,11 @@ Components:
 Install the Microsoft IoT Windows Core Project Templates for Visual Studio 2017 from the Extension Marketplace: 
 	https://marketplace.visualstudio.com/items?itemName=MicrosoftIoT.WindowsIoTCoreProjectTemplatesforVS15
 
-### Installing .NET Micro Framework
+### [Deprecated] Installing .NET Micro Framework
+
+```diff
+- .NET MicroFramework will not be supported in future versions of the SDK.
+```
 
 #### 1. Download and Install Visual Studio Community 2015 Update 3 (approx. size: 9GB)
 

--- a/doc/devguide.md
+++ b/doc/devguide.md
@@ -83,6 +83,9 @@ If you would like to develop an application using the Azure IoT SDK for C# (usin
 Contains the IoT Hub Device SDK source, unit-tests and samples. 
 This produces the `Microsoft.Azure.Devices.Client` NuGet package.
 
+```diff
+- .NET MicroFramework will not be supported in future versions of the SDK.
+```
 The src.NetMF folder contains the .NET Microframework port.
 
 ### /iothub/service

--- a/readme.md
+++ b/readme.md
@@ -35,19 +35,23 @@ Due to security considerations, build logs are not publicly available.
 | Preview                   | [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/csharp/csharp-canary1?branchName=preview)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build?definitionId=43&_a=summary&repositoryFilter=9&branchFilter=72)|
 
 ## OS platforms and hardware compatibility
+
+```diff
+- .NET MicroFramework will not be supported in future versions of the SDK.
+```
+
 The IoT Hub device SDK for .NET can be used with a broad range of OS platforms and devices.
 
 The NuGet packages provide support for the following .NET flavors:
 - .NET Standard 2.0
 - .NET Standard 1.3 (IoT Hub SDKs only)
 - .NET Framework 4.5.1 (IoT Hub SDKs only)
-- .NET MicroFramework (IoT Hub SDKs only)
 
 For details on .NET support see the [.NET Standard documentation](https://docs.microsoft.com/en-us/dotnet/standard/net-standard).
 For details on OS support see the following resources:
 - [.NET Core Runtime ID Catalog](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog)
-- [.NET MicroFramework](http://netmf.github.io)
 - [.NET Framework System Requirements](https://docs.microsoft.com/en-us/dotnet/framework/get-started/system-requirements)
+- [.NET MicroFramework](http://netmf.github.io)
 
 ## Key features and roadmap
 


### PR DESCRIPTION
Deprecating support for .NET MicroFramework in future SDK versions.
Because NETMF is no longer supported or actively in-development, we will remove all references and code related to it in a future release.
