### PR TITLE
fix(iot-dev): Fix issue where SemaphoreFullException was thrown unexpectedly

### DIFF
--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -839,6 +839,7 @@ namespace Microsoft.Azure.Devices.Client
             try
             {
                 if (Logging.IsEnabled) Logging.Enter(this, methodName, methodHandler, userContext, nameof(SetMethodHandlerAsync));
+                cancellationToken.ThrowIfCancellationRequested();
                 await _methodsDictionarySemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
                 if (methodHandler != null)
@@ -928,7 +929,7 @@ namespace Microsoft.Azure.Devices.Client
             try
             {
                 if (Logging.IsEnabled) Logging.Enter(this, methodHandler, userContext, nameof(SetMethodDefaultHandlerAsync));
-
+                cancellationToken.ThrowIfCancellationRequested();
                 await _methodsDictionarySemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 if (methodHandler != null)
                 {
@@ -1495,6 +1496,7 @@ namespace Microsoft.Azure.Devices.Client
             ValidateModuleTransportHandler("SetInputMessageHandlerAsync for a named output");
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 await _receiveSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
                 if (messageHandler != null)
@@ -1580,6 +1582,7 @@ namespace Microsoft.Azure.Devices.Client
 
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 await _receiveSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 if (messageHandler != null)
                 {

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -879,7 +879,18 @@ namespace Microsoft.Azure.Devices.Client
             }
             finally
             {
-                _methodsDictionarySemaphore.Release();
+                try
+                {
+                    _methodsDictionarySemaphore.Release();
+                }
+                catch (SemaphoreFullException e)
+                {
+                    // this semaphore is typically grabbed at the start of the method, but if
+                    // this method is cancelled while waiting to grab the semaphore, then this semaphore.release
+                    // will throw this SemaphoreFullException since it was never grabbed in the first place
+                    if (Logging.IsEnabled) Logging.Info(this, "SemaphoreFullException thrown while releasing methods dictionary semaphore, but will be ignored since that means the semaphore is available for other threads to grab again anyways");
+                }
+
                 if (Logging.IsEnabled) Logging.Exit(this, methodName, methodHandler, userContext, nameof(SetMethodHandlerAsync));
             }
         }
@@ -942,7 +953,18 @@ namespace Microsoft.Azure.Devices.Client
             }
             finally
             {
-                _methodsDictionarySemaphore.Release();
+                try
+                {
+                    _methodsDictionarySemaphore.Release();
+                }
+                catch (SemaphoreFullException e)
+                {
+                    // this semaphore is typically grabbed at the start of the method, but if
+                    // this method is cancelled while waiting to grab the semaphore, then this semaphore.release
+                    // will throw this SemaphoreFullException since it was never grabbed in the first place
+                    if (Logging.IsEnabled) Logging.Info(this, "SemaphoreFullException thrown while releasing methods dictionary semaphore, but will be ignored since that means the semaphore is available for other threads to grab again anyways");
+                }
+
                 if (Logging.IsEnabled) Logging.Exit(this, methodHandler, userContext, nameof(SetMethodDefaultHandlerAsync));
             }
         }
@@ -1047,7 +1069,17 @@ namespace Microsoft.Azure.Devices.Client
             }
             finally
             {
-                _methodsDictionarySemaphore.Release();
+                try
+                {
+                    _methodsDictionarySemaphore.Release();
+                }
+                catch (SemaphoreFullException e)
+                {
+                    // this semaphore is typically grabbed at the start of the method, but if
+                    // this method is cancelled while waiting to grab the semaphore, then this semaphore.release
+                    // will throw this SemaphoreFullException since it was never grabbed in the first place
+                    if (Logging.IsEnabled) Logging.Info(this, "SemaphoreFullException thrown while releasing methods dictionary semaphore, but will be ignored since that means the semaphore is available for other threads to grab again anyways");
+                }
             }
 
             if (m == null)
@@ -1494,7 +1526,18 @@ namespace Microsoft.Azure.Devices.Client
             }
             finally
             {
-                _receiveSemaphore.Release();
+                try
+                {
+                    _receiveSemaphore.Release();
+                }
+                catch (SemaphoreFullException e)
+                {
+                    // this semaphore is typically grabbed at the start of the method, but if
+                    // this method is cancelled while waiting to grab the semaphore, then this semaphore.release
+                    // will throw this SemaphoreFullException since it was never grabbed in the first place
+                    if (Logging.IsEnabled) Logging.Info(this, "SemaphoreFullException thrown while releasing receive semaphore, but will be ignored since that means the semaphore is available for other threads to grab again anyways");
+                }
+
                 if (Logging.IsEnabled) Logging.Exit(this, inputName, messageHandler, userContext, nameof(SetInputMessageHandlerAsync));
             }
         }
@@ -1553,7 +1596,18 @@ namespace Microsoft.Azure.Devices.Client
             }
             finally
             {
-                _receiveSemaphore.Release();
+                try
+                {
+                    _receiveSemaphore.Release();
+                }
+                catch (SemaphoreFullException e)
+                {
+                    // this semaphore is typically grabbed at the start of the method, but if
+                    // this method is cancelled while waiting to grab the semaphore, then this semaphore.release
+                    // will throw this SemaphoreFullException since it was never grabbed in the first place
+                    if (Logging.IsEnabled) Logging.Info(this, "SemaphoreFullException thrown while releasing receive semaphore, but will be ignored since that means the semaphore is available for other threads to grab again anyways");
+                }
+
                 if (Logging.IsEnabled) Logging.Exit(this, messageHandler, userContext, nameof(SetMessageHandlerAsync));
             }
         }


### PR DESCRIPTION
By putting the ```semaphore.wait()``` call inside a try block and the ```semaphore.release()``` within the finally block, the assumption is that the semaphore should always be released regardless of if the semaphore protected operations succeed or not.

The issue here was that there are cases where the finally block is reached without ever successfully grabbing the semaphore in the first place. For instance, if the task calling into setMethodHandlerAsync is cancelled while waiting to grab the semaphore, the finally block will always throw SemaphoreFullException upon release because it never owned the semaphore. 

#1502