### PR TITLE
Revert iot-hub-not-found will close the connection and reconnect

### DIFF
--- a/iothub/device/src/Common/Exceptions/IotHubSuspendedException.cs
+++ b/iothub/device/src/Common/Exceptions/IotHubSuspendedException.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DeviceMaximumQueueDepthExceededException"/> class with the message string set to the message parameter and a reference to the inner exception that is the cause of this exception.
+        /// Initializes a new instance of the <see cref="IotHubSuspendedException"/> class with the message string set to the message parameter and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">A description of the error.</param>
         /// <param name="innerException">The exception that is the cause of the current exception</param>

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTErrorAdapter.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTErrorAdapter.cs
@@ -262,10 +262,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             {
                 retException = new IotHubSuspendedException(message);
             }
-            else if (error.Condition.Equals(IotHubNotFoundError))
-            {
-                retException = new AmqpIoTResourceException(message);
-            }
             else
             {
                 retException = new IotHubException(message);


### PR DESCRIPTION
From #1382 

This PR reverts the change made in #1368 .
This is because, based on the discussion with the service team today, they have confirmed that service will send the error code :iot-hub-not-found-error over amqp, for the scenario where the hub does not exist. In this case, any retry is useless and undesirable.
Since the hub failover scenario is has a different behavior right now wrt the different protocols, any workaround that we add in the SDK has the potential to introduce more issues.

The service team is analyzing their code to come up with:

a short term fix - the service team will work to have consistency in Error Codes/Disconnection Pattern/Link Closure across AMQP and MQTT for devices in hub which is failing over. They will provide us with instructions on how the application should attempt recovery for hub failover scenarios.
long term fix - the service will provide different error codes to explicitly differentiate between “iot hub does not exist” vs “iot hub does not exist right now because it is failing over”.