### PR TITLE
Bump versions for 1/24/2020 LTS release

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.21.3</Version>
+    <Version>1.21.4</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.18.2</Version>
+    <Version>1.18.3</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.5.0</Version>
+    <Version>1.5.1</Version>
     <Title>Microsoft Azure IoT Provisioning Service Client SDK</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/shared/src/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/src/Microsoft.Azure.Devices.Shared.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.16.0</Version>
+    <Version>1.16.1</Version>
     <Title>Microsoft Azure IoT Devices Shared</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/versions.csv
+++ b/versions.csv
@@ -1,10 +1,10 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.21.3
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.18.2
-shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.16.0
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.21.4
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.18.3
+shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.16.1
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.4.0
 provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.1.9
 provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.1.6
 provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.1.8
 security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.1.6
-provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.5.0
+provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.5.1


### PR DESCRIPTION
## Microsoft.Azure.Devices.Client v1.21.4
•	Upgraded Newtonsoft dependency to 12.0.3
•	Fixed twin parsing to use DateTimeOffset instead of DateTime (#1122)
•	Fixed Mqtt adaptor not always cleaning up while closing (PR #1181)
•	Fixed MqttTransportHandler not handling ConnectExceptions correctly (#648)
•	Fixed the SDK not throwing an exception when the mqtt topic name was too large to publish (#1197)

## Microsoft.Azure.Devices v1.18.3
•	Upgraded Newtonsoft dependency to 12.0.3

## Microsoft.Azure.Devices.Shared v1.16.1
•	Upgraded Newtonsoft dependency to 12.0.3

## Microsoft.Azure.Devices.Provisioning.Service v1.5.1
•	Upgraded Newtonsoft dependency to 12.0.3
