### PR TITLE
fix(iot-device): Set a default idle timeout of 2mins over amqp

### DIFF
--- a/iothub/device/src/AmqpTransportSettings.cs
+++ b/iothub/device/src/AmqpTransportSettings.cs
@@ -43,6 +43,11 @@ namespace Microsoft.Azure.Devices.Client
         public static readonly TimeSpan DefaultOpenTimeout = TimeSpan.FromMinutes(1);
 
         /// <summary>
+        /// The default idle timeout
+        /// </summary>
+        public static readonly TimeSpan DefaultIdleTimeout = TimeSpan.FromMinutes(2);
+
+        /// <summary>
         /// The default prefetch count
         /// </summary>
         public const uint DefaultPrefetchCount = 50;
@@ -76,6 +81,7 @@ namespace Microsoft.Azure.Devices.Client
         {
             OperationTimeout = DefaultOperationTimeout;
             OpenTimeout = DefaultOpenTimeout;
+            IdleTimeout = DefaultIdleTimeout;
 
             PrefetchCount = prefetchCount <= 0
                 ? throw new ArgumentOutOfRangeException(nameof(prefetchCount), "Must be greater than zero")
@@ -103,7 +109,8 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Specify client-side heartbeat interval
+        /// Specify client-side heartbeat interval.
+        /// The default value is 2 minutes.
         /// </summary>
         public TimeSpan IdleTimeout { get; set; }
 

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             Closed = 16
         }
 
-        // Topic names for sending cloud-to-device messages
+        // Topic names for sending device-to-cloud messages
         private const string DeviceTelemetryTopicFormat = "devices/{0}/messages/events/";
         private const string ModuleTelemetryTopicFormat = "devices/{0}/modules/{1}/messages/events/";
 
@@ -397,6 +397,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         private static async void PingServer(object ctx)
         {
+            if (Logging.IsEnabled) Logging.Enter(ctx, $"Scheduled check to see if a ping request should be sent.", nameof(PingServer));
+
             var context = (IChannelHandlerContext)ctx;
             try
             {
@@ -408,6 +410,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 }
 
                 TimeSpan idleTime = DateTime.UtcNow - self._lastChannelActivityTime;
+                if (Logging.IsEnabled) Logging.Info(context, $"Idle time currently is {idleTime}.", nameof(PingServer));
 
                 if (idleTime > self._pingRequestInterval)
                 {
@@ -434,6 +437,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             {
                 ShutdownOnError(context, ex);
             }
+
+            if (Logging.IsEnabled) Logging.Exit(ctx, $"Scheduled check to see if a ping request should be sent.", nameof(PingServer));
         }
 
         private async Task ProcessConnectAckAsync(IChannelHandlerContext context, ConnAckPacket packet)

--- a/iothub/device/tests/TransportSettingsTests.cs
+++ b/iothub/device/tests/TransportSettingsTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Security.Cryptography.X509Certificates;
-using Microsoft.Azure.Devices.Client.ApiTest;
 using Microsoft.Azure.Devices.Client.Transport.Mqtt;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -146,7 +144,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        public void AmqpTransportSettings_TimeoutDefaultsAndOverrides()
+        public void AmqpTransportSettings_SetsDefaultTimeout()
         {
             // act
             var transportSetting = new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only, 200);
@@ -154,6 +152,29 @@ namespace Microsoft.Azure.Devices.Client.Test
             // assert
             Assert.AreEqual(AmqpTransportSettings.DefaultOpenTimeout, transportSetting.OpenTimeout, "Default OpenTimeout not set correctly");
             Assert.AreEqual(AmqpTransportSettings.DefaultOperationTimeout, transportSetting.OperationTimeout, "Default OperationTimeout not set correctly");
+            Assert.AreEqual(AmqpTransportSettings.DefaultIdleTimeout, transportSetting.IdleTimeout, "Default IdleTimeout not set correctly");
+            Assert.AreEqual(AmqpTransportSettings.DefaultOperationTimeout, transportSetting.DefaultReceiveTimeout, "Default DefaultReceiveTimeout not set correctly");
+        }
+
+        [TestMethod]
+        public void AmqpTransportSettings_OverridesDefaultTimeout()
+        {
+            var openTimeout = AmqpTransportSettings.DefaultOpenTimeout.Add(TimeSpan.FromMinutes(5));
+            var operationTimeout = AmqpTransportSettings.DefaultOperationTimeout.Add(TimeSpan.FromMinutes(5));
+            var idleTimeout = AmqpTransportSettings.DefaultIdleTimeout.Add(TimeSpan.FromMinutes(5));
+
+            // act
+            var transportSetting = new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only, 200)
+            {
+                OpenTimeout = openTimeout,
+                OperationTimeout = operationTimeout,
+                IdleTimeout = idleTimeout,
+            };
+
+            // assert
+            Assert.AreEqual(openTimeout, transportSetting.OpenTimeout, "OpenTimeout not set correctly");
+            Assert.AreEqual(operationTimeout, transportSetting.OperationTimeout, "OperationTimeout not set correctly");
+            Assert.AreEqual(idleTimeout, transportSetting.IdleTimeout, "IdleTimeout not set correctly");
         }
 
         [TestMethod]


### PR DESCRIPTION
The device client library currently only sets the idle timeout over Amqp if the user supplies a valid Timespan via AmpqTransportSettings.IdleTimeout. This PR updates the behavior to set a default IdleTimeout of 2 minutes.
Without this, if the user doesn't set an IdleTimeout, the client will always rely on either the server or the underlying OS to inform it of disconnection (which can potentially have delays).

Related #1535 