### PR TITLE
Clean up test logging instance references

### DIFF
--- a/e2e/test/E2EMsTestBase.cs
+++ b/e2e/test/E2EMsTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
+using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -32,7 +33,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         public void TestInitialize()
         {
             Stopwatch = Stopwatch.StartNew();
-            Logger = MsTestLogger.GetInstance(TestContext);
+            Logger = new MsTestLogger(TestContext);
             Logger.Trace($"Starting test - {TestContext.TestName}", SeverityLevel.Information);
             Logger.Event(TestStartedEventName);
 
@@ -40,7 +41,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         [TestCleanup]
-        public void TestCleanup()
+        public async Task TestCleanupAsync()
         {
             Stopwatch.Stop();
 
@@ -53,7 +54,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             Logger.Trace($"Finished test - {TestContext.TestName}", SeverityLevel.Information, extraProperties);
             Logger.Event(TestFinishedEventName, extraProperties);
             // As this is not an application that keeps running, explicitly flushing is required to ensure we do not lose any logs.
-            Logger.SafeFlush();
+            await Logger.SafeFlushAsync().ConfigureAwait(false);
 
             // Dispose the managed resources, so that each test run starts with a fresh slate.
             Dispose();

--- a/e2e/test/Helpers/CustomWebProxy.cs
+++ b/e2e/test/Helpers/CustomWebProxy.cs
@@ -9,8 +9,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 {
     public class CustomWebProxy : IWebProxy
     {
-        private static readonly TestLogger s_testLog = TestLogger.GetInstance();
+        private readonly TestLogger s_testLog;
         private long _counter = 0;
+
+        public CustomWebProxy(TestLogger logger)
+        {
+            s_testLog = logger;
+        }
 
         public ICredentials Credentials { get; set; }
 

--- a/e2e/test/Helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/Helpers/TestDeviceCallbackHandler.cs
@@ -22,11 +22,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         private SemaphoreSlim _twinCallbackSemaphore = new SemaphoreSlim(1, 1);
         private string _expectedTwinPropertyValue = null;
 
-        private static TestLogger s_log = TestLogger.GetInstance();
+        private readonly TestLogger _log;
 
-        public TestDeviceCallbackHandler(DeviceClient deviceClient)
+        public TestDeviceCallbackHandler(DeviceClient deviceClient, TestLogger logger)
         {
             _deviceClient = deviceClient;
+            _log = logger;
         }
 
         public string ExpectedTwinPropertyValue
@@ -49,7 +50,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                 {
                     try
                     {
-                        s_log.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: DeviceClient callback method: {request.Name} {request.ResponseTimeout}.");
+                        _log.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: DeviceClient callback method: {request.Name} {request.ResponseTimeout}.");
                         Assert.AreEqual(methodName, request.Name, $"The expected method name should be {methodName} but was {request.Name}");
                         Assert.AreEqual(expectedServiceRequestJson, request.DataAsJson, $"The expected method name should be {expectedServiceRequestJson} but was {request.DataAsJson}");
 
@@ -57,7 +58,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                     }
                     catch (Exception ex)
                     {
-                        s_log.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: Error during DeviceClient callback method: {ex}.");
+                        _log.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: Error during DeviceClient callback method: {ex}.");
 
                         _methodExceptionDispatch = ExceptionDispatchInfo.Capture(ex);
                         return Task.FromResult(new MethodResponse(500));
@@ -84,7 +85,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(
                 (patch, context) =>
                 {
-                    s_log.Trace($"{nameof(SetTwinPropertyUpdateCallbackHandlerAsync)}: DeviceClient callback twin: DesiredProperty: {patch}, {context}");
+                    _log.Trace($"{nameof(SetTwinPropertyUpdateCallbackHandlerAsync)}: DeviceClient callback twin: DesiredProperty: {patch}, {context}");
 
                     try
                     {

--- a/e2e/test/Helpers/TestModule.cs
+++ b/e2e/test/Helpers/TestModule.cs
@@ -21,16 +21,15 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         /// </summary>
         /// <param name="namePrefix"></param>
         /// <param name="type"></param>
-        public static async Task<TestModule> GetTestModuleAsync(string deviceNamePrefix, string moduleNamePrefix)
+        public static async Task<TestModule> GetTestModuleAsync(string deviceNamePrefix, string moduleNamePrefix, TestLogger logger)
         {
-            var log = TestLogger.GetInstance();
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(deviceNamePrefix).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(logger, deviceNamePrefix).ConfigureAwait(false);
 
             string deviceName = testDevice.Id;
             string moduleName = moduleNamePrefix + Guid.NewGuid();
 
             using var rm = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
-            log.Trace($"{nameof(GetTestModuleAsync)}: Creating module for device {deviceName}.");
+            logger.Trace($"{nameof(GetTestModuleAsync)}: Creating module for device {deviceName}.");
 
             var requestModule = new Module(deviceName, moduleName);
             Module module = await rm.AddModuleAsync(requestModule).ConfigureAwait(false);
@@ -39,7 +38,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
             var ret = new TestModule(module);
 
-            log.Trace($"{nameof(GetTestModuleAsync)}: Using device {ret.DeviceId} with module {ret.Id}.");
+            logger.Trace($"{nameof(GetTestModuleAsync)}: Using device {ret.DeviceId} with module {ret.Id}.");
             return ret;
         }
 

--- a/e2e/test/Helpers/logging/LoggedTestMethod.cs
+++ b/e2e/test/Helpers/logging/LoggedTestMethod.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices.E2ETests
     /// </summary>
     public class LoggedTestMethod : TestMethodAttribute
     {
-        private static TestLogger _logger = TestLogger.GetInstance();
+        private static TestLogger _logger = new TestLogger();
 
         public override TestResult[] Execute(ITestMethod testMethod)
         {
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     { LoggingPropertyNames.TestFailureReason, testFailureReason }
                 };
                 _logger.Trace($"Test {testMethod.TestMethodName} failed with error {testFailureReason}.", SeverityLevel.Error, extraProperties);
-                _logger.SafeFlush();
+                _logger.SafeFlushAsync();
             }
             return results;
         }

--- a/e2e/test/Helpers/logging/MsTestLogger.cs
+++ b/e2e/test/Helpers/logging/MsTestLogger.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices.E2ETests
     /// </summary>
     public class MsTestLogger : TestLogger
     {
-        private MsTestLogger(TestContext testContext) : base()
+        internal MsTestLogger(TestContext testContext) : base()
         {
             // Framework against which the test is running.
             var targetFramework = (TargetFrameworkAttribute)Assembly
@@ -29,11 +29,6 @@ namespace Microsoft.Azure.Devices.E2ETests
             Properties.Add(LoggingPropertyNames.TestClassName, testContext.FullyQualifiedTestClassName);
             Properties.Add(LoggingPropertyNames.TargetFramework, targetFramework.FrameworkName);
             Properties.Add(LoggingPropertyNames.OsInfo, operatingSystem);
-        }
-
-        public static MsTestLogger GetInstance(TestContext testContext)
-        {
-            return new MsTestLogger(testContext);
         }
     }
 }

--- a/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Azure.Devices.E2ETests
     {
         private readonly string DevicePrefix = $"E2E_{nameof(ConnectionStatusChangeHandlerTests)}_Device";
         private readonly string ModulePrefix = $"E2E_{nameof(ConnectionStatusChangeHandlerTests)}";
-        private static TestLogger s_log = TestLogger.GetInstance();
 
         [LoggedTestMethod]
         [TestCategory("LongRunning")]
@@ -107,7 +106,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         private async Task DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base(
             Client.TransportType protocol, Func<RegistryManager, string, Task> registryManagerOperation)
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix + $"_{Guid.NewGuid()}").ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix + $"_{Guid.NewGuid()}").ConfigureAwait(false);
             string deviceConnectionString = testDevice.ConnectionString;
 
             var config = new Configuration.IoTHub.DeviceConnectionStringParser(deviceConnectionString);
@@ -130,12 +129,12 @@ namespace Microsoft.Azure.Devices.E2ETests
                 };
 
                 deviceClient.SetConnectionStatusChangesHandler(statusChangeHandler);
-                s_log.Trace($"{nameof(DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Created {nameof(DeviceClient)} with device Id={testDevice.Id}");
+                Logger.Trace($"{nameof(DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Created {nameof(DeviceClient)} with device Id={testDevice.Id}");
 
                 await deviceClient.OpenAsync().ConfigureAwait(false);
 
                 // Receiving the module twin should succeed right now.
-                s_log.Trace($"{nameof(DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: DeviceClient GetTwinAsync.");
+                Logger.Trace($"{nameof(DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: DeviceClient GetTwinAsync.");
                 var twin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
                 Assert.IsNotNull(twin);
 
@@ -145,7 +144,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     await registryManagerOperation(registryManager, deviceId).ConfigureAwait(false);
                 }
 
-                s_log.Trace($"{nameof(DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Completed RegistryManager operation.");
+                Logger.Trace($"{nameof(DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Completed RegistryManager operation.");
 
                 // Artificial sleep waiting for the connection status change handler to get triggered.
                 int sleepCount = 50;
@@ -158,7 +157,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     }
                 }
 
-                s_log.Trace($"{nameof(DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Asserting connection status change.");
+                Logger.Trace($"{nameof(DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Asserting connection status change.");
 
                 Assert.AreEqual(1, deviceDisabledReceivedCount);
                 Assert.AreEqual(ConnectionStatus.Disconnected, status);
@@ -172,7 +171,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             AmqpTransportSettings amqpTransportSettings = new AmqpTransportSettings(protocol);
             ITransportSettings[] transportSettings = new ITransportSettings[] { amqpTransportSettings };
 
-            TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix + $"_{Guid.NewGuid()}", ModulePrefix).ConfigureAwait(false);
+            TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix + $"_{Guid.NewGuid()}", ModulePrefix, Logger).ConfigureAwait(false);
             ConnectionStatus? status = null;
             ConnectionStatusChangeReason? statusChangeReason = null;
             int deviceDisabledReceivedCount = 0;
