### PR TITLE
Fix for github issue #1100

### DIFF
--- a/iothub/device/src/Common/Extensions/CommonExtensions.cs
+++ b/iothub/device/src/Common/Extensions/CommonExtensions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices.Client.Extensions
                         (m.NextMatch().Success ? m.NextMatch().Index : valuePairString.Length) - (m.Index + m.Value.Length))
                 });
 
-            if (parts.Any(p => p.Length != 2))
+            if (!parts.Any() || parts.Any(p => p.Length != 2))
             {
                 throw new FormatException("Malformed Token");
             }

--- a/iothub/device/tests/ConnectionString/DeviceClientConnectionStringTests.cs
+++ b/iothub/device/tests/ConnectionString/DeviceClientConnectionStringTests.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
         [TestMethod]
         public void DeviceClientIotHubConnectionStringBuilderTest()
         {
-            string connectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=device1-.+%_#*?!(),=@$';SharedAccessKey=dGVzdFN0cmluZzE=";
+            string connectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=device1-.+%_#*?!(),=@;$';SharedAccessKey=dGVzdFN0cmluZzE=";
             var iotHubConnectionStringBuilder = IotHubConnectionStringBuilder.Create(connectionString);
             Assert.IsNotNull(iotHubConnectionStringBuilder.HostName);
             Assert.IsNotNull(iotHubConnectionStringBuilder.DeviceId);
@@ -290,11 +290,11 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             }
 
             iotHubConnectionStringBuilder.HostName = "acme.azure-devices.net";
-            iotHubConnectionStringBuilder.AuthenticationMethod = new DeviceAuthenticationWithRegistrySymmetricKey("Device1-.+%_#*?!(),=@$'", "dGVzdFN0cmluZzE=");
+            iotHubConnectionStringBuilder.AuthenticationMethod = new DeviceAuthenticationWithRegistrySymmetricKey("Device1-.+%_#*?!(),=@;$'", "dGVzdFN0cmluZzE=");
             Assert.IsTrue(iotHubConnectionStringBuilder.AuthenticationMethod is DeviceAuthenticationWithRegistrySymmetricKey);
             Assert.IsTrue(iotHubConnectionStringBuilder.SharedAccessSignature == null);
             Assert.IsTrue(iotHubConnectionStringBuilder.SharedAccessKey == "dGVzdFN0cmluZzE=");
-            Assert.IsTrue(iotHubConnectionStringBuilder.DeviceId== "Device1-.+%_#*?!(),=@$'");
+            Assert.IsTrue(iotHubConnectionStringBuilder.DeviceId== "Device1-.+%_#*?!(),=@;$'");
 
             iotHubConnectionStringBuilder.AuthenticationMethod = new DeviceAuthenticationWithToken("Device2", "SharedAccessSignature sr=dh%3a%2f%2facme.azure-devices.net&sig=dGVzdFN0cmluZzU=&se=87824124985&skn=AllAccessKey");
             Assert.IsTrue(iotHubConnectionStringBuilder.AuthenticationMethod is DeviceAuthenticationWithToken);
@@ -338,24 +338,24 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             Assert.IsTrue(iotHubConnectionStringBuilder.SharedAccessKey == null);
             Assert.IsTrue(iotHubConnectionStringBuilder.DeviceId == "Device2");
 
-            authMethod = new DeviceAuthenticationWithRegistrySymmetricKey("Device1-.+%_#*?!(),=@$'", "dGVzdFN0cmluZzE=");
+            authMethod = new DeviceAuthenticationWithRegistrySymmetricKey("Device1-.+%_#*?!(),=@;$'", "dGVzdFN0cmluZzE=");
             iotHubConnectionStringBuilder = IotHubConnectionStringBuilder.Create("acme4.azure-devices.net", authMethod);
             Assert.IsTrue(iotHubConnectionStringBuilder.AuthenticationMethod is DeviceAuthenticationWithRegistrySymmetricKey);
             Assert.IsTrue(iotHubConnectionStringBuilder.HostName == "acme4.azure-devices.net");
             Assert.IsTrue(iotHubConnectionStringBuilder.SharedAccessSignature == null);
             Assert.IsTrue(iotHubConnectionStringBuilder.SharedAccessKey == "dGVzdFN0cmluZzE=");
-            Assert.IsTrue(iotHubConnectionStringBuilder.DeviceId == "Device1-.+%_#*?!(),=@$'");
+            Assert.IsTrue(iotHubConnectionStringBuilder.DeviceId == "Device1-.+%_#*?!(),=@;$'");
 
             string hostName = "acme.azure-devices.net";
             string gatewayHostname = "gateway.acme.azure-devices.net";
-            IAuthenticationMethod authenticationMethod = new DeviceAuthenticationWithRegistrySymmetricKey("Device1-.+%_#*?!(),=@$'", "dGVzdFN0cmluZzE=");
+            IAuthenticationMethod authenticationMethod = new DeviceAuthenticationWithRegistrySymmetricKey("Device1-.+%_#*?!(),=@;$'", "dGVzdFN0cmluZzE=");
             iotHubConnectionStringBuilder = IotHubConnectionStringBuilder.Create(hostName, gatewayHostname, authenticationMethod);
             Assert.AreEqual(gatewayHostname, iotHubConnectionStringBuilder.GatewayHostName);
             Assert.AreEqual(hostName, iotHubConnectionStringBuilder.HostName);
             Assert.IsTrue(iotHubConnectionStringBuilder.AuthenticationMethod is DeviceAuthenticationWithRegistrySymmetricKey);
 
             hostName = "acme.azure-devices.net";
-            authenticationMethod = new DeviceAuthenticationWithRegistrySymmetricKey("Device1-.+%_#*?!(),=@$'", "dGVzdFN0cmluZzE=");
+            authenticationMethod = new DeviceAuthenticationWithRegistrySymmetricKey("Device1-.+%_#*?!(),=@;$'", "dGVzdFN0cmluZzE=");
             iotHubConnectionStringBuilder = IotHubConnectionStringBuilder.Create(hostName, authenticationMethod);
             Assert.AreEqual(hostName, iotHubConnectionStringBuilder.HostName);
             Assert.IsTrue(iotHubConnectionStringBuilder.AuthenticationMethod is DeviceAuthenticationWithRegistrySymmetricKey);


### PR DESCRIPTION
Fixed an issue which is occurring 'Malformed Token' when specified device id has a semicolon.

This is not the best way.
Because, if device id is specified similar to 'connection string' (has both a semicolon and an equal sign), the code still has problems.
However, in the case that device id has one of a semicolon and an equal sign, the fix is helpful.

<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
