### PR TITLE
Fix MqttTransportHandler not handling ConnectExceptions correctly

### DIFF
--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -588,6 +588,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 });
             }
 
+            if (this.channel == null)
+            {
+                throw new IotHubCommunicationException("MQTT channel was not opened");
+            }
+
             await this.connectCompletion.Task.ConfigureAwait(true);
 
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_031: `OpenAsync` shall subscribe using the '$iothub/twin/res/#' topic filter
@@ -911,6 +916,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                             return false; // Let anything else stop the application.
                         });
+                    }
+                    catch (ConnectException ex)
+                    {
+                        //same as above, we will handle DotNetty.Transport.Channels.ConnectException
+                        if (Logging.IsEnabled) Logging.Error(this, $"ConnectException trying to connect to {address.ToString()}: {ex.ToString()}", nameof(CreateChannelFactory));
                     }
                 }
 

--- a/iothub/device/tests/MqttTransportHandlerTests.cs
+++ b/iothub/device/tests/MqttTransportHandlerTests.cs
@@ -138,6 +138,26 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
             return transport;
         }
 
+        MqttTransportHandler CreateTransportHandlerWithRealChannel(out IChannel channel, string connectionString = DummyConnectionString)
+        {
+            var _channel = Substitute.For<IChannel>();
+            channel = _channel;
+            return new MqttTransportHandler(new PipelineContext(), IotHubConnectionStringExtensions.Parse(connectionString), new MqttTransportSettings(Microsoft.Azure.Devices.Client.TransportType.Mqtt_Tcp_Only), null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(IotHubCommunicationException))]
+        public async Task MqttTransportHandler_OpenAsync_OpenHandlesConnectExceptionAndThrowsWhenChannelIsNotInitialized()
+        {
+            // arrange
+            IChannel channel;
+            var transport = CreateTransportHandlerWithRealChannel(out channel);
+
+            //act
+            //Open will attempt to connect to localhost, and get a connect exception. Expected behavior is for this exception to be ignored.
+            //However, later in the open call, the lack of an opened channel should throw an IotHubCommunicationException.
+            await transport.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+        }
 
         // Tests_SRS_CSHARP_MQTT_TRANSPORT_18_031: `OpenAsync` shall subscribe using the '$iothub/twin/res/#' topic filter
         [TestMethod]


### PR DESCRIPTION
issue #648

While iterating over IP addresses for the openAsync call within MqttTransportHandler, if a ConnectException is thrown within an AggregateException, then the exception is not thrown, and the method continues iterating over IP addresses.

This PR extends the same behavior to a ConnectException that is not nested within an aggregate exception.

It also ensures that after these IP addresses have been iterated on, that a channel was opened. If no channel was opened, the open call throws an exception.