### PR TITLE
Parameterize direct method tests

### DIFF
--- a/e2e/test/iothub/method/FaultInjectionPoolAmqpTests.MethodFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/method/FaultInjectionPoolAmqpTests.MethodFaultInjectionPoolAmqpTests.cs
@@ -18,704 +18,142 @@ namespace Microsoft.Azure.Devices.E2ETests
         private const string MethodDevicePrefix = "E2E_MethodFaultInjectionPoolAmqpTests";
         private const string MethodName = "MethodE2EFaultInjectionPoolAmqpTests";
 
+        [DataTestMethod]
         // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodTcpConnRecovery_SingleConnection_Amqp()
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        public async Task Method_DeviceMethodTcpConnRecovery(Client.TransportType transportType, ConnectionStringAuthScope authScope, int poolSize, int devicesCount)
         {
             await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
                         TestDeviceType.Sasl,
-                        Client.TransportType.Amqp_Tcp_Only,
-                        PoolingOverAmqp.SingleConnection_PoolSize,
-                        PoolingOverAmqp.SingleConnection_DevicesCount,
+                        transportType,
+                        poolSize,
+                        devicesCount,
                         MethodE2ETests.SetDeviceReceiveMethodAsync,
                         FaultInjection.FaultType_Tcp,
-                        FaultInjection.FaultCloseReason_Boom)
+                        FaultInjection.FaultCloseReason_Boom,
+                        authScope: authScope)
                 .ConfigureAwait(false);
         }
 
+        [DataTestMethod]
         // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodTcpConnRecovery_SingleConnection_AmqpWs()
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        public async Task Method_DeviceMethodAmqpConnLostRecovery(Client.TransportType transportType, ConnectionStringAuthScope authScope, int poolSize, int devicesCount)
         {
             await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_Tcp,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IotHubSak_DeviceMethodTcpConnRecovery_SingleConnection_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_Tcp,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodTcpConnRecovery_SingleConnection_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_Tcp,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodAmqpConnLostRecovery_SingleConnection_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpConn,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodAmqpConnLostRecovery_SingleConnection_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpConn,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodAmqpConnLostRecovery_SingleConnection_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
+                    transportType,
+                    poolSize,
+                    devicesCount,
                     MethodE2ETests.SetDeviceReceiveMethodAsync,
                     FaultInjection.FaultType_AmqpConn,
                     FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
+                    authScope: authScope)
                 .ConfigureAwait(false);
         }
 
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodAmqpConnLostRecovery_SingleConnection_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpConn,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
+        [DataTestMethod]
         // TODO: #943 - Honor different pool sizes for different connection pool settings.
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodSessionLostRecovery_SingleConnection_Amqp()
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        public async Task Method_DeviceMethodSessionLostRecovery(Client.TransportType transportType, ConnectionStringAuthScope authScope, int poolSize, int devicesCount)
         {
             await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpSess,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodSessionLostRecovery_SingleConnection_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpSess,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodSessionLostRecovery_SingleConnection_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
+                    transportType,
+                    poolSize,
+                    devicesCount,
                     MethodE2ETests.SetDeviceReceiveMethodAsync,
                     FaultInjection.FaultType_AmqpSess,
                     FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
+                    authScope: authScope)
                 .ConfigureAwait(false);
         }
 
+        [DataTestMethod]
         // TODO: #943 - Honor different pool sizes for different connection pool settings.
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IoTHub_DeviceMethodSessionLostRecovery_SingleConnection_AmqpWs()
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        public async Task Method_DeviceMethodReqLinkDropRecovery(Client.TransportType transportType, ConnectionStringAuthScope authScope, int poolSize, int devicesCount)
         {
             await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpSess,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodReqLinkDropRecovery_SingleConnection_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodReq,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodReqLinkDropRecovery_SingleConnection_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodReq,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodReqLinkDropRecovery_SingleConnection_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
+                    transportType,
+                    poolSize,
+                    devicesCount,
                     MethodE2ETests.SetDeviceReceiveMethodAsync,
                     FaultInjection.FaultType_AmqpMethodReq,
                     FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
+                    authScope: authScope)
                 .ConfigureAwait(false);
         }
 
