### PR TITLE
Add null checks on Abandon/Reject/CompleteAsync in internal client

### DIFF
--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -400,8 +400,13 @@ namespace Microsoft.Azure.Devices.Client
         /// <returns>The previously received message</returns>
         public Task CompleteAsync(Message message)
         {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
             // Codes_SRS_DEVICECLIENT_28_015: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication, quota exceed) occurs.]
-            return CompleteAsync(message?.LockToken);
+            return CompleteAsync(message.LockToken);
         }
 
         /// <summary>
@@ -415,6 +420,7 @@ namespace Microsoft.Azure.Devices.Client
             {
                 throw new ArgumentNullException(nameof(message));
             }
+
             // Codes_SRS_DEVICECLIENT_28_015: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication, quota exceed) occurs.]
             return CompleteAsync(message.LockToken, cancellationToken);
         }
@@ -461,6 +467,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <returns>The lock identifier for the previously received message</returns>
         public Task AbandonAsync(Message message)
         {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
             return AbandonAsync(message.LockToken);
         }
 
@@ -519,6 +530,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <returns>The lock identifier for the previously received message</returns>
         public Task RejectAsync(Message message)
         {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
             return RejectAsync(message.LockToken);
         }
 
@@ -544,11 +560,11 @@ namespace Microsoft.Azure.Devices.Client
         {
             try
             {
-            // Codes_SRS_DEVICECLIENT_28_013: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication, quota exceed) occurs.]
-            using (CancellationTokenSource cts = CancellationTokenSourceFactory())
-            {
-                await SendEventAsync(message, cts.Token).ConfigureAwait(false);
-            }
+                // Codes_SRS_DEVICECLIENT_28_013: [The async operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or unrecoverable error(authentication, quota exceed) occurs.]
+                using (CancellationTokenSource cts = CancellationTokenSourceFactory())
+                {
+                    await SendEventAsync(message, cts.Token).ConfigureAwait(false);
+                }
             }
             catch (OperationCanceledException ex)
             {

--- a/iothub/device/tests/DeviceClientTests.cs
+++ b/iothub/device/tests/DeviceClientTests.cs
@@ -1137,5 +1137,101 @@ namespace Microsoft.Azure.Devices.Client.Test
             client.ProductInfo = userAgent;
             Assert.AreEqual(userAgent, client.ProductInfo);
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task CompleteAsyncThrowsForNullMessage()
+        {
+            DeviceClient client = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+            await client.CompleteAsync((Message)null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task CompleteAsyncWithCancellationTokenThrowsForNullMessage()
+        {
+            DeviceClient client = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+            await client.CompleteAsync((Message)null, CancellationToken.None);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task CompleteAsyncThrowsForNullLockToken()
+        {
+            DeviceClient client = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+            await client.CompleteAsync((string)null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task CompleteAsyncWithCancellationTokenThrowsForNullLockToken()
+        {
+            DeviceClient client = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+            await client.CompleteAsync((string)null, CancellationToken.None);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task RejectAsyncThrowsForNullMessage()
+        {
+            DeviceClient client = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+            await client.RejectAsync((Message)null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task RejectAsyncWithCancellationTokenThrowsForNullMessage()
+        {
+            DeviceClient client = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+            await client.RejectAsync((Message)null, CancellationToken.None);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task RejectAsyncThrowsForNullLockToken()
+        {
+            DeviceClient client = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+            await client.RejectAsync((string)null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task RejectAsyncWithCancellationTokenThrowsForNullLockToken()
+        {
+            DeviceClient client = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+            await client.RejectAsync((string)null, CancellationToken.None);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task AbandonAsyncThrowsForNullMessage()
+        {
+            DeviceClient client = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+            await client.AbandonAsync((Message)null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task AbandonAsyncWithCancellationTokenThrowsForNullMessage()
+        {
+            DeviceClient client = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+            await client.AbandonAsync((Message)null, CancellationToken.None);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task AbandonAsyncThrowsForNullLockToken()
+        {
+            DeviceClient client = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+            await client.AbandonAsync((string)null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task AbandonAsyncWithCancellationTokenThrowsForNullLockToken()
+        {
+            DeviceClient client = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+            await client.AbandonAsync((string)null, CancellationToken.None);
+        }
     }
 }


### PR DESCRIPTION
Issue #1089 pointed out that the null checks in our Abandon/Reject/CompleteAsync methods were inconsistent. Now all of those methods throw if the provided message or locktoken is null, and the thrown exception message matches the argument that was null.