### PR TITLE
Ensuring that logging does not take too much time

### DIFF
--- a/e2e/test/Helpers/CustomWebProxy.cs
+++ b/e2e/test/Helpers/CustomWebProxy.cs
@@ -9,12 +9,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 {
     public class CustomWebProxy : IWebProxy
     {
-        private readonly TestLogger s_testLog;
+        private readonly MsTestLogger _logger;
         private long _counter = 0;
 
-        public CustomWebProxy(TestLogger logger)
+        public CustomWebProxy(MsTestLogger logger)
         {
-            s_testLog = logger;
+            _logger = logger;
         }
 
         public ICredentials Credentials { get; set; }
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         public bool IsBypassed(Uri host)
         {
             Interlocked.Increment(ref _counter);
-            s_testLog.Trace($"{nameof(CustomWebProxy)}.{nameof(IsBypassed)} Uri = {host}");
+            _logger.Trace($"{nameof(CustomWebProxy)}.{nameof(IsBypassed)} Uri = {host}");
             return false;
         }
     }

--- a/e2e/test/Helpers/TestDevice.cs
+++ b/e2e/test/Helpers/TestDevice.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         private const int DelayAfterDeviceCreationSeconds = 0;
         private static readonly SemaphoreSlim s_semaphore = new SemaphoreSlim(1, 1);
 
-        private static TestLogger s_logger;
+        private static MsTestLogger _logger;
 
         private TestDevice(Device device, Client.IAuthenticationMethod authenticationMethod)
         {
@@ -39,9 +39,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         /// </summary>
         /// <param name="namePrefix">The prefix to apply to your device name</param>
         /// <param name="type">The way the device will authenticate</param>
-        public static async Task<TestDevice> GetTestDeviceAsync(TestLogger logger, string namePrefix, TestDeviceType type = TestDeviceType.Sasl)
+        public static async Task<TestDevice> GetTestDeviceAsync(MsTestLogger logger, string namePrefix, TestDeviceType type = TestDeviceType.Sasl)
         {
-            s_logger = logger;
+            _logger = logger;
             string prefix = namePrefix + type + "_";
 
             try
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                 await s_semaphore.WaitAsync().ConfigureAwait(false);
                 TestDevice ret = await CreateDeviceAsync(type, prefix).ConfigureAwait(false);
 
-                s_logger.Trace($"{nameof(GetTestDeviceAsync)}: Using device {ret.Id}.");
+                _logger.Trace($"{nameof(GetTestDeviceAsync)}: Using device {ret.Id}.");
                 return ret;
             }
             finally
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
             // Delete existing devices named this way and create a new one.
             using var rm = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
-            s_logger.Trace($"{nameof(GetTestDeviceAsync)}: Creating device {deviceName} with type {type}.");
+            _logger.Trace($"{nameof(GetTestDeviceAsync)}: Creating device {deviceName} with type {type}.");
 
             Client.IAuthenticationMethod auth = null;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
             Device device = await rm.AddDeviceAsync(requestDevice).ConfigureAwait(false);
 
-            s_logger.Trace($"{nameof(GetTestDeviceAsync)}: Pausing for {DelayAfterDeviceCreationSeconds}s after device was created.");
+            _logger.Trace($"{nameof(GetTestDeviceAsync)}: Pausing for {DelayAfterDeviceCreationSeconds}s after device was created.");
             await Task.Delay(DelayAfterDeviceCreationSeconds * 1000).ConfigureAwait(false);
 
             await rm.CloseAsync().ConfigureAwait(false);
@@ -128,12 +128,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             if (AuthenticationMethod == null)
             {
                 deviceClient = DeviceClient.CreateFromConnectionString(ConnectionString, transport);
-                s_logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from connection string: {transport} ID={TestLogger.IdOf(deviceClient)}");
+                _logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from connection string: {transport} ID={TestLogger.IdOf(deviceClient)}");
             }
             else
             {
                 deviceClient = DeviceClient.Create(IoTHubHostName, AuthenticationMethod, transport);
-                s_logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from IAuthenticationMethod: {transport} ID={TestLogger.IdOf(deviceClient)}");
+                _logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from IAuthenticationMethod: {transport} ID={TestLogger.IdOf(deviceClient)}");
             }
 
             return deviceClient;
@@ -148,18 +148,18 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                 if (authScope == ConnectionStringAuthScope.Device)
                 {
                     deviceClient = DeviceClient.CreateFromConnectionString(ConnectionString, transportSettings);
-                    s_logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from device connection string: ID={TestLogger.IdOf(deviceClient)}");
+                    _logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from device connection string: ID={TestLogger.IdOf(deviceClient)}");
                 }
                 else
                 {
                     deviceClient = DeviceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString, Device.Id, transportSettings);
-                    s_logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from IoTHub connection string: ID={TestLogger.IdOf(deviceClient)}");
+                    _logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from IoTHub connection string: ID={TestLogger.IdOf(deviceClient)}");
                 }
             }
             else
             {
                 deviceClient = DeviceClient.Create(IoTHubHostName, AuthenticationMethod, transportSettings);
-                s_logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from IAuthenticationMethod: ID={TestLogger.IdOf(deviceClient)}");
+                _logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from IAuthenticationMethod: ID={TestLogger.IdOf(deviceClient)}");
             }
 
             return deviceClient;

