### PR TITLE
Make ConfigurationMetrics on Configuration settable

### DIFF
--- a/iothub/service/src/Configurations/Configuration.cs
+++ b/iothub/service/src/Configurations/Configuration.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices
         /// Custom Configuration Metrics
         /// </summary>
         [JsonProperty(PropertyName = "metrics", NullValueHandling = NullValueHandling.Ignore)]
-        public ConfigurationMetrics Metrics { get; internal set; }
+        public ConfigurationMetrics Metrics { get; set; }
 
         /// <summary>
         /// Gets or sets configuration's ETag


### PR DESCRIPTION
For editing configurations using the registry manager, users need to be able to set the ConfigurationMetrics.

Node SDK already allows customers to do this, and so does the Java SDK.

[The original java issue](https://github.com/Azure/azure-iot-sdk-java/issues/600)