### PR TITLE
Trying to fix unit test failure

### DIFF
--- a/iothub/device/tests/RetryDelegatingHandlerImplicitOpenTests.cs
+++ b/iothub/device/tests/RetryDelegatingHandlerImplicitOpenTests.cs
@@ -83,14 +83,15 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             var contextMock = Substitute.For<IPipelineContext>();
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
-            innerHandlerMock.OpenAsync(CancellationToken.None).Returns(t => TaskHelpers.CompletedTask);
-            innerHandlerMock.CloseAsync(CancellationToken.None).Returns(t => TaskHelpers.CompletedTask);
+            var cancellationToken = new CancellationToken();
+
+            innerHandlerMock.OpenAsync(cancellationToken).Returns(t => TaskHelpers.CompletedTask);
+            innerHandlerMock.CloseAsync(cancellationToken).Returns(t => TaskHelpers.CompletedTask);
 
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
-            await sut.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-            await sut.CloseAsync(CancellationToken.None).ConfigureAwait(false);
+            await sut.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await sut.CloseAsync(cancellationToken).ConfigureAwait(false);
 
-            var cancellationToken = new CancellationToken();
             await ((Func<Task>)(() => sut.OpenAsync(cancellationToken))).ExpectedAsync<ObjectDisposedException>().ConfigureAwait(false);
         }
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
Trying to use the same CancellationToken object in the mock and the calls in this test. This could be causing the test to be finding a wrong mock at times. This is definitely safer than earlier code.
