### PR TITLE
fix(iot-device): Fix for retrieving message system properties over Http

### DIFF
--- a/e2e/test/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
+++ b/e2e/test/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             Client.Message testMessage = ComposeD2CSecurityTestMessage(out string eventId, out string payload, out string p1Value);
             await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
 
-            await ValidateEventAsync(deviceId, eventId, payload, p1Value, logAnalticsTestClient).ConfigureAwait(false);
+            await ValidateEventAsync(deviceId, testMessage, eventId, payload, p1Value, logAnalticsTestClient).ConfigureAwait(false);
         }
 
         private async Task SendSingleSecurityMessageModuleAsync(
@@ -180,17 +180,18 @@ namespace Microsoft.Azure.Devices.E2ETests
             Client.Message testMessage = ComposeD2CSecurityTestMessage(out string eventId, out string payload, out string p1Value);
             await moduleClient.SendEventAsync(testMessage).ConfigureAwait(false);
 
-            await ValidateEventAsync(deviceId, eventId, payload, p1Value, logAnalticsTestClient).ConfigureAwait(false);
+            await ValidateEventAsync(deviceId, testMessage, eventId, payload, p1Value, logAnalticsTestClient).ConfigureAwait(false);
         }
 
         private async Task ValidateEventAsync(
             string deviceId,
+            Client.Message message,
             string eventId,
             string payload,
             string p1Value,
             AzureSecurityCenterForIoTLogAnalyticsClient logAnalticsTestClient)
         {
-            bool isReceivedEventHub = EventHubTestListener.VerifyIfMessageIsReceived(deviceId, payload, p1Value, TimeSpan.FromSeconds(10));
+            bool isReceivedEventHub = EventHubTestListener.VerifyIfMessageIsReceived(deviceId, message, payload, p1Value, TimeSpan.FromSeconds(10));
             Assert.IsFalse(isReceivedEventHub, "Security message received in customer event hub.");
             bool isReceivedOms = await logAnalticsTestClient.IsRawEventExist(deviceId, eventId).ConfigureAwait(false);
             Assert.IsTrue(isReceivedOms, "Security message was not received in customer log analytics");

--- a/e2e/test/EventHubTestListener.cs
+++ b/e2e/test/EventHubTestListener.cs
@@ -42,14 +42,14 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         // verify required message is present in the dictionary
-        public static bool VerifyIfMessageIsReceived(string deviceId, string payload, string p1Value, TimeSpan? maxWaitTime = null)
+        public static bool VerifyIfMessageIsReceived(string deviceId, Client.Message message, string payload, string p1Value, TimeSpan? maxWaitTime = null)
         {
             if (!maxWaitTime.HasValue)
             {
                 maxWaitTime = s_maximumWaitTime;
             }
 
-            s_log.WriteLine($"Expected payload: deviceId={deviceId}; payload={payload}; property1={p1Value}");
+            s_log.WriteLine($"Expected payload: deviceId={deviceId}; messageId = {message.MessageId}, userId={message.UserId}, payload={payload}; property1={p1Value}");
 
             bool isReceived = false;
 
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     continue;
                 }
 
-                isReceived = VerifyTestMessage(eventData, deviceId, p1Value);
+                isReceived = VerifyTestMessage(eventData, deviceId, message, p1Value);
             }
 
             sw.Stop();
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 #endif
         }
 
-        private static bool VerifyTestMessage(EventData eventData, string deviceName, string p1Value)
+        private static bool VerifyTestMessage(EventData eventData, string deviceName, Client.Message message, string p1Value)
         {
 #if NET451
             var connectionDeviceId = eventData.SystemProperties["iothub-connection-device-id"].ToString();

--- a/e2e/test/FaultInjectionPoolAmqpTests.MessageReceiveFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/FaultInjectionPoolAmqpTests.MessageReceiveFaultInjectionPoolAmqpTests.cs
@@ -618,7 +618,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
             {
-                (Message msg, string messageId, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage();
+                (Message msg, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage();
                 _log.WriteLine($"{nameof(FaultInjectionPoolAmqpTests)}: Sending message to device {testDevice.Id}: payload='{payload}' p1Value='{p1Value}'");
                 await serviceClient.SendAsync(testDevice.Id, msg)
                 .ConfigureAwait(false);
@@ -626,7 +626,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 _log.WriteLine($"{nameof(FaultInjectionPoolAmqpTests)}: Preparing to receive message for device {testDevice.Id}");
                 await deviceClient.OpenAsync()
                 .ConfigureAwait(false);
-                await MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, testDevice.Id, payload, p1Value)
+                await MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, testDevice.Id, msg, payload)
                 .ConfigureAwait(false);
             };
 

--- a/e2e/test/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -866,12 +866,12 @@ namespace Microsoft.Azure.Devices.E2ETests
                 _log.WriteLine($"{nameof(FaultInjectionPoolAmqpTests)}: Preparing to send message for device {testDevice.Id}");
                 await deviceClient.OpenAsync().ConfigureAwait(false);
 
-                (Client.Message testMessage, string messageId, string payload, string p1Value) = MessageSendE2ETests.ComposeD2cTestMessage();
+                (Client.Message testMessage, string payload, string p1Value) = MessageSendE2ETests.ComposeD2cTestMessage();
 
                 _log.WriteLine($"{nameof(FaultInjectionPoolAmqpTests)}.{testDevice.Id}: payload='{payload}' p1Value='{p1Value}'");
                 await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
 
-                bool isReceived = EventHubTestListener.VerifyIfMessageIsReceived(testDevice.Id, payload, p1Value);
+                bool isReceived = EventHubTestListener.VerifyIfMessageIsReceived(testDevice.Id, testMessage, payload, p1Value);
                 Assert.IsTrue(isReceived, $"Message is not received for device {testDevice.Id}.");
             };
 

