### PR TITLE
fix(iot-device): Fix out-of-date comments on DeviceClient

### DIFF
--- a/iothub/device/src/ClientFactory.cs
+++ b/iothub/device/src/ClientFactory.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
         /// <param name="authenticationMethod">The authentication method that is used</param>
-        /// <param name="transportType">The transportType used (Http1 or Amqp)</param>
+        /// <param name="transportType">The transportType used (Http1, Amqp or Mqtt), <see cref="TransportType"/></param>
         /// <returns>InternalClient</returns>
         public static InternalClient Create(string hostname, IAuthenticationMethod authenticationMethod, TransportType transportType)
         {
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
         /// <param name="gatewayHostname">The fully-qualified DNS hostname of Gateway</param>
         /// <param name="authenticationMethod">The authentication method that is used</param>
-        /// <param name="transportType">The transportType used (Http1 or Amqp)</param>
+        /// <param name="transportType">The transportType used (Http1, Amqp or Mqtt), <see cref="TransportType"/></param>
         /// <returns>InternalClient</returns>
         public static InternalClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod, TransportType transportType)
         {
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.Devices.Client
         /// Create InternalClient from the specified connection string using the specified transport type
         /// </summary>
         /// <param name="connectionString">Connection string for the IoT hub (including DeviceId)</param>
-        /// <param name="transportType">Specifies whether Amqp or Http transport is used</param>
+        /// <param name="transportType">Specifies whether Http1, Amqp or Mqtt transport is used, <see cref="TransportType"/></param>
         /// <returns>InternalClient</returns>
         public static InternalClient CreateFromConnectionString(string connectionString, TransportType transportType)
         {

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
         /// <param name="authenticationMethod">The authentication method that is used</param>
-        /// <param name="transportType">The transportType used (Http1 or Amqp)</param>
+        /// <param name="transportType">The transportType used (Http1, Amqp or Mqtt), <see cref="TransportType"/></param>
         /// <returns>A disposable DeviceClient instance</returns>
         public static DeviceClient Create(string hostname, IAuthenticationMethod authenticationMethod, TransportType transportType)
         {
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
         /// <param name="gatewayHostname">The fully-qualified DNS hostname of Gateway</param>
         /// <param name="authenticationMethod">The authentication method that is used</param>
-        /// <param name="transportType">The transportType used (Http1 or Amqp)</param>
+        /// <param name="transportType">The transportType used (Http1, Amqp or Mqtt), <see cref="TransportType"/></param>
         /// <returns>A disposable DeviceClient instance</returns>
         public static DeviceClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod, TransportType transportType)
         {
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Devices.Client
         /// Creates a disposable DeviceClient from the specified connection string using the specified transport type
         /// </summary>
         /// <param name="connectionString">Connection string for the IoT hub (including DeviceId)</param>
-        /// <param name="transportType">Specifies whether Amqp or Http transport is used</param>
+        /// <param name="transportType">Specifies whether Http1, Amqp or Mqtt transport is used, <see cref="TransportType"/></param>
         /// <returns>A disposable DeviceClient instance</returns>
         public static DeviceClient CreateFromConnectionString(string connectionString, TransportType transportType)
         {

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -542,13 +542,15 @@ namespace Microsoft.Azure.Devices.Client
             InternalClient.SetDesiredPropertyUpdateCallbackAsync(callback, userContext, cancellationToken);
 
         /// <summary>
-        /// Retrieve a device twin object for the current device.
+        /// Retrieve the device twin properties for the current device.
+        /// For the complete device twin object, use Microsoft.Azure.Devices.RegistryManager.GetTwinAsync(string deviceId).
         /// </summary>
         /// <returns>The device twin object for the current device</returns>
         public Task<Twin> GetTwinAsync() => InternalClient.GetTwinAsync();
 
         /// <summary>
-        /// Retrieve a device twin object for the current device.
+        /// Retrieve the device twin properties for the current device.
+        /// For the complete device twin object, use Microsoft.Azure.Devices.RegistryManager.GetTwinAsync(string deviceId).
         /// </summary>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1150,7 +1150,8 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Retrieve a device twin object for the current device.
+        /// Retrieve the device twin properties for the current device.
+        /// For the complete device twin object, use Microsoft.Azure.Devices.RegistryManager.GetTwinAsync(string deviceId).
         /// </summary>
         /// <returns>The device twin object for the current device</returns>
         public async Task<Twin> GetTwinAsync()
@@ -1169,7 +1170,8 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Retrieve a device twin object for the current device.
+        /// Retrieve the device twin properties for the current device.
+        /// For the complete device twin object, use Microsoft.Azure.Devices.RegistryManager.GetTwinAsync(string deviceId).
         /// </summary>
         /// <returns>The device twin object for the current device</returns>
         public Task<Twin> GetTwinAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
The only device client creation method where Http and Amqp are the only supported protocols is device client creation using iot-hub scope connection string. (FYI for #1185 )

Also, update comment for GetTwinAsync on Device Client.
Fixes #515 