@@ -189,12 +188,12 @@ namespace Microsoft.Azure.Devices.E2ETests
             using (ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(testModule.ConnectionString, transportSettings))
             {
                 moduleClient.SetConnectionStatusChangesHandler(statusChangeHandler);
-                s_log.Trace($"{nameof(ModuleClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Created {nameof(ModuleClient)} with moduleId={testModule.Id}");
+                Logger.Trace($"{nameof(ModuleClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Created {nameof(ModuleClient)} with moduleId={testModule.Id}");
 
                 await moduleClient.OpenAsync().ConfigureAwait(false);
 
                 // Receiving the module twin should succeed right now.
-                s_log.Trace($"{nameof(ModuleClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: ModuleClient GetTwinAsync.");
+                Logger.Trace($"{nameof(ModuleClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: ModuleClient GetTwinAsync.");
                 var twin = await moduleClient.GetTwinAsync().ConfigureAwait(false);
                 Assert.IsNotNull(twin);
 
@@ -204,7 +203,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     await registryManagerOperation(registryManager, testModule.DeviceId).ConfigureAwait(false);
                 }
 
-                s_log.Trace($"{nameof(ModuleClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Completed RegistryManager operation.");
+                Logger.Trace($"{nameof(ModuleClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Completed RegistryManager operation.");
 
                 // Artificial sleep waiting for the connection status change handler to get triggered.
                 int sleepCount = 50;
@@ -217,7 +216,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     }
                 }
 
-                s_log.Trace($"{nameof(ModuleClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Asserting connection status change.");
+                Logger.Trace($"{nameof(ModuleClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Asserting connection status change.");
 
                 Assert.AreEqual(1, deviceDisabledReceivedCount);
                 Assert.AreEqual(ConnectionStatus.Disconnected, status);

