### PR TITLE
fix(e2e): Wait longer due to parallel tests.

### DIFF
--- a/e2e/test/RegistryManagerExportDevicesTests.cs
+++ b/e2e/test/RegistryManagerExportDevicesTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         private const string ExportFileNameDefault = "devices.txt";
         private const int MaxIterationWait = 30;
-        private static readonly TimeSpan s_waitDuration = TimeSpan.FromSeconds(1);
+        private static readonly TimeSpan s_waitDuration = TimeSpan.FromSeconds(5);
 
         private static readonly char[] s_newlines = new char[]
         {
@@ -102,23 +102,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                     // Concurrent jobs can be rejected, so implement a retry mechanism to handle conflicts with other tests
                     catch (JobQuotaExceededException) when (++tryCount < MaxIterationWait)
                     {
-                        // Cancel any jobs submitted by previous runs and are still running.
-                        IEnumerable<JobProperties> jobs = await registryManager.GetJobsAsync().ConfigureAwait(false);
-                        foreach (var job in jobs)
-                        {
-                            if (job.Status == JobStatus.Running)
-                            {
-                                try
-                                {
-                                    _log.WriteLine($"JobQuotaExceededException... Canceling existing running jobs.");
-                                    await registryManager.CancelJobAsync(job.JobId).ConfigureAwait(false);
-                                }
-                                catch
-                                {
-                                    // Do nothing. Best effort cancellation only.
-                                }
-                            }
-                        }
                         _log.WriteLine($"JobQuotaExceededException... waiting.");
                         await Task.Delay(s_waitDuration).ConfigureAwait(false);
                         continue;

--- a/e2e/test/RegistryManagerImportDevicesTests.cs
+++ b/e2e/test/RegistryManagerImportDevicesTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         private const string ImportFileNameDefault = "devices.txt";
         private const int MaxIterationWait = 30;
-        private static readonly TimeSpan s_waitDuration = TimeSpan.FromSeconds(1);
+        private static readonly TimeSpan s_waitDuration = TimeSpan.FromSeconds(5);
 
         private static readonly IReadOnlyList<JobStatus> s_incompleteJobs = new[]
         {
@@ -100,23 +100,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                     // Concurrent jobs can be rejected, so implement a retry mechanism to handle conflicts with other tests
                     catch (JobQuotaExceededException) when (++tryCount < MaxIterationWait)
                     {
-                        // Cancel any jobs submitted by previous runs and are still running.
-                        IEnumerable<JobProperties> jobs = await registryManager.GetJobsAsync().ConfigureAwait(false);
-                        foreach (var job in jobs)
-                        {
-                            if (job.Status == JobStatus.Running)
-                            {
-                                try
-                                {
-                                    _log.WriteLine($"JobQuotaExceededException... Canceling existing running jobs.");
-                                    await registryManager.CancelJobAsync(job.JobId).ConfigureAwait(false);
-                                }
-                                catch
-                                {
-                                    // Do nothing. Best effort cancellation only.
-                                }
-                            }
-                        }
                         _log.WriteLine($"JobQuotaExceededException... waiting.");
                         await Task.Delay(s_waitDuration).ConfigureAwait(false);
                         continue;


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
Based on my investigation, we run the tests in parallel for each framework on the pipeline. This can easily cause tests to stomp on each other. From the logs in IotHub, the average per job is 9 seconds and max is around 20 second. Given we have 5 frameworks, to be safe it would be good to wait for more than 100 seconds.

Even though we mark the tests as not-parallel using attributes, if you look at the pipeline closely, separate jobs are created for each framework and they run in parallel. Hence the parallelism does no apply to tests across frameworks. This is not the behavior I see on Visual Studio though and I think that has to do with the way VS discovers tests and runs them.

Sharing a dashboard for anyone interested - https://dataexplorer.azure.com/dashboards/4a39af25-41fa-4bab-9227-7dc5280b92ac?_startTime=1hours&_endTime=now

The initial change of trying to cancel the job will not be useful.