### PR TITLE
fix(vsts): Remove rolling builds for master branch

### DIFF
--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -4,7 +4,6 @@ trigger:
   batch: true
   branches:
     include:
-    - master
     - preview
   paths:
     exclude:


### PR DESCRIPTION
Updating description:

Right now, when any change gets merged into preview branch, we trigger 2 rolling builds on our Canary pipeline; one that runs against "master" sourcecode, and another that runs against "preview" sourcecode.
Since we don't want to test the "master" sourcecode in Canary environment, this change specifically removes the "master" rolling build trigger for "preview" branch.