--- a/e2e/test/iothub/DeviceClientX509AuthenticationE2ETests.cs
+++ b/e2e/test/iothub/DeviceClientX509AuthenticationE2ETests.cs
@@ -143,12 +143,12 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         private async Task SendMessageTest(ITransportSettings transportSetting)
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(s_devicePrefix, TestDeviceType.X509).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, TestDeviceType.X509).ConfigureAwait(false);
 
             using (DeviceClient deviceClient = testDevice.CreateDeviceClient(new[] { transportSetting }))
             {
                 await deviceClient.OpenAsync().ConfigureAwait(false);
-                await MessageSendE2ETests.SendSingleMessageAsync(deviceClient, testDevice.Id).ConfigureAwait(false);
+                await MessageSendE2ETests.SendSingleMessageAsync(deviceClient, testDevice.Id, Logger).ConfigureAwait(false);
                 await deviceClient.CloseAsync().ConfigureAwait(false);
             }
         }

--- a/e2e/test/iothub/FaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/FaultInjectionPoolAmqpTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.Devices.E2ETests
@@ -14,6 +13,5 @@ namespace Microsoft.Azure.Devices.E2ETests
     [TestCategory("LongRunning")]
     public partial class FaultInjectionPoolAmqpTests : E2EMsTestBase
     {
-        private static TestLogger _log = TestLogger.GetInstance();
     }
 }

--- a/e2e/test/iothub/FileUploadE2ETests.cs
+++ b/e2e/test/iothub/FileUploadE2ETests.cs
@@ -23,10 +23,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         private const int FileSizeSmall = 10 * 1024;
         private const int FileSizeBig = 5120 * 1024;
 
-#pragma warning disable CA1823
-        private static TestLogger s_log = TestLogger.GetInstance();
-#pragma warning restore CA1823
-
         [LoggedTestMethod]
         [TestCategory("LongRunning")]
         public async Task FileUpload_SmallFile_Http()
@@ -90,6 +86,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         private async Task UploadFileGranularAsync(Stream source, string filename, Http1TransportSettings fileUploadTransportSettings, bool x509auth = false)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(
+                Logger,
                 _devicePrefix,
                 x509auth ? TestDeviceType.X509 : TestDeviceType.Sasl).ConfigureAwait(false);
 
@@ -138,6 +135,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         private async Task UploadFileAsync(Client.TransportType transport, string filename, bool x509auth = false)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(
+                Logger,
                 _devicePrefix,
                 x509auth ? TestDeviceType.X509 : TestDeviceType.Sasl).ConfigureAwait(false);
 

--- a/e2e/test/iothub/FileUploadFaultInjectionTests.cs
+++ b/e2e/test/iothub/FileUploadFaultInjectionTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             int durationInSec = 0,
             int retryDurationInMilliSec = FaultInjection.RecoveryTimeMilliseconds)
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
 
             using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
 

--- a/e2e/test/iothub/messaging/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
+++ b/e2e/test/iothub/messaging/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         private async Task TestSecurityMessageAsync(Client.TransportType transport)
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
 
             try
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         private async Task TestSecurityMessageModuleAsync(Client.TransportType transport)
         {
-            TestModule testModule = await TestModule.GetTestModuleAsync(_devicePrefix, _modulePrefix).ConfigureAwait(false);
+            TestModule testModule = await TestModule.GetTestModuleAsync(_devicePrefix, _modulePrefix, Logger).ConfigureAwait(false);
 
             using (var moduleClient = ModuleClient.CreateFromConnectionString(testModule.ConnectionString, transport))
             {

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageReceiveFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageReceiveFaultInjectionPoolAmqpTests.cs
@@ -621,15 +621,15 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
             {
-                (Message msg, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage();
-                _log.Trace($"{nameof(FaultInjectionPoolAmqpTests)}: Sending message to device {testDevice.Id}: payload='{payload}' p1Value='{p1Value}'");
+                (Message msg, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage(Logger);
+                Logger.Trace($"{nameof(FaultInjectionPoolAmqpTests)}: Sending message to device {testDevice.Id}: payload='{payload}' p1Value='{p1Value}'");
                 await serviceClient.SendAsync(testDevice.Id, msg)
                 .ConfigureAwait(false);
 
-                _log.Trace($"{nameof(FaultInjectionPoolAmqpTests)}: Preparing to receive message for device {testDevice.Id}");
+                Logger.Trace($"{nameof(FaultInjectionPoolAmqpTests)}: Preparing to receive message for device {testDevice.Id}");
                 await deviceClient.OpenAsync()
                 .ConfigureAwait(false);
-                await MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, testDevice.Id, msg, payload)
+                await MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, testDevice.Id, msg, payload, Logger)
                 .ConfigureAwait(false);
             };
 
@@ -658,7 +658,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                     (d, t) => { return Task.FromResult(false); },
                     testOperation,
                     cleanupOperation,
-                    authScope)
+                    authScope,
+                    Logger)
                 .ConfigureAwait(false);
         }
     }

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -866,12 +866,12 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
             {
-                _log.Trace($"{nameof(FaultInjectionPoolAmqpTests)}: Preparing to send message for device {testDevice.Id}");
+                Logger.Trace($"{nameof(FaultInjectionPoolAmqpTests)}: Preparing to send message for device {testDevice.Id}");
                 await deviceClient.OpenAsync().ConfigureAwait(false);
 
-                (Client.Message testMessage, string payload, string p1Value) = MessageSendE2ETests.ComposeD2cTestMessage();
+                (Client.Message testMessage, string payload, string p1Value) = MessageSendE2ETests.ComposeD2cTestMessage(Logger);
 
-                _log.Trace($"{nameof(FaultInjectionPoolAmqpTests)}.{testDevice.Id}: payload='{payload}' p1Value='{p1Value}'");
+                Logger.Trace($"{nameof(FaultInjectionPoolAmqpTests)}.{testDevice.Id}: payload='{payload}' p1Value='{p1Value}'");
                 await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
             };
 
@@ -898,7 +898,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                     (d, t) => { return Task.FromResult(false); },
                     testOperation,
                     cleanupOperation,