+        [DataTestMethod]
         // TODO: #943 - Honor different pool sizes for different connection pool settings.
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodReqLinkDropRecovery_SingleConnection_AmqpWs()
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        public async Task Method_DeviceMethodRespLinkDropRecovery(Client.TransportType transportType, ConnectionStringAuthScope authScope, int poolSize, int devicesCount)
         {
             await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
+                    transportType,
+                    poolSize,
+                    devicesCount,
                     MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodReq,
+                    FaultInjection.FaultType_AmqpMethodResp,
                     FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
+                    authScope: authScope)
                 .ConfigureAwait(false);
         }
 
+        [DataTestMethod]
         // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodRespLinkDropRecovery_SingleConnection_Amqp()
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        public async Task Method_DeviceMethodGracefulShutdownRecovery(Client.TransportType transportType, int poolSize, int devicesCount)
         {
             await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodResp,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodRespLinkDropRecovery_SingleConnection_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodResp,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodRespLinkDropRecovery_SingleConnection_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodResp,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodRespLinkDropRecovery_SingleConnection_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodResp,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodGracefulShutdownRecovery_SingleConnection_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_GracefulShutdownAmqp,
-                    FaultInjection.FaultCloseReason_Bye)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodGracefulShutdownRecovery_SingleConnection_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_GracefulShutdownAmqp,
-                    FaultInjection.FaultCloseReason_Bye)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodTcpConnRecovery_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_Tcp,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodTcpConnRecovery_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_Tcp,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_IotHubSak_DeviceMethodTcpConnRecovery_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_Tcp,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodTcpConnRecovery_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_Tcp,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodAmqpConnLostRecovery_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpConn,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodAmqpConnLostRecovery_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpConn,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodAmqpConnLostRecovery_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpConn,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodAmqpConnLostRecovery_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpConn,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodSessionLostRecovery_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpSess,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodSessionLostRecovery_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpSess,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodSessionLostRecovery_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpSess,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [TestMethod]
-        public async Task Method_IoTHub_DeviceMethodSessionLostRecovery_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpSess,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodReqLinkDropRecovery_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodReq,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodReqLinkDropRecovery_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodReq,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodReqLinkDropRecovery_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodReq,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodReqLinkDropRecovery_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodReq,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodRespLinkDropRecovery_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodResp,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodRespLinkDropRecovery_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodResp,
-                    FaultInjection.FaultCloseReason_Boom)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodRespLinkDropRecovery_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodResp,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceMethodRespLinkDropRecovery_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_AmqpMethodResp,
-                    FaultInjection.FaultCloseReason_Boom,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodGracefulShutdownRecovery_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    FaultInjection.FaultType_GracefulShutdownAmqp,
-                    FaultInjection.FaultCloseReason_Bye)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceMethodGracefulShutdownRecovery_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryPoolOverAmqpAsync(
-                    TestDeviceType.Sasl,
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    transportType,
+                    poolSize,
+                    devicesCount,
                     MethodE2ETests.SetDeviceReceiveMethodAsync,
                     FaultInjection.FaultType_GracefulShutdownAmqp,
                     FaultInjection.FaultCloseReason_Bye)

--- a/e2e/test/iothub/method/MethodE2EPoolAmqpTests.cs
+++ b/e2e/test/iothub/method/MethodE2EPoolAmqpTests.cs
@@ -19,203 +19,45 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
         private readonly string _devicePrefix = $"E2E_{nameof(MethodE2EPoolAmqpTests)}_";
         private static readonly TestLogger s_log = TestLogger.GetInstance();
 
