### PR TITLE
Call SafeClose() on AMQP resources before calling create on AMQP library

### DIFF
--- a/iothub/device/devdoc/amqpTransportExceptions.md
+++ b/iothub/device/devdoc/amqpTransportExceptions.md
@@ -1,4 +1,6 @@
-Below is the behavior of the SDK on receiving an exception from the AMQP library being used underneath. If the exception is marked as retry-able, the SDK will implement the default retry-policy and attempt to reconnect. For exceptions not marked as retryable, it is advised to inspect the exception details and perform the necessary action as indicated below.
+Below is the behavior of the SDK on receiving an exception from the AMQP library being used underneath. If the exception is marked as retryable, the SDK will implement the default retry-policy and attempt to reconnect. For exceptions not marked as retryable, it is advised to inspect the exception details and perform the necessary action as indicated below.
+
+* NOTE - The SDK default [retry policy](./retrypolicy.md) is `ExponentialBackoff`. 
 
 |Exception Name |Error code (if available) |isRetryable  |Action                 |
 |------|------|------|------|
@@ -7,7 +9,7 @@ Below is the behavior of the SDK on receiving an exception from the AMQP library
 | AmqpConnectionFramingErrorException | amqp:connection:framing-error | Yes | SDK will retry |
 | AmqpConnectionRedirectException | amqp:connection:redirect | Yes | SDK will retry |
 | AmqpConnectionThrottledException | com.microsoft:device-container-throttled | Yes | SDK will retry, with backoff |
-| AmqpDecodeErrorException | amqp:decode-error | No | Mis-match between AMQP message sent by client and received by service; collect logs and contact service |
+| AmqpDecodeErrorException | amqp:decode-error | No | Mismatch between AMQP message sent by client and received by service; collect logs and contact service |
 | AmqpFrameSizeTooSmallException | amqp:frame-size-too-small | No | The AMQP message is not being formed correctly by the SDK, collect logs and contact SDK team |
 | AmqpIllegalStateException | amqp:illegal-state | No | Inspect the exception details, collect logs and contact service |
 | AmqpInternalErrorException | amqp:internal-error | Yes | SDK will retry |
@@ -29,3 +31,5 @@ Below is the behavior of the SDK on receiving an exception from the AMQP library
 | AmqpSessionUnattachedHandleException | amqp:session:unattached-handle | Yes | SDK will retry |
 | AmqpSessionWindowViolationException | amqp:session:window-violation | Yes | SDK will retry |
 | AmqpUnauthorizedAccessException | amqp:unauthorized-access | No | SDK will throw `UnauthorizedException` with Connection status reason `BAD_CREDENTIAL` |
+
+* NOTE - For exceptions marked as retryable, the SDK will implement its retry policy internally, and you do not need to take any action. For non-retryable exceptions, you can inspect the exception details, and if a reconnection makes sense, you should dispose of the existing `DeviceClient` instance and then initialize a new client (initializing a new `DeviceClient` instance without disposing the previously used instance will cause them to fight for the same connection resources).

--- a/iothub/device/devdoc/retrypolicy.md
+++ b/iothub/device/devdoc/retrypolicy.md
@@ -12,3 +12,26 @@ __Versions below 1.19.0 only:__ If the service is responding with a throttling e
 `new ExponentialBackoff(RetryCount, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(5))`
 
 The retry mechanism will stop after `DefaultOperationTimeoutInMilliseconds` which is currently set at 4 minutes.