-                    authScope)
+                    authScope,
+                    Logger)
                 .ConfigureAwait(false);
         }
     }

--- a/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics.Tracing;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
@@ -18,10 +17,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
     public partial class MessageReceiveFaultInjectionTests : E2EMsTestBase
     {
         private readonly string DevicePrefix = $"E2E_{nameof(MessageReceiveFaultInjectionTests)}_";
-
-#pragma warning disable CA1823
-        private static TestLogger s_log = TestLogger.GetInstance();
-#pragma warning restore CA1823
 
         [LoggedTestMethod]
         public async Task Message_TcpConnectionLossReceiveRecovery_Amqp()
@@ -200,9 +195,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
                 Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
                 {
-                    (Message message, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage();
+                    (Message message, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage(Logger);
                     await serviceClient.SendAsync(testDevice.Id, message).ConfigureAwait(false);
-                    await MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, testDevice.Id, message, payload).ConfigureAwait(false);
+                    await MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, testDevice.Id, message, payload, Logger).ConfigureAwait(false);
                 };
 
                 Func<Task> cleanupOperation = () =>
@@ -220,7 +215,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     FaultInjection.DefaultDurationInSec,
                     init,
                     testOperation,
-                    cleanupOperation).ConfigureAwait(false);
+                    cleanupOperation,
+                    Logger).ConfigureAwait(false);
             }
         }
     }

--- a/e2e/test/iothub/messaging/MessageSendE2EPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/MessageSendE2EPoolAmqpTests.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
     public class MessageSendE2EPoolAmqpTests : E2EMsTestBase
     {
         private readonly string _devicePrefix = $"E2E_{nameof(MessageSendE2EPoolAmqpTests)}_";
-        private static readonly TestLogger s_log = TestLogger.GetInstance();
 
         // TODO: #943 - Honor different pool sizes for different connection pool settings.
         [Ignore]
@@ -126,11 +125,11 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         {
             Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
             {
-                s_log.Trace($"{nameof(MessageSendE2EPoolAmqpTests)}: Preparing to send message for device {testDevice.Id}");
+                Logger.Trace($"{nameof(MessageSendE2EPoolAmqpTests)}: Preparing to send message for device {testDevice.Id}");
                 await deviceClient.OpenAsync().ConfigureAwait(false);
 
-                (Client.Message testMessage, string payload, string p1Value) = MessageSendE2ETests.ComposeD2cTestMessage();
-                s_log.Trace($"{nameof(MessageSendE2EPoolAmqpTests)}.{testDevice.Id}: messageId='{testMessage.MessageId}' payload='{payload}' p1Value='{p1Value}'");
+                (Client.Message testMessage, string payload, string p1Value) = MessageSendE2ETests.ComposeD2cTestMessage(Logger);
+                Logger.Trace($"{nameof(MessageSendE2EPoolAmqpTests)}.{testDevice.Id}: messageId='{testMessage.MessageId}' payload='{payload}' p1Value='{p1Value}'");
                 await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
             };
 
@@ -144,7 +143,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     testOperation,
                     null,
                     authScope,
-                    true)
+                    true,
+                    Logger)
                 .ConfigureAwait(false);
         }
     }

--- a/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics.Tracing;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.Client.Exceptions;
@@ -19,10 +18,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
     public partial class MessageSendFaultInjectionTests : E2EMsTestBase
     {
         private readonly string _devicePrefix = $"E2E_{nameof(MessageSendFaultInjectionTests)}_";
-
-#pragma warning disable CA1823
-        private static TestLogger s_log = TestLogger.GetInstance();
-#pragma warning restore CA1823
 
         [LoggedTestMethod]
         public async Task Message_TcpConnectionLossSendRecovery_Amqp()
@@ -410,7 +405,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
             {
-                (Client.Message testMessage, string payload, string p1Value) = MessageSendE2ETests.ComposeD2cTestMessage();
+                (Client.Message testMessage, string payload, string p1Value) = MessageSendE2ETests.ComposeD2cTestMessage(Logger);
                 await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
             };
 
@@ -425,7 +420,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     durationInSec,
                     init,
                     testOperation,
-                    () => { return Task.FromResult(false); })
+                    () => { return Task.FromResult(false); },
+                    Logger)
                 .ConfigureAwait(false);
         }
     }

--- a/e2e/test/iothub/method/MethodE2EPoolAmqpTests.cs
+++ b/e2e/test/iothub/method/MethodE2EPoolAmqpTests.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
     {
         private const string MethodName = "MethodE2EPoolAmqpTests";
         private readonly string _devicePrefix = $"E2E_{nameof(MethodE2EPoolAmqpTests)}_";
-        private static readonly TestLogger s_log = TestLogger.GetInstance();
 
         // TODO: #943 - Honor different pool sizes for different connection pool settings.
         [Ignore]
@@ -223,24 +222,25 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             Client.TransportType transport,
             int poolSize,
             int devicesCount,
-            Func<DeviceClient, string, Task<Task>> setDeviceReceiveMethod,
+            Func<DeviceClient, string, TestLogger, Task<Task>> setDeviceReceiveMethod,
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device)
         {
             Func<DeviceClient, TestDevice, Task> initOperation = async (deviceClient, testDevice) =>
             {
-                s_log.Trace($"{nameof(MethodE2EPoolAmqpTests)}: Setting method for device {testDevice.Id}");
-                Task methodReceivedTask = await setDeviceReceiveMethod(deviceClient, MethodName).ConfigureAwait(false);
+                Logger.Trace($"{nameof(MethodE2EPoolAmqpTests)}: Setting method for device {testDevice.Id}");
+                Task methodReceivedTask = await setDeviceReceiveMethod(deviceClient, MethodName, Logger).ConfigureAwait(false);
             };
 
             Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
             {
-                s_log.Trace($"{nameof(MethodE2EPoolAmqpTests)}: Preparing to receive method for device {testDevice.Id}");
+                Logger.Trace($"{nameof(MethodE2EPoolAmqpTests)}: Preparing to receive method for device {testDevice.Id}");
                 await MethodE2ETests
                     .ServiceSendMethodAndVerifyResponseAsync(
                         testDevice.Id,
                         MethodName,
                         MethodE2ETests.DeviceResponseJson,
-                        MethodE2ETests.ServiceRequestJson)
+                        MethodE2ETests.ServiceRequestJson,
+                        Logger)
                     .ConfigureAwait(false);
             };
 
