### PR TITLE
Fix issue where integer underflow caused exponential backoff time to retry to underflow

### DIFF
--- a/iothub/device/src/TransientFaultHandling/ExponentialBackoff.cs
+++ b/iothub/device/src/TransientFaultHandling/ExponentialBackoff.cs
@@ -98,24 +98,13 @@ namespace Microsoft.Azure.Devices.Client.TransientFaultHandling
                 if (currentRetryCount < this.retryCount)
                 {
                     Random random = new Random();
-                    try
-                    {
-                        checked
-                        {
-                            int num = (int) (Math.Pow(2.0, currentRetryCount) - 1.0) * random.Next((int)(this.deltaBackoff.TotalMilliseconds * 0.8), (int)(this.deltaBackoff.TotalMilliseconds * 1.2));
-                            int num2 = (int) Math.Min(this.minBackoff.TotalMilliseconds + num, this.maxBackoff.TotalMilliseconds);
-                            retryInterval = TimeSpan.FromMilliseconds(num2);
-                            return true;
-                        }
-                    }
-                    catch (OverflowException e)
-                    {
-                        //Integer overflow only occurs due to the exponential backoff calculations at high retry count
-                        // Therefore, if integer overflow occurs, it is reasonable to default to the default maxBackoff
-                        retryInterval = TimeSpan.FromMilliseconds(this.maxBackoff.TotalMilliseconds);
-                        return true;
-                    }
+                    double exponentialInterval = (Math.Pow(2.0, currentRetryCount) - 1.0) * random.Next((int) this.deltaBackoff.TotalMilliseconds * 8 / 10, (int) this.deltaBackoff.TotalMilliseconds * 12 / 10) + this.minBackoff.TotalMilliseconds;
+                    double maxInterval = this.maxBackoff.TotalMilliseconds;
+                    double num2 = Math.Min(exponentialInterval, maxInterval);
+                    retryInterval = TimeSpan.FromMilliseconds(num2);
+                    return true;
                 }
+
                 retryInterval = TimeSpan.Zero;
                 return false;
             };

--- a/iothub/device/src/TransientFaultHandling/ExponentialBackoff.cs
+++ b/iothub/device/src/TransientFaultHandling/ExponentialBackoff.cs
@@ -98,10 +98,23 @@ namespace Microsoft.Azure.Devices.Client.TransientFaultHandling
                 if (currentRetryCount < this.retryCount)
                 {
                     Random random = new Random();
-                    int num = (int)((Math.Pow(2.0, (double)currentRetryCount) - 1.0) * (double)random.Next((int)(this.deltaBackoff.TotalMilliseconds * 0.8), (int)(this.deltaBackoff.TotalMilliseconds * 1.2)));
-                    int num2 = (int)Math.Min(this.minBackoff.TotalMilliseconds + (double)num, this.maxBackoff.TotalMilliseconds);
-                    retryInterval = TimeSpan.FromMilliseconds((double)num2);
-                    return true;
+                    try
+                    {
+                        checked
+                        {
+                            int num = (int) (Math.Pow(2.0, currentRetryCount) - 1.0) * random.Next((int)(this.deltaBackoff.TotalMilliseconds * 0.8), (int)(this.deltaBackoff.TotalMilliseconds * 1.2));
+                            int num2 = (int) Math.Min(this.minBackoff.TotalMilliseconds + num, this.maxBackoff.TotalMilliseconds);
+                            retryInterval = TimeSpan.FromMilliseconds(num2);
+                            return true;
+                        }
+                    }
+                    catch (OverflowException e)
+                    {
+                        //Integer overflow only occurs due to the exponential backoff calculations at high retry count
+                        // Therefore, if integer overflow occurs, it is reasonable to default to the default maxBackoff
+                        retryInterval = TimeSpan.FromMilliseconds(this.maxBackoff.TotalMilliseconds);
+                        return true;
+                    }
                 }
                 retryInterval = TimeSpan.Zero;
                 return false;

--- a/iothub/device/tests/ExponentialBackoffTests.cs
+++ b/iothub/device/tests/ExponentialBackoffTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Client.TransientFaultHandling;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices.Client.Test
+{
+    [TestClass]
+    public class ExponentialBackoffTests
+    {
+        private const int MAX_RETRY_ATTEMPTS = 5000;
+
+        [TestMethod]
+        public async Task ExponentialBackoffDoesNotUnderflow()
+        {
+            TransientFaultHandling.ExponentialBackoff exponentialBackoff = new TransientFaultHandling.ExponentialBackoff(MAX_RETRY_ATTEMPTS, RetryStrategy.DefaultMinBackoff, RetryStrategy.DefaultMaxBackoff, RetryStrategy.DefaultClientBackoff);
+
+            TimeSpan delay = TimeSpan.Zero;
+            ShouldRetry shouldRetry = exponentialBackoff.GetShouldRetry();
+            for (int i = 1; i < MAX_RETRY_ATTEMPTS; i++)
+            {    
+                shouldRetry(i, new Exception(), out delay);
+
+                if (delay.TotalSeconds <= 0)
+                {
+                    Assert.Fail("Exponential backoff should never recommend a negative delay");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue #969

During the exponential backoff algorithm, some double values were cast to integer. When these values were large, the cast would result in an underflow which would cause the recommended next delay to be negative unexpectedly.

~~This pr alters the algorithm to only use doubles (which go to infinity, not to underflow) to fix this issue~~

Switched back to integers, and using checked statements to lookout for integer overflow