### PR TITLE
feat(iot-device): Add ClientOptions argument to ModuleClient creation…

### DIFF
--- a/iothub/device/src/Edge/EdgeModuleClientFactory.cs
+++ b/iothub/device/src/Edge/EdgeModuleClientFactory.cs
@@ -33,16 +33,19 @@ namespace Microsoft.Azure.Devices.Client.Edge
 
         private readonly ITransportSettings[] _transportSettings;
         private readonly ITrustBundleProvider _trustBundleProvider;
+        private readonly ClientOptions _options;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EdgeModuleClientFactory"/> class with transport settings.
         /// </summary>
         /// <param name="transportSettings">Prioritized list of transportTypes and their settings.</param>
         /// <param name="trustBundleProvider">Provider implementation to get trusted bundle for certificate validation.</param>
-        public EdgeModuleClientFactory(ITransportSettings[] transportSettings, ITrustBundleProvider trustBundleProvider)
+        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
+        public EdgeModuleClientFactory(ITransportSettings[] transportSettings, ITrustBundleProvider trustBundleProvider, ClientOptions options = default)
         {
             _transportSettings = transportSettings ?? throw new ArgumentNullException(nameof(transportSettings));
             _trustBundleProvider = trustBundleProvider ?? throw new ArgumentNullException(nameof(trustBundleProvider));
+            _options = options;
         }
 
         /// <summary>
@@ -72,7 +75,7 @@ namespace Microsoft.Azure.Devices.Client.Edge
                     certificateValidator = GetCertificateValidator(new List<X509Certificate2>() { expectedRoot });
                 }
 
-                return new ModuleClient(CreateInternalClientFromConnectionString(connectionString), certificateValidator);
+                return new ModuleClient(CreateInternalClientFromConnectionString(connectionString, _options), certificateValidator);
             }
             else
             {
@@ -101,7 +104,7 @@ namespace Microsoft.Azure.Devices.Client.Edge
                     certificateValidator = GetCertificateValidator(certs);
                 }
 
-                return new ModuleClient(CreateInternalClientFromAuthenticationMethod(hostname, gateway, authMethod), certificateValidator);
+                return new ModuleClient(CreateInternalClientFromAuthenticationMethod(hostname, gateway, authMethod, _options), certificateValidator);
             }
         }
 
@@ -127,14 +130,14 @@ namespace Microsoft.Azure.Devices.Client.Edge
             return NullCertificateValidator.Instance;
         }
 
-        private InternalClient CreateInternalClientFromConnectionString(string connectionString)
+        private InternalClient CreateInternalClientFromConnectionString(string connectionString, ClientOptions options)
         {
-            return ClientFactory.CreateFromConnectionString(connectionString, _transportSettings);
+            return ClientFactory.CreateFromConnectionString(connectionString, _transportSettings, options);
         }
 
-        private InternalClient CreateInternalClientFromAuthenticationMethod(string hostname, string gateway, IAuthenticationMethod authMethod)
+        private InternalClient CreateInternalClientFromAuthenticationMethod(string hostname, string gateway, IAuthenticationMethod authMethod, ClientOptions options)
         {
-            return ClientFactory.Create(hostname, gateway, authMethod, _transportSettings);
+            return ClientFactory.Create(hostname, gateway, authMethod, _transportSettings, options);
         }
 
         private static string GetValueFromEnvironment(IDictionary envVariables, string variableName)

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -164,10 +164,11 @@ namespace Microsoft.Azure.Devices.Client
         /// Creates a ModuleClient instance in an IoT Edge deployment
         /// based on environment variables.
         /// </summary>
+        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>ModuleClient instance</returns>
-        public static Task<ModuleClient> CreateFromEnvironmentAsync()
+        public static Task<ModuleClient> CreateFromEnvironmentAsync(ClientOptions options = default)
         {
-            return CreateFromEnvironmentAsync(TransportType.Amqp);
+            return CreateFromEnvironmentAsync(TransportType.Amqp, options);
         }
 
         /// <summary>
@@ -175,10 +176,11 @@ namespace Microsoft.Azure.Devices.Client
         /// based on environment variables.
         /// </summary>
         /// <param name="transportType">Specifies whether Amqp or Http transport is used</param>
+        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>ModuleClient instance</returns>
-        public static Task<ModuleClient> CreateFromEnvironmentAsync(TransportType transportType)
+        public static Task<ModuleClient> CreateFromEnvironmentAsync(TransportType transportType, ClientOptions options = default)
         {
-            return CreateFromEnvironmentAsync(ClientFactory.GetTransportSettings(transportType));
+            return CreateFromEnvironmentAsync(ClientFactory.GetTransportSettings(transportType), options);
         }
 
         /// <summary>
@@ -186,10 +188,11 @@ namespace Microsoft.Azure.Devices.Client
         /// based on environment variables.
         /// </summary>
         /// <param name="transportSettings">Prioritized list of transports and their settings</param>
+        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>ModuleClient instance</returns>
-        public static Task<ModuleClient> CreateFromEnvironmentAsync(ITransportSettings[] transportSettings)
+        public static Task<ModuleClient> CreateFromEnvironmentAsync(ITransportSettings[] transportSettings, ClientOptions options = default)
         {
-            return new EdgeModuleClientFactory(transportSettings, new TrustBundleProvider()).CreateAsync();
+            return new EdgeModuleClientFactory(transportSettings, new TrustBundleProvider(), options).CreateAsync();
         }
 
         private static ModuleClient Create(Func<InternalClient> internalClientCreator)

--- a/iothub/device/tests/Edge/EdgeModuleClientFactoryTest.cs
+++ b/iothub/device/tests/Edge/EdgeModuleClientFactoryTest.cs
@@ -45,6 +45,24 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         }
 
         [TestMethod]
+        public void TestCreate_FromConnectionStringEnvironment_ShouldCreateClientWithOptions()
+        {
+            // setup
+            var clientOptions = new ClientOptions
+            {
+                ModelId = "tempModuleId"
+            };
+            Environment.SetEnvironmentVariable(EdgehubConnectionstringVariableName, this.iotHubConnectionString);
+
+            // act
+            ModuleClient dc = ModuleClient.CreateFromEnvironmentAsync(clientOptions).Result;
+
+            Assert.IsNotNull(dc);
+
+            Environment.SetEnvironmentVariable(EdgehubConnectionstringVariableName, null);
+        }
+
+        [TestMethod]
         public void TestCreate_FromConnectionStringEnvironment_SetTransportType_ShouldCreateClient()
         {
             Environment.SetEnvironmentVariable(EdgehubConnectionstringVariableName, this.iotHubConnectionString);


### PR DESCRIPTION
… with environment variables

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
Add ClientOptions argument to the ModuleClient creation APIs