--- a/e2e/test/Helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/Helpers/TestDeviceCallbackHandler.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         private SemaphoreSlim _twinCallbackSemaphore = new SemaphoreSlim(1, 1);
         private string _expectedTwinPropertyValue = null;
 
-        private readonly TestLogger _log;
+        private readonly MsTestLogger _logger;
 
-        public TestDeviceCallbackHandler(DeviceClient deviceClient, TestLogger logger)
+        public TestDeviceCallbackHandler(DeviceClient deviceClient, MsTestLogger logger)
         {
             _deviceClient = deviceClient;
-            _log = logger;
+            _logger = logger;
         }
 
         public string ExpectedTwinPropertyValue
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                 {
                     try
                     {
-                        _log.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: DeviceClient callback method: {request.Name} {request.ResponseTimeout}.");
+                        _logger.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: DeviceClient callback method: {request.Name} {request.ResponseTimeout}.");
                         Assert.AreEqual(methodName, request.Name, $"The expected method name should be {methodName} but was {request.Name}");
                         Assert.AreEqual(expectedServiceRequestJson, request.DataAsJson, $"The expected method name should be {expectedServiceRequestJson} but was {request.DataAsJson}");
 
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                     }
                     catch (Exception ex)
                     {
-                        _log.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: Error during DeviceClient callback method: {ex}.");
+                        _logger.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: Error during DeviceClient callback method: {ex}.");
 
                         _methodExceptionDispatch = ExceptionDispatchInfo.Capture(ex);
                         return Task.FromResult(new MethodResponse(500));
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(
                 (patch, context) =>
                 {
-                    _log.Trace($"{nameof(SetTwinPropertyUpdateCallbackHandlerAsync)}: DeviceClient callback twin: DesiredProperty: {patch}, {context}");
+                    _logger.Trace($"{nameof(SetTwinPropertyUpdateCallbackHandlerAsync)}: DeviceClient callback twin: DesiredProperty: {patch}, {context}");
 
                     try
                     {

--- a/e2e/test/Helpers/TestModule.cs
+++ b/e2e/test/Helpers/TestModule.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         /// </summary>
         /// <param name="namePrefix"></param>
         /// <param name="type"></param>
-        public static async Task<TestModule> GetTestModuleAsync(string deviceNamePrefix, string moduleNamePrefix, TestLogger logger)
+        public static async Task<TestModule> GetTestModuleAsync(string deviceNamePrefix, string moduleNamePrefix, MsTestLogger logger)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(logger, deviceNamePrefix).ConfigureAwait(false);
 

--- a/e2e/test/Helpers/logging/LoggedTestMethod.cs
+++ b/e2e/test/Helpers/logging/LoggedTestMethod.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Azure.Devices.E2ETests
     /// </summary>
     public class LoggedTestMethod : TestMethodAttribute
     {
-        private static TestLogger _logger = new TestLogger();
-
         public override TestResult[] Execute(ITestMethod testMethod)
         {
             TestResult[] results = base.Execute(testMethod);
@@ -29,8 +27,9 @@ namespace Microsoft.Azure.Devices.E2ETests
                     { LoggingPropertyNames.TestClassName, testMethod.TestClassName },
                     { LoggingPropertyNames.TestFailureReason, testFailureReason }
                 };
-                _logger.Trace($"Test {testMethod.TestMethodName} failed with error {testFailureReason}.", SeverityLevel.Error, extraProperties);
-                _logger.SafeFlushAsync();
+
+                // Note: Events take long and increase run time of the test suite, so only using trace.
+                TestLogger.Instance.Trace($"Test {testMethod.TestMethodName} failed with error {testFailureReason}.", SeverityLevel.Error, extraProperties);
             }
             return results;
         }

--- a/e2e/test/Helpers/logging/MsTestLogger.cs
+++ b/e2e/test/Helpers/logging/MsTestLogger.cs
@@ -1,20 +1,34 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.Devices.E2ETests
 {
     /// <summary>
+    /// /// NOTE: USE THIS IN TESTS
     /// Ms Test framework specific logging.
+    /// Every test will have its own instance of this logger with properties specific to the test.
+    /// This logger uses the global logger to write logs but has its own set of properties.
+    /// We cannot inherit and log using this because this logger object gets disposed at the end of the test
+    /// and we will lose logs without doing a flush. Flush is expensive and should be done only once when
+    /// we exit the test suite.
     /// </summary>
-    public class MsTestLogger : TestLogger
+    public class MsTestLogger
     {
-        internal MsTestLogger(TestContext testContext) : base()
+        // Test specific properties that cannot be changed.
+        private IDictionary<string, string> MsTestProperties = new Dictionary<string, string>();
+
+        // This property bag can be used to add other properties.
+        public IDictionary<string, string> Properties { get; } = new Dictionary<string, string>();
+
+        internal MsTestLogger(TestContext testContext)
         {
             // Framework against which the test is running.
             var targetFramework = (TargetFrameworkAttribute)Assembly
@@ -25,10 +39,16 @@ namespace Microsoft.Azure.Devices.E2ETests
             string operatingSystem = RuntimeInformation.OSDescription.Trim();
 
             // Add test related properties.
-            Properties.Add(LoggingPropertyNames.TestName, testContext.TestName);
-            Properties.Add(LoggingPropertyNames.TestClassName, testContext.FullyQualifiedTestClassName);
-            Properties.Add(LoggingPropertyNames.TargetFramework, targetFramework.FrameworkName);
-            Properties.Add(LoggingPropertyNames.OsInfo, operatingSystem);
+            MsTestProperties.Add(LoggingPropertyNames.TestName, testContext.TestName);
+            MsTestProperties.Add(LoggingPropertyNames.TestClassName, testContext.FullyQualifiedTestClassName);
+            MsTestProperties.Add(LoggingPropertyNames.TargetFramework, targetFramework.FrameworkName);
+            MsTestProperties.Add(LoggingPropertyNames.OsInfo, operatingSystem);
+        }
+
+        public void Trace(string message, SeverityLevel severity = SeverityLevel.Information, IDictionary<string, string> extraProperties = null)
+        {
+            IDictionary<string, string>[] bagsToMerge = new[] { MsTestProperties, Properties, extraProperties };
+            TestLogger.Instance.Trace(message, severity, TestLogger.MergePropertyBags(bagsToMerge));
         }
     }
 }

--- a/e2e/test/Helpers/templates/FaultInjection.cs
+++ b/e2e/test/Helpers/templates/FaultInjection.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
         // --------------------------------------------------------------------------------------------------------------------------------------------------------------------
         //  --- device in normal operation --- | FaultRequested | --- <delayInSec> --- | --- Device in fault mode for <durationInSec> --- | --- device in normal operation ---
         // --------------------------------------------------------------------------------------------------------------------------------------------------------------------
-        public static async Task ActivateFaultInjectionAsync(Client.TransportType transport, string faultType, string reason, int delayInSec, int durationInSec, DeviceClient deviceClient, TestLogger logger)
+        public static async Task ActivateFaultInjectionAsync(Client.TransportType transport, string faultType, string reason, int delayInSec, int durationInSec, DeviceClient deviceClient, MsTestLogger logger)
         {
             logger.Trace($"{nameof(ActivateFaultInjectionAsync)}: Requesting fault injection type={faultType} reason={reason}, delay={delayInSec}s, duration={FaultInjection.DefaultDurationInSec}s");
 
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
             Func<DeviceClient, TestDevice, Task> initOperation,
             Func<DeviceClient, TestDevice, Task> testOperation,
             Func<Task> cleanupOperation,
-            TestLogger logger)
+            MsTestLogger logger)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(logger, devicePrefix, type).ConfigureAwait(false);
             DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);

--- a/e2e/test/Helpers/templates/FaultInjectionPoolingOverAmqp.cs
+++ b/e2e/test/Helpers/templates/FaultInjectionPoolingOverAmqp.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
             Func<DeviceClient, TestDevice, Task> testOperation,
             Func<IList<DeviceClient>, Task> cleanupOperation,
             ConnectionStringAuthScope authScope,
-            TestLogger logger)
+            MsTestLogger logger)
         {
             var transportSettings = new ITransportSettings[]
             {
@@ -207,9 +207,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
         public class AmqpConnectionStatusChange
         {
             private readonly string _deviceId;
-            private readonly TestLogger _logger;
+            private readonly MsTestLogger _logger;
 
-            public AmqpConnectionStatusChange(string deviceId, TestLogger logger)
+            public AmqpConnectionStatusChange(string deviceId, MsTestLogger logger)
             {
                 LastConnectionStatus = null;
                 LastConnectionStatusChangeReason = null;

--- a/e2e/test/Helpers/templates/PoolingOverAmqp.cs
+++ b/e2e/test/Helpers/templates/PoolingOverAmqp.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
             Func<Task> cleanupOperation,
             ConnectionStringAuthScope authScope,
             bool ignoreConnectionStatus,
-            TestLogger logger)
+            MsTestLogger logger)
         {
             var transportSettings = new ITransportSettings[]
             {
@@ -148,9 +148,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
 
         private class AmqpConnectionStatusChange
         {
-            private readonly TestLogger _logger;
+            private readonly MsTestLogger _logger;
 
-            public AmqpConnectionStatusChange(TestLogger logger)
+            public AmqpConnectionStatusChange(MsTestLogger logger)
             {
                 LastConnectionStatus = null;
                 LastConnectionStatusChangeReason = null;

--- a/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
@@ -213,9 +213,9 @@ namespace Microsoft.Azure.Devices.E2ETests
             private SemaphoreSlim _tokenRefreshSemaphore = new SemaphoreSlim(0);
             private int _counter;
 
-            private TestLogger _logger;
+            private MsTestLogger _logger;
 
-            public TestTokenRefresher(string deviceId, string key, TestLogger logger) : base(deviceId)
+            public TestTokenRefresher(string deviceId, string key, MsTestLogger logger) : base(deviceId)
             {
                 _key = key;
                 _logger = logger;
@@ -227,7 +227,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 int suggestedTimeToLive,
                 int timeBufferPercentage,
                 Client.TransportType transport,
-                TestLogger logger)
+                MsTestLogger logger)
                 : base(deviceId, suggestedTimeToLive, timeBufferPercentage)
             {
                 _key = key;

--- a/e2e/test/iothub/messaging/MessageFeedbackE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageFeedbackE2ETests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await CompleteMessageMixOrder(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only, Logger).ConfigureAwait(false);
         }
 
-        private static async Task CompleteMessageMixOrder(TestDeviceType type, Client.TransportType transport, TestLogger logger)
+        private static async Task CompleteMessageMixOrder(TestDeviceType type, Client.TransportType transport, MsTestLogger logger)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(logger, s_devicePrefix, type).ConfigureAwait(false);
             using (DeviceClient deviceClient = testDevice.CreateDeviceClient(transport))

--- a/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await ReceiveMessageInOperationTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
         }
 
-        public static (Message message, string payload, string p1Value) ComposeC2dTestMessage(TestLogger logger)
+        public static (Message message, string payload, string p1Value) ComposeC2dTestMessage(MsTestLogger logger)
         {
             var payload = Guid.NewGuid().ToString();
             var messageId = Guid.NewGuid().ToString();
@@ -237,7 +237,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             return (message, payload, p1Value);
         }
 
-        public static async Task VerifyReceivedC2DMessageAsync(Client.TransportType transport, DeviceClient dc, string deviceId, Message message, string payload, TestLogger logger)
+        public static async Task VerifyReceivedC2DMessageAsync(Client.TransportType transport, DeviceClient dc, string deviceId, Message message, string payload, MsTestLogger logger)
         {
             string receivedMessageDestination = $"/devices/{deviceId}/messages/deviceBound";
 
@@ -305,7 +305,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             Assert.IsTrue(received, $"No message received for device {deviceId} with payload={payload} in {FaultInjection.RecoveryTimeMilliseconds}.");
         }
 
-        public static async Task VerifyReceivedC2dMessageWithCancellationTokenAsync(Client.TransportType transport, DeviceClient dc, string deviceId, string payload, string p1Value, TestLogger logger)
+        public static async Task VerifyReceivedC2dMessageWithCancellationTokenAsync(Client.TransportType transport, DeviceClient dc, string deviceId, string payload, string p1Value, MsTestLogger logger)
         {
             var sw = new Stopwatch();
             bool received = false;
@@ -468,7 +468,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await serviceClient.CloseAsync().ConfigureAwait(false);
         }
 
-        private static async Task ReceiveMessageWithoutTimeoutCheckAsync(DeviceClient dc, TimeSpan bufferTime, TestLogger logger)
+        private static async Task ReceiveMessageWithoutTimeoutCheckAsync(DeviceClient dc, TimeSpan bufferTime, MsTestLogger logger)
         {
             var sw = new Stopwatch();
             while (true)

--- a/e2e/test/iothub/messaging/MessageSendE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageSendE2ETests.cs
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await moduleClient.CloseAsync().ConfigureAwait(false);
         }
 
-        public static async Task SendSingleMessageAsync(DeviceClient deviceClient, string deviceId, TestLogger logger, int messageSize = 0)
+        public static async Task SendSingleMessageAsync(DeviceClient deviceClient, string deviceId, MsTestLogger logger, int messageSize = 0)
         {
             Client.Message testMessage;
 
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             }
         }
 
-        public static async Task SendBatchMessagesAsync(DeviceClient deviceClient, string deviceId, TestLogger logger)
+        public static async Task SendBatchMessagesAsync(DeviceClient deviceClient, string deviceId, MsTestLogger logger)
         {
             var messagesToBeSent = new Dictionary<Client.Message, Tuple<string, string>>();
 
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             }
         }
 
-        public static (Client.Message message, string payload, string p1Value) ComposeD2cTestMessage(TestLogger logger)
+        public static (Client.Message message, string payload, string p1Value) ComposeD2cTestMessage(MsTestLogger logger)
         {
             string messageId = Guid.NewGuid().ToString();
             string payload = Guid.NewGuid().ToString();
@@ -358,7 +358,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             return (message, payload, p1Value);
         }
 
-        public static (Client.Message message, string payload, string p1Value) ComposeD2cTestMessageOfSpecifiedSize(int messageSize, TestLogger logger)
+        public static (Client.Message message, string payload, string p1Value) ComposeD2cTestMessageOfSpecifiedSize(int messageSize, MsTestLogger logger)
         {
             string messageId = Guid.NewGuid().ToString();
             string payload = $"{Guid.NewGuid()}_{new string('*', messageSize)}";

--- a/e2e/test/iothub/method/FaultInjectionPoolAmqpTests.MethodFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/method/FaultInjectionPoolAmqpTests.MethodFaultInjectionPoolAmqpTests.cs
@@ -727,7 +727,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             Client.TransportType transport,
             int poolSize,
             int devicesCount,
-            Func<DeviceClient, string, TestLogger, Task<Task>> setDeviceReceiveMethod,
+            Func<DeviceClient, string, MsTestLogger, Task<Task>> setDeviceReceiveMethod,
             string faultType,
             string reason,
             int delayInSec = FaultInjection.DefaultDelayInSec,

--- a/e2e/test/iothub/method/MethodE2EPoolAmqpTests.cs
+++ b/e2e/test/iothub/method/MethodE2EPoolAmqpTests.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             Client.TransportType transport,
             int poolSize,
             int devicesCount,
-            Func<DeviceClient, string, TestLogger, Task<Task>> setDeviceReceiveMethod,
+            Func<DeviceClient, string, MsTestLogger, Task<Task>> setDeviceReceiveMethod,
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device)
         {
             Func<DeviceClient, TestDevice, Task> initOperation = async (deviceClient, testDevice) =>

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await serviceClient.CloseAsync().ConfigureAwait(false);
         }
 
-        public static async Task ServiceSendMethodAndVerifyResponseAsync(string deviceId, string methodName, string respJson, string reqJson, TestLogger logger, TimeSpan responseTimeout = default, ServiceClientTransportSettings serviceClientTransportSettings = default)
+        public static async Task ServiceSendMethodAndVerifyResponseAsync(string deviceId, string methodName, string respJson, string reqJson, MsTestLogger logger, TimeSpan responseTimeout = default, ServiceClientTransportSettings serviceClientTransportSettings = default)
         {
             ServiceClient serviceClient = null;
             if (serviceClientTransportSettings == default)
@@ -249,7 +249,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             serviceClient.Dispose();
         }
 
-        public static async Task ServiceSendMethodAndVerifyResponseAsync(string deviceId, string moduleId, string methodName, string respJson, string reqJson, TestLogger logger, TimeSpan responseTimeout = default, ServiceClientTransportSettings serviceClientTransportSettings = default)
+        public static async Task ServiceSendMethodAndVerifyResponseAsync(string deviceId, string moduleId, string methodName, string respJson, string reqJson, MsTestLogger logger, TimeSpan responseTimeout = default, ServiceClientTransportSettings serviceClientTransportSettings = default)
         {
             ServiceClient serviceClient = null;
             if (serviceClientTransportSettings == default)
@@ -279,7 +279,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             serviceClient.Dispose();
         }
 
-        public static async Task<Task> SetDeviceReceiveMethodAsync(DeviceClient deviceClient, string methodName, TestLogger logger)
+        public static async Task<Task> SetDeviceReceiveMethodAsync(DeviceClient deviceClient, string methodName, MsTestLogger logger)
         {
             var methodCallReceived = new TaskCompletionSource<bool>();
 
@@ -308,7 +308,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             return methodCallReceived.Task;
         }
 
-        public static async Task<Task> SetDeviceReceiveMethodDefaultHandlerAsync(DeviceClient deviceClient, string methodName, TestLogger logger)
+        public static async Task<Task> SetDeviceReceiveMethodDefaultHandlerAsync(DeviceClient deviceClient, string methodName, MsTestLogger logger)
         {
             var methodCallReceived = new TaskCompletionSource<bool>();
 
@@ -336,7 +336,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             return methodCallReceived.Task;
         }
 
-        private static Task<Task> SetDeviceReceiveMethodObsoleteHandler(DeviceClient deviceClient, string methodName, TestLogger logger)
+        private static Task<Task> SetDeviceReceiveMethodObsoleteHandler(DeviceClient deviceClient, string methodName, MsTestLogger logger)
         {
             var methodCallReceived = new TaskCompletionSource<bool>();
 
@@ -364,7 +364,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             return Task.FromResult<Task>(methodCallReceived.Task);
         }
 
-        public static async Task<Task> SetModuleReceiveMethodAsync(ModuleClient moduleClient, string methodName, TestLogger logger)
+        public static async Task<Task> SetModuleReceiveMethodAsync(ModuleClient moduleClient, string methodName, MsTestLogger logger)
         {
             var methodCallReceived = new TaskCompletionSource<bool>();
 
@@ -393,7 +393,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             return methodCallReceived.Task;
         }
 
-        public static async Task<Task> SetModuleReceiveMethodDefaultHandlerAsync(ModuleClient moduleClient, string methodName, TestLogger logger)
+        public static async Task<Task> SetModuleReceiveMethodDefaultHandlerAsync(ModuleClient moduleClient, string methodName, MsTestLogger logger)
         {
             var methodCallReceived = new TaskCompletionSource<bool>();
 
@@ -421,7 +421,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             return methodCallReceived.Task;
         }
 
-        private async Task SendMethodAndRespondAsync(Client.TransportType transport, Func<DeviceClient, string, TestLogger, Task<Task>> setDeviceReceiveMethod, TimeSpan responseTimeout = default, ServiceClientTransportSettings serviceClientTransportSettings = default)
+        private async Task SendMethodAndRespondAsync(Client.TransportType transport, Func<DeviceClient, string, MsTestLogger, Task<Task>> setDeviceReceiveMethod, TimeSpan responseTimeout = default, ServiceClientTransportSettings serviceClientTransportSettings = default)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
             using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
@@ -437,7 +437,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await deviceClient.CloseAsync().ConfigureAwait(false);
         }
 
-        private async Task SendMethodAndRespondAsync(Client.TransportType transport, Func<ModuleClient, string, TestLogger, Task<Task>> setDeviceReceiveMethod, TimeSpan responseTimeout = default, ServiceClientTransportSettings serviceClientTransportSettings = default)
+        private async Task SendMethodAndRespondAsync(Client.TransportType transport, Func<ModuleClient, string, MsTestLogger, Task<Task>> setDeviceReceiveMethod, TimeSpan responseTimeout = default, ServiceClientTransportSettings serviceClientTransportSettings = default)
         {
             TestModule testModule = await TestModule.GetTestModuleAsync(_devicePrefix, _modulePrefix, Logger).ConfigureAwait(false);
             using var moduleClient = ModuleClient.CreateFromConnectionString(testModule.ConnectionString, transport);

--- a/e2e/test/iothub/twin/FaultInjectionPoolAmqpTests.TwinFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/twin/FaultInjectionPoolAmqpTests.TwinFaultInjectionPoolAmqpTests.cs
@@ -1470,7 +1470,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             int devicesCount,
             string faultType,
             string reason,
-            Func<DeviceClient, string, string, TestLogger, Task<Task>> setTwinPropertyUpdateCallbackAsync,
+            Func<DeviceClient, string, string, MsTestLogger, Task<Task>> setTwinPropertyUpdateCallbackAsync,
             int delayInSec = FaultInjection.DefaultDelayInSec,
             int durationInSec = FaultInjection.DefaultDurationInSec,
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device)

--- a/e2e/test/iothub/twin/TwinE2EPoolAmqpTests.cs
+++ b/e2e/test/iothub/twin/TwinE2EPoolAmqpTests.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             Client.TransportType transport,
             int poolSize,
             int devicesCount,
-            Func<DeviceClient, string, string, TestLogger, Task<Task>> setTwinPropertyUpdateCallbackAsync,
+            Func<DeviceClient, string, string, MsTestLogger, Task<Task>> setTwinPropertyUpdateCallbackAsync,
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device)
         {
             var twinPropertyMap = new Dictionary<string, List<string>>();

--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             await Twin_DeviceSetsReportedPropertyAndGetsItBackAsync(deviceClient, JArray.Parse("[1, 2, 3]"), Logger).ConfigureAwait(false);
         }
 
