### PR TITLE
Add remote certificate validation callback for websocket connections

### DIFF
--- a/iothub/device/src/AmqpTransportSettings.cs
+++ b/iothub/device/src/AmqpTransportSettings.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <summary>
         /// A callback for remote certificate validation.
-        /// If incorrectly implemented, your device may fail to connect to IoTHub and/or be open to security vulrenabilities.
+        /// If incorrectly implemented, your device may fail to connect to IoTHub and/or be open to security vulnerabilities.
         /// </summary>
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 

--- a/iothub/device/src/AmqpTransportSettings.cs
+++ b/iothub/device/src/AmqpTransportSettings.cs
@@ -141,7 +141,8 @@ namespace Microsoft.Azure.Devices.Client
         public IWebProxy Proxy { get; set; }
 
         /// <summary>
-        /// A callback for remote certificate validation
+        /// A callback for remote certificate validation.
+        /// If incorrectly implemented, your device may fail to connect to IoTHub and/or be open to security vulrenabilities.
         /// </summary>
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 

--- a/iothub/device/src/ClientFactory.cs
+++ b/iothub/device/src/ClientFactory.cs
@@ -83,11 +83,6 @@ namespace Microsoft.Azure.Devices.Client
                     throw new ArgumentException("certificate must be present in DeviceAuthenticationWithX509Certificate");
                 }
 
-                if (!connectionStringBuilder.Certificate.HasPrivateKey)
-                {
-                    throw new ArgumentException("certificate in DeviceAuthenticationWithX509Certificate must have a private key");
-                }
-
                 InternalClient dc = CreateFromConnectionString(connectionStringBuilder.ToString(), PopulateCertificateInTransportSettings(connectionStringBuilder, transportType));
                 dc.Certificate = connectionStringBuilder.Certificate;
                 return dc;
@@ -136,11 +131,6 @@ namespace Microsoft.Azure.Devices.Client
                 if (connectionStringBuilder.Certificate == null)
                 {
                     throw new ArgumentException("certificate must be present in DeviceAuthenticationWithX509Certificate");
-                }
-
-                if (!connectionStringBuilder.Certificate.HasPrivateKey)
-                {
-                    throw new ArgumentException("certificate in DeviceAuthenticationWithX509Certificate must have a private key");
                 }
 
                 InternalClient dc = CreateFromConnectionString(connectionStringBuilder.ToString(), PopulateCertificateInTransportSettings(connectionStringBuilder, transportSettings));

--- a/iothub/device/src/DeviceAuthenticationWithX509Certificate.cs
+++ b/iothub/device/src/DeviceAuthenticationWithX509Certificate.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Gets or sets the X.509 certificate associated with this device
+        /// Gets or sets the X.509 certificate associated with this device.
+        /// The private key should be available in the <see cref="X509Certificate2"/> object, or should be loaded into the system where the <see cref="DeviceClient"/> will be used. />
         /// </summary>
         public X509Certificate2 Certificate { get; set; }
 

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTTransport.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTTransport.cs
@@ -176,6 +176,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 if (_amqpTransportSettings.RemoteCertificateValidationCallback != null)
                 {
                     websocket.Options.RemoteCertificateValidationCallback = _amqpTransportSettings.RemoteCertificateValidationCallback;
+                    if (Logging.IsEnabled)
+                    {
+                        Logging.Info(this, $"{nameof(CreateClientWebSocketAsync)} Setting RemoteCertificateValidationCallback");
+                    }
                 }
 #endif
 

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTTransport.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTTransport.cs
@@ -171,6 +171,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                     websocket.Options.ClientCertificates.Add(_amqpTransportSettings.ClientCertificate);
                 }
 
+                // Support for RemoteCertificateValidationCallback for ClientWebSocket is introduced in .NET Standard 2.1
+#if NETSTANDARD2_1
+                if (_amqpTransportSettings.RemoteCertificateValidationCallback != null)
+                {
+                    websocket.Options.RemoteCertificateValidationCallback = _amqpTransportSettings.RemoteCertificateValidationCallback;
+                }
+#endif
+
                 using (var cancellationTokenSource = new CancellationTokenSource(timeout))
                 {
                     await websocket.ConnectAsync(websocketUri, cancellationTokenSource.Token).ConfigureAwait(false);

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -1013,6 +1013,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     websocket.Options.ClientCertificates.Add(settings.ClientCertificate);
                 }
 
