### PR TITLE
Set Twin DateTime property to DateTimeOffset

### DIFF
--- a/shared/src/Twin.cs
+++ b/shared/src/Twin.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// </summary>
         [DefaultValue(null)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public DateTime? StatusUpdatedTime { get; internal set; }
+        public DateTimeOffset? StatusUpdatedTime { get; internal set; }
 
         /// <summary>
         /// Corresponding Device's ConnectionState
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// </summary>
         [DefaultValue(null)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public DateTime? LastActivityTime { get; internal set; }
+        public DateTimeOffset? LastActivityTime { get; internal set; }
 
         /// <summary>
         /// Number of messages sent to the corresponding Device from the Cloud

--- a/shared/src/TwinJsonConverter.cs
+++ b/shared/src/TwinJsonConverter.cs
@@ -231,14 +231,14 @@ namespace Microsoft.Azure.Devices.Shared
                         twin.StatusReason = reader.Value as string;
                         break;
                     case StatusUpdateTimeTag:
-                        twin.StatusUpdatedTime = serializer.Deserialize<DateTime>(reader);
+                        twin.StatusUpdatedTime = serializer.Deserialize<DateTimeOffset>(reader);
                         break;
                     case ConnectionStateTag:
                         string connectionState = reader.Value as string;
                         twin.ConnectionState = connectionState?[0] == '\"' ? JsonConvert.DeserializeObject<DeviceConnectionState>(connectionState) : serializer.Deserialize<DeviceConnectionState>(reader);
                         break;
                     case LastActivityTimeTag:
-                        twin.LastActivityTime = serializer.Deserialize<DateTime>(reader);
+                        twin.LastActivityTime = serializer.Deserialize<DateTimeOffset>(reader);
                         break;
                     case CloudToDeviceMessageCountTag:
                         twin.CloudToDeviceMessageCount = serializer.Deserialize<int>(reader);


### PR DESCRIPTION
Set the Twin DateTime property as DateTimeOffset. 
The DateTimeOffset structure represents a date and time value, together with an offset that indicates how much that value differs from UTC. Thus, the value always unambiguously identifies a single point in time.

Fixes #1122 