### PR TITLE
feat(e2e): Log to AI for e2e tests.

### DIFF
--- a/common/test/TestLogging.cs
+++ b/common/test/TestLogging.cs
@@ -2,39 +2,122 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics;
-using System.Globalization;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.Devices.E2ETests
 {
+    /// <summary>
+    /// This class logs to multiple providers - Event source, Application insights
+    /// </summary>
     public class TestLogging
     {
-        private readonly static TestLogging s_instance = new TestLogging();
+        public const string Language = "C#";
+        public const string Service = "IotHub";
+        private static object _initLock = new object();
+
+        // Client to log to application insights
+        private static TelemetryClient _telemetryClient;
+
+        // Unique ID for all tests of a run.
+        private static string _testRunId;
+
+        public TestContext Context { get; set; }
+        public string TargetFramework { get; set; }
 
         private TestLogging()
         {
+            // Thread-safe initialization of the telemetry client and run Id.
+            lock (_initLock)
+            {
+                if (_telemetryClient == null)
+                {
+                    // Instrumentation key is used to connect to Application Insights instance.
+                    // The value is copied from the portal and stored in KeyVault.
+                    // The E2E tests script will load it as an environment variable and the pipelines have a task to do the same.
+                    string intrumentationKey = Environment.GetEnvironmentVariable("E2E_IKEY");
+                    if (!string.IsNullOrWhiteSpace(intrumentationKey))
+                    {
+                        var config = new TelemetryConfiguration
+                        {
+                            InstrumentationKey = intrumentationKey,
+                        };
+                        _telemetryClient = new TelemetryClient(config);
+                        _testRunId = Guid.NewGuid().ToString();
+                    }
+                }
+            }
         }
 
         private const string NullInstance = "(null)";
-        
+
         public static string IdOf(object value) => value != null ? value.GetType().Name + "#" + GetHashCode(value) : NullInstance;
 
         public static int GetHashCode(object value) => value?.GetHashCode() ?? 0;
 
-        public static TestLogging GetInstance()
+        public static TestLogging GetInstance(TestContext testContext = null)
         {
-            return s_instance;
+            var logger = new TestLogging();
+
+            if (_telemetryClient != null)
+            {
+                // Set logger properties for the current test.
+                var targetFramework = (TargetFrameworkAttribute)Assembly
+                    .GetExecutingAssembly()
+                    .GetCustomAttributes(typeof(TargetFrameworkAttribute), false)
+                    .SingleOrDefault();
+                logger.Context = testContext;
+                logger.TargetFramework = targetFramework.FrameworkName;
+            };
+
+            return logger;
         }
 
-        public void WriteLine(string message)
+        public void WriteLine(string message, SeverityLevel severity = SeverityLevel.Information, IDictionary<string, string> propertyBag = null, [CallerMemberName] string caller = null)
         {
+            // Log to event source
             EventSourceTestLogging.Log.TestMessage(message);
+
+            // Log to Application insights
+            if (_telemetryClient != null)
+            {
+                if (propertyBag == null)
+                {
+                    propertyBag = new Dictionary<string, string>();
+                }
+
+                // Add common properties
+                propertyBag.Add(LoggingPropertyNames.TestRunId, _testRunId);
+                propertyBag.Add(LoggingPropertyNames.TestFramework, TargetFramework);
+                propertyBag.Add(LoggingPropertyNames.Language, Language);
+                propertyBag.Add(LoggingPropertyNames.Service, Service);
+                if (Context != null)
+                {
+                    propertyBag.Add(LoggingPropertyNames.TestName, Context.TestName);
+                    propertyBag.Add(LoggingPropertyNames.ClassName, Context.FullyQualifiedTestClassName ?? caller);
+                    propertyBag.Add(LoggingPropertyNames.TestStatus, Context?.CurrentTestOutcome.ToString());
+                }
+
+                // Environment Variable set in Azure pipelines to correlate logs with the build number.
+                propertyBag.Add("BuildId", Environment.GetEnvironmentVariable("BUILD_BUILDID"));
+
+                _telemetryClient.TrackTrace(message, severity, propertyBag);
+            }
         }
 
-        public void WriteLine(string format, params object[] args)
+        public void Flush()
         {
-            string message = string.Format(CultureInfo.InvariantCulture, format, args);
-            EventSourceTestLogging.Log.TestMessage(message);
+            if (_telemetryClient != null)
+            {
+                _telemetryClient.Flush();
+            }
         }
     }
 }

