### PR TITLE
Bump versions for 2020-07-07 release

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.26.0</Version>
+    <Version>1.27.0</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.21.0</Version>
+    <Version>1.22.0</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client AMQP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
+++ b/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.2.3</Version>
+    <Version>1.2.4</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client HTTP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,10 +1,10 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.26.0
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.21.0
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.27.0
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.22.0
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.20.1
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.6.0
-provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.3.0
-provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.2.3
+provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.3.1
+provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.2.4
 provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.3.0
 security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.2.3
 provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.6.3


### PR DESCRIPTION
Release notes:

## Microsoft.Azure.Devices.Client v1.27.0
- Update `Microsoft.Azure.Amqp` version to `2.4.2`.
- Enable `ModuleClient` to set `ClientOptions`.
- Update the device client to accept the `ModelId` as per new format.

#Bug fixes
- Deprecate existing file upload APIs, add new ones at granular level (Get SAS uri from IoT Hub, upload to Azure Storage blob using  IoT Hub provided credentials, and then notify  IoT Hub that a file upload has completed) (#1037 , #1399).
- Fix for retrieving all message system properties set by IoT Hub, over Http protocol, for cloud-to-device messages.

## Microsoft.Azure.Devices v1.22.0
- Update `Microsoft.Azure.Amqp` version to `2.4.2`.

#Bug fixes
- Updated code to set the correct exception message (#599).
- Expose the exception code returned by the service, back to the calling application (#629).

## Microsoft.Azure.Devices.Provisioning.Transport.Amqp v1.3.1
- Update `Microsoft.Azure.Amqp` version to `2.4.2`.

## Microsoft.Azure.Devices.Provisioning.Transport.Http v1.2.4

#Bug fixes
- Fix a bug where the provisioning client did not respect the `retry-after` header sent by service, for requests getting throttled. (#1042).