--- a/e2e/test/MessageFeedbackE2ETests.cs
+++ b/e2e/test/MessageFeedbackE2ETests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 var messages = new List<Client.Message>();
                 for (int i = 0; i < MESSAGE_COUNT; i++)
                 {
-                    (Message msg, string messageId, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage();
+                    (Message msg, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage();
                     await serviceClient.SendAsync(testDevice.Id, msg).ConfigureAwait(false);
                     Client.Message message = await deviceClient.ReceiveAsync(TIMESPAN_ONE_MINUTE).ConfigureAwait(false);
                     if (message == null)

--- a/e2e/test/MessageReceiveFaultInjectionTests.cs
+++ b/e2e/test/MessageReceiveFaultInjectionTests.cs
@@ -204,9 +204,9 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
                 {
-                    (Message message, string messageId, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage();
+                    (Message message, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage();
                     await serviceClient.SendAsync(testDevice.Id, message).ConfigureAwait(false);
-                    await MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, testDevice.Id, payload, p1Value).ConfigureAwait(false);
+                    await MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, testDevice.Id, message, payload).ConfigureAwait(false);
                 };
 
                 Func<Task> cleanupOperation = () =>

--- a/e2e/test/MessageSendE2EPoolAmqpTests.cs
+++ b/e2e/test/MessageSendE2EPoolAmqpTests.cs
@@ -130,11 +130,11 @@ namespace Microsoft.Azure.Devices.E2ETests
                 s_log.WriteLine($"{nameof(MessageSendE2EPoolAmqpTests)}: Preparing to send message for device {testDevice.Id}");
                 await deviceClient.OpenAsync().ConfigureAwait(false);
 
-                (Client.Message testMessage, string messageId, string payload, string p1Value) = MessageSendE2ETests.ComposeD2cTestMessage();
-                s_log.WriteLine($"{nameof(MessageSendE2EPoolAmqpTests)}.{testDevice.Id}: messageId='{messageId}' payload='{payload}' p1Value='{p1Value}'");
+                (Client.Message testMessage, string payload, string p1Value) = MessageSendE2ETests.ComposeD2cTestMessage();
+                s_log.WriteLine($"{nameof(MessageSendE2EPoolAmqpTests)}.{testDevice.Id}: messageId='{testMessage.MessageId}' payload='{payload}' p1Value='{p1Value}'");
                 await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
 
-                bool isReceived = EventHubTestListener.VerifyIfMessageIsReceived(testDevice.Id, payload, p1Value);
+                bool isReceived = EventHubTestListener.VerifyIfMessageIsReceived(testDevice.Id, testMessage, payload, p1Value);
                 Assert.IsTrue(isReceived, "Message is not received.");
             };
 

--- a/e2e/test/MessageSendE2ETests.cs
+++ b/e2e/test/MessageSendE2ETests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -300,48 +301,51 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             if (messageSize == 0)
             {
-                (testMessage, _, payload, p1Value) = ComposeD2cTestMessage();
+                (testMessage, payload, p1Value) = ComposeD2cTestMessage();
             }
             else
             {
-                (testMessage, _, payload, p1Value) = ComposeD2cTestMessageOfSpecifiedSize(messageSize);
+                (testMessage, payload, p1Value) = ComposeD2cTestMessageOfSpecifiedSize(messageSize);
             }
 
             using (testMessage)
             {
                 await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
 
-                bool isReceived = EventHubTestListener.VerifyIfMessageIsReceived(deviceId, payload, p1Value);
+                bool isReceived = EventHubTestListener.VerifyIfMessageIsReceived(deviceId, testMessage, payload, p1Value);
                 Assert.IsTrue(isReceived, "Message is not received.");
             }
         }
 
         public static async Task SendSendBatchMessagesAndVerifyAsync(DeviceClient deviceClient, string deviceId)
         {
-            var messages = new List<Client.Message>();
+            var messagesToBeSent = new Dictionary<Client.Message, Tuple<string, string>>();
 
             try
             {
                 var props = new List<Tuple<string, string>>();
                 for (int i = 0; i < MessageBatchCount; i++)
                 {
-                    (Client.Message testMessage, string messageId, string payload, string p1Value) = ComposeD2cTestMessage();
-                    messages.Add(testMessage);
-                    props.Add(Tuple.Create(payload, p1Value));
+                    (Client.Message testMessage, string payload, string p1Value) = ComposeD2cTestMessage();
+                    messagesToBeSent.Add(testMessage, Tuple.Create(payload, p1Value));
                 }
 
-                await deviceClient.SendEventBatchAsync(messages).ConfigureAwait(false);
+                await deviceClient.SendEventBatchAsync(messagesToBeSent.Keys.ToList()).ConfigureAwait(false);
 
-                foreach (Tuple<string, string> prop in props)
+                foreach (KeyValuePair<Client.Message, Tuple<string, string>> messageEntry in messagesToBeSent)
                 {
-                    bool isReceived = EventHubTestListener.VerifyIfMessageIsReceived(deviceId, prop.Item1, prop.Item2);
+                    Client.Message message = messageEntry.Key;
+                    Tuple<string, string> prop = messageEntry.Value;
+
+                    bool isReceived = EventHubTestListener.VerifyIfMessageIsReceived(deviceId, message, prop.Item1, prop.Item2);
                     Assert.IsTrue(isReceived, "Message is not received.");
                 }
             }
             finally
             {
-                foreach (Client.Message message in messages)
+                foreach (KeyValuePair<Client.Message, Tuple<string, string>> messageEntry in messagesToBeSent)
                 {
+                    Client.Message message = messageEntry.Key;
                     message.Dispose();
                 }
             }
@@ -349,35 +353,37 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         private async Task SendSingleMessageModuleAndVerifyAsync(ModuleClient moduleClient, string deviceId)
         {
-            (Client.Message testMessage, string messageId, string payload, string p1Value) = ComposeD2cTestMessage();
+            (Client.Message testMessage, string payload, string p1Value) = ComposeD2cTestMessage();
 
             using (testMessage)
             {
                 await moduleClient.SendEventAsync(testMessage).ConfigureAwait(false);
 
-                bool isReceived = EventHubTestListener.VerifyIfMessageIsReceived(deviceId, payload, p1Value);
+                bool isReceived = EventHubTestListener.VerifyIfMessageIsReceived(deviceId, testMessage, payload, p1Value);
                 Assert.IsTrue(isReceived, "Message is not received.");
             }
         }
 
-        public static (Client.Message message, string messageId, string payload, string p1Value) ComposeD2cTestMessage()
+        public static (Client.Message message, string payload, string p1Value) ComposeD2cTestMessage()
         {
             string messageId = Guid.NewGuid().ToString();
             string payload = Guid.NewGuid().ToString();
             string p1Value = Guid.NewGuid().ToString();
+            string userId = Guid.NewGuid().ToString();
 
-            _log.WriteLine($"{nameof(ComposeD2cTestMessage)}: messageId='{messageId}' payload='{payload}' p1Value='{p1Value}'");
+            _log.WriteLine($"{nameof(ComposeD2cTestMessage)}: messageId='{messageId}' userId='{userId}' payload='{payload}' p1Value='{p1Value}'");
             var message = new Client.Message(Encoding.UTF8.GetBytes(payload))
             {
                 MessageId = messageId,
+                UserId = userId,
             };
             message.Properties.Add("property1", p1Value);
             message.Properties.Add("property2", null);
 
-            return (message, messageId, payload, p1Value);
+            return (message, payload, p1Value);
         }
 
-        public static (Client.Message message, string messageId, string payload, string p1Value) ComposeD2cTestMessageOfSpecifiedSize(int messageSize)
+        public static (Client.Message message, string payload, string p1Value) ComposeD2cTestMessageOfSpecifiedSize(int messageSize)
         {
             string messageId = Guid.NewGuid().ToString();
             string payload = $"{Guid.NewGuid()}_{new string('*', messageSize)}";
@@ -391,7 +397,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             message.Properties.Add("property1", p1Value);
             message.Properties.Add("property2", null);
 
-            return (message, messageId, payload, p1Value);
+            return (message, payload, p1Value);
         }
 
         public void Dispose()

--- a/e2e/test/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/MessageSendFaultInjectionTests.cs
@@ -409,11 +409,11 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
             {
-                (Client.Message testMessage, string messageId, string payload, string p1Value) = MessageSendE2ETests.ComposeD2cTestMessage();
+                (Client.Message testMessage, string payload, string p1Value) = MessageSendE2ETests.ComposeD2cTestMessage();
                 await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
 
                 bool isReceived = false;
-                isReceived = EventHubTestListener.VerifyIfMessageIsReceived(testDevice.Id, payload, p1Value);
+                isReceived = EventHubTestListener.VerifyIfMessageIsReceived(testDevice.Id, testMessage, payload, p1Value);
                 Assert.IsTrue(isReceived);
             };
 


### PR DESCRIPTION
An IoT Hub message is composed of -
- payload
- some pre-defined system properties
- user defined application properties

https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-construct

Some of the system properties are writeable by the SDK, others are populated only by the service.

This PR makes sure that system properties expected in c2d messages are parsed and returned properly by the SDK, over Http. Amqp and Mqtt currently do parse these properties as expected.