### PR TITLE
Enforce TLS 1.2

### DIFF
--- a/common/src/service/HttpClientHelper.cs
+++ b/common/src/service/HttpClientHelper.cs
@@ -51,9 +51,17 @@ namespace Microsoft.Azure.Devices
 
             if (customHttpProxy != DefaultWebProxySettings.Instance)
             {
-                HttpClientHandler httpClientHandler = new HttpClientHandler();
-                httpClientHandler.UseProxy = (customHttpProxy != null);
-                httpClientHandler.Proxy = customHttpProxy;
+                TlsVersions.SetLegacyAcceptableVersions();
+
+                var httpClientHandler = new HttpClientHandler
+                {
+                    UseProxy = (customHttpProxy != null),
+                    Proxy = customHttpProxy,
+#if !NET451
+                    SslProtocols = TlsVersions.AcceptableVersions,
+#endif
+                };
+
                 this.httpClientObj = new HttpClient(httpClientHandler);
             }
             else
@@ -630,7 +638,7 @@ namespace Microsoft.Azure.Devices
                     operationTimeout,
                     modifyRequestMessageFunc,
                     IsMappedToException,
-                    processResponseMessageAsync, 
+                    processResponseMessageAsync,
                     errorMappingOverrides,
                     cancellationToken);
             }
