### PR TITLE
Add additional logging for ReceiveAsync test

### DIFF
--- a/e2e/test/ServiceClientE2ETests.cs
+++ b/e2e/test/ServiceClientE2ETests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         private async Task FastTimeout()
         {
-            TimeSpan? timeout = TimeSpan.FromTicks(5);
+            TimeSpan? timeout = TimeSpan.FromTicks(1).Negate();
             await TestTimeout(timeout).ConfigureAwait(false);
         }
 

--- a/e2e/test/ServiceClientE2ETests.cs
+++ b/e2e/test/ServiceClientE2ETests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         private async Task FastTimeout()
         {
-            TimeSpan? timeout = TimeSpan.FromTicks(1).Negate();
+            TimeSpan? timeout = TimeSpan.FromTicks(10).Negate();
             await TestTimeout(timeout).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
- Add additional logging for `ReceiveAsync()` timeout test
- Use negative Timespan for `ServiceClient.SendAsync()` FastTimeout test