### PR TITLE
Fix more warnings, and possible resource leaks

### DIFF
--- a/e2e/test/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -821,27 +821,31 @@ namespace Microsoft.Azure.Devices.E2ETests
                 Assert.IsTrue(isReceived, $"Message is not received for device {testDevice.Id}.");
             };
 
-            Func<IList<DeviceClient>, Task> cleanupOperation = async (deviceClients) =>
+            Func<IList<DeviceClient>, Task> cleanupOperation = (deviceClients) =>
             {
                 foreach (DeviceClient deviceClient in deviceClients)
                 {
                     deviceClient.Dispose();
                 }
+
+                return Task.FromResult(0);
             };
 
-            await FaultInjectionPoolingOverAmqp.TestFaultInjectionPoolAmqpAsync(
-                MessageSend_DevicePrefix,
-                transport,
-                poolSize,
-                devicesCount,
-                faultType,
-                reason,
-                delayInSec,
-                durationInSec,
-                (d, t) => { return Task.FromResult<bool>(false); },
-                testOperation,
-                cleanupOperation,
-                authScope).ConfigureAwait(false);
+            await FaultInjectionPoolingOverAmqp
+                .TestFaultInjectionPoolAmqpAsync(
+                    MessageSend_DevicePrefix,
+                    transport,
+                    poolSize,
+                    devicesCount,
+                    faultType,
+                    reason,
+                    delayInSec,
+                    durationInSec,
+                    (d, t) => { return Task.FromResult(false); },
+                    testOperation,
+                    cleanupOperation,
+                    authScope)
+                .ConfigureAwait(false);
         }
     }
 }

--- a/e2e/test/MessageSendE2EPoolAmqpTests.cs
+++ b/e2e/test/MessageSendE2EPoolAmqpTests.cs
@@ -137,12 +137,14 @@ namespace Microsoft.Azure.Devices.E2ETests
                 Assert.IsTrue(isReceived, "Message is not received.");
             };
 
-            Func<IList<DeviceClient>, Task> cleanupOperation = async (deviceClients) =>
+            Func<IList<DeviceClient>, Task> cleanupOperation = (deviceClients) =>
             {
                 foreach (DeviceClient deviceClient in deviceClients)
                 {
                     deviceClient.Dispose();
                 }
+
+                return Task.FromResult(0);
             };
 
             await PoolingOverAmqp.TestPoolAmqpAsync(

--- a/e2e/test/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/MessageSendFaultInjectionTests.cs
@@ -381,9 +381,10 @@ namespace Microsoft.Azure.Devices.E2ETests
             int durationInSec = FaultInjection.DefaultDurationInSec,
             int retryDurationInMilliSec = FaultInjection.RecoveryTimeMilliseconds)
         {
-            Func<DeviceClient, TestDevice, Task> init = async (deviceClient, testDevice) =>
+            Func<DeviceClient, TestDevice, Task> init = (deviceClient, testDevice) =>
             {
                 deviceClient.OperationTimeoutInMilliseconds = (uint)retryDurationInMilliSec;
+                return Task.FromResult(0);
             };
 
             Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
@@ -396,17 +397,19 @@ namespace Microsoft.Azure.Devices.E2ETests
                 Assert.IsTrue(isReceived);
             };
 
-            await FaultInjection.TestErrorInjectionAsync(
-                DevicePrefix,
-                type,
-                transport,
-                faultType,
-                reason,
-                delayInSec,
-                durationInSec,
-                init,
-                testOperation,
-                () => { return Task.FromResult(false); }).ConfigureAwait(false);
+            await FaultInjection
+                .TestErrorInjectionAsync(
+                    DevicePrefix,
+                    type,
+                    transport,
+                    faultType,
+                    reason,
+                    delayInSec,
+                    durationInSec,
+                    init,
+                    testOperation,
+                    () => { return Task.FromResult(false); })
+                .ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/e2e/test/netstandard20/ProvisioningE2ETests.cs
+++ b/e2e/test/netstandard20/ProvisioningE2ETests.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Azure.Devices.E2ETests
         private const string InvalidIDScope = "0neFFFFFFFF";
         private const string payloadJsonData = "{\"testKey\":\"testValue\"}";
         private const string InvalidGlobalAddress = "httpbin.org";
