### PR TITLE
fix(e2e): Fix issue with script causing laptop issues

### DIFF
--- a/e2e/test/prerequisites/E2ETestsSetup/e2eTestsSetup.ps1
+++ b/e2e/test/prerequisites/E2ETestsSetup/e2eTestsSetup.ps1
@@ -123,6 +123,7 @@ if (-not ($keyVaultName -match "^[a-zA-Z][a-zA-Z0-9-]{1,22}[a-zA-Z0-9]$"))
 # New certs will be generated each time you run the script as the script cleans up in the end
 ########################################################################################################
 
+$subjectPrefix = "IoT Test"
 $rootCommonName = "$subjectPrefix Test Root CA"
 $intermediateCert1CommonName = "$subjectPrefix Intermediate 1 CA"
 $intermediateCert2CommonName = "$subjectPrefix Intermediate 2 CA"


### PR DESCRIPTION
Fixing the script that was causing windows account issues. The wrong certs were getting deleted and this should fix the problem and noone should run into this issue. 
I have a TODO to add user prompt before deleting any certs so that we know what the script is deleting before deleting. 