### PR TITLE
Fix (Im|Ex)port tests with older storage nuget

### DIFF
--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -95,9 +95,7 @@
   <!-- NetCore and .NET 4.7.2 -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.3" />
-    <PackageReference Include="Azure.Storage.Blobs">
-      <Version>12.3.0</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(AZURE_IOT_LOCALPACKAGES)' == '' ">
@@ -128,15 +126,5 @@
     <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Security.Tpm" Version="1.*" />
     <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Service" Version="1.*" />
     <ProjectReference Include="$(RootDir)\security\tpm\samples\SecurityProviderTpmSimulator\SecurityProviderTpmSimulator.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="Microsoft.VisualStudio.Threading">
-      <Version>16.5.132</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.VisualStudio.Threading">
-      <Version>16.5.132</Version>
-    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Due to a bug between System.Diagnostics.DiagnosticSource and Azure.Storage.Blob failing async container creation, these tests required console logging to be off, but when run with other tests it would still be on in the process. I've fallen back from Azure.Storage.Blob to Microsoft.Azure.Storage.Blob nuget, where the issue does not repro. It looks like it is an issue in the track2 pipeline.