### PR TITLE
Add clarification to connection status callback documentation around HTTP

### DIFF
--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -504,7 +504,7 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <summary>
         /// Registers a new delegate for the connection status changed callback. If a delegate is already associated, 
-        /// it will be replaced with the new delegate.
+        /// it will be replaced with the new delegate. Note that this callback will never be called if the client is configured to use HTTP as that protocol is stateless
         /// <param name="statusChangesHandler">The name of the method to associate with the delegate.</param>
         /// </summary>
         public void SetConnectionStatusChangesHandler(ConnectionStatusChangesHandler statusChangesHandler) =>

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -409,7 +409,7 @@ using System.Net.Http;
 
         /// <summary>
         /// Registers a new delegate for the connection status changed callback. If a delegate is already associated, 
-        /// it will be replaced with the new delegate.
+        /// it will be replaced with the new delegate. Note that this callback will never be called if the client is configured to use HTTP as that protocol is stateless
         /// <param name="statusChangesHandler">The name of the method to associate with the delegate.</param>
         /// </summary>
         public void SetConnectionStatusChangesHandler(ConnectionStatusChangesHandler statusChangesHandler) =>


### PR DESCRIPTION
Issue #864

Users were confused why connection status updates were never called when their clients used HTTP