### PR TITLE
fix(bug): Fix get file upload sas uri using certificates.

### DIFF
--- a/e2e/test/iothub/FileUploadE2ETests.cs
+++ b/e2e/test/iothub/FileUploadE2ETests.cs
@@ -33,6 +33,22 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         [LoggedTestMethod]
         [TestCategory("LongRunning")]
+        public async Task FileUpload_GetFileUploadSasUri_Http_NoFileTransportSettingSpecified()
+        {
+            string smallFileBlobName = await GetTestFileNameAsync(FileSizeSmall).ConfigureAwait(false);
+            await GetSasUriAsync(Client.TransportType.Http1, smallFileBlobName).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        [TestCategory("LongRunning")]
+        public async Task FileUpload_GetFileUploadSasUri_Http_x509_NoFileTransportSettingSpecified()
+        {
+            string smallFileBlobName = await GetTestFileNameAsync(FileSizeSmall).ConfigureAwait(false);
+            await GetSasUriAsync(Client.TransportType.Http1, smallFileBlobName, true).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        [TestCategory("LongRunning")]
         public async Task FileUpload_BigFile_Http()
         {
             string bigFile = await GetTestFileNameAsync(FileSizeBig).ConfigureAwait(false);
@@ -157,6 +173,37 @@ namespace Microsoft.Azure.Devices.E2ETests
                 using (var fileStreamSource = new FileStream(filename, FileMode.Open, FileAccess.Read))
                 {
                     await deviceClient.UploadToBlobAsync(filename, fileStreamSource).ConfigureAwait(false);
+                }
+
+                await deviceClient.CloseAsync().ConfigureAwait(false);
+            }
+        }
+
+        private async Task GetSasUriAsync(Client.TransportType transport, string blobName, bool x509auth = false)
+        {
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(
+                Logger,
+                _devicePrefix,
+                x509auth ? TestDeviceType.X509 : TestDeviceType.Sasl).ConfigureAwait(false);
+
+            DeviceClient deviceClient;
+            if (x509auth)
+            {
+                X509Certificate2 cert = Configuration.IoTHub.GetCertificateWithPrivateKey();
+
+                var auth = new DeviceAuthenticationWithX509Certificate(testDevice.Id, cert);
+                deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, auth, transport);
+            }
+            else
+            {
+                deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+            }
+
+            using (deviceClient)
+            {
+                using (var fileStreamSource = new FileStream(blobName, FileMode.Open, FileAccess.Read))
+                {
+                    FileUploadSasUriResponse sasUriResponse = await deviceClient.GetFileUploadSasUriAsync(new FileUploadSasUriRequest { BlobName = blobName });
                 }
 
                 await deviceClient.CloseAsync().ConfigureAwait(false);

--- a/e2e/test/iothub/FileUploadE2ETests.cs
+++ b/e2e/test/iothub/FileUploadE2ETests.cs
@@ -201,11 +201,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             using (deviceClient)
             {
-                using (var fileStreamSource = new FileStream(blobName, FileMode.Open, FileAccess.Read))
-                {
-                    FileUploadSasUriResponse sasUriResponse = await deviceClient.GetFileUploadSasUriAsync(new FileUploadSasUriRequest { BlobName = blobName });
-                }
-
+                FileUploadSasUriResponse sasUriResponse = await deviceClient.GetFileUploadSasUriAsync(new FileUploadSasUriRequest { BlobName = blobName });
                 await deviceClient.CloseAsync().ConfigureAwait(false);
             }
         }

--- a/iothub/device/src/ClientFactory.cs
+++ b/iothub/device/src/ClientFactory.cs
@@ -87,8 +87,23 @@ namespace Microsoft.Azure.Devices.Client
                     throw new ArgumentException("certificate must be present in DeviceAuthenticationWithX509Certificate");
                 }
 
+                // If the file upload transport settings hasn't been specified, we will create one using the client certificate on the connection string
+                if (options?.FileUploadTransportSettings == null)
+                {
+                    var fileUploadTransportSettings = new Http1TransportSettings { ClientCertificate = connectionStringBuilder.Certificate };
+                    if (options == null)
+                    {
+                        options = new ClientOptions { FileUploadTransportSettings = fileUploadTransportSettings };
+                    }
+                    else
+                    {
+                        options.FileUploadTransportSettings = fileUploadTransportSettings;
+                    }
+                }
+
                 InternalClient dc = CreateFromConnectionString(connectionStringBuilder.ToString(), PopulateCertificateInTransportSettings(connectionStringBuilder, transportType), options);
                 dc.Certificate = connectionStringBuilder.Certificate;