@@ -720,7 +728,7 @@ namespace Microsoft.Azure.Devices
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            
+
             var cts = new CancellationTokenSource(operationTimeout);
             CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cts.Token);
             return this.ExecuteAsync(

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -5,20 +5,14 @@ namespace Microsoft.Azure.Devices.Client
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
-#if !NET451
-    using System.Net.Http;
-#else
-    using System.Net;
-#endif
     using System.Threading;
     using System.Threading.Tasks;
+    using System.Security.Cryptography.X509Certificates;
+    using System.IO;
     using Microsoft.Azure.Devices.Client.Extensions;
     using Microsoft.Azure.Devices.Client.Transport;
     using Microsoft.Azure.Devices.Shared;
-    using System.Security.Cryptography.X509Certificates;
-    using System.IO;
     using Microsoft.Azure.Devices.Client.Exceptions;
 
     /// <summary>
@@ -30,7 +24,7 @@ namespace Microsoft.Azure.Devices.Client
     public delegate Task DesiredPropertyUpdateCallback(TwinCollection desiredProperties, object userContext);
 
     /// <summary>
-    ///      Delegate for method call. This will be called every time we receive a method call that was registered.
+    /// Delegate for method call. This will be called every time we receive a method call that was registered.
     /// </summary>
     /// <param name="methodRequest">Class with details about method.</param>
     /// <param name="userContext">Context object passed in when the callback was registered.</param>
@@ -38,10 +32,10 @@ namespace Microsoft.Azure.Devices.Client
     public delegate Task<MethodResponse> MethodCallback(MethodRequest methodRequest, object userContext);
 
     /// <summary>
-    ///    Status of handling a message. 
+    /// Status of handling a message.
     ///    None - Means Device SDK won't send an ackowledge of receipt.
     ///    Completed - Means Device SDK will Complete the event. Removing from the queue.
-    ///    Abandoned - Event will be Abandoned. 
+    ///    Abandoned - Event will be Abandoned.
     /// </summary>
     public enum MessageResponse { None, Completed, Abandoned };
 
@@ -111,9 +105,7 @@ namespace Microsoft.Azure.Devices.Client
         {
             if (Logging.IsEnabled) Logging.Enter(this, transportSettings, pipelineBuilder, nameof(InternalClient) + "_ctor");
 
-#if NET451
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
-#endif
+            TlsVersions.SetLegacyAcceptableVersions();
 
             this.IotHubConnectionString = iotHubConnectionString;
 
@@ -423,7 +415,8 @@ namespace Microsoft.Azure.Devices.Client
                 throw new ArgumentNullException(nameof(lockToken));
             }
 
-            try{
+            try
+            {
                 return InnerHandler.CompleteAsync(lockToken, cancellationToken);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
@@ -620,7 +613,8 @@ namespace Microsoft.Azure.Devices.Client
                 throw new ArgumentNullException(nameof(message));
             }
 
-            try{
+            try
+            {
                 return RejectAsync(message.LockToken, cancellationToken);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)

--- a/iothub/device/src/Transport/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/HttpClientHelper.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -80,6 +79,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 handler.Proxy = proxy;
             }
 
+            TlsVersions.SetLegacyAcceptableVersions();
+
             this.httpClientObj = handler != null ? new HttpClient(handler) : new HttpClient();
 #else
             if (clientCert != null)
@@ -103,6 +104,13 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 httpClientHandler.UseProxy = (proxy != null);
                 httpClientHandler.Proxy = proxy;
             }
+
+            // Enforce TLS 1.2+
+            if (httpClientHandler == null)
+            {
+                httpClientHandler = new HttpClientHandler();
+            };
+            httpClientHandler.SslProtocols = TlsVersions.AcceptableVersions;
 
             this.httpClientObj = httpClientHandler != null ? new HttpClient(httpClientHandler) : new HttpClient();
 #endif

--- a/iothub/service/src/IotHubConnection.cs
+++ b/iothub/service/src/IotHubConnection.cs
@@ -11,10 +11,9 @@ namespace Microsoft.Azure.Devices
     using System.Net.Security;
 #if !NETSTANDARD1_3
     using System.Net.WebSockets;
-    using System.Security.Authentication;
     using System.Security.Cryptography.X509Certificates;
 #endif
-
+    using System.Security.Authentication;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -136,10 +135,10 @@ namespace Microsoft.Azure.Devices
             {
                 Role = true,
                 TotalLinkCredit = prefetchCount,
-                AutoSendFlow = prefetchCount > 0, 
+                AutoSendFlow = prefetchCount > 0,
                 Source = new Source() { Address = linkAddress.AbsoluteUri },
                 SndSettleMode = null, // SenderSettleMode.Unsettled (null as it is the default and to avoid bytes on the wire)
-                RcvSettleMode = (byte)ReceiverSettleMode.Second, 
+                RcvSettleMode = (byte)ReceiverSettleMode.Second,
                 LinkName = Guid.NewGuid().ToString("N") // Use a human readable link name to help with debuggin
             };
 
@@ -183,7 +182,7 @@ namespace Microsoft.Azure.Devices
                 transport = await CreateClientWebSocketTransport(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
             else
-            {             
+            {
                 var tlsTransportSettings = this.CreateTlsTransportSettings();
                 var amqpTransportInitiator = new AmqpTransportInitiator(amqpSettings, tlsTransportSettings);
                 try
@@ -305,7 +304,7 @@ namespace Microsoft.Azure.Devices
             return websocket;
         }
 #endif
-            async Task<TransportBase> CreateClientWebSocketTransport(TimeSpan timeout)
+        async Task<TransportBase> CreateClientWebSocketTransport(TimeSpan timeout)
         {
 #if NETSTANDARD1_3
             throw new NotImplementedException("web sockets are not yet supported for UWP");
@@ -327,11 +326,11 @@ namespace Microsoft.Azure.Devices
             else
             {
 #endif
-                var websocket = await this.CreateClientWebSocketAsync(websocketUri, timeoutHelper.RemainingTime()).ConfigureAwait(false);
-                return new ClientWebSocketTransport(
-                    websocket,
-                    null,
-                    null);
+            var websocket = await this.CreateClientWebSocketAsync(websocketUri, timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            return new ClientWebSocketTransport(
+                websocket,
+                null,
+                null);
 #if NET451
             }
 #endif
@@ -370,8 +369,9 @@ namespace Microsoft.Azure.Devices
                 TargetHost = this.connectionString.HostName,
 #if !NETSTANDARD1_3
                 Certificate = null, // TODO: add client cert support
-                CertificateValidationCallback = OnRemoteCertificateValidation
+                CertificateValidationCallback = OnRemoteCertificateValidation,
 #endif
+                Protocols = TlsVersions.AcceptableVersions,
             };
 
             return tlsTransportSettings;
@@ -450,7 +450,6 @@ namespace Microsoft.Azure.Devices
             }
 
             return false;
-
         }
 #endif
         public static ArraySegment<byte> GetNextDeliveryTag(ref int deliveryTag)
@@ -475,7 +474,7 @@ namespace Microsoft.Azure.Devices
             var deliveryTag = new ArraySegment<byte>(lockTokenGuid.ToByteArray());
             return deliveryTag;
         }
-        
+
         /// <inheritdoc/>
         public void Dispose()
         {

--- a/provisioning/service/src/Contract/ContractApiHttp.cs
+++ b/provisioning/service/src/Contract/ContractApiHttp.cs
@@ -45,9 +45,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             IWebProxy webProxy = httpTransportSettings.Proxy;
             if (webProxy != DefaultWebProxySettings.Instance)
             {
-                HttpClientHandler httpClientHandler = new HttpClientHandler();
-                httpClientHandler.UseProxy = (webProxy != null);
-                httpClientHandler.Proxy = webProxy;
+                var httpClientHandler = new HttpClientHandler
+                {
+                    UseProxy = (webProxy != null),
+                    Proxy = webProxy,
+                    SslProtocols = TlsVersions.AcceptableVersions,
+                };
                 _httpClientObj = new HttpClient(httpClientHandler);
             }
             else
@@ -120,7 +123,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                             httpResponse.ReasonPhrase);
                     }
                 }
