### PR TITLE
Added SetAsDistributedTracingMessage method on Message

### DIFF
--- a/iothub/device/src/Message.cs
+++ b/iothub/device/src/Message.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         public void SetAsDistributedTracingMessage()
         {
-            Int32 unixTimestamp = (Int32)(DateTime.UtcNow.Subtract(DateTime.UnixEpoch)).TotalSeconds;
+            Int32 unixTimestamp = (Int32)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
 
             SystemProperties[MessageSystemPropertyNames.DistributedTrace] = unixTimestamp;
         }

--- a/iothub/device/src/Message.cs
+++ b/iothub/device/src/Message.cs
@@ -391,6 +391,16 @@ namespace Microsoft.Azure.Devices.Client
             SystemProperties[MessageSystemPropertyNames.InterfaceId] = CommonConstants.SecurityMessageInterfaceId;
         }
 
+        /// <summary>
+        /// Set the message as a Distributed Tracing
+        /// </summary>
+        public void SetAsDistributedTracingMessage()
+        {
+            Int32 unixTimestamp = (Int32)(DateTime.UtcNow.Subtract(DateTime.UnixEpoch)).TotalSeconds;
+
+            SystemProperties[MessageSystemPropertyNames.DistributedTrace] = unixTimestamp;
+        }
+
         private void SetSizeInBytesCalled()
         {
             Interlocked.Exchange(ref _sizeInBytesCalled, 1);

--- a/iothub/device/src/Message.cs
+++ b/iothub/device/src/Message.cs
@@ -396,9 +396,9 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         public void SetAsDistributedTracingMessage()
         {
-            Int32 unixTimestamp = (Int32)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
+            long unixTimestamp = (long)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
 
-            SystemProperties[MessageSystemPropertyNames.DistributedTrace] = unixTimestamp;
+            SystemProperties[MessageSystemPropertyNames.DistributedTrace] = $"timestamp={unixTimestamp}";
         }
 
         private void SetSizeInBytesCalled()

--- a/iothub/device/src/MessageSystemPropertyNames.cs
+++ b/iothub/device/src/MessageSystemPropertyNames.cs
@@ -50,5 +50,7 @@ namespace Microsoft.Azure.Devices.Client
         public const string InterfaceId = "iothub-interface-id";
 
         public const string ComponentName = "dt-subject";
+
+        public const string DistributedTrace = "tracestate";
     }
 }

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTMessageConverter.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTMessageConverter.cs
@@ -254,6 +254,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 amqpMessage.MessageAnnotations.Map[MessageSystemPropertyNames.ComponentName] = (string)propertyValue;
             }
 
+            if (data.SystemProperties.TryGetValue(MessageSystemPropertyNames.DistributedTrace, out propertyValue))
+            { 
+                amqpMessage.MessageAnnotations.Map[MessageSystemPropertyNames.DistributedTrace] = (string)propertyValue;
+            }
+
             if (copyUserProperties && data.Properties.Count > 0)
             {
                 foreach (var pair in data.Properties)


### PR DESCRIPTION
This enable distributing tracing also with the C# SDK.  It still miss the logic to automatically inject that system property as per cloud configuration.

<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
