### PR TITLE
fix(iot-device): Fix file upload operation for x509 auth based devices

### DIFF
--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -153,15 +153,6 @@ namespace Microsoft.Azure.Devices.Client
 
             if (options != null && options.FileUploadTransportSettings != null)
             {
-                var fileUploadTransportSettings = options.FileUploadTransportSettings;
-                if (fileUploadTransportSettings.ClientCertificate == null)
-                {
-                    // Kind of strange to take file upload transport settings from the non-file upload transport settings,
-                    // but this is the established behavior from when upload to blob didn't have transport settings,
-                    // and it shouldn't be broken for existing users
-                    fileUploadTransportSettings.ClientCertificate = Certificate;
-                }
-
                 _fileUploadHttpTransportHandler = new HttpTransportHandler(pipelineContext, IotHubConnectionString, options.FileUploadTransportSettings);
             }
             else


### PR DESCRIPTION
The X509 device auth certificates are not a required parameter that is set in the `InternalClient` constructor, instead, it is set after the `InternalClient` instance has been initialized. As a result, the `_fileUploadHttpTransportHandler` initialized in the `InternalClient` constructor was never aware of any certificate information.
The reason it works for non file upload transport handlers is because those transport handlers are initialized at the end of the delegating pipeline, and at that point, all transport related information has been properly set.