### PR TITLE
Re-enable test for twin desired property update on MQTT

### DIFF
--- a/e2e/test/TwinE2ETests.cs
+++ b/e2e/test/TwinE2ETests.cs
@@ -108,14 +108,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         public async Task Twin_ServiceSetsDesiredPropertyAndDeviceReceivesItOnNextGet_MqttWs()
         {
-            try
-            {
-                await Twin_ServiceSetsDesiredPropertyAndDeviceReceivesItOnNextGet(Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
-            }
-            catch (Newtonsoft.Json.JsonReaderException)
-            {
-                // [Ignore] // TODO: #682 - intermittently failing with JSON parsing error, especially on NET47, NET451.
-            }
+            await Twin_ServiceSetsDesiredPropertyAndDeviceReceivesItOnNextGet(Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes #682 