+                // Support for RemoteCertificateValidationCallback for ClientWebSocket is introduced in .NET Standard 2.1
+#if NETSTANDARD2_1
+                if (settings.RemoteCertificateValidationCallback != null)
+                {
+                    websocket.Options.RemoteCertificateValidationCallback = settings.RemoteCertificateValidationCallback;
+                }
+#endif
+
                 using (var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
                 {
                     await websocket.ConnectAsync(websocketUri, cancellationTokenSource.Token).ConfigureAwait(true);

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -1018,6 +1018,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 if (settings.RemoteCertificateValidationCallback != null)
                 {
                     websocket.Options.RemoteCertificateValidationCallback = settings.RemoteCertificateValidationCallback;
+                    if (Logging.IsEnabled)
+                    {
+                        Logging.Info(this, $"{nameof(CreateWebSocketChannelFactory)} Setting RemoteCertificateValidationCallback");
+                    }
                 }
 #endif
 

--- a/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
@@ -126,7 +126,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         public TimeSpan DefaultReceiveTimeout { get; set; }
 
         /// <summary>
-        /// A callback for remote certificate validation
+        /// A callback for remote certificate validation.
+        /// If incorrectly implemented, your device may fail to connect to IoTHub and/or be open to security vulrenabilities.
         /// </summary>
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 

--- a/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         /// <summary>
         /// A callback for remote certificate validation.
-        /// If incorrectly implemented, your device may fail to connect to IoTHub and/or be open to security vulrenabilities.
+        /// If incorrectly implemented, your device may fail to connect to IoTHub and/or be open to security vulnerabilities.
         /// </summary>
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 

--- a/provisioning/device/src/ProvisioningTransportHandler.cs
+++ b/provisioning/device/src/ProvisioningTransportHandler.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
         public IWebProxy Proxy { get; set; }
 
         /// <summary>
-        /// A callback for remote certificate validation
+        /// A callback for remote certificate validation.
+        /// If incorrectly implemented, your device may fail to connect to DPS and/or be open to security vulrenabilities.
         /// </summary>
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 

--- a/provisioning/device/src/ProvisioningTransportHandler.cs
+++ b/provisioning/device/src/ProvisioningTransportHandler.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.Devices.Shared;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Net.Security;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,6 +23,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
         /// Gets or sets the proxy for Provisioning Client operations.
         /// </summary>
         public IWebProxy Proxy { get; set; }
+
+        /// <summary>
+        /// A callback for remote certificate validation
+        /// </summary>
+        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 
         /// <summary>
         /// Creates an instance of the ProvisioningTransportHandler class.

--- a/provisioning/device/src/ProvisioningTransportHandler.cs
+++ b/provisioning/device/src/ProvisioningTransportHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 
         /// <summary>
         /// A callback for remote certificate validation.
-        /// If incorrectly implemented, your device may fail to connect to DPS and/or be open to security vulrenabilities.
+        /// If incorrectly implemented, your device may fail to connect to DPS and/or be open to security vulnerabilities.
         /// </summary>
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 

--- a/provisioning/transport/amqp/src/AmqpAuthStrategy.cs
+++ b/provisioning/transport/amqp/src/AmqpAuthStrategy.cs
@@ -6,6 +6,7 @@ using Microsoft.Azure.Amqp.Transport;
 using Microsoft.Azure.Devices.Provisioning.Client.Transport.Models;
 using System;
 using System.Net;
+using System.Net.Security;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
@@ -24,7 +25,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 
         public abstract AmqpSettings CreateAmqpSettings(string idScope);
 
-        public abstract Task OpenConnectionAsync(AmqpClientConnection connection, TimeSpan timeout, bool useWebSocket, IWebProxy proxy);
+        public abstract Task OpenConnectionAsync(AmqpClientConnection connection, TimeSpan timeout, bool useWebSocket, IWebProxy proxy, RemoteCertificateValidationCallback remoteCertificateValidationCallback);
 
         public abstract void SaveCredentials(RegistrationOperationStatus status);
     }

--- a/provisioning/transport/amqp/src/AmqpAuthStrategySymmetricKey.cs
+++ b/provisioning/transport/amqp/src/AmqpAuthStrategySymmetricKey.cs
@@ -12,6 +12,7 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using System.Net.Security;
 
 namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 {
@@ -41,14 +42,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             return settings;
         }
 
-        public override Task OpenConnectionAsync(AmqpClientConnection connection, TimeSpan timeout, bool useWebSocket, IWebProxy proxy)
+        public override Task OpenConnectionAsync(AmqpClientConnection connection, TimeSpan timeout, bool useWebSocket, IWebProxy proxy, RemoteCertificateValidationCallback remoteCertificateValidationCallback)
         {
-            return connection.OpenAsync(timeout, useWebSocket, null, proxy);
+            return connection.OpenAsync(timeout, useWebSocket, null, proxy, remoteCertificateValidationCallback);
         }
 
         public override void SaveCredentials(RegistrationOperationStatus operation)
         {
-            
         }
     }
 }