@@ -254,7 +254,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     testOperation,
                     null,
                     authScope,
-                    true)
+                    true,
+                    Logger)
                 .ConfigureAwait(false);
         }
     }

--- a/e2e/test/iothub/service/BulkOperationsE2ETests.cs
+++ b/e2e/test/iothub/service/BulkOperationsE2ETests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             var tagName = Guid.NewGuid().ToString();
             var tagValue = Guid.NewGuid().ToString();
 
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
             using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
 
             Twin twin = await registryManager.GetTwinAsync(testDevice.Id).ConfigureAwait(false);
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             var tagName = Guid.NewGuid().ToString();
             var tagValue = Guid.NewGuid().ToString();
 
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
             using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
 
             Twin twin = new Twin();
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             var tagName = Guid.NewGuid().ToString();
             var tagValue = Guid.NewGuid().ToString();
 
-            TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix).ConfigureAwait(false);
+            TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix, Logger).ConfigureAwait(false);
             using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
 
             Twin twin = await registryManager.GetTwinAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             var tagName = Guid.NewGuid().ToString();
             var tagValue = Guid.NewGuid().ToString();
 
-            TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix).ConfigureAwait(false);
+            TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix, Logger).ConfigureAwait(false);
 
             using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
             var twin = new Twin();

--- a/e2e/test/iothub/service/IoTHubServiceProxyE2ETests.cs
+++ b/e2e/test/iothub/service/IoTHubServiceProxyE2ETests.cs
@@ -27,10 +27,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         private const int MaxIterationWait = 30;
         private static readonly TimeSpan _waitDuration = TimeSpan.FromSeconds(5);
 
