### PR TITLE
refactor(vsts): Skip all pnp tests for preview code

### DIFF
--- a/vsts/gatedBuild.ps1
+++ b/vsts/gatedBuild.ps1
@@ -60,6 +60,9 @@ else
 	#Likely a nightly or CI build
 	Write-Host "Not a pull request build, will run all tests"
 	$runTestCmd += " -unittests -e2etests"
+
+	Write-Host "SKIPPING ALL PNP TESTS REGARDLESS"
+	$runTestCmd += " -skipPnPTests"
 }
 
 

--- a/vsts/releaseTest.ps1
+++ b/vsts/releaseTest.ps1
@@ -16,6 +16,10 @@ Write-Host List active docker containers
 docker ps -a
 
 $runTestCmd = ".\build.ps1 -build -clean -configuration RELEASE -framework $env:FRAMEWORK -e2etests"
+
+Write-Host "SKIPPING ALL PNP TESTS REGARDLESS"
+$runTestCmd += " -skipPnPTests"
+
 Invoke-Expression $runTestCmd
 
 $gateFailed = $LASTEXITCODE


### PR DESCRIPTION
PnP code, and by extension, pnp tests have not been updated to reflect the latest service side changes.
Hence, these tests are being skipped, until we start working on pnp changes again.