### PR TITLE
Release version 1.23.2 of Microsoft.Azure.Devices.Client

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.23.1</Version>
+    <Version>1.23.2</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <Authors>Microsoft</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/versions.csv
+++ b/versions.csv
@@ -1,5 +1,5 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.23.1
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.23.2
 iothub\service\src\Microsoft.Azure.Devices.csproj, 1.19.0
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.18.0
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.5.0


### PR DESCRIPTION
## Microsoft.Azure.Devices.Client v1.23.2

- When using AMQP, ppplication properties with a null value will now be sent to the hub, matching MQTT/HTTP behavior (#919)
- Improve AMQP reconnection resiliency
- SDK will now retry on more error codes over AMQP. For more details, see amqp transport exceptions.
  - `amqp:internal-error`
  - `amqp:link :transfer-limit-exceeded`
  - `amqp:resource-locked`