### PR TITLE
refactor(iot-service): Bump service API version now that 2020-03-13 is available in all regions

### DIFF
--- a/e2e/test/RegistryManagerExportDevicesTests.cs
+++ b/e2e/test/RegistryManagerExportDevicesTests.cs
@@ -53,13 +53,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         [DataRow(StorageAuthenticationType.IdentityBased)]
         public async Task RegistryManager_ExportDevices(StorageAuthenticationType storageAuthenticationType)
         {
-            // Remove after removal of environment variable
-            if (storageAuthenticationType == StorageAuthenticationType.IdentityBased
-                && Environment.GetEnvironmentVariable("EnableStorageIdentity") != "1")
-            {
-                return;
-            }
-
             // arrange
 
             StorageContainer storageContainer = null;

--- a/e2e/test/RegistryManagerImportDevicesTests.cs
+++ b/e2e/test/RegistryManagerImportDevicesTests.cs
@@ -47,13 +47,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         [DataRow(StorageAuthenticationType.IdentityBased)]
         public async Task RegistryManager_ImportDevices(StorageAuthenticationType storageAuthenticationType)
         {
-            // Remove after removal of environment variable
-            if (storageAuthenticationType == StorageAuthenticationType.IdentityBased
-                && Environment.GetEnvironmentVariable("EnableStorageIdentity") != "1")
-            {
-                return;
-            }
-
             // arrange
 
             StorageContainer storageContainer = null;

--- a/iothub/service/src/AmqpServiceClient.cs
+++ b/iothub/service/src/AmqpServiceClient.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Azure.Devices
 {
     internal sealed class AmqpServiceClient : ServiceClient
     {
-        private const string StatisticsUriFormat = "/statistics/service?" + ClientApiVersionHelper.ApiVersionQueryStringDefault;
-        private const string PurgeMessageQueueFormat = "/devices/{0}/commands?" + ClientApiVersionHelper.ApiVersionQueryStringDefault;
-        private const string DeviceMethodUriFormat = "/twins/{0}/methods?" + ClientApiVersionHelper.ApiVersionQueryStringDefault;
-        private const string ModuleMethodUriFormat = "/twins/{0}/modules/{1}/methods?" + ClientApiVersionHelper.ApiVersionQueryStringDefault;
+        private const string StatisticsUriFormat = "/statistics/service?" + ClientApiVersionHelper.ApiVersionQueryString;
+        private const string PurgeMessageQueueFormat = "/devices/{0}/commands?" + ClientApiVersionHelper.ApiVersionQueryString;
+        private const string DeviceMethodUriFormat = "/twins/{0}/methods?" + ClientApiVersionHelper.ApiVersionQueryString;
+        private const string ModuleMethodUriFormat = "/twins/{0}/modules/{1}/methods?" + ClientApiVersionHelper.ApiVersionQueryString;
         private static readonly TimeSpan s_defaultOperationTimeout = TimeSpan.FromSeconds(100);
 
         private readonly FaultTolerantAmqpObject<SendingAmqpLink> _faultTolerantSendingLink;

--- a/iothub/service/src/ClientApiVersionHelper.cs
+++ b/iothub/service/src/ClientApiVersionHelper.cs
@@ -11,14 +11,11 @@ namespace Microsoft.Azure.Devices
     internal class ClientApiVersionHelper
     {
         private const string ApiVersionQueryPrefix = "api-version=";
-        private const string ApiVersionGA = "2016-02-03";
         private const string ApiVersionDefault = "2020-03-13";
 
         /// <summary>
         /// The default API version to use for all data-plane service calls
         /// </summary>
         public const string ApiVersionQueryString = ApiVersionQueryPrefix + ApiVersionDefault;
-
-        public const string ApiVersionQueryStringGA = ApiVersionQueryPrefix + ApiVersionGA;
     }
 }

--- a/iothub/service/src/ClientApiVersionHelper.cs
+++ b/iothub/service/src/ClientApiVersionHelper.cs
@@ -12,22 +12,12 @@ namespace Microsoft.Azure.Devices
     {
         private const string ApiVersionQueryPrefix = "api-version=";
         private const string ApiVersionGA = "2016-02-03";
-        private const string ApiVersionDefault = "2019-10-01";
-        private const string ApiVersionLimitedAvailability = "2020-03-13";
-
-        // For import/export devices jobs, a new parameter is available in a
-        // new api-version, which is only available in a few initial regions.
-        // Control access via an environment variable. If a user wishes to try it out,
-        // they can set "EnabledStorageIdentity" to "1". Otherwise, the SDK will still
-        // default to the latest, broadly-supported api-version used in this SDK.
-        internal static bool IsStorageIdentityEnabled => StringComparer.OrdinalIgnoreCase.Equals("1", Environment.GetEnvironmentVariable("EnableStorageIdentity"));
+        private const string ApiVersionDefault = "2020-03-13";
 
         /// <summary>
         /// The default API version to use for all data-plane service calls
         /// </summary>
-        public const string ApiVersionQueryStringDefault = ApiVersionQueryPrefix + ApiVersionDefault;
-
-        public const string ApiVersionQueryStringLimitedAvailability = ApiVersionQueryPrefix + ApiVersionLimitedAvailability;
+        public const string ApiVersionQueryString = ApiVersionQueryPrefix + ApiVersionDefault;
 
         public const string ApiVersionQueryStringGA = ApiVersionQueryPrefix + ApiVersionGA;
     }

--- a/iothub/service/src/HttpRegistryManager.cs
+++ b/iothub/service/src/HttpRegistryManager.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Azure.Devices
         private const string AdminUriFormat = "/$admin/{0}?{1}";
         private const string RequestUriFormat = "/devices/{0}?{1}";
         private const string JobsUriFormat = "/jobs{0}?{1}";
-        private const string StatisticsUriFormat = "/statistics/devices?" + ClientApiVersionHelper.ApiVersionQueryStringDefault;
+        private const string StatisticsUriFormat = "/statistics/devices?" + ClientApiVersionHelper.ApiVersionQueryString;
         private const string DevicesRequestUriFormat = "/devices/?top={0}&{1}";
-        private const string DevicesQueryUriFormat = "/devices/query?" + ClientApiVersionHelper.ApiVersionQueryStringDefault;
+        private const string DevicesQueryUriFormat = "/devices/query?" + ClientApiVersionHelper.ApiVersionQueryString;
         private const string WildcardEtag = "*";
 
         private const string ContinuationTokenHeader = "x-ms-continuation";
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices
         private const string ConfigurationRequestUriFormat = "/configurations/{0}?{1}";
         private const string ConfigurationsRequestUriFormat = "/configurations/?top={0}&{1}";
 
-        private const string ApplyConfigurationOnDeviceUriFormat = "/devices/{0}/applyConfigurationContent?" + ClientApiVersionHelper.ApiVersionQueryStringDefault;
+        private const string ApplyConfigurationOnDeviceUriFormat = "/devices/{0}/applyConfigurationContent?" + ClientApiVersionHelper.ApiVersionQueryString;
 
         private static readonly TimeSpan regexTimeoutMilliseconds = TimeSpan.FromMilliseconds(500);
 
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.Devices
 
             return BulkDeviceOperationsAsync<BulkRegistryOperationResult>(
                exportImportDeviceList,
-               ClientApiVersionHelper.ApiVersionQueryStringDefault,
+               ClientApiVersionHelper.ApiVersionQueryString,
                cancellationToken);
         }
 
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.Devices
         {
             return BulkDeviceOperationsAsync<BulkRegistryOperationResult>(
                 GenerateExportImportDeviceListForBulkOperations(devices, ImportMode.Create),
-                ClientApiVersionHelper.ApiVersionQueryStringDefault,
+                ClientApiVersionHelper.ApiVersionQueryString,
                 cancellationToken);
         }
 
@@ -519,7 +519,7 @@ namespace Microsoft.Azure.Devices
         {
             return BulkDeviceOperationsAsync<BulkRegistryOperationResult>(
                 GenerateExportImportDeviceListForBulkOperations(devices, forceUpdate ? ImportMode.Update : ImportMode.UpdateIfMatchETag),
-                ClientApiVersionHelper.ApiVersionQueryStringDefault,
+                ClientApiVersionHelper.ApiVersionQueryString,
                 cancellationToken);
         }
 
@@ -621,7 +621,7 @@ namespace Microsoft.Azure.Devices
         {
             return BulkDeviceOperationsAsync<BulkRegistryOperationResult>(
                 GenerateExportImportDeviceListForBulkOperations(devices, forceRemove ? ImportMode.Delete : ImportMode.DeleteIfMatchETag),
-                ClientApiVersionHelper.ApiVersionQueryStringDefault,
+                ClientApiVersionHelper.ApiVersionQueryString,
                 cancellationToken);
         }
 
@@ -1051,19 +1051,7 @@ namespace Microsoft.Azure.Devices
                 { HttpStatusCode.Forbidden, async (responseMessage) => new JobQuotaExceededException(await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage).ConfigureAwait(false))}
             };
 
