### PR TITLE
Add additional logging info for E2E tests

### DIFF
--- a/e2e/test/MessageReceiveE2ETests.cs
+++ b/e2e/test/MessageReceiveE2ETests.cs
@@ -473,7 +473,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     TimeSpan maxLatency = TimeSpan.FromMilliseconds(dc.OperationTimeoutInMilliseconds) + bufferTime;
                     if (sw.Elapsed > maxLatency)
                     {
-                        Assert.Fail($"ReceiveAsync did not return in {maxLatency}.");
+                        Assert.Fail($"ReceiveAsync did not return in {maxLatency}, instead it took {sw.Elapsed}.");
                     }
                 }
             }

--- a/e2e/test/MessageReceiveE2ETests.cs
+++ b/e2e/test/MessageReceiveE2ETests.cs
@@ -362,7 +362,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                     if (transport == Client.TransportType.Amqp || transport == Client.TransportType.Amqp_Tcp_Only || transport == Client.TransportType.Amqp_WebSocket_Only)
                     {
                         // For AMQP because of static 1 min interval check the cancellation token, in worst case it will block upto extra 1 min to return
-                        await ReceiveMessageWithoutTimeoutCheck(deviceClient, TIMESPAN_ONE_MINUTE).ConfigureAwait(false);
+                        TimeSpan bufferForAmqp = TIMESPAN_ONE_MINUTE + TIMESPAN_ONE_SECOND;
+                        await ReceiveMessageWithoutTimeoutCheck(deviceClient, bufferForAmqp).ConfigureAwait(false);
                     }
                     else
                     {

--- a/e2e/test/MessageReceiveE2ETests.cs
+++ b/e2e/test/MessageReceiveE2ETests.cs
@@ -362,7 +362,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     if (transport == Client.TransportType.Amqp || transport == Client.TransportType.Amqp_Tcp_Only || transport == Client.TransportType.Amqp_WebSocket_Only)
                     {
                         // For AMQP because of static 1 min interval check the cancellation token, in worst case it will block upto extra 1 min to return
-                        TimeSpan bufferForAmqp = TIMESPAN_ONE_MINUTE + TIMESPAN_ONE_SECOND;
+                        TimeSpan bufferForAmqp = TIMESPAN_ONE_MINUTE.Add(TIMESPAN_ONE_SECOND);
                         await ReceiveMessageWithoutTimeoutCheck(deviceClient, bufferForAmqp).ConfigureAwait(false);
                     }
                     else

--- a/e2e/test/ServiceClientE2ETests.cs
+++ b/e2e/test/ServiceClientE2ETests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             using (ServiceClient sender = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString))
             {
-                _log.WriteLine($"Testing ServiceClient SendAsync() timeout={timeout}");
+                _log.WriteLine($"Testing ServiceClient SendAsync() timeout in ticks={timeout?.Ticks}");
                 await sender.SendAsync(testDevice.Id, new Message(Encoding.ASCII.GetBytes("Dummy Message")), timeout).ConfigureAwait(false);
             }
         }

--- a/e2e/test/ServiceClientE2ETests.cs
+++ b/e2e/test/ServiceClientE2ETests.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 }
                 finally
                 {
+                    sw.Stop();
                     _log.WriteLine($"Testing ServiceClient SendAsync(): exiting test after time={sw.Elapsed}; ticks={sw.ElapsedTicks}");
                 }
             }

--- a/e2e/test/ServiceClientE2ETests.cs
+++ b/e2e/test/ServiceClientE2ETests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         private async Task FastTimeout()
         {
-            TimeSpan? timeout = TimeSpan.FromTicks(1);
+            TimeSpan? timeout = TimeSpan.FromTicks(5);
             await TestTimeout(timeout).ConfigureAwait(false);
         }
 

--- a/e2e/test/ServiceClientE2ETests.cs
+++ b/e2e/test/ServiceClientE2ETests.cs
@@ -4,6 +4,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Text;
 using System.Threading.Tasks;
@@ -54,8 +55,18 @@ namespace Microsoft.Azure.Devices.E2ETests
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             using (ServiceClient sender = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString))
             {
+                Stopwatch sw = new Stopwatch();
+                sw.Start();
+
                 _log.WriteLine($"Testing ServiceClient SendAsync() timeout in ticks={timeout?.Ticks}");
-                await sender.SendAsync(testDevice.Id, new Message(Encoding.ASCII.GetBytes("Dummy Message")), timeout).ConfigureAwait(false);
+                try
+                {
+                    await sender.SendAsync(testDevice.Id, new Message(Encoding.ASCII.GetBytes("Dummy Message")), timeout).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _log.WriteLine($"Testing ServiceClient SendAsync(): exiting test after time={sw.Elapsed}; ticks={sw.ElapsedTicks}");
+                }
             }
         }
 


### PR DESCRIPTION
This PR contains changes for the 2 tests that have been failing quite consistently in the past:
1. `ReceiveMessageInOperationTimeout` test - this was failing since the `ReceiveAsync` sometimes takes a couple of ms over a min to return. I've added an additional second of wait time, and also added logs that prints the time the operation actually took to return.
2. `Message_TimeOutReachedResponse` test - this test sometimes fails to timeout in 1 tick. I am unable to repro this in local runs, so I've increased the timeout to 5 ticks (can be reverted), and also added logs to indicate when the operation actually completes/ throws and exception.

These changes should give us further information if the tests fail in future runs.