+        [DataTestMethod]
         // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceReceivesMethodAndResponse_SingleConnection_Amqp()
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        public async Task Method_DeviceReceivesMethodAndResponse(Client.TransportType transportType, ConnectionStringAuthScope authScope, int poolSize, int devicesCount)
         {
             await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceReceivesMethodAndResponse_SingleConnection_AmqpWs()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceReceivesMethodAndResponse_SingleConnection_Amqp()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
+                    transportType,
+                    poolSize,
+                    devicesCount,
                     MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    authScope: ConnectionStringAuthScope.IoTHub)
+                    authScope)
                 .ConfigureAwait(false);
         }
 
+        [DataTestMethod]
         // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceReceivesMethodAndResponse_SingleConnection_AmqpWs()
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        //[DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.SingleConnection_PoolSize, PoolingOverAmqp.SingleConnection_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.Device, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, ConnectionStringAuthScope.IoTHub, PoolingOverAmqp.MultipleConnections_PoolSize, PoolingOverAmqp.MultipleConnections_DevicesCount)]
+        public async Task Method_DeviceReceivesMethodAndResponseWithDefaultHandler(Client.TransportType transportType, ConnectionStringAuthScope authScope, int poolSize, int devicesCount)
         {
             await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceReceivesMethodAndResponseWithDefaultHandler_SingleConnection_Amqp()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodDefaultHandlerAsync)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceReceivesMethodAndResponseWithDefaultHandler_SingleConnection_AmqpWs()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodDefaultHandlerAsync)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceReceivesMethodAndResponseWithDefaultHandler_SingleConnection_Amqp()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
+                    transportType,
+                    poolSize,
+                    devicesCount,
                     MethodE2ETests.SetDeviceReceiveMethodDefaultHandlerAsync,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        // TODO: #943 - Honor different pool sizes for different connection pool settings.