-#pragma warning disable CA1823
-        private static TestLogger _log = TestLogger.GetInstance();
-#pragma warning restore CA1823
-
         [LoggedTestMethod]
         public async Task ServiceClient_Message_SendSingleMessage_WithProxy()
         {
@@ -61,7 +57,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
 
         private async Task SendSingleMessageService(ServiceClientTransportSettings transportSettings)
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
             using (DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString))
             using (ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(s_connectionString, TransportType.Amqp, transportSettings))
             {
@@ -105,7 +101,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                     // Concurrent jobs can be rejected, so implement a retry mechanism to handle conflicts with other tests
                     catch (ThrottlingException) when (++tryCount < MaxIterationWait)
                     {
-                        _log.Trace($"ThrottlingException... waiting.");
+                        Logger.Trace($"ThrottlingException... waiting.");
                         await Task.Delay(_waitDuration).ConfigureAwait(false);
                         continue;
                     }
@@ -119,7 +115,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             var payload = Guid.NewGuid().ToString();
             var p1Value = Guid.NewGuid().ToString();
 
-            _log.Trace($"{nameof(ComposeD2CTestMessage)}: messageId='{messageId}' payload='{payload}' p1Value='{p1Value}'");
+            Logger.Trace($"{nameof(ComposeD2CTestMessage)}: messageId='{messageId}' payload='{payload}' p1Value='{p1Value}'");
             var message = new Message(Encoding.UTF8.GetBytes(payload))
             {
                 MessageId = messageId,

--- a/e2e/test/iothub/service/RegistryManagerExportDevicesTests.cs
+++ b/e2e/test/iothub/service/RegistryManagerExportDevicesTests.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
     [TestCategory("IoTHub")]
     public class RegistryManagerExportDevicesTests : E2EMsTestBase
     {
-        private readonly TestLogger _log = TestLogger.GetInstance();
-
         // A bug in either Azure.Storage.Blob or System.Diagnostics causes an exception during container creation
         // so for now, we need to use the older storage nuget.
         // https://github.com/Azure/azure-sdk-for-net/issues/10476
@@ -58,7 +56,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             string deviceId = $"{nameof(RegistryManager_ExportDevices)}-{StorageContainer.GetRandomSuffix(4)}";
             var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
 
-            _log.Trace($"Using deviceId {deviceId}");
+            Logger.Trace($"Using deviceId {deviceId}");
 
             try
             {
@@ -66,7 +64,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                 storageContainer = await StorageContainer
                     .GetInstanceAsync(containerName)
                     .ConfigureAwait(false);
-                _log.Trace($"Using container {storageContainer.Uri}");
+                Logger.Trace($"Using container {storageContainer.Uri}");
 
                 Uri containerUri = storageAuthenticationType == StorageAuthenticationType.KeyBased
                     ? storageContainer.SasUri
@@ -101,7 +99,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                     // Concurrent jobs can be rejected, so implement a retry mechanism to handle conflicts with other tests
                     catch (JobQuotaExceededException) when (++tryCount < MaxIterationWait)
                     {
-                        _log.Trace($"JobQuotaExceededException... waiting.");
+                        Logger.Trace($"JobQuotaExceededException... waiting.");
                         await Task.Delay(_waitDuration).ConfigureAwait(false);
                         continue;
                     }
@@ -112,7 +110,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                 {
                     await Task.Delay(_waitDuration).ConfigureAwait(false);
                     exportJobResponse = await registryManager.GetJobAsync(exportJobResponse.JobId).ConfigureAwait(false);
-                    _log.Trace($"Job {exportJobResponse.JobId} is {exportJobResponse.Status} with progress {exportJobResponse.Progress}%");
+                    Logger.Trace($"Job {exportJobResponse.JobId} is {exportJobResponse.Status} with progress {exportJobResponse.Progress}%");
                     if (!s_incompleteJobs.Contains(exportJobResponse.Status))
                     {
                         break;
@@ -139,7 +137,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                     ExportImportDevice device = JsonConvert.DeserializeObject<ExportImportDevice>(serializedDeivce);
                     if (StringComparer.Ordinal.Equals(device.Id, deviceId))
                     {
-                        _log.Trace($"Found device in export as [{serializedDeivce}]");
+                        Logger.Trace($"Found device in export as [{serializedDeivce}]");
                         foundDeviceInExport = true;
                         break;
                     }

--- a/e2e/test/iothub/service/RegistryManagerImportDevicesTests.cs
+++ b/e2e/test/iothub/service/RegistryManagerImportDevicesTests.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
     [TestCategory("IoTHub")]
     public class RegistryManagerImportDevicesTests : E2EMsTestBase
     {
-        private readonly TestLogger _log = TestLogger.GetInstance();
-
         // A bug in either Storage or System.Diagnostics causes an exception during container creation
         // so for now, we need to use the older storage nuget.
         // https://github.com/Azure/azure-sdk-for-net/issues/10476
@@ -52,7 +50,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             string deviceId = $"{nameof(RegistryManager_ImportDevices)}-{StorageContainer.GetRandomSuffix(4)}";
             var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
 
-            _log.Trace($"Using deviceId {deviceId}");
+            Logger.Trace($"Using deviceId {deviceId}");
 
             try
             {
@@ -60,7 +58,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                 storageContainer = await StorageContainer
                     .GetInstanceAsync(containerName)
                     .ConfigureAwait(false);
-                _log.Trace($"Using container {storageContainer.Uri}");
+                Logger.Trace($"Using container {storageContainer.Uri}");
 
                 Uri containerUri = storageAuthenticationType == StorageAuthenticationType.KeyBased
                     ? storageContainer.SasUri
@@ -99,7 +97,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                     // Concurrent jobs can be rejected, so implement a retry mechanism to handle conflicts with other tests
                     catch (JobQuotaExceededException) when (++tryCount < MaxIterationWait)
                     {
-                        _log.Trace($"JobQuotaExceededException... waiting.");
+                        Logger.Trace($"JobQuotaExceededException... waiting.");
                         await Task.Delay(s_waitDuration).ConfigureAwait(false);
                         continue;
                     }
@@ -110,7 +108,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                 {
                     await Task.Delay(1000).ConfigureAwait(false);
                     importJobResponse = await registryManager.GetJobAsync(importJobResponse.JobId).ConfigureAwait(false);
-                    _log.Trace($"Job {importJobResponse.JobId} is {importJobResponse.Status} with progress {importJobResponse.Progress}%");
+                    Logger.Trace($"Job {importJobResponse.JobId} is {importJobResponse.Status} with progress {importJobResponse.Progress}%");
                     if (!s_incompleteJobs.Contains(importJobResponse.Status))
                     {
                         break;
@@ -134,7 +132,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                     }
                     catch (Exception ex)
                     {
-                        _log.Trace($"Could not find device on iteration {i} due to [{ex.Message}]");
+                        Logger.Trace($"Could not find device on iteration {i} due to [{ex.Message}]");
                     }
                 }
                 if (device == null)

--- a/e2e/test/iothub/service/ServiceClientE2ETests.cs
+++ b/e2e/test/iothub/service/ServiceClientE2ETests.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
     public class ServiceClientE2ETests : E2EMsTestBase
     {
         private readonly string DevicePrefix = $"E2E_{nameof(ServiceClientE2ETests)}_";
-        private static TestLogger s_log = TestLogger.GetInstance();
 
         [LoggedTestMethod]
         [ExpectedException(typeof(TimeoutException))]
@@ -47,13 +46,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
 
         private async Task TestTimeout(TimeSpan? timeout)
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
             using var sender = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
 
             Stopwatch sw = new Stopwatch();
             sw.Start();
 
-            s_log.Trace($"Testing ServiceClient SendAsync() timeout in ticks={timeout?.Ticks}");
+            Logger.Trace($"Testing ServiceClient SendAsync() timeout in ticks={timeout?.Ticks}");
             try
             {
                 await sender.SendAsync(testDevice.Id, new Message(Encoding.ASCII.GetBytes("Dummy Message")), timeout).ConfigureAwait(false);
@@ -61,7 +60,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             finally
             {
                 sw.Stop();
-                s_log.Trace($"Testing ServiceClient SendAsync(): exiting test after time={sw.Elapsed}; ticks={sw.ElapsedTicks}");
+                Logger.Trace($"Testing ServiceClient SendAsync(): exiting test after time={sw.Elapsed}; ticks={sw.ElapsedTicks}");
             }
         }
     }

--- a/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
+++ b/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
     public class TwinFaultInjectionTests : E2EMsTestBase
     {
         private static readonly string s_devicePrefix = $"E2E_{nameof(TwinFaultInjectionTests)}_";
-        private static readonly TestLogger s_log = TestLogger.GetInstance();
 
         [LoggedTestMethod]
         [TestCategory("FaultInjection")]
@@ -248,7 +247,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     FaultInjection.DefaultDurationInSec,
                     (d, t) => { return Task.FromResult<bool>(false); },
                     testOperation,
-                    () => { return Task.FromResult<bool>(false); })
+                    () => { return Task.FromResult<bool>(false); },
+                    Logger)
                 .ConfigureAwait(false);
         }
 
@@ -279,7 +279,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             // Configure the callback and start accepting twin changes.
             Func<DeviceClient, TestDevice, Task> initOperation = async (deviceClient, testDevice) =>
             {
-                testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient);
+                testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, Logger);
                 await testDeviceCallbackHandler.SetTwinPropertyUpdateCallbackHandlerAsync(propName).ConfigureAwait(false);
             };
 
@@ -289,7 +289,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                 var propValue = Guid.NewGuid().ToString();
                 testDeviceCallbackHandler.ExpectedTwinPropertyValue = propValue;
 
-                s_log.Trace($"{nameof(Twin_DeviceDesiredPropertyUpdateRecoveryAsync)}: name={propName}, value={propValue}");
+                Logger.Trace($"{nameof(Twin_DeviceDesiredPropertyUpdateRecoveryAsync)}: name={propName}, value={propValue}");
 
                 Task serviceSendTask = RegistryManagerUpdateDesiredPropertyAsync(testDevice.Id, propName, propValue);
                 Task twinReceivedTask = testDeviceCallbackHandler.WaitForTwinCallbackAsync(cts.Token);
@@ -314,7 +314,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     FaultInjection.DefaultDurationInSec,
                     initOperation,
                     testOperation,
-                    () => { return Task.FromResult(false); })
+                    () => { return Task.FromResult(false); },
+                    Logger)
                 .ConfigureAwait(false);
         }
     }

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         private readonly string _idPrefix = $"e2e-{nameof(ProvisioningE2ETests).ToLower()}-";
 
         private readonly VerboseTestLogger _verboseLog = VerboseTestLogger.GetInstance();
