### PR TITLE
Fix issue where integer underflow caused exponential backoff time to retry to underflow

### DIFF
--- a/iothub/device/src/TransientFaultHandling/ExponentialBackoff.cs
+++ b/iothub/device/src/TransientFaultHandling/ExponentialBackoff.cs
@@ -98,9 +98,9 @@ namespace Microsoft.Azure.Devices.Client.TransientFaultHandling
                 if (currentRetryCount < this.retryCount)
                 {
                     Random random = new Random();
-                    int num = (int)((Math.Pow(2.0, (double)currentRetryCount) - 1.0) * (double)random.Next((int)(this.deltaBackoff.TotalMilliseconds * 0.8), (int)(this.deltaBackoff.TotalMilliseconds * 1.2)));
-                    int num2 = (int)Math.Min(this.minBackoff.TotalMilliseconds + (double)num, this.maxBackoff.TotalMilliseconds);
-                    retryInterval = TimeSpan.FromMilliseconds((double)num2);
+                    double num = ((Math.Pow(2.0, currentRetryCount) - 1.0) * random.Next((int)(this.deltaBackoff.TotalMilliseconds * 0.8), (int)(this.deltaBackoff.TotalMilliseconds * 1.2)));
+                    double num2 = Math.Min(this.minBackoff.TotalMilliseconds + num, this.maxBackoff.TotalMilliseconds);
+                    retryInterval = TimeSpan.FromMilliseconds(num2);
                     return true;
                 }
                 retryInterval = TimeSpan.Zero;

--- a/iothub/device/tests/ExponentialBackoffTests.cs
+++ b/iothub/device/tests/ExponentialBackoffTests.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Azure.Devices.Client.TransientFaultHandling;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices.Client.Test
+{
+    [TestClass]
+    public class ExponentialBackoffTests
+    {
+        private const int MAX_RETRY_ATTEMPTS = 5000;
+
+        [TestMethod]
+        public async Task ExponentialBackoffDoesNotUnderflow()
+        {
+            TransientFaultHandling.ExponentialBackoff exponentialBackoff = new TransientFaultHandling.ExponentialBackoff(MAX_RETRY_ATTEMPTS, RetryStrategy.DefaultMinBackoff, RetryStrategy.DefaultMaxBackoff, RetryStrategy.DefaultClientBackoff);
+
+            TimeSpan delay = TimeSpan.Zero;
+            ShouldRetry shouldRetry = exponentialBackoff.GetShouldRetry();
+            for (int i = 1; i < MAX_RETRY_ATTEMPTS; i++)
+            {    
+                shouldRetry(i, new Exception(), out delay);
+                if (delay.TotalSeconds <= 0)
+                {
+                    Assert.Fail("Exponential backoff should never recommend a negative delay");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue #969 

During the exponential backoff algorithm, some double values were cast to integer. When these values were large, the cast would result in an underflow which would cause the recommended next delay to be negative unexpectedly.

This pr alters the algorithm to only use doubles (which go to infinity, not to underflow) to fix this issue