### PR TITLE
fix(iot-service): Fix proxy handling for requests with per-request timeouts

### DIFF
--- a/common/src/service/HttpClientHelper.cs
+++ b/common/src/service/HttpClientHelper.cs
@@ -30,10 +30,10 @@ namespace Microsoft.Azure.Devices
         readonly Uri baseAddress;
         readonly IAuthorizationHeaderProvider authenticationHeaderProvider;
         readonly IReadOnlyDictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>> defaultErrorMapping;
-        HttpClient httpClientObj;
-        HttpClient httpClientObjWithPerRequestTimeout;
-        bool isDisposed;
         readonly TimeSpan defaultOperationTimeout;
+        readonly IWebProxy customHttpProxy;
+        readonly Action<HttpClient> preRequestActionForAllRequests;
+
 
         public HttpClientHelper(
             Uri baseAddress,
@@ -49,34 +49,7 @@ namespace Microsoft.Azure.Devices
                 new ReadOnlyDictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>(defaultErrorMapping);
             this.defaultOperationTimeout = timeout;
 
-            if (customHttpProxy != DefaultWebProxySettings.Instance)
-            {
-                HttpClientHandler httpClientHandler = new HttpClientHandler();
-                httpClientHandler.UseProxy = (customHttpProxy != null);
-                httpClientHandler.Proxy = customHttpProxy;
-                this.httpClientObj = new HttpClient(httpClientHandler);
-            }
-            else
-            {
-                this.httpClientObj = new HttpClient();
-            }
 
-            this.httpClientObj.BaseAddress = this.baseAddress;
-            this.httpClientObj.Timeout = timeout;
-            this.httpClientObj.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(CommonConstants.MediaTypeForDeviceManagementApis));
-            this.httpClientObj.DefaultRequestHeaders.ExpectContinue = false;
-
-            this.httpClientObjWithPerRequestTimeout = new HttpClient();
-            this.httpClientObjWithPerRequestTimeout.BaseAddress = this.baseAddress;
-            this.httpClientObjWithPerRequestTimeout.Timeout = Timeout.InfiniteTimeSpan;
-            this.httpClientObjWithPerRequestTimeout.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(CommonConstants.MediaTypeForDeviceManagementApis));
-            this.httpClientObjWithPerRequestTimeout.DefaultRequestHeaders.ExpectContinue = false;
-
-            if (preRequestActionForAllRequests != null)
-            {
-                preRequestActionForAllRequests(this.httpClientObj);
-                preRequestActionForAllRequests(this.httpClientObjWithPerRequestTimeout);
-            }
         }
 
         public Task<T> GetAsync<T>(
@@ -112,7 +85,7 @@ namespace Microsoft.Azure.Devices
             {
                 if (throwIfNotFound)
                 {
-                    await this.ExecuteWithOperationTimeoutAsync(
+                    await this.ExecuteWithCustomOperationTimeoutAsync(
                         HttpMethod.Get,
                         new Uri(this.baseAddress, requestUri),
                         operationTimeout,
@@ -124,7 +97,7 @@ namespace Microsoft.Azure.Devices
                 }
                 else
                 {
-                    await this.ExecuteWithOperationTimeoutAsync(
+                    await this.ExecuteWithCustomOperationTimeoutAsync(
                        HttpMethod.Get,
                        new Uri(this.baseAddress, requestUri),
                         operationTimeout,
@@ -149,15 +122,18 @@ namespace Microsoft.Azure.Devices
                 }
                 else
                 {
-                    await this.ExecuteAsync(
-                       this.httpClientObj,
-                       HttpMethod.Get,
-                       new Uri(this.baseAddress, requestUri),
-                       (requestMsg, token) => AddCustomHeaders(requestMsg, customHeaders),
-                       message => !(message.IsSuccessStatusCode || message.StatusCode == HttpStatusCode.NotFound),
-                       async (message, token) => result = message.StatusCode == HttpStatusCode.NotFound ? (default(T)) : await ReadResponseMessageAsync<T>(message, token).ConfigureAwait(false),
-                       errorMappingOverrides,
-                       cancellationToken).ConfigureAwait(false);
+                    using (var httpClient = buildHttpClient(defaultOperationTimeout))
+                    {
+                        await this.ExecuteAsync(
+                            httpClient,
+                           HttpMethod.Get,
+                           new Uri(this.baseAddress, requestUri),
+                           (requestMsg, token) => AddCustomHeaders(requestMsg, customHeaders),
+                           message => !(message.IsSuccessStatusCode || message.StatusCode == HttpStatusCode.NotFound),
+                           async (message, token) => result = message.StatusCode == HttpStatusCode.NotFound ? (default(T)) : await ReadResponseMessageAsync<T>(message, token).ConfigureAwait(false),
+                           errorMappingOverrides,
+                           cancellationToken).ConfigureAwait(false);
+                    }
                 }
             }
 
@@ -624,13 +600,13 @@ namespace Microsoft.Azure.Devices
 
             if (operationTimeout != this.defaultOperationTimeout && operationTimeout > TimeSpan.Zero)
             {
-                return this.ExecuteWithOperationTimeoutAsync(
+                return this.ExecuteWithCustomOperationTimeoutAsync(
                     HttpMethod.Post,
                     new Uri(this.baseAddress, requestUri),
                     operationTimeout,
                     modifyRequestMessageFunc,
                     IsMappedToException,
-                    processResponseMessageAsync, 
+                    processResponseMessageAsync,
                     errorMappingOverrides,
                     cancellationToken);
             }
@@ -690,7 +666,7 @@ namespace Microsoft.Azure.Devices
             return result;
         }
 
-        Task ExecuteAsync(
+        async Task ExecuteAsync(
             HttpMethod httpMethod,
             Uri requestUri,
             Func<HttpRequestMessage, CancellationToken, Task> modifyRequestMessageAsync,
@@ -698,18 +674,21 @@ namespace Microsoft.Azure.Devices
             IDictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>> errorMappingOverrides,
             CancellationToken cancellationToken)
         {
-            return this.ExecuteAsync(
-                this.httpClientObj,
-                httpMethod,
-                requestUri,
-                modifyRequestMessageAsync,
-                IsMappedToException,
-                processResponseMessageAsync,
-                errorMappingOverrides,
-                cancellationToken);
+            using (var httpClient = buildHttpClient(this.defaultOperationTimeout))
+            {
+                await this.ExecuteAsync(
+                    httpClient,
+                    httpMethod,
+                    requestUri,
+                    modifyRequestMessageAsync,
+                    IsMappedToException,
+                    processResponseMessageAsync,
+                    errorMappingOverrides,
+                    cancellationToken).ConfigureAwait(false);
+            }
         }
 
-        Task ExecuteWithOperationTimeoutAsync(
+        async Task ExecuteWithCustomOperationTimeoutAsync(
             HttpMethod httpMethod,
             Uri requestUri,
             TimeSpan operationTimeout,
@@ -720,18 +699,21 @@ namespace Microsoft.Azure.Devices
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            
-            var cts = new CancellationTokenSource(operationTimeout);
-            CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cts.Token);
-            return this.ExecuteAsync(
-                this.httpClientObjWithPerRequestTimeout,
-                httpMethod,
-                requestUri,
-                modifyRequestMessageAsync,
-                IsMappedToException,
-                processResponseMessageAsync,
-                errorMappingOverrides,
-                linkedCts.Token);
+
+            using (var httpClient = buildHttpClient(Timeout.InfiniteTimeSpan))
+            {
+                var cts = new CancellationTokenSource(operationTimeout);
+                CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cts.Token);
+                await this.ExecuteAsync(
+                    httpClient,
+                    httpMethod,
+                    requestUri,
+                    modifyRequestMessageAsync,
+                    isMappedToException,
+                    processResponseMessageAsync,
+                    errorMappingOverrides,
+                    linkedCts.Token).ConfigureAwait(false);
+            }
         }
 
         public static bool IsMappedToException(HttpResponseMessage message)
@@ -863,18 +845,33 @@ namespace Microsoft.Azure.Devices
             return await exception.ConfigureAwait(false);
         }
 
-        public void Dispose()
+        private HttpClient buildHttpClient(TimeSpan timeout)
         {
-            if (!this.isDisposed)
+            HttpClient httpClient;
+            if (customHttpProxy != DefaultWebProxySettings.Instance)
             {
-                this.httpClientObj?.Dispose();
-                this.httpClientObjWithPerRequestTimeout?.Dispose();
-
-                this.httpClientObj = null;
-                this.httpClientObjWithPerRequestTimeout = null;
+                HttpClientHandler httpClientHandler = new HttpClientHandler();
+                httpClientHandler.UseProxy = (customHttpProxy != null);
+                httpClientHandler.Proxy = customHttpProxy;
+                httpClient = new HttpClient(httpClientHandler);
+            }
+            else
+            {
+                httpClient = new HttpClient();
             }
 
-            this.isDisposed = true;
+            httpClient.BaseAddress = this.baseAddress;
+            httpClient.Timeout = timeout;
+            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(CommonConstants.MediaTypeForDeviceManagementApis));
+            httpClient.DefaultRequestHeaders.ExpectContinue = false;
+
+            preRequestActionForAllRequests?.Invoke(httpClient);
+
+            return httpClient;
+        }
+
+        public void Dispose()
+        {
         }
     }
 }

--- a/common/src/service/HttpClientHelper.cs
+++ b/common/src/service/HttpClientHelper.cs
@@ -122,10 +122,10 @@ namespace Microsoft.Azure.Devices
                 }
                 else
                 {
-                    using (var httpClient = buildHttpClient(defaultOperationTimeout))
+                    using (var httpClient = BuildHttpClient(defaultOperationTimeout))
                     {
                         await this.ExecuteAsync(
-                            httpClient,
+                           httpClient,
                            HttpMethod.Get,
                            new Uri(this.baseAddress, requestUri),
                            (requestMsg, token) => AddCustomHeaders(requestMsg, customHeaders),
@@ -674,7 +674,7 @@ namespace Microsoft.Azure.Devices
             IDictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>> errorMappingOverrides,
             CancellationToken cancellationToken)
         {
-            using (var httpClient = buildHttpClient(this.defaultOperationTimeout))
+            using (var httpClient = BuildHttpClient(this.defaultOperationTimeout))
             {
                 await this.ExecuteAsync(
                     httpClient,
@@ -700,7 +700,7 @@ namespace Microsoft.Azure.Devices
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            using (var httpClient = buildHttpClient(Timeout.InfiniteTimeSpan))
+            using (var httpClient = BuildHttpClient(Timeout.InfiniteTimeSpan))
             {
                 var cts = new CancellationTokenSource(operationTimeout);
                 CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cts.Token);
@@ -845,7 +845,7 @@ namespace Microsoft.Azure.Devices
             return await exception.ConfigureAwait(false);
         }
 
-        private HttpClient buildHttpClient(TimeSpan timeout)
+        private HttpClient BuildHttpClient(TimeSpan timeout)
         {
             HttpClient httpClient;
             if (customHttpProxy != DefaultWebProxySettings.Instance)

--- a/e2e/test/MethodE2ETests.cs
+++ b/e2e/test/MethodE2ETests.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
+using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,6 +23,8 @@ namespace Microsoft.Azure.Devices.E2ETests
         private readonly string DevicePrefix = $"E2E_{nameof(MethodE2ETests)}_";
         private const string MethodName = "MethodE2ETest";
         private static TestLogging _log = TestLogging.GetInstance();
+
+        private const double defaultMethodTimeoutMinutes = 1;
 
         private readonly ConsoleEventListener _listener;
 
@@ -102,6 +105,28 @@ namespace Microsoft.Azure.Devices.E2ETests
             await SendMethodAndRespond(Client.TransportType.Amqp_WebSocket_Only, SetDeviceReceiveMethodDefaultHandler).ConfigureAwait(false);
         }
 
+        [TestMethod]
+        public async Task Method_ServiceSendsMethodThroughProxyWithDefaultTimeout()
+        {
+            ServiceClientTransportSettings serviceClientTransportSettings = new ServiceClientTransportSettings()
+            {
+                HttpProxy = new WebProxy(Configuration.IoTHub.ProxyServerAddress)
+            };
+
+            await SendMethodAndRespond(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethod, serviceClientTransportSettings).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Method_ServiceSendsMethodThroughProxyWithCustomTimeout()
+        {
+            ServiceClientTransportSettings serviceClientTransportSettings = new ServiceClientTransportSettings()
+            {
+                HttpProxy = new WebProxy(Configuration.IoTHub.ProxyServerAddress)
+            };
+
+            await SendMethodAndRespond(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethod, 5, serviceClientTransportSettings).ConfigureAwait(false);
+        }
+
         public static async Task ServiceSendMethodAndVerifyResponse(string deviceName, string methodName, string respJson, string reqJson)
         {
             using (ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString))
@@ -110,12 +135,31 @@ namespace Microsoft.Azure.Devices.E2ETests
                 CloudToDeviceMethodResult response =
                     await serviceClient.InvokeDeviceMethodAsync(
                         deviceName,
-                        new CloudToDeviceMethod(methodName, TimeSpan.FromMinutes(5)).SetPayloadJson(reqJson)).ConfigureAwait(false);
+                        new CloudToDeviceMethod(methodName, TimeSpan.FromMinutes(defaultMethodTimeoutMinutes)).SetPayloadJson(reqJson)).ConfigureAwait(false);
 
                 _log.WriteLine($"{nameof(ServiceSendMethodAndVerifyResponse)}: Method status: {response.Status}.");
-                Assert.AreEqual(200, response.Status, $"The expected respose status should be 200 but was {response.Status}");
+                Assert.AreEqual(200, response.Status, $"The expected response status should be 200 but was {response.Status}");
                 string payload = response.GetPayloadAsJson();
-                Assert.AreEqual(respJson, payload, $"The expected respose payload should be {respJson} but was {payload}");
+                Assert.AreEqual(respJson, payload, $"The expected response payload should be {respJson} but was {payload}");
+
+                await serviceClient.CloseAsync().ConfigureAwait(false);
+            }
+        }
+
+        public static async Task ServiceSendMethodAndVerifyResponse(string deviceName, string methodName, string respJson, string reqJson, double responseTimeoutMinutes, ServiceClientTransportSettings serviceClientTransportSettings)
+        {
+            using (ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString, TransportType.Amqp, serviceClientTransportSettings))
+            {
+                _log.WriteLine($"{nameof(ServiceSendMethodAndVerifyResponse)}: Invoke method {methodName}.");
+                CloudToDeviceMethodResult response =
+                    await serviceClient.InvokeDeviceMethodAsync(
+                        deviceName,
+                        new CloudToDeviceMethod(methodName, TimeSpan.FromMinutes(responseTimeoutMinutes)).SetPayloadJson(reqJson)).ConfigureAwait(false);
+
+                _log.WriteLine($"{nameof(ServiceSendMethodAndVerifyResponse)}: Method status: {response.Status}.");
+                Assert.AreEqual(200, response.Status, $"The expected response status should be 200 but was {response.Status}");
+                string payload = response.GetPayloadAsJson();
+                Assert.AreEqual(respJson, payload, $"The expected response payload should be {respJson} but was {payload}");
 
                 await serviceClient.CloseAsync().ConfigureAwait(false);
             }
@@ -208,6 +252,16 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         private async Task SendMethodAndRespond(Client.TransportType transport, Func<DeviceClient, string, Task<Task>> setDeviceReceiveMethod)
         {
+            await SendMethodAndRespond(transport, setDeviceReceiveMethod, new ServiceClientTransportSettings()).ConfigureAwait(false);
+        }
+
+        private async Task SendMethodAndRespond(Client.TransportType transport, Func<DeviceClient, string, Task<Task>> setDeviceReceiveMethod, ServiceClientTransportSettings serviceClientTransportSettings)
+        {
+            await SendMethodAndRespond(transport, setDeviceReceiveMethod, defaultMethodTimeoutMinutes, serviceClientTransportSettings).ConfigureAwait(false);
+        }
+
+        private async Task SendMethodAndRespond(Client.TransportType transport, Func<DeviceClient, string, Task<Task>> setDeviceReceiveMethod, double responseTimeoutMinutes, ServiceClientTransportSettings serviceClientTransportSettings)
+        {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
 
             using (DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport))
@@ -215,7 +269,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 Task methodReceivedTask = await setDeviceReceiveMethod(deviceClient, MethodName).ConfigureAwait(false);
 
                 await Task.WhenAll(
-                    ServiceSendMethodAndVerifyResponse(testDevice.Id, MethodName, DeviceResponseJson, ServiceRequestJson),
+                    ServiceSendMethodAndVerifyResponse(testDevice.Id, MethodName, DeviceResponseJson, ServiceRequestJson, responseTimeoutMinutes, serviceClientTransportSettings),
                     methodReceivedTask).ConfigureAwait(false);
 
                 await deviceClient.CloseAsync().ConfigureAwait(false);

--- a/e2e/test/RegistryManagerE2ETests.cs
+++ b/e2e/test/RegistryManagerE2ETests.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.Devices.Shared;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Diagnostics.Tracing;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Devices.E2ETests
@@ -67,6 +68,21 @@ namespace Microsoft.Azure.Devices.E2ETests
                 await registryManager.RemoveDeviceAsync(deviceId).ConfigureAwait(false);
 
                 Assert.IsTrue(actual.Capabilities != null && actual.Capabilities.IotEdge);
+            }
+        }
+
+        [TestMethod]
+        public async Task RegistryManager_AddDeviceWithProxy()
+        {
+            string deviceId = DevicePrefix + Guid.NewGuid();
+            HttpTransportSettings transportSettings = new HttpTransportSettings
+            {
+                Proxy = new WebProxy(Configuration.IoTHub.ProxyServerAddress)
+            };
+            using (RegistryManager registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString, transportSettings))
+            {
+                Device device = new Device(deviceId);
+                await registryManager.AddDeviceAsync(device).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
The http client helper class defined two different http client instances where the only difference was the client level timeout. Because of this, one of those http clients did not respect the proxy settings, if any were provided.

This PR consolidates the logic such that only one http client is maintained, and that one client does respect the proxy settings if any are provided

Now an http client is created for each request. This is done because the httpClient.Timeout property will be set before each request, but the http client library will throw if that property is changed after the client has been used to send a request. The alternative is to just have two httpClients, but that was what we had already and it was very confusing and prone to being inconsistently maintained