-        private readonly TestLogger _log = TestLogger.GetInstance();
 
         public enum EnrollmentType
         {
@@ -482,7 +481,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
                 using var cts = new CancellationTokenSource(PassingTimeoutMiliseconds);
 
-                _log.Trace("ProvisioningDeviceClient RegisterAsync . . . ");
+                Logger.Trace("ProvisioningDeviceClient RegisterAsync . . . ");
                 DeviceRegistrationResult result = await provClient.RegisterAsync(cts.Token).ConfigureAwait(false);
 
                 ValidateDeviceRegistrationResult(false, result);
@@ -611,10 +610,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
                 using var cts = new CancellationTokenSource(FailingTimeoutMiliseconds);
 
-                _log.Trace("ProvisioningDeviceClient RegisterAsync . . . ");
+                Logger.Trace("ProvisioningDeviceClient RegisterAsync . . . ");
                 DeviceRegistrationResult result = await provClient.RegisterAsync(cts.Token).ConfigureAwait(false);
 
-                _log.Trace($"{result.Status}");
+                Logger.Trace($"{result.Status}");
 
                 Assert.AreEqual(ProvisioningRegistrationStatusType.Failed, result.Status);
                 Assert.IsNull(result.AssignedHub);
@@ -725,7 +724,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                 var exception = await Assert.ThrowsExceptionAsync<ProvisioningTransportException>(
                     () => provClient.RegisterAsync(cts.Token)).ConfigureAwait(false);
 
-                _log.Trace($"Exception: {exception}");
+                Logger.Trace($"Exception: {exception}");
             }
         }
 
@@ -781,12 +780,12 @@ transport);
 
             using var cts = new CancellationTokenSource(FailingTimeoutMiliseconds);
 
-            _log.Trace("ProvisioningDeviceClient RegisterAsync . . . ");
+            Logger.Trace("ProvisioningDeviceClient RegisterAsync . . . ");
             ProvisioningTransportException exception = await Assert.
                 ThrowsExceptionAsync<ProvisioningTransportException>(() => provClient.RegisterAsync(cts.Token))
                 .ConfigureAwait(false);
 
-            _log.Trace($"Exception: {exception}");
+            Logger.Trace($"Exception: {exception}");
         }
 
         #endregion InvalidGlobalAddress
@@ -824,20 +823,20 @@ transport);
         {
             using (DeviceClient iotClient = DeviceClient.Create(result.AssignedHub, auth, transportProtocol))
             {
-                _log.Trace("DeviceClient OpenAsync.");
+                Logger.Trace("DeviceClient OpenAsync.");
                 await iotClient.OpenAsync().ConfigureAwait(false);
-                _log.Trace("DeviceClient SendEventAsync.");
+                Logger.Trace("DeviceClient SendEventAsync.");
                 await iotClient.SendEventAsync(
                     new Client.Message(Encoding.UTF8.GetBytes("TestMessage"))).ConfigureAwait(false);
 
                 if (sendReportedPropertiesUpdate)
                 {
-                    _log.Trace("DeviceClient updating desired properties.");
+                    Logger.Trace("DeviceClient updating desired properties.");
                     Twin twin = await iotClient.GetTwinAsync().ConfigureAwait(false);
                     await iotClient.UpdateReportedPropertiesAsync(new TwinCollection($"{{\"{new Guid()}\":\"{new Guid()}\"}}")).ConfigureAwait(false);
                 }
 
-                _log.Trace("DeviceClient CloseAsync.");
+                Logger.Trace("DeviceClient CloseAsync.");
                 await iotClient.CloseAsync().ConfigureAwait(false);
             }
         }
@@ -870,12 +869,12 @@ transport);
 
                     var provisioningService = ProvisioningServiceClient.CreateFromConnectionString(Configuration.Provisioning.ConnectionString);
 
-                    _log.Trace($"Getting enrollment: RegistrationID = {registrationId}");
+                    Logger.Trace($"Getting enrollment: RegistrationID = {registrationId}");
                     IndividualEnrollment individualEnrollment = new IndividualEnrollment(registrationId, new TpmAttestation(base64Ek)) { AllocationPolicy = allocationPolicy, ReprovisionPolicy = reprovisionPolicy, IotHubs = iothubs, CustomAllocationDefinition = customAllocationDefinition, Capabilities = capabilities };
                     IndividualEnrollment enrollment = await provisioningService.CreateOrUpdateIndividualEnrollmentAsync(individualEnrollment).ConfigureAwait(false);
                     var attestation = new TpmAttestation(base64Ek);
                     enrollment.Attestation = attestation;
-                    _log.Trace($"Updating enrollment: RegistrationID = {registrationId} EK = '{base64Ek}'");
+                    Logger.Trace($"Updating enrollment: RegistrationID = {registrationId} EK = '{base64Ek}'");
                     await provisioningService.CreateOrUpdateIndividualEnrollmentAsync(enrollment).ConfigureAwait(false);
 
                     return tpmSim;
