### PR TITLE
fix(test): test result indicates GetJobAsync can return null, avoid NRE

### DIFF
--- a/e2e/test/RegistryManagerExportDevicesTests.cs
+++ b/e2e/test/RegistryManagerExportDevicesTests.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 // act
 
                 JobProperties exportJobResponse = null;
+                string jobId = null;
                 for (int i = 0; i < MaxIterationWait; ++i)
                 {
                     try
@@ -102,6 +103,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                                     null,
                                     storageAuthenticationType))
                            .ConfigureAwait(false);
+                        jobId = exportJobResponse.JobId;
                         break;
                     }
                     // Concurrent jobs can be rejected, so implement a retry mechanism to handle conflicts with other tests
@@ -117,9 +119,10 @@ namespace Microsoft.Azure.Devices.E2ETests
                 for (int i = 0; i < MaxIterationWait; ++i)
                 {
                     await Task.Delay(s_waitDuration).ConfigureAwait(false);
-                    exportJobResponse = await registryManager.GetJobAsync(exportJobResponse.JobId).ConfigureAwait(false);
-                    _log.WriteLine($"Job {exportJobResponse.JobId} is {exportJobResponse.Status} with progress {exportJobResponse.Progress}%");
-                    if (!s_incompleteJobs.Contains(exportJobResponse.Status))
+                    exportJobResponse = await registryManager.GetJobAsync(jobId).ConfigureAwait(false);
+                    _log.WriteLine($"Job {jobId} is [{exportJobResponse?.Status}] with progress [{exportJobResponse?.Progress}%]");
+                    if (exportJobResponse != null
+                        && !s_incompleteJobs.Contains(exportJobResponse.Status))
                     {
                         break;
                     }

--- a/e2e/test/RegistryManagerImportDevicesTests.cs
+++ b/e2e/test/RegistryManagerImportDevicesTests.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 // act
 
+                string jobId = null;
                 JobProperties importJobResponse = null;
                 for (int i = 0; i < MaxIterationWait; ++i)
                 {
@@ -100,6 +101,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                                     null,
                                     storageAuthenticationType))
                             .ConfigureAwait(false);
+                        jobId = importJobResponse.JobId;
                         break;
                     }
                     // Concurrent jobs can be rejected, so implement a retry mechanism to handle conflicts with other tests
@@ -115,9 +117,10 @@ namespace Microsoft.Azure.Devices.E2ETests
                 for (int i = 0; i < MaxIterationWait; ++i)
                 {
                     await Task.Delay(1000).ConfigureAwait(false);
-                    importJobResponse = await registryManager.GetJobAsync(importJobResponse.JobId).ConfigureAwait(false);
-                    _log.WriteLine($"Job {importJobResponse.JobId} is {importJobResponse.Status} with progress {importJobResponse.Progress}%");
-                    if (!s_incompleteJobs.Contains(importJobResponse.Status))
+                    importJobResponse = await registryManager.GetJobAsync(jobId).ConfigureAwait(false);
+                    _log.WriteLine($"Job {jobId} is [{importJobResponse?.Status}] with progress [{importJobResponse?.Progress}%]");
+                    if (importJobResponse != null
+                        && !s_incompleteJobs.Contains(importJobResponse.Status))
                     {
                         break;
                     }


### PR DESCRIPTION
https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/results?buildId=55368&view=ms.vss-test-web.build-test-results-tab&runId=1431320&resultId=100466&paneView=debug

```
Test method Microsoft.Azure.Devices.E2ETests.RegistryManagerImportDevicesTests.RegistryManager_ImportDevices threw exception:

System.NullReferenceException: Object reference not set to an instance of an object.


Stack trace
    at Microsoft.Azure.Devices.E2ETests.RegistryManagerImportDevicesTests.<RegistryManager_ImportDevices>d__6.MoveNext() in D:\a\1\s\e2e\test\RegistryManagerImportDevicesTests.cs:line 118
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.Azure.Devices.E2ETests.RegistryManagerImportDevicesTests.<RegistryManager_ImportDevices>d__6.MoveNext() in D:\a\1\s\e2e\test\RegistryManagerImportDevicesTests.cs:line 160
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.ThreadOperations.ExecuteWithAbortSafety(Action action)
```