### PR TITLE
refactor(e2e): Address gap in registry manager

### DIFF
--- a/e2e/test/iothub/service/RegistryManagerE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryManagerE2ETests.cs
@@ -92,12 +92,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         public async Task RegistryManager_BulkLifecycle()
         {
             int bulkCount = 50;
-            string[] deviceIds = new string[bulkCount];
             List<Device> devices = new List<Device>();
             for (int i = 0; i < bulkCount; i++)
             {
-                deviceIds[i] = _devicePrefix + Guid.NewGuid();
-                devices.Add(new Device(deviceIds[i]));
+                devices.Add(new Device(_devicePrefix + Guid.NewGuid()));
             }
 
             var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
@@ -115,9 +113,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             List<Twin> twins = new List<Twin>();
             string expectedProperty = "someNewProperty";
             string expectedPropertyValue = "someNewPropertyValue";
-            foreach (string deviceId in deviceIds)
+            foreach (Device device in devices)
             {
-                Twin twin = await registryManager.GetTwinAsync(deviceId).ConfigureAwait(false);
+                Twin twin = await registryManager.GetTwinAsync(device.Id).ConfigureAwait(false);
                 twin.Properties.Desired[expectedProperty] = expectedPropertyValue;
                 twins.Add(twin);
             }
@@ -125,9 +123,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             // Test that you can update twins in bulk
             await registryManager.UpdateTwins2Async(twins).ConfigureAwait(false);
 
-            foreach (string deviceId in deviceIds)
+            foreach (Device device in devices)
             {
-                Twin twin = await registryManager.GetTwinAsync(deviceId).ConfigureAwait(false);
+                Twin twin = await registryManager.GetTwinAsync(device.Id).ConfigureAwait(false);
                 Assert.IsNotNull(twin.Properties.Desired[expectedProperty]);
                 Assert.AreEqual(expectedPropertyValue, (string)twin.Properties.Desired[expectedProperty]);
             }

--- a/e2e/test/iothub/service/RegistryManagerE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryManagerE2ETests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Azure.Devices.Common.Exceptions;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
 using Microsoft.Azure.Devices.Shared;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -84,6 +85,62 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                 await registryManager.RemoveDeviceAsync(deviceId).ConfigureAwait(false);
 
                 Assert.IsTrue(actual.Capabilities.IotEdge);
+            }
+        }
+
+        [LoggedTestMethod]
+        public async Task RegistryManager_BulkLifecycle()
+        {
+            int bulkCount = 50;
+            string[] deviceIds = new string[bulkCount];
+            List<Device> devices = new List<Device>();
+            for (int i = 0; i < bulkCount; i++)
+            {
+                deviceIds[i] = _devicePrefix + Guid.NewGuid();
+                devices.Add(new Device(deviceIds[i]));
+            }
+
+            var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+
+            // Test that you can create devices in bulk
+            var bulkAddResult = await registryManager.AddDevices2Async(devices).ConfigureAwait(false);
+            Assert.IsTrue(bulkAddResult.IsSuccessful);
+
+            foreach (Device device in devices)
+            {
+                // After a bulk add, every device should be able to be retrieved
+                Assert.IsNotNull(await registryManager.GetDeviceAsync(device.Id).ConfigureAwait(false));
+            }
+
+            List<Twin> twins = new List<Twin>();
+            string expectedProperty = "someNewProperty";
+            string expectedPropertyValue = "someNewPropertyValue";
+            foreach (string deviceId in deviceIds)
+            {
+                Twin twin = await registryManager.GetTwinAsync(deviceId).ConfigureAwait(false);
+                twin.Properties.Desired[expectedProperty] = expectedPropertyValue;
+                twins.Add(twin);
+            }
+
+            // Test that you can update twins in bulk
+            await registryManager.UpdateTwins2Async(twins).ConfigureAwait(false);
+
+            foreach (string deviceId in deviceIds)
+            {
+                Twin twin = await registryManager.GetTwinAsync(deviceId).ConfigureAwait(false);
+                Assert.IsNotNull(twin.Properties.Desired[expectedProperty]);
+                Assert.AreEqual(expectedPropertyValue, (string)twin.Properties.Desired[expectedProperty]);
+            }
+
+            // Test that you can delete device identities in bulk
+            var bulkDeleteResult = await registryManager.RemoveDevices2Async(devices, true, default).ConfigureAwait(false);
+
+            Assert.IsTrue(bulkDeleteResult.IsSuccessful);
+
+            foreach (Device device in devices)
+            {
+                // After a bulk delete, every device should not be found
+                Assert.IsNull(await registryManager.GetDeviceAsync(device.Id).ConfigureAwait(false));
             }
         }
 


### PR DESCRIPTION
Bulk device and twin APIs were missing an e2e test