### PR TITLE
Updating System.Net.Http package to 3.3.4 for security

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -83,7 +83,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System.Web" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <!-- NetStandard 2.0 and net472 -->

--- a/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
+++ b/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System.Web" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/iothub/service/tests/Microsoft.Azure.Devices.Tests.csproj
+++ b/iothub/service/tests/Microsoft.Azure.Devices.Tests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <Reference Include="System.Web" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description of the changes
System.Net.Http needs to 3.3.4 to protect against security vulnerabilities in the older versions. This change updates our SDK to use this new version of the package.

## Reference/Link to the issue solved with this PR (if any)
https://msazure.visualstudio.com/One/_boards/board/t/IoT-Developers%20and%20Devices-Managed/Backlog%20items/?workitem=4167095