@@ -972,8 +971,8 @@ transport);
         private void ValidateDeviceRegistrationResult(bool validatePayload, DeviceRegistrationResult result)
         {
             Assert.IsNotNull(result);
-            _log.Trace($"{result.Status} (Error Code: {result.ErrorCode}; Error Message: {result.ErrorMessage})");
-            _log.Trace($"ProvisioningDeviceClient AssignedHub: {result.AssignedHub}; DeviceID: {result.DeviceId}");
+            Logger.Trace($"{result.Status} (Error Code: {result.ErrorCode}; Error Message: {result.ErrorMessage})");
+            Logger.Trace($"ProvisioningDeviceClient AssignedHub: {result.AssignedHub}; DeviceID: {result.DeviceId}");
 
             Assert.AreEqual(ProvisioningRegistrationStatusType.Assigned, result.Status, $"Unexpected provisioning status, substatus: {result.Substatus}, error code: {result.ErrorCode}, error message: {result.ErrorMessage}");
             Assert.IsNotNull(result.AssignedHub);

--- a/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
 #pragma warning disable CA1823
         private readonly VerboseTestLogger _verboseLog = VerboseTestLogger.GetInstance();
-        private readonly TestLogger _log = TestLogger.GetInstance();
 #pragma warning restore CA1823
 
         [LoggedTestMethod]

--- a/e2e/test/provisioning/ReprovisioningE2ETests.cs
+++ b/e2e/test/provisioning/ReprovisioningE2ETests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
 #pragma warning disable CA1823
         private readonly VerboseTestLogger _verboseLog = VerboseTestLogger.GetInstance();
-        private readonly TestLogger _log = TestLogger.GetInstance();
 #pragma warning restore CA1823
 
         [LoggedTestMethod]
@@ -313,20 +312,20 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         {
             using (DeviceClient iotClient = DeviceClient.Create(result.AssignedHub, auth, transportProtocol))
             {
-                _log.Trace("DeviceClient OpenAsync.");
+                Logger.Trace("DeviceClient OpenAsync.");
                 await iotClient.OpenAsync().ConfigureAwait(false);
-                _log.Trace("DeviceClient SendEventAsync.");
+                Logger.Trace("DeviceClient SendEventAsync.");
                 await iotClient.SendEventAsync(
                     new Client.Message(Encoding.UTF8.GetBytes("TestMessage"))).ConfigureAwait(false);
 
                 if (sendReportedPropertiesUpdate)
                 {
-                    _log.Trace("DeviceClient updating desired properties.");
+                    Logger.Trace("DeviceClient updating desired properties.");
                     Twin twin = await iotClient.GetTwinAsync().ConfigureAwait(false);
                     await iotClient.UpdateReportedPropertiesAsync(new TwinCollection($"{{\"{new Guid()}\":\"{new Guid()}\"}}")).ConfigureAwait(false);
                 }
 
-                _log.Trace("DeviceClient CloseAsync.");
+                Logger.Trace("DeviceClient CloseAsync.");
                 await iotClient.CloseAsync().ConfigureAwait(false);
             }
         }
@@ -361,12 +360,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
                     var provisioningService = ProvisioningServiceClient.CreateFromConnectionString(Configuration.Provisioning.ConnectionString);
 
-                    _log.Trace($"Getting enrollment: RegistrationID = {registrationId}");
+                    Logger.Trace($"Getting enrollment: RegistrationID = {registrationId}");
                     IndividualEnrollment individualEnrollment = new IndividualEnrollment(registrationId, new TpmAttestation(base64Ek)) { AllocationPolicy = allocationPolicy, ReprovisionPolicy = reprovisionPolicy, IotHubs = iothubs, CustomAllocationDefinition = customAllocationDefinition, Capabilities = capabilities };
                     IndividualEnrollment enrollment = await provisioningService.CreateOrUpdateIndividualEnrollmentAsync(individualEnrollment).ConfigureAwait(false);
                     var attestation = new TpmAttestation(base64Ek);
                     enrollment.Attestation = attestation;
-                    _log.Trace($"Updating enrollment: RegistrationID = {registrationId} EK = '{base64Ek}'");
+                    Logger.Trace($"Updating enrollment: RegistrationID = {registrationId} EK = '{base64Ek}'");
                     await provisioningService.CreateOrUpdateIndividualEnrollmentAsync(enrollment).ConfigureAwait(false);
 
                     return tpmSim;
@@ -463,8 +462,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         private void ValidateDeviceRegistrationResult(DeviceRegistrationResult result)
         {
             Assert.IsNotNull(result);
-            _log.Trace($"{result.Status} (Error Code: {result.ErrorCode}; Error Message: {result.ErrorMessage})");
-            _log.Trace($"ProvisioningDeviceClient AssignedHub: {result.AssignedHub}; DeviceID: {result.DeviceId}");
+            Logger.Trace($"{result.Status} (Error Code: {result.ErrorCode}; Error Message: {result.ErrorMessage})");
+            Logger.Trace($"ProvisioningDeviceClient AssignedHub: {result.AssignedHub}; DeviceID: {result.DeviceId}");
 
             Assert.AreEqual(ProvisioningRegistrationStatusType.Assigned, result.Status, $"Unexpected provisioning status, substatus: {result.Substatus}, error code: {result.ErrorCode}, error message: {result.ErrorMessage}");
             Assert.IsNotNull(result.AssignedHub);
@@ -516,9 +515,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         {
             using (DeviceClient iotClient = DeviceClient.Create(result.AssignedHub, auth, transportProtocol))
             {
-                _log.Trace("DeviceClient OpenAsync.");
+                Logger.Trace("DeviceClient OpenAsync.");
                 await iotClient.OpenAsync().ConfigureAwait(false);
-                _log.Trace("DeviceClient SendEventAsync.");
+                Logger.Trace("DeviceClient SendEventAsync.");
                 await iotClient.SendEventAsync(
                     new Client.Message(Encoding.UTF8.GetBytes("TestMessage"))).ConfigureAwait(false);
 
@@ -546,7 +545,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     }
                 }
 
-                _log.Trace("DeviceClient CloseAsync.");
+                Logger.Trace("DeviceClient CloseAsync.");
                 await iotClient.CloseAsync().ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
This PR removes the test logger instance initialization from each test class, and instead, references them from the base class directly.

This does not solve the increase in test suite running time, but is a first step in isolating the logging changes.