+
+The SDK also provides a `NoRetry` implementation of the `IRetryPolicy`. This can be used if you do not want the client to retry after getting disconnected.
+
+You can also supply your custom retry policy to the `DeviceClient` by implementing the `IRetryPolicy` interface.
+
+``` C#
+public class MyCustomRetryPolicy : IRetryPolicy
+{
+    /// <summary>
+    /// Returns true if, based on the parameters, the operation should be retried.
+    /// </summary>
+    /// <param name="currentRetryCount">How many times the operation has been retried.</param>
+    /// <param name="lastException">Operation exception.</param>
+    /// <param name="retryInterval">Next retry should be performed after this time interval.</param>
+    /// <returns>True if the operation should be retried, false otherwise.</returns>
+    public bool ShouldRetry(int currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+    {
+        // Implement your retry strategy here
+    }
+}
+
+deviceClient.SetRetryPolicy(new MyCustomRetryPolicy(...));
+```

--- a/iothub/device/devdoc/transportExceptions.md
+++ b/iothub/device/devdoc/transportExceptions.md
@@ -1,0 +1,31 @@
+Below is the behavior of the SDK on receiving an exception from the AMQP library being used underneath. If the exception is marked as retry-able, the SDK will implement the default retry-policy and attempt to reconnect. For exceptions not marked as retryable, it is advised to inspect the exception details and perform the necessary action as indicated below.
+
+|Exception Name |Error code (if available) |isRetryable  |Action                 |
+|------|------|------|------|
+| | | | 
+| AmqpConnectionForcedException | amqp:connection:forced error | Yes | SDK will retry |
+| AmqpConnectionFramingErrorException | amqp:connection:framing-error | Yes | SDK will retry |
+| AmqpConnectionRedirectException | amqp:connection:redirect | Yes | SDK will retry |
+| AmqpConnectionThrottledException | com.microsoft:device-container-throttled | Yes | SDK will retry, with backoff |
+| AmqpDecodeErrorException | amqp:decode-error | No | Mis-match between AMQP message sent by client and received by service; collect logs and contact service |
+| AmqpFrameSizeTooSmallException | amqp:frame-size-too-small | No | The AMQP message is not being formed correctly by the SDK, collect logs and contact SDK team |
+| AmqpIllegalStateException | amqp:illegal-state | No | Inspect the exception details, collect logs and contact service |
+| AmqpInternalErrorException | amqp:internal-error | Yes | SDK will retry |
+| AmqpInvalidFieldException | amqp:invalid-field | No | Inspect the exception details, collect logs and contact service |
+| AmqpLinkDetachForcedException | amqp:link :detach-forced | Yes | SDK will retry |
+| AmqpLinkMessageSizeExceededException | amqp:link :message-size-exceeded | No | The AMQP message size exceeded the value supported by the link, collect logs and contact service |
+| AmqpLinkRedirectException	| amqp:link :redirect | Yes | SDK will retry | 
+| AmqpLinkStolenException | amqp:link stolen | Yes | SDK will retry |
+| AmqpLinkTransferLimitExceededException | amqp:link :transfer-limit-exceeded | Yes | SDK will retry |
+| AmqpNotAllowedException	| amqp:not-allowed | No | Inspect the exception details, collect logs and contact service |
+| AmqpNotFoundException | amqp:not-found | No | Inspect the exception details, collect logs and contact service |
+| AmqpNotImplementedException | amqp:not-implemented | No | Inspect the exception details, collect logs and contact service |
+| AmqpPreconditionFailedException | amqp:precondition-failed | No | Inspect the exception details, collect logs and contact service |
+| AmqpResourceDeletedException | amqp:resource-deleted | No | Inspect the exception details, collect logs and contact service |
+| AmqpResourceLimitExceededException | amqp:resource-limit-exceeded | No | Inspect the exception details, collect logs and contact service |
+| AmqpResourceLockedException | amqp:resource-locked | Yes | SDK will retry |
+| AmqpSessionErrantLinkException | amqp:session:errant-link | Yes | SDK will retry |
+| AmqpSessionHandleInUseException | amqp:session:handle-in-use | Yes | SDK will retry |
+| AmqpSessionUnattachedHandleException | amqp:session:unattached-handle | Yes | SDK will retry |
+| AmqpSessionWindowViolationException | amqp:session:window-violation | Yes | SDK will retry |
+| AmqpUnauthorizedAccessException | amqp:unauthorized-access | No | SDK will throw `UnauthorizedException` with Connection status reason `BAD_CREDENTIAL` |

