### PR TITLE
feat(iothub-service): Expose DTDL model Id property for pnp devices.

### DIFF
--- a/iothub/service/src/Device.cs
+++ b/iothub/service/src/Device.cs
@@ -110,5 +110,13 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         [JsonProperty(PropertyName = "deviceScope", NullValueHandling = NullValueHandling.Ignore)]
         public virtual string Scope { get; set; }
+
+        /// <summary>
+        /// The DTDL model id of the device.
+        /// The value will be null for a non-pnp device.
+        /// The value will be null for a pnp device until the device connects and registers with the model id.
+        /// </summary>
+        [JsonProperty(PropertyName = "digital-twin-model-id", NullValueHandling = NullValueHandling.Ignore)]
+        public virtual string ModelId { get; set; }
     }
 }


### PR DESCRIPTION
## Description of the changes
Exposing the DTDL model Id on the device identity object.
This property will be returned on GET calls once we call the service with the new API version. Until then this should have no side effects.

## Reference/Link to the issue solved with this PR (if any)
https://msazure.visualstudio.com/One/_workitems/edit/7479580
