### PR TITLE
refactor(iot-service): Model Id changes for Twin

### DIFF
--- a/shared/src/TwinJsonConverter.cs
+++ b/shared/src/TwinJsonConverter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices.Shared
         private const string CloudToDeviceMessageCountTag = "cloudToDeviceMessageCount";
         private const string AuthenticationTypeTag = "authenticationType";
         private const string X509ThumbprintTag = "x509Thumbprint";
-        private const string ModelId = "digital-twin-model-id";
+        private const string ModelId = "modelId";
 
         /// <summary>
         /// Converts <see cref="Twin"/> to its equivalent Json representation.


### PR DESCRIPTION
Property name is now changed to "modelId"
Tested and verified with Sample.