-                catch(AggregateException ex)
+                catch (AggregateException ex)
                 {
                     var innerExceptions = ex.Flatten().InnerExceptions;
                     if (innerExceptions.Any(e => e is TimeoutException))
@@ -207,9 +210,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
 
         protected virtual void Dispose(bool disposing)
         {
-            if(disposing)
+            if (disposing)
             {
-                if(_httpClientObj != null)
+                if (_httpClientObj != null)
                 {
                     _httpClientObj.Dispose();
                     _httpClientObj = null;

--- a/provisioning/transport/amqp/src/AmqpClientConnection.cs
+++ b/provisioning/transport/amqp/src/AmqpClientConnection.cs
@@ -7,7 +7,6 @@ using Microsoft.Azure.Amqp.Sasl;
 using Microsoft.Azure.Amqp.Transport;
 using Microsoft.Azure.Devices.Shared;
 using System;
-using System.Diagnostics;
 using System.Net;
 using System.Net.WebSockets;
 using System.Security.Cryptography.X509Certificates;
@@ -54,11 +53,17 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             if (Logging.IsEnabled) Logging.Enter(this, $"{nameof(AmqpClientConnection)}.{nameof(OpenAsync)}");
             var hostName = _uri.Host;
 
-            var tcpSettings = new TcpTransportSettings { Host = hostName, Port = _uri.Port != -1 ? _uri.Port : AmqpConstants.DefaultSecurePort };
+            var tcpSettings = new TcpTransportSettings
+            {
+                Host = hostName,
+                Port = _uri.Port != -1 ? _uri.Port : AmqpConstants.DefaultSecurePort,
+            };
+
             TransportSettings = new TlsTransportSettings(tcpSettings)
             {
                 TargetHost = hostName,
-                Certificate = clientCert
+                Certificate = clientCert,
+                Protocols = TlsVersions.AcceptableVersions,
             };
 
             TransportBase transport;
@@ -83,7 +88,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                     bool operationPending = transport.WriteAsync(args);
 
                     if (Logging.IsEnabled) Logging.Info(this, $"{nameof(AmqpClientConnection)}.{nameof(OpenAsync)}: Sent Protocol Header: {_sentHeader.ToString()} operationPending: {operationPending} completedSynchronously: {args.CompletedSynchronously}");
-                    
+
                     if (!operationPending)
                     {
                         args.CompletedCallback(args);

--- a/provisioning/transport/amqp/src/ProvisioningTransportHandlerAmqp.cs
+++ b/provisioning/transport/amqp/src/ProvisioningTransportHandlerAmqp.cs
@@ -107,7 +107,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 cancellationToken.ThrowIfCancellationRequested();
 
                 string correlationId = Guid.NewGuid().ToString();
-                DeviceRegistration deviceRegistration = (message.Payload != null && message.Payload.Length > 0) ? new DeviceRegistration { Payload = new JRaw(message.Payload) } : null;
+                DeviceRegistration deviceRegistration = (message.Payload != null && message.Payload.Length > 0)
+                    ? new DeviceRegistration { Payload = new JRaw(message.Payload) }
+                    : null;
 
                 RegistrationOperationStatus operation = await RegisterDeviceAsync(connection, correlationId, deviceRegistration).ConfigureAwait(false);
 

--- a/provisioning/transport/http/src/ProvisioningTransportHandlerHttp.cs
+++ b/provisioning/transport/http/src/ProvisioningTransportHandlerHttp.cs
@@ -78,7 +78,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                     Port = Port,
                 };
 
-                HttpClientHandler httpClientHandler = new HttpClientHandler();
+                var httpClientHandler = new HttpClientHandler
+                {
+                    SslProtocols = TlsVersions.AcceptableVersions,
+                };
 
                 if (Proxy != DefaultWebProxySettings.Instance)
                 {

--- a/provisioning/transport/mqtt/src/ProvisioningTransportHandlerMqtt.cs
+++ b/provisioning/transport/mqtt/src/ProvisioningTransportHandlerMqtt.cs
@@ -179,8 +179,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 ((SecurityProviderX509)message.Security).GetAuthenticationCertificate();
 
             var tlsSettings = new ClientTlsSettings(
-                message.GlobalDeviceEndpoint,
-                new List<X509Certificate> { clientCertificate });
+                TlsVersions.AcceptableVersions,
+                true, // checkCertificateRevocation
+                new List<X509Certificate> { clientCertificate },
+                message.GlobalDeviceEndpoint);
             return ProvisionOverTcpCommonAsync(message, tlsSettings, cancellationToken);
         }
 
@@ -192,6 +194,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             cancellationToken.ThrowIfCancellationRequested();
 
             var tlsSettings = new ClientTlsSettings(
+                TlsVersions.AcceptableVersions,
+                false,
+                new List<X509Certificate>(0),
                 message.GlobalDeviceEndpoint);
 
             return ProvisionOverTcpCommonAsync(message, tlsSettings, cancellationToken);

--- a/shared/src/TlsVersions.cs
+++ b/shared/src/TlsVersions.cs
@@ -1,0 +1,29 @@
+﻿using System.Security.Authentication;
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// A common place to specify TLS information for the project.
+    /// </summary>
+    /// <remarks>
+    /// As newer TLS versions come out, we should simply update them here and have all code that needs to
+    /// know reference this class so they all get updated and we don't risk missing a line.
+    /// </remarks>
+    public static class TlsVersions
+    {
+        /// <summary>
+        /// The acceptable versions of TLS
+        /// </summary>
+        public const SslProtocols AcceptableVersions = SslProtocols.Tls12;
+
+        /// <summary>
+        /// Sets the acceptable versions of TLS for .NET framework 4.5.1.
+        /// </summary>
+        public static void SetLegacyAcceptableVersions()
+        {
+#if NET451
+            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
+#endif
+        }
+    }
+}


### PR DESCRIPTION
## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.

## Description of the changes
Trial run to enforce TLS 1.2 from client connections to prevent man-in-the-middle attacks using older security technology.

Not yet resolved is what we'll do when TLS 1.3 comes out. As it stands, we'd have to edit TlsVersions.cs to update the acceptable versions, immediately release a new package, and have customers update to the new published version.

Needs manual testing/debugging, and investigate unit tests.

## Reference/Link to the issue solved with this PR (if any)
6007040