-        public static async Task Twin_DeviceSetsReportedPropertyAndGetsItBackAsync(DeviceClient deviceClient, object propValue, TestLogger logger)
+        public static async Task Twin_DeviceSetsReportedPropertyAndGetsItBackAsync(DeviceClient deviceClient, object propValue, MsTestLogger logger)
         {
             var propName = Guid.NewGuid().ToString();
 
@@ -299,7 +299,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             Assert.AreEqual(JsonConvert.SerializeObject(actual), JsonConvert.SerializeObject(propValue));
         }
 
-        public static async Task<Task> SetTwinPropertyUpdateCallbackHandlerAsync(DeviceClient deviceClient, string expectedPropName, object expectedPropValue, TestLogger logger)
+        public static async Task<Task> SetTwinPropertyUpdateCallbackHandlerAsync(DeviceClient deviceClient, string expectedPropName, object expectedPropValue, MsTestLogger logger)
         {
             var propertyUpdateReceived = new TaskCompletionSource<bool>();
             string userContext = "myContext";
@@ -332,7 +332,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             return propertyUpdateReceived.Task;
         }
 
-        private static async Task<Task> SetTwinPropertyUpdateCallbackObsoleteHandlerAsync(DeviceClient deviceClient, string expectedPropName, object expectedPropValue, TestLogger logger)
+        private static async Task<Task> SetTwinPropertyUpdateCallbackObsoleteHandlerAsync(DeviceClient deviceClient, string expectedPropName, object expectedPropValue, MsTestLogger logger)
         {
 #pragma warning disable CS0618
 
@@ -379,7 +379,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             await registryManager.CloseAsync().ConfigureAwait(false);
         }
 
-        private async Task Twin_ServiceSetsDesiredPropertyAndDeviceReceivesEventAsync(Client.TransportType transport, Func<DeviceClient, string, object, TestLogger, Task<Task>> setTwinPropertyUpdateCallbackAsync, object propValue)
+        private async Task Twin_ServiceSetsDesiredPropertyAndDeviceReceivesEventAsync(Client.TransportType transport, Func<DeviceClient, string, object, MsTestLogger, Task<Task>> setTwinPropertyUpdateCallbackAsync, object propValue)
         {
             var propName = Guid.NewGuid().ToString();
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
Addressing the issue of tests timing out on enabling AI on our CI and nightly pipelines
1) Added a global static logger to use for logging. This is ensure we don't have to flush after each test. We will only flush at the end of test suite to ensure all logs are really sent to AI.
2) Removed logging events as they seem to take double the time as traces (I will try to follow up with AI to understand why there is a performance impact using their service). 
As a result of these changes, the CI and nightly will take the same time as they took earlier. If we observe differently after a few days of trial, I will investigate further.