### PR TITLE
Expose a way for IoTEdge to pass DeviceCapabilityModelId to IoTHub

### DIFF
--- a/iothub/device/src/AmqpTransportSettings.cs
+++ b/iothub/device/src/AmqpTransportSettings.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Azure.Devices.Client
         /// Used by Edge runtime to specify an authentication chain for Edge-to-Edge connections
         /// </summary>
         internal string AuthenticationChain { get; set; }
+
+        /// <summary>
+        /// Used by Edge runtime for Plug and Play devices
+        /// </summary>
+        internal string DeviceCapabilityModelId { get; set; }
         
         /// <summary>
         /// To enable certificate revocation check. Default to be false.

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTErrorAdapter.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTErrorAdapter.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
         public static readonly AmqpSymbol ApiVersion = AmqpIoTConstants.Vendor + ":api-version";
         public static readonly AmqpSymbol ChannelCorrelationId = AmqpIoTConstants.Vendor + ":channel-correlation-id";
         public static readonly AmqpSymbol AuthChain = AmqpIoTConstants.Vendor + ":auth-chain";
+        public static readonly AmqpSymbol DeviceCapabilityModelId = AmqpIoTConstants.Vendor + ":digital-twin-model-id";
+
 
         private const int MaxSizeInInfoMap = 32 * 1024;
 

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTSession.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTSession.cs
@@ -232,6 +232,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 amqpLinkSettings.AddProperty(AmqpIoTErrorAdapter.AuthChain, deviceIdentity.AmqpTransportSettings.AuthenticationChain);
             }
 
+            if (!deviceIdentity.AmqpTransportSettings.DeviceCapabilityModelId.IsNullOrWhiteSpace())
+            {
+                amqpLinkSettings.AddProperty(AmqpIoTErrorAdapter.DeviceCapabilityModelId, deviceIdentity.AmqpTransportSettings.DeviceCapabilityModelId);
+            }
+
             try
             {
                 SendingAmqpLink sendingLink = new SendingAmqpLink(amqpLinkSettings);
@@ -295,6 +300,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             if (!deviceIdentity.AmqpTransportSettings.AuthenticationChain.IsNullOrWhiteSpace())
             {
                 amqpLinkSettings.AddProperty(AmqpIoTErrorAdapter.AuthChain, deviceIdentity.AmqpTransportSettings.AuthenticationChain);
+            }
+
+            if (!deviceIdentity.AmqpTransportSettings.DeviceCapabilityModelId.IsNullOrWhiteSpace())
+            {
+                amqpLinkSettings.AddProperty(AmqpIoTErrorAdapter.DeviceCapabilityModelId, deviceIdentity.AmqpTransportSettings.DeviceCapabilityModelId);
             }
 
             if (correlationId != null)

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         private const string ApiVersionParam = "api-version";
         private const string DeviceClientTypeParam = "DeviceClientType";
         private const string AuthChainParam = "auth-chain";
+        private const string DeviceCapabilityModelIdParam = "digital-twin-model-id";
         private const char SegmentSeparatorChar = '/';
         private const char SingleSegmentWildcardChar = '+';
         private const char MultiSegmentWildcardChar = '#';
@@ -296,6 +297,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 if (!this.mqttTransportSettings.AuthenticationChain.IsNullOrWhiteSpace())
                 {
                     usernameString += $"&{AuthChainParam}={Uri.EscapeDataString(this.mqttTransportSettings.AuthenticationChain)}";
+                }
+
+                if (!this.mqttTransportSettings.DeviceCapabilityModelId.IsNullOrWhiteSpace())
+                {
+                    usernameString += $"&{DeviceCapabilityModelIdParam}={Uri.EscapeDataString(this.mqttTransportSettings.DeviceCapabilityModelId)}";
                 }
 
                 var connectPacket = new ConnectPacket

--- a/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
@@ -23,6 +23,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         /// </summary>
         internal string AuthenticationChain { get; set; }
 
+        /// <summary>
+        /// Used by Edge runtime to specify the device capability model ID of Plug and Play devices
+        /// </summary>
+        internal string DeviceCapabilityModelId { get; set; }
+
         private const bool DefaultCleanSession = false;
         private const bool DefaultDeviceReceiveAckCanTimeout = false;
         private const bool DefaultHasWill = false;


### PR DESCRIPTION
Currently Edge does not have any support for Plug and Play. This change adds the necessary Id, the Device Capability Model Id (referred to as "digital-twin-model-id"). Edge can set the property via reflection and the SDK will send the ID along to IoTHub so that the device is successfully registered as a PNP device with its DCMID. 

This PR is very similar to https://github.com/Azure/azure-iot-sdk-csharp/commit/ae85bab9d8e62a990c4238da3cf7d3105921a315

In that change, we added a way for IoTEdge to change the authentication chain via reflection to pass to IoTHub. 

This change does the exact same thing, but instead with the DeviceCapabilityModelId that is needed for Plug and Play devices. 

Note: The name of the DeviceCapabilityModelId might be moving towards just ModelId or CapabilityModelId. 
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