--- a/iothub/device/src/RetryPolicies/ExponentialBackoff.cs
+++ b/iothub/device/src/RetryPolicies/ExponentialBackoff.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Returns true if, based on the parameters the operation should be retried.
+        /// Returns true if, based on the parameters, the operation should be retried.
         /// </summary>
         /// <param name="currentRetryCount">How many times the operation has been retried.</param>
         /// <param name="lastException">Operation exception.</param>


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
- Call SafeClose() on AMQP resources before calling create on AMQP library

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->

Currently, the SDK is follows the below logic for retrying AMQP transport exceptions:

|Exception Name |Error code (if available) |isRetryable  |Action                 |
|------|------|------|------|
| AmqpConnectionForcedException | amqp:connection:forced error | Yes | SDK will retry |
| AmqpConnectionFramingErrorException | amqp:connection:framing-error | Yes | SDK will retry |
| AmqpConnectionRedirectException | amqp:connection:redirect | Yes | SDK will retry |
| AmqpConnectionThrottledException | com.microsoft:device-container-throttled | Yes | SDK will retry, with backoff |
| AmqpDecodeErrorException | amqp:decode-error | No | Mis-match between AMQP message sent by client and received by service; collect logs and contact service |
| AmqpFrameSizeTooSmallException | amqp:frame-size-too-small | No | The AMQP message is not being formed correctly by the SDK, collect logs and contact SDK team |
| AmqpIllegalStateException | amqp:illegal-state | No | Inspect the exception details, collect logs and contact service |
| AmqpInternalErrorException | amqp:internal-error | Yes | SDK will retry |
| AmqpInvalidFieldException | amqp:invalid-field | No | Inspect the exception details, collect logs and contact service |
| AmqpLinkDetachForcedException | amqp:link :detach-forced | Yes | SDK will retry |
| AmqpLinkMessageSizeExceededException | amqp:link :message-size-exceeded | No | The AMQP message size exceeded the value supported by the link, collect logs and contact service |
| AmqpLinkRedirectException	| amqp:link :redirect | Yes | SDK will retry | 
| AmqpLinkStolenException | amqp:link stolen | Yes | SDK will retry |
| AmqpLinkTransferLimitExceededException | amqp:link :transfer-limit-exceeded | Yes | SDK will retry |
| AmqpNotAllowedException	| amqp:not-allowed | No | Inspect the exception details, collect logs and contact service |
| AmqpNotFoundException | amqp:not-found | No | Inspect the exception details, collect logs and contact service |
| AmqpNotImplementedException | amqp:not-implemented | No | Inspect the exception details, collect logs and contact service |
| AmqpPreconditionFailedException | amqp:precondition-failed | No | Inspect the exception details, collect logs and contact service |
| AmqpResourceDeletedException | amqp:resource-deleted | No | Inspect the exception details, collect logs and contact service |
| AmqpResourceLimitExceededException | amqp:resource-limit-exceeded | No | Inspect the exception details, collect logs and contact service |
| AmqpResourceLockedException | amqp:resource-locked | Yes | SDK will retry |
| AmqpSessionErrantLinkException | amqp:session:errant-link | Yes | SDK will retry |
| AmqpSessionHandleInUseException | amqp:session:handle-in-use | Yes | SDK will retry |
| AmqpSessionUnattachedHandleException | amqp:session:unattached-handle | Yes | SDK will retry |
| AmqpSessionWindowViolationException | amqp:session:window-violation | Yes | SDK will retry |
| AmqpUnauthorizedAccessException | amqp:unauthorized-access | No | SDK will throw `UnauthorizedException` with Connection status reason `BAD_CREDENTIAL` |