-        private static string ProxyServerAddress = Configuration.IoTHub.ProxyServerAddress;
-        private readonly string IdPrefix = $"e2e-{nameof(ProvisioningE2ETests).ToLower()}-";
+        private static string s_proxyServerAddress = Configuration.IoTHub.ProxyServerAddress;
+        private readonly string _idPrefix = $"e2e-{nameof(ProvisioningE2ETests).ToLower()}-";
 
         private readonly VerboseTestLogging _verboseLog = VerboseTestLogging.GetInstance();
         private readonly TestLogging _log = TestLogging.GetInstance();
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [DoNotParallelize] //TPM tests need to execute in serial as tpm only accepts one connection at a time
         public async Task ProvisioningDeviceClient_ValidRegistrationId_HttpWithProxy_Tpm_RegisterOk_IndividualEnrollment()
         {
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Http1, AttestationType.Tpm, EnrollmentType.Individual, true, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Http1, AttestationType.Tpm, EnrollmentType.Individual, true, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestCategory("Proxy")]
         public async Task ProvisioningDeviceClient_ValidRegistrationId_AmqpWsWithProxy_X509Individual_RegisterOk()
         {
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Amqp_WebSocket_Only, AttestationType.x509, EnrollmentType.Individual, true, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Amqp_WebSocket_Only, AttestationType.x509, EnrollmentType.Individual, true, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestCategory("Proxy")]
         public async Task ProvisioningDeviceClient_ValidRegistrationId_MqttWsWithProxy_X509Individual_RegisterOk()
         {
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Mqtt_WebSocket_Only, AttestationType.x509, EnrollmentType.Individual, true, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Mqtt_WebSocket_Only, AttestationType.x509, EnrollmentType.Individual, true, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestCategory("Proxy")]
         public async Task ProvisioningDeviceClient_ValidRegistrationId_HttpWithProxy_SymmetricKey_RegisterOk_GroupEnrollment()
         {
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Http1, AttestationType.SymmetricKey, EnrollmentType.Group, true, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Http1, AttestationType.SymmetricKey, EnrollmentType.Group, true, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -225,28 +225,28 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestCategory("LongRunning")]
         public async Task ProvisioningDeviceClient_ValidRegistrationId_AmqpWithProxy_SymmetricKey_RegisterOk_GroupEnrollment()
         {
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Amqp, AttestationType.SymmetricKey, EnrollmentType.Group, true, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Amqp, AttestationType.SymmetricKey, EnrollmentType.Group, true, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         [TestCategory("Proxy")]
         [TestMethod]
         public async Task ProvisioningDeviceClient_ValidRegistrationId_MqttWithProxy_SymmetricKey_RegisterOk_GroupEnrollment()
         {
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Mqtt, AttestationType.SymmetricKey, EnrollmentType.Group, true, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Mqtt, AttestationType.SymmetricKey, EnrollmentType.Group, true, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         [TestCategory("Proxy")]
         [TestMethod]
         public async Task ProvisioningDeviceClient_ValidRegistrationId_AmqpWsWithProxy_SymmetricKey_RegisterOk_GroupEnrollment()
         {
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Amqp_WebSocket_Only, AttestationType.SymmetricKey, EnrollmentType.Group, true, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Amqp_WebSocket_Only, AttestationType.SymmetricKey, EnrollmentType.Group, true, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         [TestCategory("Proxy")]
         [TestMethod]
         public async Task ProvisioningDeviceClient_ValidRegistrationId_MqttWsWithProxy_SymmetricKey_RegisterOk_GroupEnrollment()
         {
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Mqtt_WebSocket_Only, AttestationType.SymmetricKey, EnrollmentType.Group, true, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Mqtt_WebSocket_Only, AttestationType.SymmetricKey, EnrollmentType.Group, true, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -402,14 +402,14 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestCategory("Proxy")]
         public async Task ProvisioningDeviceClient_ValidRegistrationId_HttpWithProxy_SymmetricKey_RegisterOk_IndividualEnrollment()
         {
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Http1, AttestationType.SymmetricKey, EnrollmentType.Individual, true, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Http1, AttestationType.SymmetricKey, EnrollmentType.Individual, true, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         [TestMethod]
         [TestCategory("Proxy")]
         public async Task ProvisioningDeviceClient_ValidRegistrationId_AmqpWithProxy_SymmetricKey_RegisterOk_IndividualEnrollment()
         {
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Amqp, AttestationType.SymmetricKey, EnrollmentType.Individual, true, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Amqp, AttestationType.SymmetricKey, EnrollmentType.Individual, true, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -417,21 +417,21 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestCategory("LongRunning")]
         public async Task ProvisioningDeviceClient_ValidRegistrationId_AmqpWsWithProxy_SymmetricKey_RegisterOk_IndividualEnrollment()
         {
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Amqp, AttestationType.SymmetricKey, EnrollmentType.Individual, true, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Amqp, AttestationType.SymmetricKey, EnrollmentType.Individual, true, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         [TestMethod]
         [TestCategory("Proxy")]
         public async Task ProvisioningDeviceClient_ValidRegistrationId_MqttWithProxy_SymmetricKey_RegisterOk_IndividualEnrollment()
         {
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Mqtt, AttestationType.SymmetricKey, EnrollmentType.Individual, true, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Mqtt, AttestationType.SymmetricKey, EnrollmentType.Individual, true, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         [TestMethod]
         [TestCategory("Proxy")]
         public async Task ProvisioningDeviceClient_ValidRegistrationId_MqttWsWithProxy_SymmetricKey_RegisterOk_IndividualEnrollment()
         {
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Mqtt, AttestationType.SymmetricKey, EnrollmentType.Individual, true, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Mqtt, AttestationType.SymmetricKey, EnrollmentType.Individual, true, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         public async Task ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
@@ -442,7 +442,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             string proxyServerAddress = null)
         {
             //Default reprovisioning settings: Hashed allocation, no reprovision policy, hub names, or custom allocation policy
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(transportType, attestationType, enrollmentType, setCustomProxy, null, AllocationPolicy.Hashed, null, null, null, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(transportType, attestationType, enrollmentType, setCustomProxy, null, AllocationPolicy.Hashed, null, null, null, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         public async Task ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
@@ -455,7 +455,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             //Default reprovisioning settings: Hashed allocation, no reprovision policy, hub names, or custom allocation policy
             List<String> iothubs = new List<string>() { IotHubConnectionStringBuilder.Create(Configuration.IoTHub.ConnectionString).HostName };
-            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(transportType, attestationType, enrollmentType, setCustomProxy, null, AllocationPolicy.Hashed, null, iothubs, capabilities, ProxyServerAddress).ConfigureAwait(false);
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(transportType, attestationType, enrollmentType, setCustomProxy, null, AllocationPolicy.Hashed, null, iothubs, capabilities, s_proxyServerAddress).ConfigureAwait(false);
         }
 
         public async Task ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
@@ -470,7 +470,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             DeviceCapabilities deviceCapabilities,
             string proxyServerAddress = null)
         {
-            string groupId = IdPrefix + AttestationTypeToString(attestationType) + "-" + Guid.NewGuid();
+            string groupId = _idPrefix + AttestationTypeToString(attestationType) + "-" + Guid.NewGuid();
             using (ProvisioningTransportHandler transport = CreateTransportHandlerFromName(transportType))
             using (SecurityProvider security = await CreateSecurityProviderFromName(attestationType, enrollmentType, groupId, reprovisionPolicy, allocationPolicy, customAllocationDefinition, iothubs, deviceCapabilities).ConfigureAwait(false))
             {
@@ -478,7 +478,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 if (ImplementsWebProxy(transportType) && setCustomProxy)
                 {
-                    transport.Proxy = (proxyServerAddress != null) ? new WebProxy(ProxyServerAddress) : null;
+                    transport.Proxy = (proxyServerAddress != null) ? new WebProxy(s_proxyServerAddress) : null;
                 }
 
                 ProvisioningDeviceClient provClient = ProvisioningDeviceClient.Create(
@@ -515,8 +515,8 @@ namespace Microsoft.Azure.Devices.E2ETests
             string expectedDestinationHub,
             string proxyServerAddress = null)
         {
-            ProvisioningServiceClient provisioningServiceClient = CreateProvisioningService(ProxyServerAddress);
-            string groupId = IdPrefix + AttestationTypeToString(attestationType) + "-" + Guid.NewGuid();
+            ProvisioningServiceClient provisioningServiceClient = CreateProvisioningService(s_proxyServerAddress);
+            string groupId = _idPrefix + AttestationTypeToString(attestationType) + "-" + Guid.NewGuid();
 
             var customAllocationDefinition = new CustomAllocationDefinition
             {
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 //Check basic provisioning
                 if (ImplementsWebProxy(transportProtocol) && setCustomProxy)
                 {
-                    transport.Proxy = (proxyServerAddress != null) ? new WebProxy(ProxyServerAddress) : null;
+                    transport.Proxy = (proxyServerAddress != null) ? new WebProxy(s_proxyServerAddress) : null;
                 }
 
                 var provClient = ProvisioningDeviceClient.Create(
@@ -912,7 +912,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                             EnrollmentGroup symmetricKeyEnrollmentGroup = await CreateEnrollmentGroup(provisioningServiceClient, AttestationType.SymmetricKey, groupId, reprovisionPolicy, allocationPolicy, customAllocationDefinition, iothubs, capabilities).ConfigureAwait(false);
                             Assert.IsTrue(symmetricKeyEnrollmentGroup.Attestation is SymmetricKeyAttestation);
                             SymmetricKeyAttestation symmetricKeyAttestation = (SymmetricKeyAttestation)symmetricKeyEnrollmentGroup.Attestation;
-                            string registrationIdSymmetricKey = IdPrefix + Guid.NewGuid();
+                            string registrationIdSymmetricKey = _idPrefix + Guid.NewGuid();
                             string primaryKeyEnrollmentGroup = symmetricKeyAttestation.PrimaryKey;
                             string secondaryKeyEnrollmentGroup = symmetricKeyAttestation.SecondaryKey;
 
@@ -982,6 +982,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             Assert.AreEqual(ProvisioningRegistrationStatusType.Assigned, result.Status, $"Unexpected provisioning status, substatus: {result.Substatus}, error code: {result.ErrorCode}, error message: {result.ErrorMessage}");
             Assert.IsNotNull(result.AssignedHub);
             Assert.IsNotNull(result.DeviceId);
+
             if (validatePayload)
             {
                 if (payloadJsonData != null)
@@ -991,7 +992,9 @@ namespace Microsoft.Azure.Devices.E2ETests
                 }
                 else
                 {
+#pragma warning disable CS0162 // Unreachable code detected
                     Assert.IsNull(result.JsonPayload);
+#pragma warning restore CS0162 // Unreachable code detected
                 }
             }
             else

--- a/iothub/device/src/Common/Exceptions/DeviceAlreadyExistsException.cs
+++ b/iothub/device/src/Common/Exceptions/DeviceAlreadyExistsException.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
         {
         }
 
+#pragma warning disable CA2229 // Implement serialization constructors. Would change public API.
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DeviceAlreadyExistsException"/> class with the specified serialization and context information.
         /// </summary>
@@ -48,5 +50,7 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
             : base(info, context)
         {
         }
+
+#pragma warning restore CA2229 // Implement serialization constructors
     }
 }

--- a/iothub/device/src/Common/Exceptions/DeviceDisabledException.cs
+++ b/iothub/device/src/Common/Exceptions/DeviceDisabledException.cs
@@ -62,6 +62,8 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
         {
         }
 
+#pragma warning disable CA2229 // Implement serialization constructors. Would change public API.
+
         /// <summary>
         /// Obsolete: This exception is not thrown by the SDK.
         /// </summary>
@@ -71,5 +73,7 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
             : base(info, context)
         {
         }
+
+#pragma warning restore CA2229 // Implement serialization constructors
     }
 }

--- a/iothub/device/src/Common/Exceptions/DeviceNotFoundException.cs
+++ b/iothub/device/src/Common/Exceptions/DeviceNotFoundException.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
         {
         }
 
+#pragma warning disable CA2229 // Implement serialization constructors. Would change public API.
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DeviceNotFoundException"/> class with the specified serialization and context information.
         /// </summary>
@@ -72,5 +74,7 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
             : base(info, context)
         {
         }
+
+#pragma warning restore CA2229 // Implement serialization constructors
     }
 }

--- a/iothub/device/src/Common/Exceptions/ExceptionHandlingHelper.cs
+++ b/iothub/device/src/Common/Exceptions/ExceptionHandlingHelper.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
             mappings.Add(HttpStatusCode.Unauthorized, async (response) => new UnauthorizedException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
             mappings.Add(HttpStatusCode.Forbidden, async (response) => new QuotaExceededException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
             mappings.Add(HttpStatusCode.PreconditionFailed, async (response) => new DeviceMessageLockLostException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
-            mappings.Add(HttpStatusCode.RequestEntityTooLarge, async (response) => new MessageTooLargeException(await GetExceptionMessageAsync(response).ConfigureAwait(false))); ;
+            mappings.Add(HttpStatusCode.RequestEntityTooLarge, async (response) => new MessageTooLargeException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
             mappings.Add(HttpStatusCode.InternalServerError, async (response) => new ServerErrorException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
             mappings.Add(HttpStatusCode.ServiceUnavailable, async (response) => new ServerBusyException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
             mappings.Add((System.Net.HttpStatusCode)429, async (response) => new IotHubThrottledException(await GetExceptionMessageAsync(response).ConfigureAwait(false), null));

--- a/iothub/device/src/Common/Exceptions/IotHubException.cs
+++ b/iothub/device/src/Common/Exceptions/IotHubException.cs
@@ -18,41 +18,15 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
         [NonSerialized]
         private const string TrackingIdValueSerializationStoreName = "IotHubException-TrackingId";
 
-        [NonSerialized]
-        private bool _isTransient;
-
-        [NonSerialized]
-        private string _trackingId;
-
         /// <summary>
         /// Gets a value indicating if the error is transient.
         /// </summary>
-        public bool IsTransient
-        {
-            get
-            {
-                return _isTransient;
-            }
-            private set
-            {
-                _isTransient = value;
-            }
-        }
+        public bool IsTransient { get; private set; }
 
         /// <summary>
         /// Gets or sets the Azure IoT service-side Tracking ID in Support Requests.
         /// </summary>
-        public string TrackingId
-        {
-            get
-            {
-                return _trackingId;
-            }
-            set
-            {
-                _trackingId = value;
-            }
-        }
+        public string TrackingId { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IotHubException"/> class.
@@ -63,7 +37,7 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
 
         internal IotHubException(bool isTransient) : base()
         {
-            this.IsTransient = isTransient;
+            IsTransient = isTransient;
         }
 
         /// <summary>
@@ -146,8 +120,8 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
         protected IotHubException(string message, Exception innerException, bool isTransient, string trackingId)
             : base(message, innerException)
         {
-            this.IsTransient = isTransient;
-            this.TrackingId = trackingId;
+            IsTransient = isTransient;
+            TrackingId = trackingId;
         }
 
         /// <summary>
@@ -160,8 +134,8 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
         {
             if (info != null)
             {
-                _isTransient = info.GetBoolean(IsTransientValueSerializationStoreName);
-                _trackingId = info.GetString(TrackingIdValueSerializationStoreName);
+                IsTransient = info.GetBoolean(IsTransientValueSerializationStoreName);
+                TrackingId = info.GetString(TrackingIdValueSerializationStoreName);
             }
         }
 
@@ -173,8 +147,8 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue(IsTransientValueSerializationStoreName, _isTransient);
-            info.AddValue(TrackingIdValueSerializationStoreName, _trackingId);
+            info.AddValue(IsTransientValueSerializationStoreName, IsTransient);
+            info.AddValue(TrackingIdValueSerializationStoreName, TrackingId);
         }
     }
 }

--- a/iothub/device/src/Common/Exceptions/IotHubNotFoundException.cs
+++ b/iothub/device/src/Common/Exceptions/IotHubNotFoundException.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
         /// </summary>
         /// <param name="info">An object that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">An object that contains contextual information about the source or destination.</param>
-        private IotHubNotFoundException(SerializationInfo info, StreamingContext context)
+        protected IotHubNotFoundException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }

--- a/iothub/device/src/Common/Exceptions/IotHubSuspendedException.cs
+++ b/iothub/device/src/Common/Exceptions/IotHubSuspendedException.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
         {
         }
 
-        private IotHubSuspendedException(SerializationInfo info, StreamingContext context)
+        protected IotHubSuspendedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }

--- a/iothub/device/src/Common/Exceptions/ServerErrorException.cs
+++ b/iothub/device/src/Common/Exceptions/ServerErrorException.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
         /// <summary>
         /// Initializes a new instance of the <see cref="ServerErrorException"/> class.
         /// </summary>
-        public ServerErrorException() : base(isTransient: true)
+        public ServerErrorException()
+            : base(isTransient: true)
         {
         }
 

--- a/iothub/device/src/Edge/EdgeModuleClientFactory.cs
+++ b/iothub/device/src/Edge/EdgeModuleClientFactory.cs
@@ -18,21 +18,21 @@ namespace Microsoft.Azure.Devices.Client.Edge
     /// </summary>
     internal class EdgeModuleClientFactory
     {
-        const string DefaultApiVersion = "2018-06-28";
-        const string IotEdgedUriVariableName = "IOTEDGE_WORKLOADURI";
-        const string IotHubHostnameVariableName = "IOTEDGE_IOTHUBHOSTNAME";
-        const string GatewayHostnameVariableName = "IOTEDGE_GATEWAYHOSTNAME";
-        const string DeviceIdVariableName = "IOTEDGE_DEVICEID";
-        const string ModuleIdVariableName = "IOTEDGE_MODULEID";
-        const string ModuleGenerationIdVariableName = "IOTEDGE_MODULEGENERATIONID";
-        const string AuthSchemeVariableName = "IOTEDGE_AUTHSCHEME";
-        const string SasTokenAuthScheme = "SasToken";
-        const string EdgehubConnectionstringVariableName = "EdgeHubConnectionString";
-        const string IothubConnectionstringVariableName = "IotHubConnectionString";
-        const string EdgeCaCertificateFileVariableName = "EdgeModuleCACertificateFile";
+        private const string DefaultApiVersion = "2018-06-28";
+        private const string IotEdgedUriVariableName = "IOTEDGE_WORKLOADURI";
+        private const string IotHubHostnameVariableName = "IOTEDGE_IOTHUBHOSTNAME";
+        private const string GatewayHostnameVariableName = "IOTEDGE_GATEWAYHOSTNAME";
+        private const string DeviceIdVariableName = "IOTEDGE_DEVICEID";
+        private const string ModuleIdVariableName = "IOTEDGE_MODULEID";
+        private const string ModuleGenerationIdVariableName = "IOTEDGE_MODULEGENERATIONID";
+        private const string AuthSchemeVariableName = "IOTEDGE_AUTHSCHEME";
+        private const string SasTokenAuthScheme = "SasToken";
+        private const string EdgehubConnectionstringVariableName = "EdgeHubConnectionString";
+        private const string IothubConnectionstringVariableName = "IotHubConnectionString";
+        private const string EdgeCaCertificateFileVariableName = "EdgeModuleCACertificateFile";
 
-        readonly ITransportSettings[] transportSettings;
-        readonly ITrustBundleProvider trustBundleProvider;
+        private readonly ITransportSettings[] _transportSettings;
+        private readonly ITrustBundleProvider _trustBundleProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EdgeModuleClientFactory"/> class with transport settings.
@@ -41,24 +41,23 @@ namespace Microsoft.Azure.Devices.Client.Edge
         /// <param name="trustBundleProvider">Provider implementation to get trusted bundle for certificate validation.</param>
         public EdgeModuleClientFactory(ITransportSettings[] transportSettings, ITrustBundleProvider trustBundleProvider)
         {
-            this.transportSettings = transportSettings ?? throw new ArgumentNullException(nameof(transportSettings));
-            this.trustBundleProvider = trustBundleProvider ?? throw new ArgumentNullException(nameof(trustBundleProvider));
+            _transportSettings = transportSettings ?? throw new ArgumentNullException(nameof(transportSettings));
+            _trustBundleProvider = trustBundleProvider ?? throw new ArgumentNullException(nameof(trustBundleProvider));
         }
 
         /// <summary>
         /// Creates a ModuleClient instance based on environment.
         /// </summary>
-        /// <returns></returns>
         public Task<ModuleClient> CreateAsync()
         {
-            return this.CreateInternalClientFromEnvironmentAsync();
+            return CreateInternalClientFromEnvironmentAsync();
         }
 
-        async Task<ModuleClient> CreateInternalClientFromEnvironmentAsync()
+        private async Task<ModuleClient> CreateInternalClientFromEnvironmentAsync()
         {
             IDictionary envVariables = Environment.GetEnvironmentVariables();
 
-            string connectionString = this.GetValueFromEnvironment(envVariables, EdgehubConnectionstringVariableName) ?? this.GetValueFromEnvironment(envVariables, IothubConnectionstringVariableName);
+            string connectionString = GetValueFromEnvironment(envVariables, EdgehubConnectionstringVariableName) ?? GetValueFromEnvironment(envVariables, IothubConnectionstringVariableName);
 
             // First try to create from connection string and if env variable for connection string is not found try to create from edgedUri
             if (!string.IsNullOrWhiteSpace(connectionString))
@@ -70,20 +69,20 @@ namespace Microsoft.Azure.Devices.Client.Edge
                 {
                     Debug.WriteLine("EdgeModuleClientFactory setupTrustBundle from file");
                     var expectedRoot = new X509Certificate2(certPath);
-                    certificateValidator = this.GetCertificateValidator(new List<X509Certificate2>() { expectedRoot });
+                    certificateValidator = GetCertificateValidator(new List<X509Certificate2>() { expectedRoot });
                 }
 
-                return new ModuleClient(this.CreateInternalClientFromConnectionString(connectionString), certificateValidator);
+                return new ModuleClient(CreateInternalClientFromConnectionString(connectionString), certificateValidator);
             }
             else
             {
-                string edgedUri = this.GetValueFromEnvironment(envVariables, IotEdgedUriVariableName) ?? throw new InvalidOperationException($"Environment variable {IotEdgedUriVariableName} is required.");
-                string deviceId = this.GetValueFromEnvironment(envVariables, DeviceIdVariableName) ?? throw new InvalidOperationException($"Environment variable {DeviceIdVariableName} is required.");
-                string moduleId = this.GetValueFromEnvironment(envVariables, ModuleIdVariableName) ?? throw new InvalidOperationException($"Environment variable {ModuleIdVariableName} is required.");
-                string hostname = this.GetValueFromEnvironment(envVariables, IotHubHostnameVariableName) ?? throw new InvalidOperationException($"Environment variable {IotHubHostnameVariableName} is required.");
-                string authScheme = this.GetValueFromEnvironment(envVariables, AuthSchemeVariableName) ?? throw new InvalidOperationException($"Environment variable {AuthSchemeVariableName} is required.");
-                string generationId = this.GetValueFromEnvironment(envVariables, ModuleGenerationIdVariableName) ?? throw new InvalidOperationException($"Environment variable {ModuleGenerationIdVariableName} is required.");
-                string gateway = this.GetValueFromEnvironment(envVariables, GatewayHostnameVariableName);
+                string edgedUri = GetValueFromEnvironment(envVariables, IotEdgedUriVariableName) ?? throw new InvalidOperationException($"Environment variable {IotEdgedUriVariableName} is required.");
+                string deviceId = GetValueFromEnvironment(envVariables, DeviceIdVariableName) ?? throw new InvalidOperationException($"Environment variable {DeviceIdVariableName} is required.");
+                string moduleId = GetValueFromEnvironment(envVariables, ModuleIdVariableName) ?? throw new InvalidOperationException($"Environment variable {ModuleIdVariableName} is required.");
+                string hostname = GetValueFromEnvironment(envVariables, IotHubHostnameVariableName) ?? throw new InvalidOperationException($"Environment variable {IotHubHostnameVariableName} is required.");
+                string authScheme = GetValueFromEnvironment(envVariables, AuthSchemeVariableName) ?? throw new InvalidOperationException($"Environment variable {AuthSchemeVariableName} is required.");
+                string generationId = GetValueFromEnvironment(envVariables, ModuleGenerationIdVariableName) ?? throw new InvalidOperationException($"Environment variable {ModuleGenerationIdVariableName} is required.");
+                string gateway = GetValueFromEnvironment(envVariables, GatewayHostnameVariableName);
 
                 if (!string.Equals(authScheme, SasTokenAuthScheme, StringComparison.OrdinalIgnoreCase))
                 {
@@ -98,23 +97,23 @@ namespace Microsoft.Azure.Devices.Client.Edge
                 ICertificateValidator certificateValidator = NullCertificateValidator.Instance;
                 if (!string.IsNullOrEmpty(gateway))
                 {
-                    IList<X509Certificate2> certs = await trustBundleProvider.GetTrustBundleAsync(new Uri(edgedUri), DefaultApiVersion).ConfigureAwait(false);
-                    certificateValidator = this.GetCertificateValidator(certs);
+                    IList<X509Certificate2> certs = await _trustBundleProvider.GetTrustBundleAsync(new Uri(edgedUri), DefaultApiVersion).ConfigureAwait(false);
+                    certificateValidator = GetCertificateValidator(certs);
                 }
 
-                return new ModuleClient(this.CreateInternalClientFromAuthenticationMethod(hostname, gateway, authMethod), certificateValidator);
+                return new ModuleClient(CreateInternalClientFromAuthenticationMethod(hostname, gateway, authMethod), certificateValidator);
             }
         }
 
         private ICertificateValidator GetCertificateValidator(IList<X509Certificate2> certs)
         {
-            if (certs.Count() != 0)
+            if (certs.Count != 0)
             {
                 Debug.WriteLine("EdgeModuleClientFactory.GetCertificateValidator()");
                 if (IsOSPlatform(OSPlatform.Windows))
                 {
                     Debug.WriteLine("EdgeModuleClientFactory GetCertificateValidator on Windows");
-                    var certValidator = CustomCertificateValidator.Create(certs, transportSettings);
+                    var certValidator = CustomCertificateValidator.Create(certs, _transportSettings);
                     return certValidator;
                 }
                 else
@@ -128,24 +127,21 @@ namespace Microsoft.Azure.Devices.Client.Edge
             return NullCertificateValidator.Instance;
         }
 
-        InternalClient CreateInternalClientFromConnectionString(string connectionString)
+        private InternalClient CreateInternalClientFromConnectionString(string connectionString)
         {
-            return ClientFactory.CreateFromConnectionString(connectionString, this.transportSettings);
+            return ClientFactory.CreateFromConnectionString(connectionString, _transportSettings);
         }
 
-        InternalClient CreateInternalClientFromAuthenticationMethod(string hostname, string gateway, IAuthenticationMethod authMethod)
+        private InternalClient CreateInternalClientFromAuthenticationMethod(string hostname, string gateway, IAuthenticationMethod authMethod)
         {
-            return ClientFactory.Create(hostname, gateway, authMethod, this.transportSettings);
+            return ClientFactory.Create(hostname, gateway, authMethod, _transportSettings);
         }
 
-        string GetValueFromEnvironment(IDictionary envVariables, string variableName)
+        private static string GetValueFromEnvironment(IDictionary envVariables, string variableName)
         {
-            if (envVariables.Contains(variableName))
-            {
-                return envVariables[variableName].ToString();
-            }
-
-            return null;
+            return envVariables.Contains(variableName)
+                ? envVariables[variableName].ToString()
+                : null;
         }
     }
 }

--- a/iothub/device/src/GlobalSuppressions.cs
+++ b/iothub/device/src/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Not localizing", Scope = "module")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "SDK hides non-actionable errors from user", Scope = "module")]

--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -102,6 +102,9 @@
 
   <ItemGroup>
     <!-- FXCop -->
-    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/iothub/device/src/TransientFaultHandling/AsyncExecution.cs
+++ b/iothub/device/src/TransientFaultHandling/AsyncExecution.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //Copyright(c) Microsoft.All rights reserved.
 //Microsoft would like to thank its contributors, a list
 //of whom are at http://aka.ms/entlib-contributors
@@ -23,74 +25,99 @@ using Microsoft.Azure.Devices.Client.TransientFaultHandling.Properties;
 // THIS FILE HAS BEEN MODIFIED FROM ITS ORIGINAL FORM.
 // Change Log:
 // 9/1/2017 jasminel Renamed namespace to Microsoft.Azure.Devices.Client.TransientFaultHandling.
+// 3/11/2020 drwill Misc code cleanup for code style and fxcopy warnings
 
 namespace Microsoft.Azure.Devices.Client.TransientFaultHandling
 {
     /// <summary>
-    /// Provides a wrapper for a non-generic <see cref="T:System.Threading.Tasks.Task" /> and calls into the pipeline
-    /// to retry only the generic version of the <see cref="T:System.Threading.Tasks.Task" />.
+    /// Provides a wrapper for a non-generic <see cref="System.Threading.Tasks.Task" /> and calls into the pipeline
+    /// to retry only the generic version of the <see cref="System.Threading.Tasks.Task" />.
     /// </summary>
     internal class AsyncExecution : AsyncExecution<bool>
     {
         private static Task<bool> cachedBoolTask;
 
-        public AsyncExecution(Func<Task> taskAction, ShouldRetry shouldRetry, Func<Exception, bool> isTransient, Action<int, Exception, TimeSpan> onRetrying, bool fastFirstRetry, CancellationToken cancellationToken) : base(() => AsyncExecution.StartAsGenericTask(taskAction), shouldRetry, isTransient, onRetrying, fastFirstRetry, cancellationToken)
+        public AsyncExecution(
+            Func<Task> taskAction,
+            ShouldRetry shouldRetry,
+            Func<Exception, bool> isTransient,
+            Action<int, Exception, TimeSpan> onRetrying,
+            bool fastFirstRetry,
+            CancellationToken cancellationToken)
+            : base(() => AsyncExecution.StartAsGenericTask(taskAction), shouldRetry, isTransient, onRetrying, fastFirstRetry, cancellationToken)
         {
         }
 
         /// <summary>
-        /// Wraps the non-generic <see cref="T:System.Threading.Tasks.Task" /> into a generic <see cref="T:System.Threading.Tasks.Task" />.
+        /// Wraps the non-generic <see cref="System.Threading.Tasks.Task" /> into a generic <see cref="System.Threading.Tasks.Task" />.
         /// </summary>
         /// <param name="taskAction">The task to wrap.</param>
-        /// <returns>A <see cref="T:System.Threading.Tasks.Task" /> that wraps the non-generic <see cref="T:System.Threading.Tasks.Task" />.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task" /> that wraps the non-generic <see cref="System.Threading.Tasks.Task" />.</returns>
         private static Task<bool> StartAsGenericTask(Func<Task> taskAction)
         {
             Task task = taskAction();
+
             if (task == null)
             {
-                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, Resources.TaskCannotBeNull, new object[]
-                {
-                    "taskAction"
-                }), "taskAction");
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        Resources.TaskCannotBeNull,
+                        new object[]
+                        {
+                            "taskAction"
+                        }),
+                    nameof(taskAction));
             }
+
             if (task.Status == TaskStatus.RanToCompletion)
             {
-                return AsyncExecution.GetCachedTask();
+                return GetCachedTask();
             }
+
             if (task.Status == TaskStatus.Created)
             {
-                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, Resources.TaskMustBeScheduled, new object[]
-                {
-                    "taskAction"
-                }), "taskAction");
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        Resources.TaskMustBeScheduled,
+                        new object[]
+                        {
+                            "taskAction"
+                        }),
+                    nameof(taskAction));
             }
-            TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
-            task.ContinueWith(delegate (Task t)
-            {
-                if (t.IsFaulted)
-                {
-                    tcs.TrySetException(t.Exception.InnerExceptions);
-                    return;
-                }
-                if (t.IsCanceled)
-                {
-                    tcs.TrySetCanceled();
-                    return;
-                }
-                tcs.TrySetResult(true);
-            }, TaskContinuationOptions.ExecuteSynchronously);
+
+            var tcs = new TaskCompletionSource<bool>();
+            task.ContinueWith(
+                delegate (Task t)
+                  {
+                      if (t.IsFaulted)
+                      {
+                          tcs.TrySetException(t.Exception.InnerExceptions);
+                          return;
+                      }
+                      if (t.IsCanceled)
+                      {
+                          tcs.TrySetCanceled();
+                          return;
+                      }
+                      tcs.TrySetResult(true);
+                  },
+                TaskContinuationOptions.ExecuteSynchronously);
+
             return tcs.Task;
         }
 
         private static Task<bool> GetCachedTask()
         {
-            if (AsyncExecution.cachedBoolTask == null)
+            if (cachedBoolTask == null)
             {
-                TaskCompletionSource<bool> taskCompletionSource = new TaskCompletionSource<bool>();
+                var taskCompletionSource = new TaskCompletionSource<bool>();
                 taskCompletionSource.TrySetResult(true);
-                AsyncExecution.cachedBoolTask = taskCompletionSource.Task;
+                cachedBoolTask = taskCompletionSource.Task;
             }
-            return AsyncExecution.cachedBoolTask;
+            return cachedBoolTask;
         }
     }
 }

