### PR TITLE
refactor(yaml): Make gate run in parallel fix

### DIFF
--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -22,7 +22,7 @@ jobs:
     displayName: Linux
     strategy:
       # Change maxParallel to 1 make builds run in serial rather than in parallel
-      maxParallel: 3
+      maxParallel: 100
       matrix:
         .Net Core 3.1:
           FRAMEWORK: netcoreapp3.1
@@ -121,7 +121,7 @@ jobs:
     displayName: Windows
     strategy:
       # Change maxParallel to 1 make builds run in serial rather than in parallel
-      maxParallel: 3
+      maxParallel: 100
       matrix:
         .Net Core 3.1:
           FRAMEWORK: netcoreapp3.1


### PR DESCRIPTION
3 in parallel used to be correct, since we had 3 frameworks to test for. Now that we have 4 for windows, we may as well bump up this value to a max value so we don't have to increment it each time we add a supported framework