-            // The new api-version is only available in a few initial regions
-            // Control access via an environment variable. If a user wishes to try it out,
-            // they can set "EnabledStorageIdentity" to "1". Otherwise, the SDK will still
-            // default to the latest, broadly-supported api-version used in this SDK.
-            string clientApiVersion = ClientApiVersionHelper.ApiVersionQueryStringDefault;
-            if (ClientApiVersionHelper.IsStorageIdentityEnabled)
-            {
-                clientApiVersion = ClientApiVersionHelper.ApiVersionQueryStringLimitedAvailability;
-            }
-            else
-            {
-                jobProperties.StorageAuthenticationType = null;
-            }
+            string clientApiVersion = ClientApiVersionHelper.ApiVersionQueryString;
 
             return _httpClientHelper.PostAsync<JobProperties, JobProperties>(
                 GetJobUri("/create", clientApiVersion),
@@ -1400,7 +1388,7 @@ namespace Microsoft.Azure.Devices
         {
             return BulkDeviceOperationsAsync<BulkRegistryOperationResult>(
                 GenerateExportImportDeviceListForTwinBulkOperations(twins, forceUpdate ? ImportMode.UpdateTwin : ImportMode.UpdateTwinIfMatchETag),
-                ClientApiVersionHelper.ApiVersionQueryStringDefault,
+                ClientApiVersionHelper.ApiVersionQueryString,
                 cancellationToken);
         }
 
@@ -1449,38 +1437,38 @@ namespace Microsoft.Azure.Devices
         private static Uri GetRequestUri(string deviceId)
         {
             deviceId = WebUtility.UrlEncode(deviceId);
-            return new Uri(RequestUriFormat.FormatInvariant(deviceId, ClientApiVersionHelper.ApiVersionQueryStringDefault), UriKind.Relative);
+            return new Uri(RequestUriFormat.FormatInvariant(deviceId, ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative);
         }
 
         private static Uri GetModulesRequestUri(string deviceId, string moduleId)
         {
             deviceId = WebUtility.UrlEncode(deviceId);
             moduleId = WebUtility.UrlEncode(moduleId);
-            return new Uri(ModulesRequestUriFormat.FormatInvariant(deviceId, moduleId, ClientApiVersionHelper.ApiVersionQueryStringDefault), UriKind.Relative);
+            return new Uri(ModulesRequestUriFormat.FormatInvariant(deviceId, moduleId, ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative);
         }
 
         private static Uri GetModulesOnDeviceRequestUri(string deviceId)
         {
             deviceId = WebUtility.UrlEncode(deviceId);
-            return new Uri(ModulesOnDeviceRequestUriFormat.FormatInvariant(deviceId, ClientApiVersionHelper.ApiVersionQueryStringDefault), UriKind.Relative);
+            return new Uri(ModulesOnDeviceRequestUriFormat.FormatInvariant(deviceId, ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative);
         }
 
         private static Uri GetModuleTwinRequestUri(string deviceId, string moduleId)
         {
             deviceId = WebUtility.UrlEncode(deviceId);
             moduleId = WebUtility.UrlEncode(moduleId);
-            return new Uri(ModuleTwinUriFormat.FormatInvariant(deviceId, moduleId, ClientApiVersionHelper.ApiVersionQueryStringDefault), UriKind.Relative);
+            return new Uri(ModuleTwinUriFormat.FormatInvariant(deviceId, moduleId, ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative);
         }
 
         private static Uri GetConfigurationRequestUri(string configurationId)
         {
             configurationId = WebUtility.UrlEncode(configurationId);
-            return new Uri(ConfigurationRequestUriFormat.FormatInvariant(configurationId, ClientApiVersionHelper.ApiVersionQueryStringDefault), UriKind.Relative);
+            return new Uri(ConfigurationRequestUriFormat.FormatInvariant(configurationId, ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative);
         }
 
         private static Uri GetConfigurationsRequestUri(int maxCount)
         {
-            return new Uri(ConfigurationsRequestUriFormat.FormatInvariant(maxCount, ClientApiVersionHelper.ApiVersionQueryStringDefault), UriKind.Relative);
+            return new Uri(ConfigurationsRequestUriFormat.FormatInvariant(maxCount, ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative);
         }
 
         private static Uri GetApplyConfigurationOnDeviceRequestUri(string deviceId)
@@ -1495,14 +1483,14 @@ namespace Microsoft.Azure.Devices
 
         // apiVersion parameter should be removed after the "next" api-version is available in all regions
         // and go back to hard-coding
-        private static Uri GetJobUri(string jobId, string apiVersion = ClientApiVersionHelper.ApiVersionQueryStringDefault)
+        private static Uri GetJobUri(string jobId, string apiVersion = ClientApiVersionHelper.ApiVersionQueryString)
         {
             return new Uri(JobsUriFormat.FormatInvariant(jobId, apiVersion), UriKind.Relative);
         }
 
         private static Uri GetDevicesRequestUri(int maxCount)
         {
-            return new Uri(DevicesRequestUriFormat.FormatInvariant(maxCount, ClientApiVersionHelper.ApiVersionQueryStringDefault), UriKind.Relative);
+            return new Uri(DevicesRequestUriFormat.FormatInvariant(maxCount, ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative);
         }
 
         private static Uri QueryDevicesRequestUri()
@@ -1512,7 +1500,7 @@ namespace Microsoft.Azure.Devices
 
         private static Uri GetAdminUri(string operation)
         {
-            return new Uri(AdminUriFormat.FormatInvariant(operation, ClientApiVersionHelper.ApiVersionQueryStringDefault), UriKind.Relative);
+            return new Uri(AdminUriFormat.FormatInvariant(operation, ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative);
         }
 
         private static Uri GetStatisticsUri()
@@ -1523,19 +1511,19 @@ namespace Microsoft.Azure.Devices
         private static Uri GetTwinUri(string deviceId)
         {
             deviceId = WebUtility.UrlEncode(deviceId);
-            return new Uri(TwinUriFormat.FormatInvariant(deviceId, ClientApiVersionHelper.ApiVersionQueryStringDefault), UriKind.Relative);
+            return new Uri(TwinUriFormat.FormatInvariant(deviceId, ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative);
         }
 
         private static Uri GetTwinTagsUri(string deviceId)
         {
             deviceId = WebUtility.UrlEncode(deviceId);
-            return new Uri(TwinTagsUriFormat.FormatInvariant(deviceId, ClientApiVersionHelper.ApiVersionQueryStringDefault), UriKind.Relative);
+            return new Uri(TwinTagsUriFormat.FormatInvariant(deviceId, ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative);
         }
 
         private static Uri GetTwinDesiredPropertiesUri(string deviceId)
         {
             deviceId = WebUtility.UrlEncode(deviceId);
-            return new Uri(TwinDesiredPropertiesUriFormat.FormatInvariant(deviceId, ClientApiVersionHelper.ApiVersionQueryStringDefault), UriKind.Relative);
+            return new Uri(TwinDesiredPropertiesUriFormat.FormatInvariant(deviceId, ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative);
         }
 
         private static void ValidateDeviceId(Device device)

--- a/iothub/service/src/HttpRegistryManager.cs
+++ b/iothub/service/src/HttpRegistryManager.cs
@@ -1481,8 +1481,6 @@ namespace Microsoft.Azure.Devices
             return new Uri(RequestUriFormat.FormatInvariant(string.Empty, apiVersionQueryString), UriKind.Relative);
         }
 
-        // apiVersion parameter should be removed after the "next" api-version is available in all regions
-        // and go back to hard-coding
         private static Uri GetJobUri(string jobId, string apiVersion = ClientApiVersionHelper.ApiVersionQueryString)
         {
             return new Uri(JobsUriFormat.FormatInvariant(jobId, apiVersion), UriKind.Relative);

--- a/iothub/service/src/HttpRegistryManager.cs
+++ b/iothub/service/src/HttpRegistryManager.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.Devices
         {
             return BulkDeviceOperationsAsync<string[]>(
                 GenerateExportImportDeviceListForBulkOperations(devices, ImportMode.Create),
-                ClientApiVersionHelper.ApiVersionQueryStringGA,
+                ClientApiVersionHelper.ApiVersionQueryString,
                 cancellationToken);
         }
 
@@ -506,7 +506,7 @@ namespace Microsoft.Azure.Devices
         {
             return BulkDeviceOperationsAsync<string[]>(
                 GenerateExportImportDeviceListForBulkOperations(devices, forceUpdate ? ImportMode.Update : ImportMode.UpdateIfMatchETag),
-                ClientApiVersionHelper.ApiVersionQueryStringGA,
+                ClientApiVersionHelper.ApiVersionQueryString,
                 cancellationToken);
         }
 
@@ -608,7 +608,7 @@ namespace Microsoft.Azure.Devices
         {
             return BulkDeviceOperationsAsync<string[]>(
                 GenerateExportImportDeviceListForBulkOperations(devices, forceRemove ? ImportMode.Delete : ImportMode.DeleteIfMatchETag),
-                ClientApiVersionHelper.ApiVersionQueryStringGA,
+                ClientApiVersionHelper.ApiVersionQueryString,
                 cancellationToken);
         }
 

--- a/iothub/service/src/JobClient/HttpJobClient.cs
+++ b/iothub/service/src/JobClient/HttpJobClient.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Devices
             EnsureInstanceNotClosed();
 
             return _httpClientHelper.PostAsync<string, JobResponse>(
-                new Uri(CancelJobUriFormat.FormatInvariant(jobId, ClientApiVersionHelper.ApiVersionQueryStringDefault), UriKind.Relative),
+                new Uri(CancelJobUriFormat.FormatInvariant(jobId, ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative),
                 null,
                 null,
                 null,
@@ -259,7 +259,7 @@ namespace Microsoft.Azure.Devices
 
         private static Uri BuildQueryJobUri(JobType? jobType, JobStatus? jobStatus)
         {
-            var stringBuilder = new StringBuilder(JobsQueryFormat.FormatInvariant(ClientApiVersionHelper.ApiVersionQueryStringDefault));
+            var stringBuilder = new StringBuilder(JobsQueryFormat.FormatInvariant(ClientApiVersionHelper.ApiVersionQueryString));
 
             if (jobType != null)
             {
@@ -276,7 +276,7 @@ namespace Microsoft.Azure.Devices
 
         private static Uri GetJobUri(string jobId)
         {
-            return new Uri(JobsUriFormat.FormatInvariant(jobId ?? string.Empty, ClientApiVersionHelper.ApiVersionQueryStringDefault), UriKind.Relative);
+            return new Uri(JobsUriFormat.FormatInvariant(jobId ?? string.Empty, ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative);
         }
     }
 }

--- a/iothub/service/src/JobProperties.cs
+++ b/iothub/service/src/JobProperties.cs
@@ -114,8 +114,6 @@ namespace Microsoft.Azure.Devices
 
         /// <summary>
         /// Specifies authentication type being used for connecting to storage account.
-        /// For a short time, the feature that uses this enum is only available in limited regions.
-        /// Enable use of it by setting an environment variable of "EnableStorageIdentity" to "1".
         /// </summary>
         [JsonProperty(PropertyName = "storageAuthenticationType", NullValueHandling = NullValueHandling.Ignore)]
         public StorageAuthenticationType? StorageAuthenticationType { get; set; }


### PR DESCRIPTION
This API version was only available in certain regions previously, but now that it is available in every region, we can make all service client operations use this

We can also get rid of the environment variable lookup that was previously used to toggle between a widely available service API version and the selectively available service api version