+
                 return dc;
             }
 

--- a/iothub/device/src/ClientOptions.cs
+++ b/iothub/device/src/ClientOptions.cs
@@ -20,6 +20,6 @@ namespace Microsoft.Azure.Devices.Client
         /// If FileUploadTransportSettings is not provided, then file upload operations will use the client certificates configured
         /// in the transport settings set for the non-file upload operations.
         /// </summary>
-        public Http1TransportSettings FileUploadTransportSettings { get; set; }
+        public Http1TransportSettings FileUploadTransportSettings { get; set; } = new Http1TransportSettings();
     }
 }

--- a/iothub/device/src/ClientOptions.cs
+++ b/iothub/device/src/ClientOptions.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <summary>
         /// The transport settings to use for all file upload operations, regardless of what protocol the device
-        /// client is configured with. All file upload operations take place over https. If no client certificates
-        /// are configured to this object, then file upload operations will use the client certificates configured
+        /// client is configured with. All file upload operations take place over https. 
+        /// If FileUploadTransportSettings is not provided, then file upload operations will use the client certificates configured
         /// in the transport settings set for the non-file upload operations.
         /// </summary>
-        public Http1TransportSettings FileUploadTransportSettings { get; set; } = new Http1TransportSettings();
+        public Http1TransportSettings FileUploadTransportSettings { get; set; }
     }
 }

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Devices.Client
             if (Logging.IsEnabled) Logging.Associate(this, transportSettings, nameof(InternalClient));
             _transportSettings = transportSettings;
 
-            if (options != null && options.FileUploadTransportSettings != null)
+            if (options?.FileUploadTransportSettings != null)
             {
                 _fileUploadHttpTransportHandler = new HttpTransportHandler(pipelineContext, IotHubConnectionString, options.FileUploadTransportSettings);
             }

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -150,8 +150,15 @@ namespace Microsoft.Azure.Devices.Client
 
             if (Logging.IsEnabled) Logging.Associate(this, transportSettings, nameof(InternalClient));
             _transportSettings = transportSettings;
-            
-            _fileUploadHttpTransportHandler = new HttpTransportHandler(pipelineContext, IotHubConnectionString, options.FileUploadTransportSettings);
+
+            if (options?.FileUploadTransportSettings != null) 
+            {
+                _fileUploadHttpTransportHandler = new HttpTransportHandler(pipelineContext, IotHubConnectionString, options.FileUploadTransportSettings);
+            }
+            else
+            {
+                _fileUploadHttpTransportHandler = new HttpTransportHandler(pipelineContext, IotHubConnectionString, new Http1TransportSettings());
+            }
 
             if (Logging.IsEnabled) Logging.Exit(this, transportSettings, pipelineBuilder, nameof(InternalClient) + "_ctor");
         }

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -150,15 +150,8 @@ namespace Microsoft.Azure.Devices.Client
 
             if (Logging.IsEnabled) Logging.Associate(this, transportSettings, nameof(InternalClient));
             _transportSettings = transportSettings;
-
-            if (options?.FileUploadTransportSettings != null)
-            {
-                _fileUploadHttpTransportHandler = new HttpTransportHandler(pipelineContext, IotHubConnectionString, options.FileUploadTransportSettings);
-            }
-            else
-            {
-                _fileUploadHttpTransportHandler = new HttpTransportHandler(pipelineContext, IotHubConnectionString, new Http1TransportSettings());
-            }
+            
+            _fileUploadHttpTransportHandler = new HttpTransportHandler(pipelineContext, IotHubConnectionString, options.FileUploadTransportSettings);
 
             if (Logging.IsEnabled) Logging.Exit(this, transportSettings, pipelineBuilder, nameof(InternalClient) + "_ctor");
         }


### PR DESCRIPTION
Currently there is a bug on the Device client when it's instantiated using the x509 authentication.
The ClientCertificate is set on the internal client after the client has been initialized and if the user doesn't provide the clientOption to specify the FileUloadTransferSetting, we will be using the default Http transport handler which will not contain the certificate.