### PR TITLE
feat(iot-dev): Add client options to module client constructors

### DIFF
--- a/iothub/device/src/ClientOptions.cs
+++ b/iothub/device/src/ClientOptions.cs
@@ -4,12 +4,12 @@
 namespace Microsoft.Azure.Devices.Client
 {
     /// <summary>
-    /// Options that allow configuration of the device client instance during initialization.
+    /// Options that allow configuration of the device or module client instance during initialization.
     /// </summary>
     public class ClientOptions
     {
         /// <summary>
-        /// The digital twins model Id associated with the device client instance.
+        /// The digital twins model Id associated with the device or module client instance.
         /// This feature is currently supported only over MQTT.
         /// </summary>
         public string ModelId { get; set; }

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -47,10 +47,11 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
         /// <param name="authenticationMethod">The authentication method that is used</param>
+        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>ModuleClient</returns>
-        public static ModuleClient Create(string hostname, IAuthenticationMethod authenticationMethod)
+        public static ModuleClient Create(string hostname, IAuthenticationMethod authenticationMethod, ClientOptions options = default)
         {
-            return Create(() => ClientFactory.Create(hostname, authenticationMethod));
+            return Create(() => ClientFactory.Create(hostname, authenticationMethod, options));
         }
 
         /// <summary>
@@ -59,10 +60,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
         /// <param name="authenticationMethod">The authentication method that is used</param>
         /// <param name="gatewayHostname">The fully-qualified DNS hostname of Gateway</param>
+        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>ModuleClient</returns>
-        public static ModuleClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod)
+        public static ModuleClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod, ClientOptions options = default)
         {
-            return Create(() => ClientFactory.Create(hostname, gatewayHostname, authenticationMethod));
+            return Create(() => ClientFactory.Create(hostname, gatewayHostname, authenticationMethod, options));
         }
 
         /// <summary>
@@ -71,10 +73,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
         /// <param name="authenticationMethod">The authentication method that is used</param>
         /// <param name="transportType">The transportType used (Http1 or Amqp)</param>
+        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>ModuleClient</returns>
-        public static ModuleClient Create(string hostname, IAuthenticationMethod authenticationMethod, TransportType transportType)
+        public static ModuleClient Create(string hostname, IAuthenticationMethod authenticationMethod, TransportType transportType, ClientOptions options = default)
         {
-            return Create(() => ClientFactory.Create(hostname, authenticationMethod, transportType));
+            return Create(() => ClientFactory.Create(hostname, authenticationMethod, transportType, options));
         }
 
         /// <summary>
@@ -84,10 +87,12 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="gatewayHostname">The fully-qualified DNS hostname of Gateway</param>
         /// <param name="authenticationMethod">The authentication method that is used</param>
         /// <param name="transportType">The transportType used (Http1 or Amqp)</param>
+        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>ModuleClient</returns>
-        public static ModuleClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod, TransportType transportType)
+        public static ModuleClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod, 
+            TransportType transportType, ClientOptions options = default)
         {
-            return Create(() => ClientFactory.Create(hostname, gatewayHostname, authenticationMethod, transportType));
+            return Create(() => ClientFactory.Create(hostname, gatewayHostname, authenticationMethod, transportType, options));
         }
 
         /// <summary>
@@ -96,11 +101,12 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="hostname">The fully-qualified DNS hostname of IoT Hub</param>
         /// <param name="authenticationMethod">The authentication method that is used</param>
         /// <param name="transportSettings">Prioritized list of transportTypes and their settings</param>
+        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>ModuleClient</returns>
         public static ModuleClient Create(string hostname, IAuthenticationMethod authenticationMethod,
-            ITransportSettings[] transportSettings)
+            ITransportSettings[] transportSettings, ClientOptions options = default)
         {
-            return Create(() => ClientFactory.Create(hostname, authenticationMethod, transportSettings));
+            return Create(() => ClientFactory.Create(hostname, authenticationMethod, transportSettings, options));
         }
 
         /// <summary>
@@ -110,21 +116,23 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="gatewayHostname">The fully-qualified DNS hostname of Gateway</param>
         /// <param name="authenticationMethod">The authentication method that is used</param>
         /// <param name="transportSettings">Prioritized list of transportTypes and their settings</param>
+        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>ModuleClient</returns>
         public static ModuleClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod,
