### PR TITLE
Expose a way for nested Edge to pass authentication chain to IoT Hub

### DIFF
--- a/iothub/device/src/AmqpTransportSettings.cs
+++ b/iothub/device/src/AmqpTransportSettings.cs
@@ -17,6 +17,12 @@ namespace Microsoft.Azure.Devices.Client
         private readonly TransportType _transportType;
         private TimeSpan _operationTimeout;
         private TimeSpan _openTimeout;
+
+        /// <summary>
+        /// Used by Edge runtime to specify an authentication chain for Edge-to-Edge connections
+        /// </summary>
+        internal string AuthenticationChain { get; set; }
+        
         /// <summary>
         /// To enable certificate revocation check. Default to be false.
         /// </summary>

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTErrorAdapter.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTErrorAdapter.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
         public static readonly AmqpSymbol ClientVersion = AmqpIoTConstants.Vendor + ":client-version";
         public static readonly AmqpSymbol ApiVersion = AmqpIoTConstants.Vendor + ":api-version";
         public static readonly AmqpSymbol ChannelCorrelationId = AmqpIoTConstants.Vendor + ":channel-correlation-id";
+        public static readonly AmqpSymbol AuthChain = AmqpIoTConstants.Vendor + ":auth-chain";
 
         private const int MaxSizeInInfoMap = 32 * 1024;
 

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTSession.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTSession.cs
@@ -208,6 +208,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
         )
         {
             if (Logging.IsEnabled) Logging.Enter(typeof(AmqpIoTSession), deviceIdentity, $"{nameof(OpenSendingAmqpLinkAsync)}");
+
             AmqpLinkSettings amqpLinkSettings = new AmqpLinkSettings
             {
                 LinkName = linkSuffix,
@@ -224,6 +225,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             if (CorrelationId != null)
             {
                 amqpLinkSettings.AddProperty(AmqpIoTErrorAdapter.ChannelCorrelationId, CorrelationId);
+            }
+
+            if (!deviceIdentity.AmqpTransportSettings.AuthenticationChain.IsNullOrWhiteSpace())
+            {
+                amqpLinkSettings.AddProperty(AmqpIoTErrorAdapter.AuthChain, deviceIdentity.AmqpTransportSettings.AuthenticationChain);
             }
 
             try
@@ -285,6 +291,12 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             amqpLinkSettings.AddProperty(AmqpIoTErrorAdapter.TimeoutName, timeout.TotalMilliseconds);
             amqpLinkSettings.AddProperty(AmqpIoTErrorAdapter.ClientVersion, deviceIdentity.ProductInfo.ToString());
             amqpLinkSettings.AddProperty(AmqpIoTErrorAdapter.ApiVersion, ClientApiVersionHelper.ApiVersionString);
+
+            if (!deviceIdentity.AmqpTransportSettings.AuthenticationChain.IsNullOrWhiteSpace())
+            {
+                amqpLinkSettings.AddProperty(AmqpIoTErrorAdapter.AuthChain, deviceIdentity.AmqpTransportSettings.AuthenticationChain);
+            }
+
             if (correlationId != null)
             {
                 amqpLinkSettings.AddProperty(AmqpIoTErrorAdapter.ChannelCorrelationId, correlationId);

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -43,6 +43,9 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         private const string DeviceCommandTopicFilterFormat = "devices/{0}/messages/devicebound/#";
         private const string DeviceTelemetryTopicFormat = "devices/{0}/messages/events/";
         private const string ModuleTelemetryTopicFormat = "devices/{0}/modules/{1}/messages/events/";
+        private const string ApiVersionParam = "api-version";
+        private const string DeviceClientTypeParam = "DeviceClientType";
+        private const string AuthChainParam = "auth-chain";
         private const char SegmentSeparatorChar = '/';
         private const char SingleSegmentWildcardChar = '+';
         private const char MultiSegmentWildcardChar = '#';
@@ -288,11 +291,18 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     Debug.Assert(this.mqttTransportSettings.ClientCertificate != null);
                 }
 
+                string usernameString = $"{this.iotHubHostName}/{id}/?{ApiVersionParam}={ClientApiVersionHelper.ApiVersionString}&{DeviceClientTypeParam}={Uri.EscapeDataString(this.productInfo.ToString())}";
+
+                if (!this.mqttTransportSettings.AuthenticationChain.IsNullOrWhiteSpace())
+                {
+                    usernameString += $"&{AuthChainParam}={Uri.EscapeDataString(this.mqttTransportSettings.AuthenticationChain)}";
+                }
+
                 var connectPacket = new ConnectPacket
                 {
                     ClientId = id,
                     HasUsername = true,
-                    Username = $"{this.iotHubHostName}/{id}/?api-version={ClientApiVersionHelper.ApiVersionString}&DeviceClientType={Uri.EscapeDataString(this.productInfo.ToString())}",
+                    Username = usernameString,
                     HasPassword = !string.IsNullOrEmpty(password),
                     Password = password,
                     KeepAliveInSeconds = this.mqttTransportSettings.KeepAliveInSeconds,

--- a/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
     {
         private readonly TransportType _transportType;
 
+        /// <summary>
+        /// Used by Edge runtime to specify an authentication chain for Edge-to-Edge connections
+        /// </summary>
+        internal string AuthenticationChain { get; set; }
+
         private const bool DefaultCleanSession = false;
         private const bool DefaultDeviceReceiveAckCanTimeout = false;
         private const bool DefaultHasWill = false;

--- a/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
+++ b/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
@@ -30,10 +30,10 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
+    <Reference Include="System.Web" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <Reference Include="System.Web" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/iothub/device/tests/Mqtt/MqttIotHubAdapterTest.cs
+++ b/iothub/device/tests/Mqtt/MqttIotHubAdapterTest.cs
@@ -5,10 +5,14 @@ namespace Microsoft.Azure.Devices.Client.Test.Mqtt
 {
     using DotNetty.Codecs.Mqtt.Packets;
     using DotNetty.Transport.Channels;
+    using FluentAssertions;
     using Microsoft.Azure.Devices.Client.Transport.Mqtt;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
     using System;
+    using System.Collections.Generic;
+    using System.Collections.Specialized;
+    using System.Linq;
     using System.Threading.Tasks;
 
     [TestClass]
@@ -98,6 +102,35 @@ namespace Microsoft.Azure.Devices.Client.Test.Mqtt
                 (packet) => new UnsubAckPacket() { PacketId = packet.PacketId };
 
             await SendRequestAndAcknowledgementsInSpecificOrder(request, ackFactory, true).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public void TestAuthenticationChain()
+        {
+            const string authChain = "leaf;edge1;edge2";
+            var passwordProvider = new Mock<IAuthorizationProvider>();
+            var mqttIotHubEventHandler = new Mock<IMqttIotHubEventHandler>();
+            var productInfo = new ProductInfo();
+            var mqttTransportSetting = new MqttTransportSettings(TransportType.Mqtt_Tcp_Only) { HasWill = false };
+            var channelHandlerContext = new Mock<IChannelHandlerContext>();
+            var mqttIotHubAdapter = new MqttIotHubAdapter("deviceId", string.Empty, string.Empty, passwordProvider.Object, mqttTransportSetting, null, mqttIotHubEventHandler.Object, productInfo);
+
+            // Set an authchain on the transport settings
+            mqttTransportSetting.AuthenticationChain = authChain;
+
+            // Save all the messages from the context
+            List<object> messages = new List<object>();
+            channelHandlerContext.Setup(context => context.WriteAndFlushAsync(It.IsAny<object>())).Callback((object message) => messages.Add(message)).Returns(TaskHelpers.CompletedTask);
+
+            // Act
+            channelHandlerContext.Setup(context => context.Channel.EventLoop.ScheduleAsync(It.IsAny<Action>(), It.IsAny<TimeSpan>())).Returns(TaskHelpers.CompletedTask);
+            channelHandlerContext.SetupGet(context => context.Handler).Returns(mqttIotHubAdapter);
+            mqttIotHubAdapter.ChannelActive(channelHandlerContext.Object);
+
+            // Assert: the auth chain should be part of the username
+            ConnectPacket connectPacket = messages.First().As<ConnectPacket>();
+            NameValueCollection queryParams = System.Web.HttpUtility.ParseQueryString(connectPacket.Username);
+            Assert.AreEqual(authChain, queryParams.Get("auth-chain"));
         }
 
         private async Task SendRequestAndAcknowledgementsInSpecificOrder<T>(T requestPacket, Func<T, PacketWithId> ackFactory, bool receiveResponseBeforeSendingRequestContinues)


### PR DESCRIPTION
To enable nested Edge scenarios, the Edge runtime needs to pass up the chain of all parent Edge devices to IoT Hub when connecting on behalf of a child device.  This means the following for the two different supported protocols.

AMQP:
Add a new link property "AuthChain" of format "edge1;edge2;..." on both the Sending/Receiving links

MQTT:
Augment the username payload with a new "AuthChain" suffix of the format:
$"{iotHubHostName}/{id}/?api-version={version}&DeviceClientType={type}"&AuthChain=edge1;edge2;..."

Since this behavior is Edge specific, it doesn't make sense to expose a public API to support it.  This PR is a proposal for the smallest change we can think of to enable this.

AmqpTransportSettings and MqttTransportSettings now both have a **internal** property that Edge can set at client creation time using System.Reflection.  At connection/link establishing time, AmqpIoTSession and MqttIotHubAdapter would read this property from the corresponding transport setting, and if it exists, add it to the connection payload.

We then would make the corresponding change in IoT Hub service to consume this new payload as part of auth.