--- a/iothub/device/tests/DeviceClientTwinApiTests.cs
+++ b/iothub/device/tests/DeviceClientTwinApiTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             await innerHandler.
                 Received(1).
                 EnableTwinPatchAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
-            Assert.AreEqual(client.InternalClient.desiredPropertyUpdateCallback, myCallback);
+            Assert.AreEqual(client.InternalClient._desiredPropertyUpdateCallback, myCallback);
         }
 
         // Tests_SRS_DEVICECLIENT_18_003: `SetDesiredPropertyUpdateCallbackAsync` shall call the transport to register for PATCHes on it's first call.
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             await innerHandler.
                 Received(1).
                 EnableTwinPatchAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
-            Assert.AreEqual(client.InternalClient.desiredPropertyUpdateCallback, myCallback);
+            Assert.AreEqual(client.InternalClient._desiredPropertyUpdateCallback, myCallback);
         }
 
         // Tests_SRS_DEVICECLIENT_18_004: `SetDesiredPropertyUpdateCallback` shall not call the transport to register for PATCHes on subsequent calls

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -153,6 +153,9 @@
 
   <ItemGroup>
     <!-- FXCop -->
-    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/provisioning/device/src/CertificateInstaller.cs
+++ b/provisioning/device/src/CertificateInstaller.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 {
     internal static class CertificateInstaller
     {
-        private static HashSet<string> _installedCertificates = new HashSet<string>();
-        private static object _lock = new object();
+        private static readonly HashSet<string> s_installedCertificates = new HashSet<string>();
+        private static readonly object s_lock = new object();
 
         static CertificateInstaller()
         {
@@ -22,15 +22,15 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                     store.Open(OpenFlags.ReadOnly);
                     foreach (X509Certificate2 certificate in store.Certificates)
                     {
-                        _installedCertificates.Add(certificate.Thumbprint);
+                        s_installedCertificates.Add(certificate.Thumbprint);
                     }
                 }
             }
             catch (Exception ex)
             {
-                if(Logging.IsEnabled) Logging.Error(
-                    null, 
-                    $"{nameof(CertificateInstaller)} failed to read store: {ex}.");
+                if (Logging.IsEnabled) Logging.Error(
+                     null,
+                     $"{nameof(CertificateInstaller)} failed to read store: {ex}.");
             }
         }
 
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         {
             if (certificates == null) return;
 
-            lock (_lock)
+            lock (s_lock)
             {
                 using (var store = new X509Store(StoreName.CertificateAuthority, StoreLocation.CurrentUser))
                 {
@@ -46,13 +46,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
                     foreach (X509Certificate2 certificate in certificates)
                     {
-                        if (!_installedCertificates.Contains(certificate.Thumbprint))
+                        if (!s_installedCertificates.Contains(certificate.Thumbprint))
                         {
                             if (Logging.IsEnabled)
                                 Logging.Info(null, $"{nameof(CertificateInstaller)} adding {certificate.Thumbprint}");
 
                             store.Add(certificate);
-                            _installedCertificates.Add(certificate.Thumbprint);
+                            s_installedCertificates.Add(certificate.Thumbprint);
                         }
                     }
                 }

--- a/provisioning/device/src/GlobalSuppressions.cs
+++ b/provisioning/device/src/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Not localizing", Scope = "module")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "SDK hides non-actionable errors from user", Scope = "module")]

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -50,6 +50,9 @@
 
   <ItemGroup>
     <!-- FXCop -->
-    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/provisioning/service/src/Config/EnrollmentGroup.cs
+++ b/provisioning/service/src/Config/EnrollmentGroup.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     ///
     /// The content of this class will be serialized in a JSON format and sent as a body of the rest API to the
     ///    provisioning service.
-    ///    
+    ///
     /// The content of this class can be filled by a JSON, received from the provisioning service, as result of a
     ///    EnrollmentGroup operation like create, update, or query EnrollmentGroup.
     /// </remarks>
@@ -84,9 +84,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Creates a new instance of <code>EnrollmentGroup</code>.
         /// </summary>
         /// <remarks>
-        /// This constructor creates an instance of the EnrollmentGroup object with the minimum set of 
-        /// information required by the provisioning service. A valid EnrollmentGroup must contain the 
-        /// enrollmentGroupId, which uniquely identify this enrollmentGroup, and the attestation mechanism, 
+        /// This constructor creates an instance of the EnrollmentGroup object with the minimum set of
+        /// information required by the provisioning service. A valid EnrollmentGroup must contain the
+        /// enrollmentGroupId, which uniquely identify this enrollmentGroup, and the attestation mechanism,
         /// which must X509.
         ///
         /// Other parameters can be added by calling the setters on this object.
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// }
         /// </code>
         /// </example>
-        /// <param name="enrollmentGroupId">the <code>string</code> that uniquely identify this enrollmentGroup in the provisioning 
+        /// <param name="enrollmentGroupId">the <code>string</code> that uniquely identify this enrollmentGroup in the provisioning
         ///     service. It cannot be <code>null</code> or empty.</param>
         /// <param name="attestation">the <see cref="Attestation"/> object with the attestation mechanism. It cannot be <code>null</code>.</param>
         /// <exception cref="ArgumentNullException">if one of the provided parameters is not correct</exception>
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             string eTag,
             DeviceCapabilities capabilities)
         {
-            /* SRS_ENROLLMENT_GROUP_21_003: [The constructor shall throws ProvisioningServiceClientException if one of the 
+            /* SRS_ENROLLMENT_GROUP_21_003: [The constructor shall throws ProvisioningServiceClientException if one of the
                                                     provided parameters in JSON is not valid.] */
             if (attestation == null)
             {
@@ -223,19 +223,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </remarks>
         /// <exception cref="ArgumentException">if the provided string does not fit the enrollmentGroup Id requirements</exception>
         [JsonProperty(PropertyName = "enrollmentGroupId")]
-        public string EnrollmentGroupId
-        {
-            get
-            {
-                return _enrollmentGroupId;
-            }
-
-            private set
-            {
-                _enrollmentGroupId = value;
-            }
-        }
-        private string _enrollmentGroupId;
+        public string EnrollmentGroupId { get; private set; }
 
         /// <summary>
         /// Current registration state.
@@ -255,10 +243,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         [JsonIgnore]
         public Attestation Attestation
         {
-            get
-            {
-                return _attestation.GetAttestation();
-            }
+            get => _attestation.GetAttestation();
             set
             {
                 if (value == null)
@@ -325,26 +310,31 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         [JsonProperty(PropertyName = "capabilities", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public DeviceCapabilities Capabilities { get; set; }
 
-        /// <summary> 
+        /// <summary>
         /// The behavior when a device is re-provisioned to an IoT hub.
         /// </summary>
         [JsonProperty(PropertyName = "reprovisionPolicy", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public ReprovisionPolicy ReprovisionPolicy { get; set; }
 
-        /// <summary> 
+        /// <summary>
         /// The allocation policy of this resource. Overrides the tenant level allocation policy.
         /// </summary>
         [JsonProperty(PropertyName = "allocationPolicy", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public AllocationPolicy? AllocationPolicy { get; set; }
-        /// <summary> 
+
+#pragma warning disable CA2227 // Collection properties should be read only. Will not change public API
+
+        /// <summary>
         /// The list of names of IoT hubs the device(s) in this resource can be allocated to. Must be a subset of tenant level list of IoT hubs
         /// </summary>
         [JsonProperty(PropertyName = "iotHubs", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public ICollection<string> IotHubs { get; set; }
 
-        /// <summary> 
-        /// Custom allocation definition.  
-        /// </summary>  
+#pragma warning restore CA2227 // Collection properties should be read only
+
+        /// <summary>
+        /// Custom allocation definition.
+        /// </summary>
         [JsonProperty(PropertyName = "customAllocationDefinition", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public CustomAllocationDefinition CustomAllocationDefinition { get; set; }
     }

--- a/provisioning/service/src/Config/IndividualEnrollment.cs
+++ b/provisioning/service/src/Config/IndividualEnrollment.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 namespace Microsoft.Azure.Devices.Provisioning.Service
 {
     /// <summary>
-    /// Representation of a single Device Provisioning Service enrollment and their accessors with a JSON serializer 
+    /// Representation of a single Device Provisioning Service enrollment and their accessors with a JSON serializer
     ///     and deserializer.
     /// </summary>
     /// <remarks>
@@ -18,17 +18,17 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     ///
     /// To create or update an Enrollment on the provisioning service you should fill this object and call the
     /// public API <see cref="ProvisioningServiceClient.CreateOrUpdateIndividualEnrollmentAsync(IndividualEnrollment)"/>.
-    /// 
+    ///
     /// The minimum information required by the provisioning service is the <code>RegistrationId</code> and the
     /// <code>Attestation</code>.
     ///
     /// A new device can be provisioned by three attestation mechanisms, Trust Platform Module (see <see cref=
-    /// "TpmAttestation"/>), X509 (see <see cref="X509Attestation"/>) or Symmetric Key (see <see cref="SymmetricKeyAttestation"/>). The definition of each one you 
+    /// "TpmAttestation"/>), X509 (see <see cref="X509Attestation"/>) or Symmetric Key (see <see cref="SymmetricKeyAttestation"/>). The definition of each one you
     /// should use depending on the physical authentication hardware that the device contains.
     ///
     /// The content of this class will be serialized in a JSON format and sent as a body of the rest API to the
-    /// provisioning service. Or the content of this class can be filled by a JSON, received from the provisioning 
-    /// service, as result of a individualEnrollment operation like create, update, or query. 
+    /// provisioning service. Or the content of this class can be filled by a JSON, received from the provisioning
+    /// service, as result of a individualEnrollment operation like create, update, or query.
     /// </remarks>
     /// <example>
     /// When serialized, an individualEnrollment will look like the following example:
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     ///     "provisioningStatus":"enabled"
     /// }
     /// </code>
-    /// 
+    ///
     /// The following JSON is a sample of the individualEnrollment response, received from the provisioning service.
     /// <code>
     /// {
@@ -72,9 +72,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Creates a new instance of <code>IndividualEnrollment</code>.
         /// </summary>
         /// <remarks>
-        /// This constructor creates an instance of the IndividualEnrollment object with the minimum set of 
-        /// information required by the provisioning service. A valid individualEnrollment must contain the 
-        /// registrationId, which uniquely identify this enrollment, and the attestation mechanism, which can 
+        /// This constructor creates an instance of the IndividualEnrollment object with the minimum set of
+        /// information required by the provisioning service. A valid individualEnrollment must contain the
+        /// registrationId, which uniquely identify this enrollment, and the attestation mechanism, which can
         /// be TPM, X509, or Symmetric key.
         ///
         /// Other parameters can be added by calling the setters on this object.
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// }
         /// </code>
         /// </example>
-        /// <param name="registrationId">the <code>string</code> that uniquely identify this enrollment in the provisioning 
+        /// <param name="registrationId">the <code>string</code> that uniquely identify this enrollment in the provisioning
         ///     service. It cannot be <code>null</code> or empty.</param>
         /// <param name="attestation">the <see cref="Attestation"/> object with the attestation mechanism. It cannot be <code>null</code>.</param>
         /// <exception cref="ArgumentNullException">if one of the provided parameters is not correct</exception>
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             string eTag,
             DeviceCapabilities capabilities)
         {
-            /* SRS_INDIVIDUAL_ENROLLMENT_21_003: [The constructor shall throws ProvisioningServiceClientException if one of the 
+            /* SRS_INDIVIDUAL_ENROLLMENT_21_003: [The constructor shall throws ProvisioningServiceClientException if one of the
                                                     provided parameters in JSON is not valid.] */
             if (attestation == null)
             {
@@ -213,6 +213,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 _registrationId = value;
             }
         }
+
         private string _registrationId;
 
         /// <summary>
@@ -238,6 +239,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 }
             }
         }
+
         private string _deviceId;
 
         /// <summary>
@@ -321,28 +323,32 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         [JsonProperty(PropertyName = "capabilities", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public DeviceCapabilities Capabilities { get; set; }
 
-        /// <summary> 
+        /// <summary>
         /// The behavior when a device is re-provisioned to an IoT hub.
         /// </summary>
         [JsonProperty(PropertyName = "reprovisionPolicy", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public ReprovisionPolicy ReprovisionPolicy { get; set; }
 
-        /// <summary> 
-        /// Custom allocation definition.  
-        /// </summary>  
+        /// <summary>
+        /// Custom allocation definition.
+        /// </summary>
         [JsonProperty(PropertyName = "customAllocationDefinition", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public CustomAllocationDefinition CustomAllocationDefinition { get; set; }
 
-        /// <summary> 
+        /// <summary>
         /// The allocation policy of this resource. Overrides the tenant level allocation policy.
         /// </summary>
         [JsonProperty(PropertyName = "allocationPolicy", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public AllocationPolicy? AllocationPolicy { get; set; }
 
-        /// <summary> 
+#pragma warning disable CA2227 // Collection properties should be read only. Would change public API.
+
+        /// <summary>
         /// The list of names of IoT hubs the device in this resource can be allocated to. Must be a subset of tenant level list of IoT hubs
         /// </summary>
         [JsonProperty(PropertyName = "iotHubs", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public ICollection<string> IotHubs { get; set; }
+
+#pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/provisioning/service/src/Contract/ContractApiHttp.cs
+++ b/provisioning/service/src/Contract/ContractApiHttp.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Azure.Devices.Common;
-using Microsoft.Azure.Devices.Common.Service.Auth;
-using Microsoft.Azure.Devices.Shared;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -11,10 +8,12 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Security.Authentication;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Devices.Common;
+using Microsoft.Azure.Devices.Common.Service.Auth;
+using Microsoft.Azure.Devices.Shared;
 
 namespace Microsoft.Azure.Devices.Provisioning.Service
 {
@@ -24,7 +23,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
 
         private readonly Uri _baseAddress;
         private readonly IAuthorizationHeaderProvider _authenticationHeaderProvider;
-        private HttpClient _httpClientObj;
+
+        private HttpClientHandler _httpClientHandler = null;
+        private HttpClient _httpClientObj = null;
 
         private static readonly TimeSpan s_defaultOperationTimeout = TimeSpan.FromSeconds(100);
 
@@ -32,7 +33,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// CONSTRUCTOR
         /// </summary>
         /// <param name="baseAddress">the <code>Uri</code> HTTP endpoint in the service.</param>
-        /// <param name="authenticationHeaderProvider">the <see cref="IAuthorizationHeaderProvider"/> that will provide the 
+        /// <param name="authenticationHeaderProvider">the <see cref="IAuthorizationHeaderProvider"/> that will provide the
         ///     authorization token for the HTTP communication.</param>
         /// <param name="httpTransportSettings"> Specifies HTTP Transport Settings for the request</param>
         public ContractApiHttp(
@@ -43,7 +44,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             _baseAddress = baseAddress;
             _authenticationHeaderProvider = authenticationHeaderProvider;
 
-            var httpClientHandler = new HttpClientHandler
+            _httpClientHandler = new HttpClientHandler
             {
                 // Cannot specify a specific protocol here, as desired due to an error:
                 //   ProvisioningDeviceClient_ValidRegistrationId_AmqpWithProxy_SymmetricKey_RegisterOk_GroupEnrollment failing for me with System.PlatformNotSupportedException: Operation is not supported on this platform.
@@ -55,17 +56,16 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             IWebProxy webProxy = httpTransportSettings.Proxy;
             if (webProxy != DefaultWebProxySettings.Instance)
             {
-                httpClientHandler.UseProxy = (webProxy != null);
-                httpClientHandler.Proxy = webProxy;
+                _httpClientHandler.UseProxy = webProxy != null;
+                _httpClientHandler.Proxy = webProxy;
             }
 
-            _httpClientObj = new HttpClient(httpClientHandler)
+            _httpClientObj = new HttpClient(_httpClientHandler)
             {
                 BaseAddress = _baseAddress,
                 Timeout = s_defaultOperationTimeout,
             };
-            _httpClientObj.DefaultRequestHeaders.Accept.Add(
-                new MediaTypeWithQualityHeaderValue(MediaTypeForDeviceManagementApis));
+            _httpClientObj.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeForDeviceManagementApis));
             _httpClientObj.DefaultRequestHeaders.ExpectContinue = false;
         }
 
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="cancellationToken">the task cancellation Token.</param>
         /// <returns>The <see cref="ContractApiResponse"/> with the HTTP response.</returns>
         /// <exception cref="ProvisioningServiceClientException">if the cancellation was requested.</exception>
-        /// <exception cref="ProvisioningServiceClientTransportException">if there is a error in the HTTP communication 
+        /// <exception cref="ProvisioningServiceClientTransportException">if there is a error in the HTTP communication
         ///     between client and service.</exception>
         /// <exception cref="ProvisioningServiceClientHttpException">if the service answer the request with error status.</exception>
         public async Task<ContractApiResponse> RequestAsync(
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         {
             ContractApiResponse response;
 
-            using (HttpRequestMessage msg = new HttpRequestMessage(httpMethod, requestUri))
+            using (var msg = new HttpRequestMessage(httpMethod, requestUri))
             {
                 if (!string.IsNullOrEmpty(body))
                 {
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 return;
             }
 
-            StringBuilder quotedIfMatch = new StringBuilder();
+            var quotedIfMatch = new StringBuilder();
 
             if (!ifMatch.StartsWith("\"", StringComparison.OrdinalIgnoreCase))
             {
@@ -215,12 +215,18 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
 
         protected virtual void Dispose(bool disposing)
         {
-            if(disposing)
+            if (disposing)
             {
-                if(_httpClientObj != null)
+                if (_httpClientObj != null)
                 {
                     _httpClientObj.Dispose();
                     _httpClientObj = null;
+                }
+
+                if (_httpClientHandler != null)
+                {
+                    _httpClientHandler.Dispose();
+                    _httpClientHandler = null;
                 }
             }
         }

--- a/provisioning/service/src/GlobalSuppressions.cs
+++ b/provisioning/service/src/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Not localizing", Scope = "module")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "SDK hides non-actionable errors from user", Scope = "module")]

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -50,7 +50,10 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/provisioning/transport/amqp/src/ClientWebSocketTransport.cs
+++ b/provisioning/transport/amqp/src/ClientWebSocketTransport.cs
@@ -14,44 +14,32 @@ namespace Microsoft.Azure.Amqp.Transport
 {
     internal sealed class ClientWebSocketTransport : TransportBase, IDisposable
     {
-        private static readonly AsyncCallback onReadComplete = OnReadComplete;
-        private static readonly AsyncCallback onWriteComplete = OnWriteComplete;
-        private static readonly TimeSpan CloseTimeout = TimeSpan.FromSeconds(30);
+        private static readonly AsyncCallback s_onReadComplete = OnReadComplete;
+        private static readonly AsyncCallback s_onWriteComplete = OnWriteComplete;
+        private static readonly TimeSpan s_closeTimeout = TimeSpan.FromSeconds(30);
 
-        private readonly ClientWebSocket webSocket;
-        private readonly EndPoint localEndPoint;
-        private readonly EndPoint remoteEndPoint;
-        private volatile CancellationTokenSource writeCancellationTokenSource;
-        private bool disposed;
+        private readonly ClientWebSocket _webSocket;
+        private readonly EndPoint _localEndPoint;
+        private readonly EndPoint _remoteEndPoint;
+        private CancellationTokenSource _writeCancellationTokenSource;
+        private bool _disposed;
 
         public ClientWebSocketTransport(ClientWebSocket clientwebSocket, EndPoint localEndpoint, EndPoint remoteEndpoint)
             : base("clientwebsocket")
         {
-            webSocket = clientwebSocket;
-            localEndPoint = localEndpoint;
-            remoteEndPoint = remoteEndpoint;
-            writeCancellationTokenSource = new CancellationTokenSource();
+            _webSocket = clientwebSocket;
+            _localEndPoint = localEndpoint;
+            _remoteEndPoint = remoteEndpoint;
+            _writeCancellationTokenSource = new CancellationTokenSource();
         }
 
-        public override string LocalEndPoint
-        {
-            get { return localEndPoint.ToString(); }
-        }
+        public override string LocalEndPoint => _localEndPoint.ToString();
 
-        public override string RemoteEndPoint
-        {
-            get { return remoteEndPoint.ToString(); }
-        }
+        public override string RemoteEndPoint => _remoteEndPoint.ToString();
 
-        public override bool RequiresCompleteFrames
-        {
-            get { return true; }
-        }
+        public override bool RequiresCompleteFrames => true;
 
-        public override bool IsSecure
-        {
-            get { return true; }
-        }
+        public override bool IsSecure => true;
 
         public override void SetMonitor(ITransportMonitor usageMeter)
         {
@@ -64,17 +52,17 @@ namespace Microsoft.Azure.Amqp.Transport
 
             args.Exception = null; // null out any exceptions
 
-            Task<bool> taskResult = WriteAsyncCore(args);
+            Task<bool> taskResult = WriteAsyncCoreAsync(args);
             if (WriteTaskDone(taskResult, args))
             {
                 return false;
             }
 
-            taskResult.ToAsyncResult(onWriteComplete, args);
+            taskResult.ToAsyncResult(s_onWriteComplete, args);
             return true;
         }
 
-        private async Task<bool> WriteAsyncCore(TransportAsyncCallbackArgs args)
+        private async Task<bool> WriteAsyncCoreAsync(TransportAsyncCallbackArgs args)
         {
             bool succeeded = false;
             try
@@ -82,14 +70,14 @@ namespace Microsoft.Azure.Amqp.Transport
                 if (args.Buffer != null)
                 {
                     var arraySegment = new ArraySegment<byte>(args.Buffer, args.Offset, args.Count);
-                    await webSocket.SendAsync(arraySegment, WebSocketMessageType.Binary, true, writeCancellationTokenSource.Token).ConfigureAwait(false);
+                    await _webSocket.SendAsync(arraySegment, WebSocketMessageType.Binary, true, _writeCancellationTokenSource.Token).ConfigureAwait(false);
                 }
                 else
                 {
                     foreach (ByteBuffer byteBuffer in args.ByteBufferList)
                     {
-                        await webSocket.SendAsync(new ArraySegment<byte>(byteBuffer.Buffer, byteBuffer.Offset, byteBuffer.Length),
-                            WebSocketMessageType.Binary, true, writeCancellationTokenSource.Token).ConfigureAwait(false);
+                        await _webSocket.SendAsync(new ArraySegment<byte>(byteBuffer.Buffer, byteBuffer.Offset, byteBuffer.Length),
+                            WebSocketMessageType.Binary, true, _writeCancellationTokenSource.Token).ConfigureAwait(false);
                     }
                 }
 
@@ -129,23 +117,24 @@ namespace Microsoft.Azure.Amqp.Transport
             var arraySegment = new ArraySegment<byte>(args.Buffer, args.Offset, args.Count);
 
             args.Exception = null;   // null out any exceptions
-            Task<int> taskResult = ReadAsyncCore(arraySegment);
+            Task<int> taskResult = ReadCoreAsync(arraySegment);
             if (ReadTaskDone(taskResult, args))
             {
                 return false;
             }
 
-            taskResult.ToAsyncResult(onReadComplete, args);
+            taskResult.ToAsyncResult(s_onReadComplete, args);
             return true;
         }
 
-        private async Task<int> ReadAsyncCore(ArraySegment<byte> seg)
+        private async Task<int> ReadCoreAsync(ArraySegment<byte> seg)
         {
             bool succeeded = false;
             try
             {
-                WebSocketReceiveResult receiveResult = await webSocket.ReceiveAsync(
-                    seg, CancellationToken.None).ConfigureAwait(false);
+                WebSocketReceiveResult receiveResult = await _webSocket
+                    .ReceiveAsync(seg, CancellationToken.None)
+                    .ConfigureAwait(false);
 
                 succeeded = true;
                 return receiveResult.Count;
@@ -180,10 +169,10 @@ namespace Microsoft.Azure.Amqp.Transport
 
         protected override bool CloseInternal()
         {
-            var webSocketState = webSocket.State;
+            WebSocketState webSocketState = _webSocket.State;
             if (webSocketState != WebSocketState.Closed && webSocketState != WebSocketState.Aborted)
             {
-                Task.Run(() => CloseInternalAsync(CloseTimeout));
+                Task.Run(() => CloseInternalAsync(s_closeTimeout));
             }
 
             return true;
@@ -198,7 +187,7 @@ namespace Microsoft.Azure.Amqp.Transport
 
                 using (var cancellationTokenSource = new CancellationTokenSource(timeout))
                 {
-                    await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationTokenSource.Token).ConfigureAwait(false);
+                    await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationTokenSource.Token).ConfigureAwait(false);
                 }
             }
             catch (Exception)
@@ -213,7 +202,7 @@ namespace Microsoft.Azure.Amqp.Transport
         {
             try
             {
-                writeCancellationTokenSource.Cancel();
+                _writeCancellationTokenSource.Cancel();
             }
             catch (ObjectDisposedException)
             {
@@ -223,11 +212,11 @@ namespace Microsoft.Azure.Amqp.Transport
 
         protected override void AbortInternal()
         {
-            if (!disposed && webSocket.State != WebSocketState.Aborted)
+            if (!_disposed && _webSocket.State != WebSocketState.Aborted)
             {
-                disposed = true;
-                webSocket.Abort();
-                webSocket.Dispose();
+                _disposed = true;
+                _webSocket.Abort();
+                _webSocket.Dispose();
             }
         }
 
@@ -243,7 +232,7 @@ namespace Microsoft.Azure.Amqp.Transport
 
         private static void HandleReadComplete(IAsyncResult result)
         {
-            Task<int> taskResult = (Task<int>)result;
+            var taskResult = (Task<int>)result;
             var args = (TransportAsyncCallbackArgs)taskResult.AsyncState;
 
             ReadTaskDone(taskResult, args);
@@ -285,7 +274,7 @@ namespace Microsoft.Azure.Amqp.Transport
 
         private static void HandleWriteComplete(IAsyncResult result)
         {
-            Task taskResult = (Task)result;
+            var taskResult = (Task)result;
             var args = (TransportAsyncCallbackArgs)taskResult.AsyncState;
             WriteTaskDone(taskResult, args);
             args.CompletedCallback(args);
@@ -318,7 +307,7 @@ namespace Microsoft.Azure.Amqp.Transport
 
         private void ThrowIfNotOpen()
         {
-            var webSocketState = webSocket.State;
+            WebSocketState webSocketState = _webSocket.State;
             if (webSocketState == WebSocketState.Open)
             {
                 return;
@@ -337,7 +326,8 @@ namespace Microsoft.Azure.Amqp.Transport
 
         public void Dispose()
         {
-            throw new NotImplementedException();
+            _writeCancellationTokenSource?.Dispose();
+            _writeCancellationTokenSource = null;
         }
     }
 }

--- a/provisioning/transport/amqp/src/GlobalSuppressions.cs
+++ b/provisioning/transport/amqp/src/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Not localizing", Scope = "module")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "SDK hides non-actionable errors from user", Scope = "module")]

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -88,6 +88,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.2" />
-    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/provisioning/transport/http/src/GlobalSuppressions.cs
+++ b/provisioning/transport/http/src/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Not localizing", Scope = "module")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "SDK hides non-actionable errors from user", Scope = "module")]

--- a/provisioning/transport/http/src/HttpAuthStrategyTpm.cs
+++ b/provisioning/transport/http/src/HttpAuthStrategyTpm.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                     $"Authentication key not found. OperationId=${operation?.OperationId}");
 
                 throw new ProvisioningTransportException(
-                    "Authentication key not found.", 
+                    "Authentication key not found.",
                     null,
                     false);
             }

--- a/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
+++ b/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
@@ -83,7 +83,10 @@
 
   <ItemGroup>
     <!-- FXCop -->
-    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
   </ItemGroup>
 

--- a/provisioning/transport/http/src/ProvisioningTransportHandlerHttp.cs
+++ b/provisioning/transport/http/src/ProvisioningTransportHandlerHttp.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
     {
         private static readonly TimeSpan s_defaultOperationPoolingIntervalMilliseconds = TimeSpan.FromSeconds(2);
         private const int DefaultHttpsPort = 443;
+
         /// <summary>
         /// Creates an instance of the ProvisioningTransportHandlerHttp class.
         /// </summary>
@@ -42,6 +43,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled) Logging.Enter(this, $"{nameof(ProvisioningTransportHandlerHttp)}.{nameof(RegisterAsync)}");
+
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/provisioning/transport/mqtt/src/GlobalSuppressions.cs
+++ b/provisioning/transport/mqtt/src/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Not localizing", Scope = "module")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "SDK hides non-actionable errors from user", Scope = "module")]

--- a/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
+++ b/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
@@ -97,6 +97,9 @@
     <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
 
     <!-- FXCop -->
-    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/provisioning/transport/mqtt/src/ProvisioningTransportHandlerMqtt.cs
+++ b/provisioning/transport/mqtt/src/ProvisioningTransportHandlerMqtt.cs
@@ -79,6 +79,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
         {
             if (Logging.IsEnabled) Logging.Enter(this, $"{nameof(ProvisioningTransportHandlerMqtt)}.{nameof(RegisterAsync)}");
 
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
             cancellationToken.ThrowIfCancellationRequested();
 
             RegistrationOperationStatus operation = null;

--- a/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
+++ b/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
@@ -48,7 +48,10 @@
     <PackageReference Include="Microsoft.TSS" Version="2.1.1" />
 
     <!-- FXCop -->
-    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/shared/src/GlobalSuppressions.cs
+++ b/shared/src/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Not localizing", Scope = "module")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "SDK hides non-actionable errors from user", Scope = "module")]

--- a/shared/src/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/src/Microsoft.Azure.Devices.Shared.csproj
@@ -41,6 +41,9 @@
 
   <ItemGroup>
     <!-- FXCop -->
-    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
+    <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/shared/src/StringFormattingExtensions.cs
+++ b/shared/src/StringFormattingExtensions.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Globalization;
+
 namespace Microsoft.Azure.Devices.Common
 {
-    using System;
-    using System.Globalization;
-
     /// <summary>
     /// String extension class for common operations.
     /// This class is used by the SDK and should not be directly used by applications.
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.Common
         /// <returns>A copy of format in which the format item or items have been replaced by the string representation of arg0.</returns>
         public static string FormatErrorForUser(this string message, string activityId, int errorCode)
         {
-            return StringFormattingExtensions.FormatForUser(message, activityId, DateTime.UtcNow, errorCode);
+            return FormatForUser(message, activityId, DateTime.UtcNow, errorCode);
         }
 
         /// <summary>
@@ -54,7 +54,9 @@ namespace Microsoft.Azure.Devices.Common
         /// <returns>The truncated string.</returns>
         public static string Truncate(this string message, int maximumSize)
         {
-            return message.Length > maximumSize ? message.Substring(0, maximumSize) + "...(truncated)" : message;
+            return (message?.Length ?? 0) > maximumSize
+                ? message.Substring(0, maximumSize) + "...(truncated)"
+                : message;
         }
     }
 }

--- a/shared/src/TlsVersions.cs
+++ b/shared/src/TlsVersions.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Authentication;
 
 namespace Microsoft.Azure.Devices.Shared
@@ -41,6 +43,7 @@ namespace Microsoft.Azure.Devices.Shared
         private System.Net.SecurityProtocolType _net451Protocol = (System.Net.SecurityProtocolType)PreferredProtocol;
 #endif
 
+#pragma warning disable CA5397 // Do not use deprecated SslProtocols values
         private const SslProtocols AllowedProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
         private const SslProtocols PreferredProtocol = SslProtocols.Tls12;
 
@@ -84,6 +87,8 @@ namespace Microsoft.Azure.Devices.Shared
             _net451Protocol = (System.Net.SecurityProtocolType)protocols;
 #endif
         }
+
+#pragma warning restore CA5397 // Do not use deprecated SslProtocols values
 
         /// <summary>
         /// Sets the acceptable versions of TLS over HTTPS or websocket for .NET framework 4.5.1, as it does not offer a "SystemDefault" option. No-op for other .NET versions.


### PR DESCRIPTION
Updated to latest FxCop nuget. That fixed some false warnings, but introduces new standards.

Two such standards that we consistently break is not having hard-coded strings as error messages, and catching System.Exception. Rather than fix all those (ha) or suppress each one individually, I chose to add globalsuppression files to each project.

Most warning fixes are:

- using nameof for parameter validation exception params
- parameter null checking
- calling dispose on IDisposable objects just before they would be out of scope (oops! - pay special attention to these changes please)
- adding some missed parameter xml tags
- methods marked as async that didn't make await anything
- some exceptions had a public ctor with serialization info param, which apparently shouldn't be public. As we can't change the public API, these have been suppressed.
- compare strings using StringComparer.Ordinal/Invariant.Equals
- using string.IsNullOrWhiteSpace or equiv
- do not use Count() method if Length or Count properties are available

Also included are style changes including:

- usings outside of namespace
- using auto properties where possible
- auto-property getter and setter all on one line
- simply property getter or setter use lambda notation for fewer lines
- class member names, visibility, and readonly when appropriate
- removing "this." now that ambiguity is gone with field names
- formatting method calls and parameters for easier reading, when they get long