-            ITransportSettings[] transportSettings)
+            ITransportSettings[] transportSettings, ClientOptions options = default)
         {
-            return Create(() => ClientFactory.Create(hostname, gatewayHostname, authenticationMethod, transportSettings));
+            return Create(() => ClientFactory.Create(hostname, gatewayHostname, authenticationMethod, transportSettings, options));
         }
 
         /// <summary>
         /// Create a ModuleClient using Amqp transport from the specified connection string
         /// </summary>
         /// <param name="connectionString">Connection string for the IoT hub (including DeviceId)</param>
+        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>ModuleClient</returns>
-        public static ModuleClient CreateFromConnectionString(string connectionString)
+        public static ModuleClient CreateFromConnectionString(string connectionString, ClientOptions options = default)
         {
-            return Create(() => ClientFactory.CreateFromConnectionString(connectionString));
+            return Create(() => ClientFactory.CreateFromConnectionString(connectionString, options));
         }
 
         /// <summary>
@@ -132,10 +140,11 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="connectionString">Connection string for the IoT hub (including DeviceId)</param>
         /// <param name="transportType">Specifies whether Amqp or Http transport is used</param>
+        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>ModuleClient</returns>
-        public static ModuleClient CreateFromConnectionString(string connectionString, TransportType transportType)
+        public static ModuleClient CreateFromConnectionString(string connectionString, TransportType transportType, ClientOptions options = default)
         {
-            return Create(() => ClientFactory.CreateFromConnectionString(connectionString, transportType));
+            return Create(() => ClientFactory.CreateFromConnectionString(connectionString, transportType, options));
         }
 
         /// <summary>
@@ -143,11 +152,12 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="connectionString">Connection string for the IoT hub (with DeviceId)</param>
         /// <param name="transportSettings">Prioritized list of transports and their settings</param>
+        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>ModuleClient</returns>
         public static ModuleClient CreateFromConnectionString(string connectionString,
-            ITransportSettings[] transportSettings)
+            ITransportSettings[] transportSettings, ClientOptions options = default)
         {
-            return Create(() => ClientFactory.CreateFromConnectionString(connectionString, transportSettings));
+            return Create(() => ClientFactory.CreateFromConnectionString(connectionString, transportSettings, options));
         }
 
         /// <summary>

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -295,9 +295,9 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     Debug.Assert(this.mqttTransportSettings.ClientCertificate != null);
                 }
 
-                // This check is added to enable the device client to avail plug and play features. For devices that pass in the model Id, the SDK will enable plug and play features
-                // by using the PnP-enabled service API version, and appending the model Id to the MQTT CONNECT packet (in the username).
-                // For devices that do not have the model Id set, the SDK will use the GA service API version. 
+                // This check is added to enable the device or module client to available plug and play features. For devices or modules that pass in the model Id, 
+                // the SDK will enable plug and play features by using the PnP-enabled service API version, and appending the model Id to the MQTT CONNECT packet (in the username).
+                // For devices or modules that do not have the model Id set, the SDK will use the GA service API version. 
                 string serviceParams = null;
                 if (string.IsNullOrWhiteSpace(_options?.ModelId))
                 {

--- a/iothub/device/tests/ModuleClientTests.cs
+++ b/iothub/device/tests/ModuleClientTests.cs
@@ -73,6 +73,22 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
+        public void ModuleClient_CreateFromConnectionString_WithClientOptions()
+        {
+            // setup
+            var clientOptions = new ClientOptions
+            {
+                ModelId = "tempModuleId"
+            };
+
+            // act
+            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, clientOptions);
+
+            // assert
+            Assert.IsNotNull(moduleClient);
+        }
+
+        [TestMethod]
         // Tests_SRS_DEVICECLIENT_33_003: [** It shall EnableEventReceiveAsync when called for the first time. **]**
         public async Task ModuleClient_SetReceiveCallbackAsync_SetCallback()
         {

--- a/iothub/device/tests/ModuleClientTests.cs
+++ b/iothub/device/tests/ModuleClientTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        public void ModuleClient_CreateFromConnectionString_WithClientOptions()
+        public void ModuleClient_CreateFromConnectionStringWithClientOptions_DoesNotThrow()
         {
             // setup
             var clientOptions = new ClientOptions
@@ -83,9 +83,6 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // act
             var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, clientOptions);
-
-            // assert
-            Assert.IsNotNull(moduleClient);
         }
 
         [TestMethod]


### PR DESCRIPTION
This will allow user to set the module ID when setting up the module client

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
Change the constructors of the module client to allow passing in client options

## Reference/Link to the issue solved with this PR (if any)
PBI 7468678