--- a/e2e/test/BulkOperationsE2ETests.cs
+++ b/e2e/test/BulkOperationsE2ETests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Devices.E2ETests
     [TestClass]
     [TestCategory("E2E")]
     [TestCategory("IoTHub")]
-    public class BulkOperationsE2ETests : IDisposable
+    public class BulkOperationsE2ETests : E2ETestBase, IDisposable
     {
         private readonly string DevicePrefix = $"E2E_{nameof(BulkOperationsE2ETests)}_";
         private readonly string ModulePrefix = $"E2E_{nameof(BulkOperationsE2ETests)}_";

--- a/e2e/test/CombinedClientOperationsPoolAmqpTests.cs
+++ b/e2e/test/CombinedClientOperationsPoolAmqpTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices.E2ETests
     [TestClass]
     [TestCategory("E2E")]
     [TestCategory("IoTHub")]
-    public class CombinedClientOperationsPoolAmqpTests : IDisposable
+    public class CombinedClientOperationsPoolAmqpTests : E2ETestBase, IDisposable
     {
         private const string MethodName = "MethodE2ECombinedOperationsTest";
         private readonly string _devicePrefix = $"E2E_{nameof(CombinedClientOperationsPoolAmqpTests)}_";

--- a/e2e/test/E2ETestBase.cs
+++ b/e2e/test/E2ETestBase.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Devices.E2ETests
+{
+    /// <summary>
+    /// This class creates an instance of the logger for each test and logs the test result along with other useful information.
+    /// </summary>
+    public class E2ETestBase
+    {
+        protected TestLogging Logger { get; set; }
+        private Stopwatch Stopwatch { get; set; }
+        public TestContext TestContext { get; set; }
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            Stopwatch = Stopwatch.StartNew();
+            Logger = TestLogging.GetInstance(TestContext);
+            Logger.WriteLine($"Starting test - {TestContext.TestName}", SeverityLevel.Information);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            Stopwatch.Stop();
+            double elapsed = Stopwatch.Elapsed.TotalSeconds;
+            var properties = new Dictionary<string, string>
+            {
+                { LoggingPropertyNames.SecondsElapsed, elapsed.ToString() }
+            };
+            Logger.WriteLine($"Finished test - {TestContext.TestName}", SeverityLevel.Information, properties);
+            // As this is not an application that keeps running, explicitly flushing is required to ensure we do not lose any logs.
+            // The recommendation from AI is to wait for 5 seconds after flushing.
+            Logger.Flush();
+            Thread.Sleep(5000);
+        }
+    }
+}

--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -79,6 +79,7 @@
   <!-- All Platforms -->
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.14.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />

--- a/e2e/test/LoggingPropertyNames.cs
+++ b/e2e/test/LoggingPropertyNames.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.Devices.E2ETests
+{
+    /// <summary>
+    /// The property names to log to telemetry.
+    /// </summary>
+    public class LoggingPropertyNames
+    {
+        public const string TestRunId = "TestRunId";
+        public const string TestName = "TestName";
+        public const string ClassName = "ClassName";
+        public const string TestFramework = "TestFramework";
+        public const string TestStatus = "TestStatus";
+        public const string SecondsElapsed = "SecondsElapsed";
+        public const string Language = "Language";
+        public const string Service = "Service";
+    }
+}


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
This change is the first part to start logging to Application Insights. I have not done any renaming of classes/methods in the PR as I wanted to keep the review short. Will make necessary changes in following PRs.

Logging from our E2E tests to Application Insights.
Logging the following properties:
Unique TestRunId
BuildId - for pipeline
TestName
ClassName(calller)
TestResult
TestRunTime
TargetFramework
Language
Service

Currently only two classes are on-boarded to this. I have added a task to onboard every other class. There is also the issue of all helpers initializing their own loggers. In a following PR I will make changes to pass logger from the tests to the helpers instead so that the logs are correctly correlated.

![image](https://user-images.githubusercontent.com/14096264/87845577-689fed00-c87d-11ea-969a-db88b7c3c782.png)
