### PR TITLE
Improve exception message for missing SecurityProvider on ProvisioningTransportHandlerMqtt.RegisterAsync

### DIFF
--- a/provisioning/transport/mqtt/src/ProvisioningTransportHandlerMqtt.cs
+++ b/provisioning/transport/mqtt/src/ProvisioningTransportHandlerMqtt.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 {
                     if (Logging.IsEnabled) Logging.Error(this, $"Invalid {nameof(SecurityProvider)} type.");
                     throw new NotSupportedException(
-                        $"{nameof(message.Security)} must be of type {nameof(SecurityProviderX509)}");
+                        $"{nameof(message.Security)} must be of type {nameof(SecurityProviderSymmetricKey)} or {nameof(SecurityProviderX509)}");
                 }
 
                 return ConvertToProvisioningRegistrationResult(operation.RegistrationState);


### PR DESCRIPTION
## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] **There are no tests for exception messages so no tests were updated**
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
Improved misleading exception text for missing SecurityProvider on ProvisioningTransportHandlerMqtt.RegisterAsync.  Previously it stated only X509 was supported, which was not true.

## Reference/Link to the issue solved with this PR (if any)
Fixes #1290 
