### PR TITLE
fix(iot-dev): Remove unnecessary DNS lookup in mqtt stack

### DIFF
--- a/e2e/test/MessageSendE2ETests.cs
+++ b/e2e/test/MessageSendE2ETests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         [TestMethod]
         [TestCategory("Proxy")]
-        public async Task Message_DeviceSendSingleMessage_Http_WithCustomeProxy()
+        public async Task Message_DeviceSendSingleMessage_Http_WithCustomProxy()
         {
             Http1TransportSettings httpTransportSettings = new Http1TransportSettings();
             CustomWebProxy proxy = new CustomWebProxy();

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -568,7 +568,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         private async Task OpenAsyncInternal(CancellationToken cancellationToken)
         {
-            if (_webProxy != DefaultWebProxySettings.Instance)
+            if (isProxyConfigured())
             {
                 //No need to do a DNS lookup since we have the proxy address already
                 _serverAddresses = new IPAddress[0];
@@ -976,7 +976,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 try
                 {
-                    if (_webProxy != DefaultWebProxySettings.Instance)
+                    if (isProxyConfigured())
                     {
                         // Configure proxy server
                         websocket.Options.Proxy = _webProxy;
@@ -1107,6 +1107,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             if (Logging.IsEnabled) Logging.Info(null, "EventLoopGroup threads count was not set.");
             return new MultithreadEventLoopGroup();
+        }
+
+        private bool isProxyConfigured()
+        {
+            return _webProxy != null && _webProxy != DefaultWebProxySettings.Instance;
         }
     }
 }

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -568,7 +568,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         private async Task OpenAsyncInternal(CancellationToken cancellationToken)
         {
-            if (isProxyConfigured())
+            if (IsProxyConfigured())
             {
                 //No need to do a DNS lookup since we have the proxy address already
                 _serverAddresses = new IPAddress[0];
@@ -976,7 +976,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 try
                 {
-                    if (isProxyConfigured())
+                    if (IsProxyConfigured())
                     {
                         // Configure proxy server
                         websocket.Options.Proxy = _webProxy;
@@ -1109,7 +1109,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             return new MultithreadEventLoopGroup();
         }
 
-        private bool isProxyConfigured()
+        private bool IsProxyConfigured()
         {
             return _webProxy != null && _webProxy != DefaultWebProxySettings.Instance;
         }


### PR DESCRIPTION
When a proxy is present, there is no need to lookup the DNS of the host as the proxy will handle that. 

See #1063 