### PR TITLE
LTS_PATCH- fix(bug): Fix get file upload sas uri using certificates. (#1534)

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -224,7 +224,7 @@ try
 {
     if ($sign)
     {
-        if ($localPackagesAvailableForTesting)
+        if (-not $localPackagesAvailableForTesting)
         {
             throw "Local NuGet package source path is not set, required when signing packages."
         }

--- a/iothub/device/src/ClientFactory.cs
+++ b/iothub/device/src/ClientFactory.cs
@@ -87,8 +87,23 @@ namespace Microsoft.Azure.Devices.Client
                     throw new ArgumentException("certificate must be present in DeviceAuthenticationWithX509Certificate");
                 }
 
+                // If the file upload transport settings hasn't been specified, we will create one using the client certificate on the connection string
+                if (options?.FileUploadTransportSettings == null)
+                {
+                    var fileUploadTransportSettings = new Http1TransportSettings { ClientCertificate = connectionStringBuilder.Certificate };
+                    if (options == null)
+                    {
+                        options = new ClientOptions { FileUploadTransportSettings = fileUploadTransportSettings };
+                    }
+                    else
+                    {
+                        options.FileUploadTransportSettings = fileUploadTransportSettings;
+                    }
+                }
+
                 InternalClient dc = CreateFromConnectionString(connectionStringBuilder.ToString(), PopulateCertificateInTransportSettings(connectionStringBuilder, transportType), options);
                 dc.Certificate = connectionStringBuilder.Certificate;
+
                 return dc;
             }
 

--- a/iothub/device/src/ClientOptions.cs
+++ b/iothub/device/src/ClientOptions.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <summary>
         /// The transport settings to use for all file upload operations, regardless of what protocol the device
-        /// client is configured with. All file upload operations take place over https. If no client certificates
-        /// are configured to this object, then file upload operations will use the client certificates configured
+        /// client is configured with. All file upload operations take place over https. 
+        /// If FileUploadTransportSettings is not provided, then file upload operations will use the client certificates configured
         /// in the transport settings set for the non-file upload operations.
         /// </summary>
         public Http1TransportSettings FileUploadTransportSettings { get; set; } = new Http1TransportSettings();

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Devices.Client
             if (Logging.IsEnabled) Logging.Associate(this, transportSettings, nameof(InternalClient));
             _transportSettings = transportSettings;
 
-            if (options != null && options.FileUploadTransportSettings != null)
+            if (options?.FileUploadTransportSettings != null) 
             {
                 _fileUploadHttpTransportHandler = new HttpTransportHandler(pipelineContext, IotHubConnectionString, options.FileUploadTransportSettings);
             }

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -151,14 +151,7 @@ namespace Microsoft.Azure.Devices.Client
             if (Logging.IsEnabled) Logging.Associate(this, transportSettings, nameof(InternalClient));
             _transportSettings = transportSettings;
 
-            if (options?.FileUploadTransportSettings != null) 
-            {
-                _fileUploadHttpTransportHandler = new HttpTransportHandler(pipelineContext, IotHubConnectionString, options.FileUploadTransportSettings);
-            }
-            else
-            {
-                _fileUploadHttpTransportHandler = new HttpTransportHandler(pipelineContext, IotHubConnectionString, new Http1TransportSettings());
-            }
+            _fileUploadHttpTransportHandler = new HttpTransportHandler(pipelineContext, IotHubConnectionString, options.FileUploadTransportSettings);
 
             if (Logging.IsEnabled) Logging.Exit(this, transportSettings, pipelineBuilder, nameof(InternalClient) + "_ctor");
         }

--- a/readme.md
+++ b/readme.md
@@ -175,8 +175,8 @@ Below is a table showing the mapping of the LTS branches to the packages release
 
 | Release | Github Branch | LTS Status | LTS Start Date | Maintenance End Date | Removed Date |
 | :-----------: | :-----------: | :--------: | :------------: | :------------------: | :----------: |
-| [2020-8-19](https://github.com/Azure/azure-iot-sdk-csharp/tree/lts_2020-8-19) | lts_2020_08   | Active     | 2020-08-19     | 2021-8-19           | 2023-8-19   |
-| [2020-1-31](https://github.com/Azure/azure-iot-sdk-csharp/tree/lts_2020-1-31_patch1) | lts_2020_01   | Deprecated     | 2020-01-31     | 2020-06-30           | 2020-12-31   |
+| [2020-9-4](https://github.com/Azure/azure-iot-sdk-csharp/tree/lts_2020-9-4) | [lts_2020_08](https://github.com/Azure/azure-iot-sdk-csharp/tree/lts_2020_08)   | Active     | 2020-08-19     | 2021-8-19           | 2023-8-19   |
+| [2020-1-31](https://github.com/Azure/azure-iot-sdk-csharp/tree/lts_2020-1-31_patch1) | [lts_2020_01](https://github.com/Azure/azure-iot-sdk-csharp/tree/lts_2020_01)   | Deprecated     | 2020-01-31     | 2020-06-30           | 2020-12-31   |
 
 - <sup>1</sup> All scheduled dates are subject to change by the Azure IoT SDK team.
 

--- a/readme.md
+++ b/readme.md
@@ -175,7 +175,7 @@ Below is a table showing the mapping of the LTS branches to the packages release
 
 | Release | Github Branch | LTS Status | LTS Start Date | Maintenance End Date | Removed Date |
 | :-----------: | :-----------: | :--------: | :------------: | :------------------: | :----------: |
-| [2020-9-4](https://github.com/Azure/azure-iot-sdk-csharp/tree/lts_2020-9-4) | [lts_2020_08](https://github.com/Azure/azure-iot-sdk-csharp/tree/lts_2020_08)   | Active     | 2020-08-19     | 2021-8-19           | 2023-8-19   |
+| [2020-9-23](https://github.com/Azure/azure-iot-sdk-csharp/tree/lts_2020-9-23) | [lts_2020_08](https://github.com/Azure/azure-iot-sdk-csharp/tree/lts_2020_08)   | Active     | 2020-08-19     | 2021-8-19           | 2023-8-19   |
 | [2020-1-31](https://github.com/Azure/azure-iot-sdk-csharp/tree/lts_2020-1-31_patch1) | [lts_2020_01](https://github.com/Azure/azure-iot-sdk-csharp/tree/lts_2020_01)   | Deprecated     | 2020-01-31     | 2020-06-30           | 2020-12-31   |
 
 - <sup>1</sup> All scheduled dates are subject to change by the Azure IoT SDK team.


### PR DESCRIPTION
Currently there is a bug on the Device client when it's instantiated using the x509 authentication.
The ClientCertificate is set on the internal client after the client has been initialized and if the user doesn't provide the clientOption to specify the FileUloadTransferSetting, we will be using the default Http transport handler which will not contain the certificate.