-        [Ignore]
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceReceivesMethodAndResponseWithDefaultHandler_SingleConnection_AmqpWs()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodDefaultHandlerAsync,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceReceivesMethodAndResponse_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceReceivesMethodAndResponse_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceReceivesMethodAndResponse_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceReceivesMethodAndResponse_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodAsync,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceReceivesMethodAndResponseWithDefaultHandler_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodDefaultHandlerAsync)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceSak_DeviceReceivesMethodAndResponseWithDefaultHandler_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodDefaultHandlerAsync)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceReceivesMethodAndResponseWithDefaultHandler_MultipleConnections_Amqp()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodDefaultHandlerAsync,
-                    authScope: ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_IoTHubSak_DeviceReceivesMethodAndResponseWithDefaultHandler_MultipleConnections_AmqpWs()
-        {
-            await SendMethodAndRespondPoolOverAmqp(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    MethodE2ETests.SetDeviceReceiveMethodDefaultHandlerAsync,
-                    authScope: ConnectionStringAuthScope.IoTHub)
+                    authScope)
                 .ConfigureAwait(false);
         }
 

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -27,78 +27,50 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
 
         private static readonly TimeSpan s_defaultMethodTimeoutMinutes = TimeSpan.FromMinutes(1);
 
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponse_Mqtt()
+        [DataTestMethod]
+        [DataRow(Client.TransportType.Mqtt_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Mqtt_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Mqtt_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Mqtt_WebSocket_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.X509)]
+        public async Task Method_DeviceReceivesMethodAndResponse(Client.TransportType transportType, TestDeviceType authenticationType)
         {
-            await SendMethodAndRespondAsync(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethodAsync).ConfigureAwait(false);
+            await SendMethodAndRespondAsync(transportType, SetDeviceReceiveMethodAsync, authenticationType).ConfigureAwait(false);
         }
 
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponse_MqttWs()
+        [DataTestMethod]
+        [DataRow(Client.TransportType.Mqtt_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Mqtt_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Mqtt_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Mqtt_WebSocket_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.X509)]
+        public async Task Method_DeviceReceivesMethodAndResponseWithObseletedSetMethodHandler(Client.TransportType transportType, TestDeviceType authenticationType)
         {
-            await SendMethodAndRespondAsync(Client.TransportType.Mqtt_WebSocket_Only, SetDeviceReceiveMethodAsync).ConfigureAwait(false);
+            await SendMethodAndRespondAsync(transportType, SetDeviceReceiveMethodObsoleteHandler, authenticationType).ConfigureAwait(false);
         }
 
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponseWithObseletedSetMethodHandler_Mqtt()
+        [DataTestMethod]
+        [DataRow(Client.TransportType.Mqtt_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Mqtt_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Mqtt_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Mqtt_WebSocket_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.X509)]
+        public async Task Method_DeviceReceivesMethodAndResponseWithDefaultMethodHandler(Client.TransportType transportType, TestDeviceType authenticationType)
         {
-            await SendMethodAndRespondAsync(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethodObsoleteHandler).ConfigureAwait(false);
+            await SendMethodAndRespondAsync(transportType, SetDeviceReceiveMethodDefaultHandlerAsync, authenticationType).ConfigureAwait(false);
         }
 
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponseWithObseletedSetMethodHandler_MqttWs()
-        {
-            await SendMethodAndRespondAsync(Client.TransportType.Mqtt_WebSocket_Only, SetDeviceReceiveMethodObsoleteHandler).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponseWithDefaultMethodHandler_Mqtt()
-        {
-            await SendMethodAndRespondAsync(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethodDefaultHandlerAsync).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponseWithDefaultMethodHandler_MqttWs()
-        {
-            await SendMethodAndRespondAsync(Client.TransportType.Mqtt_WebSocket_Only, SetDeviceReceiveMethodDefaultHandlerAsync).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponse_Amqp()
-        {
-            await SendMethodAndRespondAsync(Client.TransportType.Amqp_Tcp_Only, SetDeviceReceiveMethodAsync).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponse_AmqpWs()
-        {
-            await SendMethodAndRespondAsync(Client.TransportType.Amqp_WebSocket_Only, SetDeviceReceiveMethodAsync).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponseWithObseletedSetMethodHandler_Amqp()
-        {
-            await SendMethodAndRespondAsync(Client.TransportType.Amqp_Tcp_Only, SetDeviceReceiveMethodObsoleteHandler).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponseWithObseletedSetMethodHandler_AmqpWs()
-        {
-            await SendMethodAndRespondAsync(Client.TransportType.Amqp_WebSocket_Only, SetDeviceReceiveMethodObsoleteHandler).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponseWithDefaultMethodHandler_Amqp()
-        {
-            await SendMethodAndRespondAsync(Client.TransportType.Amqp_Tcp_Only, SetDeviceReceiveMethodDefaultHandlerAsync).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponseWithDefaultMethodHandler_AmqpWs()
-        {
-            await SendMethodAndRespondAsync(Client.TransportType.Amqp_WebSocket_Only, SetDeviceReceiveMethodDefaultHandlerAsync).ConfigureAwait(false);
-        }
-
+        // Note that this test is not parameterized on device side settings. This test is about testing if the service
+        // client can communicate through a proxy as expected
         [TestMethod]
         public async Task Method_ServiceSendsMethodThroughProxyWithDefaultTimeout()
         {
@@ -107,9 +79,11 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                 HttpProxy = new WebProxy(Configuration.IoTHub.ProxyServerAddress)
             };
 
-            await SendMethodAndRespondAsync(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethodAsync, serviceClientTransportSettings).ConfigureAwait(false);
+            await SendMethodAndRespondAsync(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethodAsync, serviceClientTransportSettings, TestDeviceType.Sasl).ConfigureAwait(false);
         }
 
+        // Note that this test is not parameterized on device side settings. This test is about testing if the service
+        // client can communicate through a proxy as expected
         [TestMethod]
         public async Task Method_ServiceSendsMethodThroughProxyWithCustomTimeout()
         {
@@ -118,9 +92,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                 HttpProxy = new WebProxy(Configuration.IoTHub.ProxyServerAddress)
             };
 
-            await SendMethodAndRespondAsync(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethodAsync, TimeSpan.FromMinutes(5), serviceClientTransportSettings).ConfigureAwait(false);
+            await SendMethodAndRespondAsync(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethodAsync, TimeSpan.FromMinutes(5), serviceClientTransportSettings, TestDeviceType.Sasl).ConfigureAwait(false);
         }
 
+        // Note that this test is not parameterized on device side settings. This test does not depend on having a registered device
         [TestMethod]
         public async Task Method_ServiceInvokeDeviceMethodWithUnknownDeviceThrows()
         {
@@ -267,19 +242,19 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             return Task.FromResult<Task>(methodCallReceived.Task);
         }
 
-        private async Task SendMethodAndRespondAsync(Client.TransportType transport, Func<DeviceClient, string, Task<Task>> setDeviceReceiveMethod)
+        private async Task SendMethodAndRespondAsync(Client.TransportType transport, Func<DeviceClient, string, Task<Task>> setDeviceReceiveMethod, TestDeviceType authenticationType)
         {
-            await SendMethodAndRespondAsync(transport, setDeviceReceiveMethod, new ServiceClientTransportSettings()).ConfigureAwait(false);
+            await SendMethodAndRespondAsync(transport, setDeviceReceiveMethod, new ServiceClientTransportSettings(), authenticationType).ConfigureAwait(false);
         }
 
-        private async Task SendMethodAndRespondAsync(Client.TransportType transport, Func<DeviceClient, string, Task<Task>> setDeviceReceiveMethod, ServiceClientTransportSettings serviceClientTransportSettings)
+        private async Task SendMethodAndRespondAsync(Client.TransportType transport, Func<DeviceClient, string, Task<Task>> setDeviceReceiveMethod, ServiceClientTransportSettings serviceClientTransportSettings, TestDeviceType authenticationType)
         {
-            await SendMethodAndRespondAsync(transport, setDeviceReceiveMethod, s_defaultMethodTimeoutMinutes, serviceClientTransportSettings).ConfigureAwait(false);
+            await SendMethodAndRespondAsync(transport, setDeviceReceiveMethod, s_defaultMethodTimeoutMinutes, serviceClientTransportSettings, authenticationType).ConfigureAwait(false);
         }
 
-        private async Task SendMethodAndRespondAsync(Client.TransportType transport, Func<DeviceClient, string, Task<Task>> setDeviceReceiveMethod, TimeSpan responseTimeout, ServiceClientTransportSettings serviceClientTransportSettings)
+        private async Task SendMethodAndRespondAsync(Client.TransportType transport, Func<DeviceClient, string, Task<Task>> setDeviceReceiveMethod, TimeSpan responseTimeout, ServiceClientTransportSettings serviceClientTransportSettings, TestDeviceType authenticationType)
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix, authenticationType).ConfigureAwait(false);
             using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
 
             Task methodReceivedTask = await setDeviceReceiveMethod(deviceClient, MethodName).ConfigureAwait(false);

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
         private async Task SendMethodAndRespondAsync(Client.TransportType transport, Func<DeviceClient, string, Task<Task>> setDeviceReceiveMethod, TimeSpan responseTimeout, ServiceClientTransportSettings serviceClientTransportSettings, TestDeviceType authenticationType)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix, authenticationType).ConfigureAwait(false);
-            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+            using var deviceClient = testDevice.CreateDeviceClient(transport);
 
             Task methodReceivedTask = await setDeviceReceiveMethod(deviceClient, MethodName).ConfigureAwait(false);
 

--- a/e2e/test/iothub/method/MethodFaultInjectionTests.cs
+++ b/e2e/test/iothub/method/MethodFaultInjectionTests.cs
@@ -28,176 +28,112 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
         private const string MethodName = "MethodE2ETest";
         private static TestLogger s_log = TestLogger.GetInstance();
 
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponseRecovery_MqttWs()
+        [DataTestMethod]
+        [DataRow(Client.TransportType.Mqtt_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Mqtt_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Mqtt_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Mqtt_WebSocket_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.X509)]
+        public async Task Method_DeviceMethodGracefulShutdownRecovery(Client.TransportType transportType, TestDeviceType authenticationType)
         {
-            await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Mqtt_WebSocket_Only,
-                    FaultInjection.FaultType_Tcp,
-                    FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
-                .ConfigureAwait(false);
-        }
+            var faultType = FaultInjection.FaultType_GracefulShutdownMqtt;
+            if (transportType == Client.TransportType.Amqp || transportType == Client.TransportType.Amqp_Tcp_Only || transportType == Client.TransportType.Amqp_WebSocket_Only)
+            {
+                faultType = FaultInjection.FaultType_GracefulShutdownAmqp;
+            }
 
-        [TestMethod]
-        public async Task Method_DeviceMethodGracefulShutdownRecovery_Mqtt()
-        {
             await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Mqtt_Tcp_Only,
-                    FaultInjection.FaultType_GracefulShutdownMqtt,
+                    transportType,
+                    authenticationType,
+                    faultType,
                     FaultInjection.FaultCloseReason_Bye,
                     FaultInjection.DefaultDelayInSec)
                 .ConfigureAwait(false);
         }
 
-        [TestMethod]
-        public async Task Method_DeviceReceivesMethodAndResponseRecovery_Mqtt()
+        [DataTestMethod]
+        [DataRow(Client.TransportType.Mqtt_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Mqtt_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Mqtt_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Mqtt_WebSocket_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.X509)]
+        public async Task Method_DeviceMethodTcpConnRecovery_Amqp(Client.TransportType transportType, TestDeviceType authenticationType)
         {
-            await SendMethodAndRespondRecoveryAsync(Client.TransportType.Mqtt_Tcp_Only,
+            await SendMethodAndRespondRecoveryAsync(
+                    transportType,
+                    authenticationType,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
                     FaultInjection.DefaultDelayInSec)
                 .ConfigureAwait(false);
         }
 
-        [TestMethod]
-        public async Task Method_DeviceMethodGracefulShutdownRecovery_MqttWs()
+        [DataTestMethod]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.X509)]
+        public async Task Method_DeviceMethodAmqpConnectionLostRecovery(Client.TransportType transportType, TestDeviceType authenticationType)
         {
             await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Mqtt_WebSocket_Only,
-                    FaultInjection.FaultType_GracefulShutdownMqtt,
-                    FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceMethodTcpConnRecovery_Amqp()
-        {
-            await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    FaultInjection.FaultType_Tcp,
-                    FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceMethodTcpConnRecovery_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryAsync(Client.TransportType.Amqp_WebSocket_Only,
-                    FaultInjection.FaultType_Tcp,
-                    FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceMethodAmqpConnLostRecovery_Amqp()
-        {
-            await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Amqp_Tcp_Only,
+                    transportType,
+                    authenticationType,
                     FaultInjection.FaultType_AmqpConn,
                     FaultInjection.FaultCloseReason_Boom,
                     FaultInjection.DefaultDelayInSec)
                 .ConfigureAwait(false);
         }
 
-        [TestMethod]
-        public async Task Method_DeviceMethodAmqpConnLostRecovery_AmqpWs()
+        [DataTestMethod]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.X509)]
+        public async Task Method_DeviceMethodAmqpSessionLostRecovery(Client.TransportType transportType, TestDeviceType authenticationType)
         {
             await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    FaultInjection.FaultType_AmqpConn,
-                    FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceMethodSessionLostRecovery_Amqp()
-        {
-            await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Amqp_Tcp_Only,
+                    transportType,
+                    authenticationType,
                     FaultInjection.FaultType_AmqpSess,
                     FaultInjection.FaultCloseReason_Boom,
                     FaultInjection.DefaultDelayInSec)
                 .ConfigureAwait(false);
         }
 
-        [TestMethod]
-        public async Task Method_DeviceMethodSessionLostRecovery_AmqpWs()
+        [DataTestMethod]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.X509)]
+        public async Task Method_DeviceMethodReqLinkDropRecovery(Client.TransportType transportType, TestDeviceType authenticationType)
         {
             await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    FaultInjection.FaultType_AmqpSess,
-                    FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceMethodReqLinkDropRecovery_Amqp()
-        {
-            await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Amqp_Tcp_Only,
+                    transportType,
+                    authenticationType,
                     FaultInjection.FaultType_AmqpMethodReq,
                     FaultInjection.FaultCloseReason_Boom,
                     FaultInjection.DefaultDelayInSec)
                 .ConfigureAwait(false);
         }
 
