### PR TITLE
Provide validation while setting Twin property to ensure they respect naming restrictions

### DIFF
--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -3,7 +3,7 @@
 This document describes how to prepare your development environment to build and use the **Microsoft Azure IoT device client SDK for .NET**
 
 1.  [Prerequisites required to build the SDK](#min_setup)
-2.  [Optional prerequisites required to test Xamarin and Windows IoT(#advanced)
+2.  [Optional prerequisites required to test Xamarin and Windows IoT](#advanced)
 3.  [Test prerequisites](#testprereq)
 
 <a name="min_setup"/>

--- a/iothub/device/tests/TwinCollectionTests.cs
+++ b/iothub/device/tests/TwinCollectionTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.Azure.Devices.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Devices.Client.Tests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class TwinCollectionTests
+    {
+        [TestMethod]
+        public void TwinCollection_PropertyNameIncludesADot_ThrowsException()
+        {
+            // arrange
+            string propName = "Test.Property";
+            string propValue = Guid.NewGuid().ToString();
+            var twinCollection = new TwinCollection();
+
+            // act & assert
+            Assert.ThrowsException<ArgumentException>(() => twinCollection[propName] = propValue);
+        }
+
+        [TestMethod]
+        public void TwinCollection_PropertyNameIncludesADollarSign_ThrowsException()
+        {
+            // arrange
+            string propName = "$TestProperty";
+            string propValue = Guid.NewGuid().ToString();
+            var twinCollection = new TwinCollection();
+
+            // act & assert
+            Assert.ThrowsException<ArgumentException>(() => twinCollection[propName] = propValue);
+        }
+
+        [TestMethod]
+        public void TwinCollection_PropertyNameWithValidName_SavesInfo()
+        {
+            // arrange
+            string propName = "testProperty";
+            string propValue = Guid.NewGuid().ToString();
+            var twinCollection = new TwinCollection {[propName] = propValue};
+
+            // act & assert
+
+            // assert
+            Assert.AreEqual(propValue, twinCollection[propName]?.ToString(), "Twin property value should be the same.");
+        }
+    }
+}

--- a/shared/src/TwinCollection.cs
+++ b/shared/src/TwinCollection.cs
@@ -154,7 +154,29 @@ namespace Microsoft.Azure.Devices.Shared
                     throw new ArgumentOutOfRangeException(nameof(propertyName));
                 }
             }
-            set => TrySetMemberInternal(propertyName, value);
+            set
+            {
+                if (propertyName == null)
+                {
+                    throw new ArgumentNullException(nameof(propertyName),"Property name cannot be null");
+                }
+#pragma warning disable CA1307 // Specify StringComparison
+                else if (propertyName.Contains("."))
+                {
+                    throw new ArgumentException(
+                        "Property name cannot contain '.' in its name. Learn more on https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-device-twins");
+                }
+                else if (propertyName.Contains("$"))
+                {
+                    throw new ArgumentException(
+                        "Property name cannot contain '$' in its name. Learn more on https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-device-twins");
+                }
+#pragma warning restore CA1307 // Specify StringComparison
+                else
+                {
+                    TrySetMemberInternal(propertyName, value);
+                }
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
Provide validation while setting Twin property to ensure they respect naming restrictions.
> **Keys:** All keys in JSON objects are UTF-8 encoded, case-sensitive, and up-to 1 KB in length. Allowed characters exclude UNICODE control characters (segments C0 and C1), and ., $, and SP.

Learn more on https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-device-twins.

I did not add, however, validation for UNICODE characters given I'm not sure if you want to go that far. In terms of "SP" I'm not sure what that means so didn't add that either.

## Why?

Yesterday I was using a property along the lines of `Property.Sample` where the SDK threw an exception along the lines of `Service did not provide a response` and it took a while to notice that the name was not allowed.

If the validation would happen during setting the name it would be a major help for people who are new to twins.

## Reference/Link to the issue solved with this PR (if any)
None, but happy to open in case of need.
