### PR TITLE
manually add sources to build script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -109,7 +109,7 @@ Function BuildProject($path, $message) {
         }
     }
 
-    & dotnet build --verbosity $verbosity --configuration $configuration
+    & dotnet build --verbosity $verbosity --configuration $configuration --sources https://api.nuget.org/v3/index.json
 
     if ($LASTEXITCODE -ne 0) {
         throw "Build failed: $label"

--- a/build.ps1
+++ b/build.ps1
@@ -109,7 +109,7 @@ Function BuildProject($path, $message) {
         }
     }
 
-    & dotnet build --verbosity $verbosity --configuration $configuration --sources https://api.nuget.org/v3/index.json
+    & dotnet build --verbosity $verbosity --configuration $configuration --source https://api.nuget.org/v3/index.json
 
     if ($LASTEXITCODE -ne 0) {
         throw "Build failed: $label"


### PR DESCRIPTION
Azure devops is having some issues finding our nuget dependencies, and it doesn't appear to be checking nuget.org as a source, so editing the build script to manually specify nuget.org as the source for all packages