### PR TITLE
 Update JobQuotaExceededException to include the associated http error reason

### DIFF
--- a/e2e/test/RegistryManagerExportDevicesTests.cs
+++ b/e2e/test/RegistryManagerExportDevicesTests.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [TestCategory("LongRunning")]
         [Timeout(120000)]
+        [DoNotParallelize]
         [DataRow(StorageAuthenticationType.KeyBased)]
         [DataRow(StorageAuthenticationType.IdentityBased)]
         public async Task RegistryManager_ExportDevices(StorageAuthenticationType storageAuthenticationType)

--- a/e2e/test/RegistryManagerImportDevicesTests.cs
+++ b/e2e/test/RegistryManagerImportDevicesTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [DataTestMethod]
         [TestCategory("LongRunning")]
         [Timeout(120000)]
+        [DoNotParallelize]
         [DataRow(StorageAuthenticationType.KeyBased)]
         [DataRow(StorageAuthenticationType.IdentityBased)]
         public async Task RegistryManager_ImportDevices(StorageAuthenticationType storageAuthenticationType)

--- a/iothub/service/src/Common/Exceptions/JobQuotaExceededException.cs
+++ b/iothub/service/src/Common/Exceptions/JobQuotaExceededException.cs
@@ -1,17 +1,33 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.Azure.Devices.Common.Exceptions
 {
-    using System;
-
+    /// <summary>
+    /// Exception thrown when IoT Hub exceeds the available quota for active jobs
+    /// </summary>
     [Serializable]
     public sealed class JobQuotaExceededException : IotHubException
     {
-        public JobQuotaExceededException()
-            : base("Job quota has been exceeded")
-        {
+        private const string JobQuotaExceededMessage = "Job quota has been exceeded";
 
+        /// <summary>
+        /// Initializes an instance of JobQuotaExceededException with the default message
+        /// </summary>
+        public JobQuotaExceededException()
+            : base(JobQuotaExceededMessage)
+        {
+        }
+
+        /// <summary>
+        /// Initializes an instance of JobQuotaExceededException with the message from the Http response filled in
+        /// </summary>
+        /// <param name="message">The error message returned in the Http response</param>
+        public JobQuotaExceededException(string message)
+            : base(message)
+        {
         }
     }
 }

--- a/iothub/service/src/HttpRegistryManager.cs
+++ b/iothub/service/src/HttpRegistryManager.cs
@@ -1048,7 +1048,7 @@ namespace Microsoft.Azure.Devices
 
             var errorMappingOverrides = new Dictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>
             {
-                { HttpStatusCode.Forbidden, responseMessage => Task.FromResult((Exception) new JobQuotaExceededException())}
+                { HttpStatusCode.Forbidden, async (responseMessage) => new JobQuotaExceededException(await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage).ConfigureAwait(false))}
             };
 
             // The new api-version is only available in a few initial regions


### PR DESCRIPTION
These tests have been failing consistently in our nightly, with the job quota having been exceeded. Marking them to run serially. 