-        [TestMethod]
-        public async Task Method_DeviceMethodReqLinkDropRecovery_AmqpWs()
+        [DataTestMethod]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.Sasl)]
+        [DataRow(Client.TransportType.Amqp_Tcp_Only, TestDeviceType.X509)]
+        [DataRow(Client.TransportType.Amqp_WebSocket_Only, TestDeviceType.X509)]
+        public async Task Method_DeviceMethodRespLinkDropRecovery(Client.TransportType transportType, TestDeviceType authenticationType)
         {
             await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    FaultInjection.FaultType_AmqpMethodReq,
-                    FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceMethodRespLinkDropRecovery_Amqp()
-        {
-            await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Amqp_Tcp_Only,
+                    transportType,
+                    authenticationType,
                     FaultInjection.FaultType_AmqpMethodResp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceMethodRespLinkDropRecovery_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    FaultInjection.FaultType_AmqpMethodResp,
-                    FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceMethodGracefulShutdownRecovery_Amqp()
-        {
-            await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    FaultInjection.FaultType_GracefulShutdownAmqp,
-                    FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
-                .ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task Method_DeviceMethodGracefulShutdownRecovery_AmqpWs()
-        {
-            await SendMethodAndRespondRecoveryAsync(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    FaultInjection.FaultType_GracefulShutdownAmqp,
-                    FaultInjection.FaultCloseReason_Bye,
                     FaultInjection.DefaultDelayInSec)
                 .ConfigureAwait(false);
         }
@@ -248,7 +184,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             }
         }
 
-        private async Task SendMethodAndRespondRecoveryAsync(Client.TransportType transport, string faultType, string reason, int delayInSec)
+        private async Task SendMethodAndRespondRecoveryAsync(Client.TransportType transport, TestDeviceType authenticationType, string faultType, string reason, int delayInSec)
         {
             TestDeviceCallbackHandler testDeviceCallbackHandler = null;
             using var cts = new CancellationTokenSource(FaultInjection.RecoveryTimeMilliseconds);
@@ -280,7 +216,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await FaultInjection
                 .TestErrorInjectionAsync(
                     DevicePrefix,
-                    TestDeviceType.Sasl,
+                    authenticationType,
                     transport,
                     faultType,
                     reason,


### PR DESCRIPTION
I'm working on addressing the test gaps in our direct method tests, but this is the first step in making that feasible. Pretty much all of these test suites had copy/pasted versions of the same test but with one parameter different.

The only difference in testing that this PR brings is the use of x509 devices to the basic direct method tests. Previously, all direct method tests used SAS based devices. Now the test suite will test SAS and x509 devices for coverage.

Notably missing from direct method tests are invoking methods on modules. I'll address that in another PR to keep this one simpler