### PR TITLE
Decreased MQTT packet id range to 15 bit. 

### DIFF
--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -900,7 +900,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             Debug.Assert(lockTaken);
             unchecked
             {
-                ret = ++_packetId == 0 ? ++_packetId : _packetId;
+                _packetId = (ushort)(++_packetId % 0x8000);
+                ret = _packetId == 0 ? ++_packetId : _packetId;
             }
             _packetIdLock.Exit();
 


### PR DESCRIPTION
The reason is that Publish packets clear the highest (15th) bit of the counter in some scenarios, and so packetId = 0x8000 becomes 0x0000 which in turn is an invalid value for a packet id.