### PR TITLE
fix(e2e-tests): Update the E2E resources ARM template to increase delivery count

### DIFF
--- a/e2e/test/prerequisites/E2ETestsSetup/e2eTestsArmTemplate.json
+++ b/e2e/test/prerequisites/E2ETestsSetup/e2eTestsArmTemplate.json
@@ -246,23 +246,23 @@
         "eventHubEndpoints": {
           "events": {
             "retentionTimeInDays": 1,
-            "partitionCount": 4
+            "partitionCount": 10
           }
         },
         "cloudToDevice": {
           "defaultTtlAsIso8601": "PT1H",
-          "maxDeliveryCount": 10,
+          "maxDeliveryCount": 100,
           "feedback": {
             "ttlAsIso8601": "PT1H",
-            "lockDurationAsIso8601": "PT60S",
-            "maxDeliveryCount": 10
+            "lockDurationAsIso8601": "PT5S",
+            "maxDeliveryCount": 100
           }
         },
         "messagingEndpoints": {
           "fileNotifications": {
             "ttlAsIso8601": "PT1H",
-            "lockDurationAsIso8601": "PT1M",
-            "maxDeliveryCount": 10
+            "lockDurationAsIso8601": "PT5S",
+            "maxDeliveryCount": 100
           }
         },
         "StorageEndPoints": {


### PR DESCRIPTION
- Increase the c2d message and file upload notification delivery counts
- Decrease c2d message and file upload notification lock duration
- Increase the no of partitions on our event hub instance

Increasing the max delivery count for file upload operation has resulted in a significant decrease in file upload e2e test failures (notifications not being received).