### PR TITLE
fix(iot-device): Update comments for device client creation methods

### DIFF
--- a/iothub/device/src/ClientFactory.cs
+++ b/iothub/device/src/ClientFactory.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="connectionString">IoT Hub-Scope Connection string for the IoT hub (without DeviceId)</param>
         /// <param name="deviceId">Id of the device</param>
-        /// <param name="transportType">The transportType used (Http1 or Amqp)</param>
+        /// <param name="transportType">The transportType used (Http1, Amqp or Mqtt), <see cref="TransportType"/></param>
         /// <returns>InternalClient</returns>
         public static InternalClient CreateFromConnectionString(string connectionString, string deviceId, TransportType transportType)
         {

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="connectionString">IoT Hub-Scope Connection string for the IoT hub (without DeviceId)</param>
         /// <param name="deviceId">Id of the device</param>
-        /// <param name="transportType">The transportType used (Http1 or Amqp)</param>
+        /// <param name="transportType">The transportType used (Http1, Amqp or Mqtt), <see cref="TransportType"/></param>
         /// <returns>A disposable DeviceClient instance</returns>
         public static DeviceClient CreateFromConnectionString(string connectionString, string deviceId, TransportType transportType)
         {


### PR DESCRIPTION
All 3 protocols (Amqp, Mqtt and Http) support iot-hub scoped connection strings for device connection.
An interesting point here is that the iot-hub scoped connection string can also be used to create device client instances for _x509 devices_, over amqp and http; but not mqtt. Getting some clarification on this from service team.