--- a/provisioning/transport/amqp/src/AmqpAuthStrategyTpm.cs
+++ b/provisioning/transport/amqp/src/AmqpAuthStrategyTpm.cs
@@ -8,6 +8,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Provisioning.Client.Transport.Models;
 using System.Net;
+using System.Net.Security;
 
 namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 {
@@ -36,9 +37,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             return settings;
         }
 
-        public override Task OpenConnectionAsync(AmqpClientConnection connection, TimeSpan timeout, bool useWebSocket, IWebProxy proxy)
+        public override Task OpenConnectionAsync(AmqpClientConnection connection, TimeSpan timeout, bool useWebSocket, IWebProxy proxy, RemoteCertificateValidationCallback remoteCertificateValidationCallback)
         {
-            return connection.OpenAsync(timeout, useWebSocket, null, proxy);
+            return connection.OpenAsync(timeout, useWebSocket, null, proxy, remoteCertificateValidationCallback);
         }
 
         public override void SaveCredentials(RegistrationOperationStatus operation)

--- a/provisioning/transport/amqp/src/AmqpAuthStrategyX509.cs
+++ b/provisioning/transport/amqp/src/AmqpAuthStrategyX509.cs
@@ -8,12 +8,13 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Provisioning.Client.Transport.Models;
 using System.Net;
+using System.Net.Security;
 
 namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 {
     internal class AmqpAuthStrategyX509 : AmqpAuthStrategy
     {
-        SecurityProviderX509 _security;
+        private SecurityProviderX509 _security;
 
         public AmqpAuthStrategyX509(SecurityProviderX509 security)
         {
@@ -25,10 +26,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             return new AmqpSettings();
         }
 
-        public override Task OpenConnectionAsync(AmqpClientConnection connection, TimeSpan timeout, bool useWebSocket, IWebProxy proxy)
+        public override Task OpenConnectionAsync(AmqpClientConnection connection, TimeSpan timeout, bool useWebSocket, IWebProxy proxy, RemoteCertificateValidationCallback remoteCertificateValidationCallback)
         {
             X509Certificate2 clientCert = _security.GetAuthenticationCertificate();
-            return connection.OpenAsync(timeout, useWebSocket, clientCert, proxy);
+            return connection.OpenAsync(timeout, useWebSocket, clientCert, proxy, remoteCertificateValidationCallback);
         }
 
         public override void SaveCredentials(RegistrationOperationStatus status)

--- a/provisioning/transport/amqp/src/ProvisioningTransportHandlerAmqp.cs
+++ b/provisioning/transport/amqp/src/ProvisioningTransportHandlerAmqp.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 string linkEndpoint = $"{message.IdScope}/registrations/{registrationId}";
 
                 connection = authStrategy.CreateConnection(builder.Uri, message.IdScope);
-                await authStrategy.OpenConnectionAsync(connection, s_timeoutConstant, useWebSocket, Proxy).ConfigureAwait(false);
+                await authStrategy.OpenConnectionAsync(connection, s_timeoutConstant, useWebSocket, Proxy, RemoteCertificateValidationCallback).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
 
                 await CreateLinksAsync(


### PR DESCRIPTION
This PR brings in the following changes:
- Implement remote certificate validation callback over websocket connections for IoT Hub
- Implement remote certificate validation callback for tcp and websocket connections for DPS
- Remove x509 certificate private key check for device client - the service requires the public key to be sent for authentication, the private key is required for TLS negotiation, and can be a part of the `X509Certificate2` object sent to service, or installed on the system directly.