### PR TITLE
Add clarification to device operation timeout documentation

### DIFF
--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -206,7 +206,10 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Stores the timeout used in the operation retries.
+        /// Stores the timeout used in the operation retries. Note that this value is ignored for operations
+        /// where a cancellation token is provided. For example, SendEventAsync(Message) will use this timeout, but 
+        /// SendEventAsync(Message, CancellationToken) will not. The latter operation will only be canceled by the 
+        /// provided cancellation token.
         /// </summary>
         // Codes_SRS_DEVICECLIENT_28_002: [This property shall be defaulted to 240000 (4 minutes).]
         public uint OperationTimeoutInMilliseconds

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -210,7 +210,10 @@ using System.Net.Http;
         }
 
         /// <summary>
-        /// Stores the timeout used in the operation retries.
+        /// Stores the timeout used in the operation retries. Note that this value is ignored for operations
+        /// where a cancellation token is provided. For example, SendEventAsync(Message) will use this timeout, but 
+        /// SendEventAsync(Message, CancellationToken) will not. The latter operation will only be canceled by the 
+        /// provided cancellation token.
         /// </summary>
         // Codes_SRS_DEVICECLIENT_28_002: [This property shall be defaulted to 240000 (4 minutes).]
         public uint OperationTimeoutInMilliseconds


### PR DESCRIPTION
Device Operation Timeout, by design, is only used for operations where user does not provide their own cancellation token. Adding clarification to the header for this timeout so users know not to expect it to matter for any operations with explicitly provided cancellation tokens

Solves part of issue #1081 