### PR TITLE
refactor(e2e): Disabling digital twin e2e test project in source rather than script

### DIFF
--- a/digitaltwin/e2e/tests/Microsoft.Azure.Devices.DigitalTwin.E2ETests.csproj
+++ b/digitaltwin/e2e/tests/Microsoft.Azure.Devices.DigitalTwin.E2ETests.csproj
@@ -4,6 +4,10 @@
     <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.2</TargetFrameworks>
     <IsPackable>false</IsPackable>
+
+    <!-- Disabling this test project because we don't need to run it -->
+    <IsTestProject>false</IsTestProject>
+
     <RootNamespace>Microsoft.Azure.Devices.DigitalTwin.E2ETests</RootNamespace>
     <AssemblyName>Microsoft.Azure.Devices.DigitalTwin.E2ETests</AssemblyName>
     <RootDir>$(MSBuildProjectDirectory)\..\..\..</RootDir>
@@ -25,8 +29,8 @@
     <ProjectReference Include="$(RootDir)\digitaltwin\device\src\Microsoft.Azure.Devices.DigitalTwin.Client.csproj" />
     <ProjectReference Include="$(RootDir)\digitaltwin\service\src\Microsoft.Azure.Devices.DigitalTwin.Service.csproj" />
   </ItemGroup>
-  
-   <ItemGroup Condition=" '$(AZURE_IOT_LOCALPACKAGES)' != '' ">
+
+  <ItemGroup Condition=" '$(AZURE_IOT_LOCALPACKAGES)' != '' ">
     <PackageReference Include="Microsoft.Azure.Devices.DigitalTwin.Client" Version="1.0.0-preview-*" />
     <PackageReference Include="Microsoft.Azure.Devices.DigitalTwin.Service" Version="1.0.0-preview-*" />
   </ItemGroup>

--- a/vsts/gatedBuild.ps1
+++ b/vsts/gatedBuild.ps1
@@ -43,17 +43,6 @@ if (IsPullRequestBuild)
 	{
 		Write-Host "Will run Iot Hub tests"
 	}	
-	
-	#if (ShouldSkipPnPTests) 
-	#{
-		#Write-Host "Will skip PnP tests"
-		Write-Host "SKIPPING ALL PNP TESTS REGARDLESS"
-		$runTestCmd += " -skipPnPTests"
-	#}
-	#else 
-	#{
-	#	Write-Host "Will run Digital Twin tests"
-	#}
 }
 else 
 {

--- a/vsts/releaseTest.ps1
+++ b/vsts/releaseTest.ps1
@@ -17,9 +17,6 @@ docker ps -a
 
 $runTestCmd = ".\build.ps1 -build -clean -configuration RELEASE -framework $env:FRAMEWORK -e2etests"
 
-Write-Host "SKIPPING ALL PNP TESTS REGARDLESS"
-$runTestCmd += " -skipPnPTests"
-
 Invoke-Expression $runTestCmd
 
 $gateFailed = $LASTEXITCODE


### PR DESCRIPTION
The "-skipPnPTests" flag wasn't working, and we should investigate that later. For now though, no one runs these tests, so they should be disabled in source