### PR TITLE
Add support for ns2.1

### DIFF
--- a/common/src/service/StringValidationHelper.cs
+++ b/common/src/service/StringValidationHelper.cs
@@ -9,10 +9,11 @@ namespace Microsoft.Azure.Devices.Common
     internal static class StringValidationHelper
     {
         private const char Base64Padding = '=';
-        private static readonly HashSet<char> base64Table = 
+
+        private static readonly HashSet<char> base64Table =
             new HashSet<char>{  'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O',
                                 'P','Q','R','S','T','U','V','W','X','Y','Z','a','b','c','d',
-                                'e','f','g','h','i','j','k','l','m','n','o','p','q','r','s', 
+                                'e','f','g','h','i','j','k','l','m','n','o','p','q','r','s',
                                 't','u','v','w','x','y','z','0','1','2','3','4','5','6','7',
                                 '8','9','+','/' };
 
@@ -54,7 +55,11 @@ namespace Microsoft.Azure.Devices.Common
 
         public static bool IsBase64String(string value)
         {
+#if NETSTANDARD2_1
+            value = value.Replace("\r", string.Empty, StringComparison.Ordinal).Replace("\n", string.Empty, StringComparison.Ordinal);
+#else
             value = value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+#endif
 
             if (value.Length == 0 || (value.Length % 4) != 0)
             {

--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1.18;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.1;netstandard2.0;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <!-- TODO #176: Enable warnings as errors. -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
@@ -49,6 +49,10 @@
     <common>$(RootDir)\common\src</common>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <SupportsNetStandard20AndAbove Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">true</SupportsNetStandard20AndAbove>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="DotNetty.Codecs.Mqtt" Version="0.6.0" />
     <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
@@ -90,8 +94,8 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
-  <!-- NetStandard 2.0 and net472 -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472' ">
+  <!-- NetStandard 2.1, NetStandard 2.0 and net472 -->
+  <ItemGroup Condition="'$(SupportsNetStandard20AndAbove)' == 'true'">
     <Compile Include="$(Common)\DefaultWebProxySettings.cs" />
     <Compile Include="ModernDotNet\Common\IOThreadTimerSlim.cs" />
     <Compile Include="ModernDotNet\HsmAuthentication\Transport\HttpUdsMessageHandler.cs" />
@@ -99,7 +103,7 @@
     <Compile Include="ModernDotNet\HsmAuthentication\Transport\HttpRequestResponseSerializer.cs" />
     <Compile Include="ModernDotNet\HsmAuthentication\Transport\UnixDomainSocketEndPoint.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(SupportsNetStandard20AndAbove)' == 'true'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
   </ItemGroup>

--- a/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
+++ b/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1;netcoreapp2.1.18;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'netcoreapp3.1'">False</IsTestProject>
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
 
     <IsPackable>false</IsPackable>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
@@ -14,11 +14,15 @@
     <DefaultItemExcludes>HsmAuthentication/**;$(DefaultItemExcludes)</DefaultItemExcludes>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net451'">
+  <PropertyGroup>
+    <SupportsNetStandard20AndAbove Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">true</SupportsNetStandard20AndAbove>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(SupportsNetStandard20AndAbove)' == 'true'">
     <Compile Include="HsmAuthentication\**" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1' Or '$(TargetFramework)' == 'net472' ">
+  <ItemGroup Condition="'$(SupportsNetStandard20AndAbove)' == 'true'">
     <Compile Remove="ClientWebSocketTransportTests.cs" />
     <Compile Remove="Mqtt\ClientWebSocketChannelTests.cs" />
   </ItemGroup>
@@ -30,10 +34,10 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
-    <Reference Include="System.Web" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net472' ">
+    <Reference Include="System.Web" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <!-- TODO #176: Enable warnings as errors. -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
@@ -36,6 +36,10 @@
     <PackageProjectUrl>https://github.com/Azure/azure-iot-sdk-csharp</PackageProjectUrl>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>IoT Microsoft Azure IoTHub Service Client SDK Manage Devices .NET</PackageTags>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SupportsNetStandard20AndAbove Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">true</SupportsNetStandard20AndAbove>
   </PropertyGroup>
 
   <ItemGroup>
@@ -146,12 +150,12 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <!-- NetStandard 2.0 and net472 -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472' ">
+  <!-- NetStandard 2.1, NetStandard 2.0 and net472 -->
+  <ItemGroup Condition="'$(SupportsNetStandard20AndAbove)' == 'true'">
     <Compile Include="$(Common)\DefaultWebProxySettings.cs" />
     <Compile Include="ModernDotNet\Common\IOThreadTimerSlim.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472' ">
+  <ItemGroup Condition="'$(SupportsNetStandard20AndAbove)' == 'true'">
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
   </ItemGroup>

--- a/iothub/service/tests/Microsoft.Azure.Devices.Tests.csproj
+++ b/iothub/service/tests/Microsoft.Azure.Devices.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1;netcoreapp2.1.18;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'netcoreapp3.1'">False</IsTestProject>
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
@@ -18,8 +18,7 @@
     <PackageReference Include="Moq" Version="4.8.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
-    <Reference Include="System.Web" Version="4.0.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.Tests.csproj
+++ b/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="('$(TargetFramework)' != 'netcoreapp3.1')">False</IsTestProject>
+    <IsTestProject Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/provisioning/service/src/Auth/SharedAccessSignatureAuthorizationRule.cs
+++ b/provisioning/service/src/Auth/SharedAccessSignatureAuthorizationRule.cs
@@ -57,7 +57,11 @@ namespace Microsoft.Azure.Devices.Common.Service.Auth
 
         public override int GetHashCode()
         {
+#if NETSTANDARD2_1
+            return (_primaryKey + _secondaryKey).GetHashCode(StringComparison.Ordinal);
+#else
             return (_primaryKey + _secondaryKey).GetHashCode();
+#endif
         }
     }
 }

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.Tests.csproj
+++ b/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="('$(TargetFramework)' != 'netcoreapp3.1')">False</IsTestProject>
+    <IsTestProject Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <!-- FXCop TODO: #176 re-enable warnings as errors. -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RootNamespace>Microsoft.Azure.Devices.Provisioning.Client.Transport</RootNamespace>

--- a/provisioning/transport/amqp/tests/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.Tests.csproj
+++ b/provisioning/transport/amqp/tests/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="('$(TargetFramework)' != 'netcoreapp3.1')">False</IsTestProject>
+    <IsTestProject Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/provisioning/transport/http/src/Generated/RuntimeRegistration.cs
+++ b/provisioning/transport/http/src/Generated/RuntimeRegistration.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
     /// <summary>
     /// RuntimeRegistration operations.
     /// </summary>
-    internal partial class RuntimeRegistration 
+    internal partial class RuntimeRegistration
         : IServiceOperations<DeviceProvisioningServiceRuntimeClient>, IRuntimeRegistration
     {
         /// <summary>
@@ -75,10 +75,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
         /// A response object containing the response body and response headers.
         /// </return>
         public async Task<HttpOperationResponse<RegistrationOperationStatus>> OperationStatusLookupWithHttpMessagesAsync(
-            string registrationId, 
-            string operationId, 
-            string idScope, 
-            Dictionary<string, List<string>> customHeaders = null, 
+            string registrationId,
+            string operationId,
+            string idScope,
+            Dictionary<string, List<string>> customHeaders = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             if (registrationId == null)
@@ -111,12 +111,19 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             // Construct URL
             var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new Uri(
-                new Uri(_baseUrl + (_baseUrl.EndsWith("/", StringComparison.Ordinal) ? "" : "/")), 
+                new Uri(_baseUrl + (_baseUrl.EndsWith("/", StringComparison.Ordinal) ? "" : "/")),
                 "{idScope}/registrations/{registrationId}/operations/{operationId}").ToString();
 
+#if NETSTANDARD2_1
+            _url = _url.Replace("{registrationId}", Uri.EscapeDataString(registrationId), StringComparison.Ordinal);
+            _url = _url.Replace("{operationId}", Uri.EscapeDataString(operationId), StringComparison.Ordinal);
+            _url = _url.Replace("{idScope}", Uri.EscapeDataString(idScope), StringComparison.Ordinal);
+#else
             _url = _url.Replace("{registrationId}", Uri.EscapeDataString(registrationId));
             _url = _url.Replace("{operationId}", Uri.EscapeDataString(operationId));
             _url = _url.Replace("{idScope}", Uri.EscapeDataString(idScope));
+#endif
+
             // Create HTTP transport objects
             var _httpRequest = new HttpRequestMessage();
             HttpResponseMessage _httpResponse = null;
@@ -124,10 +131,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             _httpRequest.RequestUri = new Uri(_url);
             // Set Headers
 
-
             if (customHeaders != null)
             {
-                foreach(var _header in customHeaders)
+                foreach (var _header in customHeaders)
                 {
                     if (_httpRequest.Headers.Contains(_header.Key))
                     {
@@ -162,10 +168,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             if ((int)_statusCode != 200 && (int)_statusCode != 202)
             {
                 var ex = new HttpOperationException(string.Format(CultureInfo.InvariantCulture, "Operation returned an invalid status code '{0}'", _statusCode));
-                if (_httpResponse.Content != null) {
+                if (_httpResponse.Content != null)
+                {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 }
-                else {
+                else
+                {
                     _responseContent = string.Empty;
                 }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
@@ -263,10 +271,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
         /// A response object containing the response body and response headers.
         /// </return>
         public async Task<HttpOperationResponse<Models.DeviceRegistrationResult>> DeviceRegistrationStatusLookupWithHttpMessagesAsync(
-            string registrationId, 
-            string idScope, 
-            DeviceRegistration deviceRegistration = default(DeviceRegistration), 
-            Dictionary<string, List<string>> customHeaders = null, 
+            string registrationId,
+            string idScope,
+            DeviceRegistration deviceRegistration = default(DeviceRegistration),
+            Dictionary<string, List<string>> customHeaders = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             if (registrationId == null)
@@ -295,8 +303,15 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             // Construct URL
             var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/", StringComparison.Ordinal) ? "" : "/")), "{idScope}/registrations/{registrationId}").ToString();
+
+#if NETSTANDARD2_1
+            _url = _url.Replace("{registrationId}", Uri.EscapeDataString(registrationId), StringComparison.Ordinal);
+            _url = _url.Replace("{idScope}", Uri.EscapeDataString(idScope), StringComparison.Ordinal);
+#else
             _url = _url.Replace("{registrationId}", Uri.EscapeDataString(registrationId));
             _url = _url.Replace("{idScope}", Uri.EscapeDataString(idScope));
+#endif
+
             // Create HTTP transport objects
             var _httpRequest = new HttpRequestMessage();
             HttpResponseMessage _httpResponse = null;
@@ -304,10 +319,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             _httpRequest.RequestUri = new Uri(_url);
             // Set Headers
 
-
             if (customHeaders != null)
             {
-                foreach(var _header in customHeaders)
+                foreach (var _header in customHeaders)
                 {
                     if (_httpRequest.Headers.Contains(_header.Key))
                     {
@@ -319,11 +333,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 
             // Serialize Request
             string _requestContent = null;
-            if(deviceRegistration != null)
+            if (deviceRegistration != null)
             {
                 _requestContent = SafeJsonConvert.SerializeObject(deviceRegistration, Client.SerializationSettings);
                 _httpRequest.Content = new StringContent(_requestContent, Encoding.UTF8);
-                _httpRequest.Content.Headers.ContentType =MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                _httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
             }
             // Set Credentials
             if (Client.Credentials != null)
@@ -348,10 +362,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             if ((int)_statusCode != 200)
             {
                 var ex = new HttpOperationException(string.Format(CultureInfo.InvariantCulture, "Operation returned an invalid status code '{0}'", _statusCode));
-                if (_httpResponse.Content != null) {
+                if (_httpResponse.Content != null)
+                {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 }
-                else {
+                else
+                {
                     _responseContent = string.Empty;
                 }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
@@ -435,11 +451,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
         /// A response object containing the response body and response headers.
         /// </return>
         public async Task<HttpOperationResponse<RegistrationOperationStatus>> RegisterDeviceWithHttpMessagesAsync(
-            string registrationId, 
-            string idScope, 
-            DeviceRegistration deviceRegistration = default(DeviceRegistration), 
-            bool? forceRegistration = default(bool?), 
-            Dictionary<string, List<string>> customHeaders = null, 
+            string registrationId,
+            string idScope,
+            DeviceRegistration deviceRegistration = default(DeviceRegistration),
+            bool? forceRegistration = default(bool?),
+            Dictionary<string, List<string>> customHeaders = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             if (registrationId == null)
@@ -447,7 +463,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 throw new ValidationException(ValidationRules.CannotBeNull, "registrationId");
             }
             if (idScope == null)
-            {                throw new ValidationException(ValidationRules.CannotBeNull, "idScope");
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "idScope");
             }
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
@@ -468,14 +485,21 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             // Construct URL
             var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/", StringComparison.Ordinal) ? "" : "/")), "{idScope}/registrations/{registrationId}/register").ToString();
+
+#if NETSTANDARD2_1
+            _url = _url.Replace("{registrationId}", Uri.EscapeDataString(registrationId), StringComparison.Ordinal);
+            _url = _url.Replace("{idScope}", Uri.EscapeDataString(idScope), StringComparison.Ordinal);
+#else
             _url = _url.Replace("{registrationId}", Uri.EscapeDataString(registrationId));
             _url = _url.Replace("{idScope}", Uri.EscapeDataString(idScope));
+#endif
+
             List<string> _queryParameters = new List<string>();
             if (forceRegistration != null)
             {
                 _queryParameters.Add(string.Format(
                     CultureInfo.InvariantCulture,
-                    "forceRegistration={0}", 
+                    "forceRegistration={0}",
                     Uri.EscapeDataString(SafeJsonConvert.SerializeObject(forceRegistration, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
@@ -489,10 +513,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             _httpRequest.RequestUri = new Uri(_url);
             // Set Headers
 
-
             if (customHeaders != null)
             {
-                foreach(var _header in customHeaders)
+                foreach (var _header in customHeaders)
                 {
                     if (_httpRequest.Headers.Contains(_header.Key))
                     {
@@ -504,7 +527,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 
             // Serialize Request
             string _requestContent = null;
-            if(deviceRegistration != null)
+            if (deviceRegistration != null)
             {
                 _requestContent = SafeJsonConvert.SerializeObject(deviceRegistration, Client.SerializationSettings);
                 _httpRequest.Content = new StringContent(_requestContent, Encoding.UTF8);
@@ -533,10 +556,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             if ((int)_statusCode != 202)
             {
                 var ex = new HttpOperationException(string.Format(CultureInfo.InvariantCulture, "Operation returned an invalid status code '{0}'", _statusCode));
-                if (_httpResponse.Content != null) {
+                if (_httpResponse.Content != null)
+                {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 }
-                else {
+                else
+                {
                     _responseContent = string.Empty;
                 }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);

--- a/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
+++ b/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RootNamespace>Microsoft.Azure.Devices.Provisioning.Client.Transport</RootNamespace>

--- a/provisioning/transport/http/src/TPM/TpmCredentials.cs
+++ b/provisioning/transport/http/src/TPM/TpmCredentials.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
         private const string SASHeaderName = "SharedAccessSignature";
         private volatile string _sasToken;
 
-        public TpmCredentials(): base()
+        public TpmCredentials() : base()
         {
         }
 
@@ -25,7 +25,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             {
                 Action<string> action = (value) =>
                 {
+#if NETSTANDARD2_1
+                    _sasToken = value.Replace(SASHeaderName + " ", "", StringComparison.Ordinal);
+#else
                     _sasToken = value.Replace(SASHeaderName + " ", "");
+#endif
                     SetAuthorizationHeader(request, _sasToken);
                 };
 

--- a/provisioning/transport/http/tests/Microsoft.Azure.Devices.Provisioning.Transport.Http.Tests.csproj
+++ b/provisioning/transport/http/tests/Microsoft.Azure.Devices.Provisioning.Transport.Http.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="('$(TargetFramework)' != 'netcoreapp3.1')">False</IsTestProject>
+    <IsTestProject Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
+++ b/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RootNamespace>Microsoft.Azure.Devices.Provisioning.Client.Transport</RootNamespace>

--- a/provisioning/transport/mqtt/tests/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.Tests.csproj
+++ b/provisioning/transport/mqtt/tests/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="('$(TargetFramework)' != 'netcoreapp3.1')">False</IsTestProject>
+    <IsTestProject Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ If you would like to build or change the SDK source code, please follow the [dev
 The IoT Hub device SDK for .NET can be used with a broad range of OS platforms and devices.
 
 The NuGet packages provide support for the following .NET flavors:
+- .NET Standard 2.1
 - .NET Standard 2.0
 - .NET Framework 4.7.2 (IoT Hub SDKs only)
 - .NET Framework 4.5.1 (IoT Hub SDKs only)

--- a/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
+++ b/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/security/tpm/tests/Microsoft.Azure.Devices.Provisioning.Security.Tpm.Tests.csproj
+++ b/security/tpm/tests/Microsoft.Azure.Devices.Provisioning.Security.Tpm.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="('$(TargetFramework)' != 'netcoreapp3.1')">False</IsTestProject>
+    <IsTestProject Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/shared/src/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/src/Microsoft.Azure.Devices.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.1;netstandard2.0;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/shared/tests/Microsoft.Azure.Devices.Shared.Tests.csproj
+++ b/shared/tests/Microsoft.Azure.Devices.Shared.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Microsoft.Azure.Devices.Shared.Tests</RootNamespace>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1;netcoreapp2.1.18;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'netcoreapp3.1'">False</IsTestProject>
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
 
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>

--- a/tools/TLS Protocols Tests/ReadMe/readme.md
+++ b/tools/TLS Protocols Tests/ReadMe/readme.md
@@ -20,8 +20,8 @@ To run it, you will need:
 1. Set the necessary environment variables specified in the Program.cs file.
   - If using VS, open the project properties' Debug tab. You can configure environment variables in there.
 1. Run the project:
-  - If using VS, open Program.cs and select either net451 or netcoreapp2.0., and set **TLS protocol tests** as the startup project.
-  - If running from command-line, use `dotnet run -f net451` or `dotnet run -f netcoreapp2.0`
+  - If using VS, open Program.cs and select either net451 or netcoreapp2.1., and set **TLS protocol tests** as the startup project.
+  - If running from command-line, use `dotnet run -f net451` or `dotnet run -f netcoreapp2.1`
 1. Observe output of the tool.
   - If the device client failed to connect it will report the exception types and messages.
     - The key error for when a common TLS protocol could not be negotiated is: _System.ComponentModel.Win32Exception: The client and server cannot communicate, because they do not possess a common algorithm_

--- a/vsts/gatedBuild.ps1
+++ b/vsts/gatedBuild.ps1
@@ -48,7 +48,7 @@ else
 {
 	#Likely a nightly or CI build
 	Write-Host "Not a pull request build, will run all tests"
-	$runTestCmd += " -e2etests"	
+	$runTestCmd += " -unittests -e2etests"
 }
 
 

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -26,6 +26,8 @@ jobs:
       matrix:
         .Net Core 3.1:
           FRAMEWORK: netcoreapp3.1
+        .Net Core 2.1.18:
+          FRAMEWORK: netcoreapp2.1.18
 
     condition: succeeded()
     pool:
@@ -99,9 +101,9 @@ jobs:
         condition: always()
 
       - task: PublishBuildArtifacts@1
-        displayName: "Publish Artifact: testresults_linux"
+        displayName: "Publish Artifact: testresults_linux_$(FRAMEWORK)"
         inputs:
-          ArtifactName: testresults_linux
+          ArtifactName: testresults_linux_$(FRAMEWORK)
 
         condition: always()
 
@@ -109,7 +111,7 @@ jobs:
         displayName: "Publish Test Results **/*.trx"
         inputs:
           testRunner: VSTest
-          testRunTitle: "Linux Tests (netcoreapp3.1)"
+          testRunTitle: "Linux Tests ($(FRAMEWORK))"
           testResultsFiles: "**/*.trx"
 
         condition: always()
@@ -123,6 +125,8 @@ jobs:
       matrix:
         .Net Core 3.1:
           FRAMEWORK: netcoreapp3.1
+        .Net Core 2.1.18:
+          FRAMEWORK: netcoreapp2.1.18
         .Net Framework 4.7.2:
           FRAMEWORK: net472
         .Net Framework 4.5.1:


### PR DESCRIPTION
This PR brings in the following changes:

1. Update pipeline script to run unit tests for CI and nightly builds.
2. Add support for .netstandard2.1
3. Add an additional target framework for tests (.netcoreapp2.1.18).  This is the latest stable version of .netcore2.1, which is in [LTS until 2021-08-21](https://dotnet.microsoft.com/download/dotnet-core)
Now the .netcoreapp3.1 test project references the ns2.1 dll, while the .netstandard2.1.18 test project references the ns2.0 dll. Other test project references remain the same as before.
4. Addition of ns2.1 support required the `String.Replace(string, string)` calls to be updated to `Replace(String, String, StringComparison)`. However, the overload with `StringComparion` is not available in <ns2.1 implementations, so I had to add #if directives.