### PR TITLE
Add support for DPS provisioning flow for pnp samples

### DIFF
--- a/iothub/device/samples/PnpDeviceSamples/Thermostat/Parameter.cs
+++ b/iothub/device/samples/PnpDeviceSamples/Thermostat/Parameter.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using CommandLine;
+
+namespace Thermostat
+{
+    /// <summary>
+    /// Parameters for the application supplied via command line arguments. It default to environment variables..
+    /// </summary>
+    internal class Parameters
+    {
+        [Option(
+            's',
+            "DeviceProvisioningType",
+            HelpText = "(Required) The provisioning type that will be used for provisioning the device for the sample. Possible values include dps, hubConnectionString (case-insensitive)." +
+            "\nDefaults to environment variable \"IOTHUB_DEVICE_SECURITY_TYPE\".")]
+        public string DeviceProvisioningType { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_SECURITY_TYPE");
+
+        [Option(
+            'p',
+            "PrimaryConnectionString",
+            HelpText = "(Required if DeviceProvisioningType is \"hubConnectionString\"). \nThe primary connection string for the device to simulate." +
+            "\nDefaults to environment variable \"IOTHUB_DEVICE_CONNECTION_STRING\".")]
+        public string PrimaryConnectionString { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_CONNECTION_STRING");
+
+        [Option(
+            'e',
+            "DpsEndpoint",
+            HelpText = "(Required if DeviceProvisioningType is \"dps\"). \nThe DPS endpoint to use during device provisioning." +
+            "\nDefaults to environment variable \"IOTHUB_DEVICE_DPS_ENDPOINT\".")]
+        public string DpsEndpoint { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_ENDPOINT");
+
+        [Option(
+            'i',
+            "DpsIdScope",
+            HelpText = "(Required if DeviceProvisioningType is \"dps\"). \nThe DPS ID Scope to use during device provisioning." +
+            "\nDefaults to environment variable \"IOTHUB_DEVICE_DPS_ID_SCOPE\".")]
+        public string DpsIdScope { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_ID_SCOPE");
+
+        [Option(
+            'd',
+            "DeviceId",
+            HelpText = "(Required if DeviceProvisioningType is \"dps\"). \nThe device registration Id to use during device provisioning." +
+            "\nDefaults to environment variable \"IOTHUB_DEVICE_DPS_DEVICE_ID\".")]
+        public string DeviceId { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_DEVICE_ID");
+
+        [Option(
+            'k',
+            "DeviceSymmetricKey",
+            HelpText = "(Required if DeviceProvisioningType is \"dps\"). \nThe device symmetric key to use during device provisioning." +
+            "\nDefaults to environment variable \"IOTHUB_DEVICE_DPS_DEVICE_KEY\".")]
+        public string DeviceSymmetricKey { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_DEVICE_KEY");
+
+        public bool Validate()
+        {
+            if (string.IsNullOrWhiteSpace(DeviceProvisioningType))
+            {
+                throw new ArgumentNullException(nameof(DeviceProvisioningType), "Device provisioning type needs to be specified, please set the environment variable \"IOTHUB_DEVICE_SECURITY_TYPE\"" +
+                    "or pass in \"-s | --DeviceProvisioningType\" through command line.");
+            }
+
+            return (DeviceProvisioningType.ToLowerInvariant()) switch
+            {
+                "dps" => !string.IsNullOrWhiteSpace(DpsEndpoint)
+                                       && !string.IsNullOrWhiteSpace(DpsIdScope)
+                                       && !string.IsNullOrWhiteSpace(DeviceId)
+                                       && !string.IsNullOrWhiteSpace(DeviceSymmetricKey),
+                "hubconnectionstring" => !string.IsNullOrWhiteSpace(PrimaryConnectionString),
+                _ => throw new ArgumentException($"Unrecognized value for device provisioning received: {DeviceProvisioningType}." +
+                        $" It should be either \"dps\" or \"hubConnectionString\" (case-insensitive)."),
+            };
+        }
+    }
+}

--- a/iothub/device/samples/PnpDeviceSamples/Thermostat/Parameter.cs
+++ b/iothub/device/samples/PnpDeviceSamples/Thermostat/Parameter.cs
@@ -13,63 +13,63 @@ namespace Thermostat
     {
         [Option(
             's',
-            "DeviceProvisioningType",
-            HelpText = "(Required) The provisioning type that will be used for provisioning the device for the sample. Possible values include dps, hubConnectionString (case-insensitive)." +
+            "DeviceSecurityType",
+            HelpText = "(Required) The provisioning type that will be used for provisioning the device for the sample. Possible values include dps, connectionString (case-insensitive)." +
             "\nDefaults to environment variable \"IOTHUB_DEVICE_SECURITY_TYPE\".")]
-        public string DeviceProvisioningType { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_SECURITY_TYPE");
+        public string DeviceSecurityType { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_SECURITY_TYPE");
 
         [Option(
             'p',
             "PrimaryConnectionString",
-            HelpText = "(Required if DeviceProvisioningType is \"hubConnectionString\"). \nThe primary connection string for the device to simulate." +
+            HelpText = "(Required if DeviceSecurityType is \"connectionString\"). \nThe primary connection string for the device to simulate." +
             "\nDefaults to environment variable \"IOTHUB_DEVICE_CONNECTION_STRING\".")]
         public string PrimaryConnectionString { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_CONNECTION_STRING");
 
         [Option(
             'e',
             "DpsEndpoint",
-            HelpText = "(Required if DeviceProvisioningType is \"dps\"). \nThe DPS endpoint to use during device provisioning." +
+            HelpText = "(Required if DeviceSecurityType is \"dps\"). \nThe DPS endpoint to use during device provisioning." +
             "\nDefaults to environment variable \"IOTHUB_DEVICE_DPS_ENDPOINT\".")]
         public string DpsEndpoint { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_ENDPOINT");
 
         [Option(
             'i',
             "DpsIdScope",
-            HelpText = "(Required if DeviceProvisioningType is \"dps\"). \nThe DPS ID Scope to use during device provisioning." +
+            HelpText = "(Required if DeviceSecurityType is \"dps\"). \nThe DPS ID Scope to use during device provisioning." +
             "\nDefaults to environment variable \"IOTHUB_DEVICE_DPS_ID_SCOPE\".")]
         public string DpsIdScope { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_ID_SCOPE");
 
         [Option(
             'd',
             "DeviceId",
-            HelpText = "(Required if DeviceProvisioningType is \"dps\"). \nThe device registration Id to use during device provisioning." +
+            HelpText = "(Required if DeviceSecurityType is \"dps\"). \nThe device registration Id to use during device provisioning." +
             "\nDefaults to environment variable \"IOTHUB_DEVICE_DPS_DEVICE_ID\".")]
         public string DeviceId { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_DEVICE_ID");
 
         [Option(
             'k',
             "DeviceSymmetricKey",
-            HelpText = "(Required if DeviceProvisioningType is \"dps\"). \nThe device symmetric key to use during device provisioning." +
+            HelpText = "(Required if DeviceSecurityType is \"dps\"). \nThe device symmetric key to use during device provisioning." +
             "\nDefaults to environment variable \"IOTHUB_DEVICE_DPS_DEVICE_KEY\".")]
         public string DeviceSymmetricKey { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_DEVICE_KEY");
 
         public bool Validate()
         {
-            if (string.IsNullOrWhiteSpace(DeviceProvisioningType))
+            if (string.IsNullOrWhiteSpace(DeviceSecurityType))
             {
-                throw new ArgumentNullException(nameof(DeviceProvisioningType), "Device provisioning type needs to be specified, please set the environment variable \"IOTHUB_DEVICE_SECURITY_TYPE\"" +
-                    "or pass in \"-s | --DeviceProvisioningType\" through command line.");
+                throw new ArgumentNullException(nameof(DeviceSecurityType), "Device provisioning type needs to be specified, please set the environment variable \"IOTHUB_DEVICE_SECURITY_TYPE\"" +
+                    "or pass in \"-s | --DeviceSecurityType\" through command line.");
             }
 
-            return (DeviceProvisioningType.ToLowerInvariant()) switch
+            return (DeviceSecurityType.ToLowerInvariant()) switch
             {
                 "dps" => !string.IsNullOrWhiteSpace(DpsEndpoint)
-                                       && !string.IsNullOrWhiteSpace(DpsIdScope)
-                                       && !string.IsNullOrWhiteSpace(DeviceId)
-                                       && !string.IsNullOrWhiteSpace(DeviceSymmetricKey),
-                "hubconnectionstring" => !string.IsNullOrWhiteSpace(PrimaryConnectionString),
-                _ => throw new ArgumentException($"Unrecognized value for device provisioning received: {DeviceProvisioningType}." +
-                        $" It should be either \"dps\" or \"hubConnectionString\" (case-insensitive)."),
+                        && !string.IsNullOrWhiteSpace(DpsIdScope)
+                        && !string.IsNullOrWhiteSpace(DeviceId)
+                        && !string.IsNullOrWhiteSpace(DeviceSymmetricKey),
+                "connectionstring" => !string.IsNullOrWhiteSpace(PrimaryConnectionString),
+                _ => throw new ArgumentException($"Unrecognized value for device provisioning received: {DeviceSecurityType}." +
+                        $" It should be either \"dps\" or \"connectionString\" (case-insensitive)."),
             };
         }
     }

--- a/iothub/device/samples/PnpDeviceSamples/Thermostat/Program.cs
+++ b/iothub/device/samples/PnpDeviceSamples/Thermostat/Program.cs
@@ -2,27 +2,16 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.Provisioning.Client;
 using Microsoft.Azure.Devices.Provisioning.Client.Transport;
 using Microsoft.Azure.Devices.Shared;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 namespace Thermostat
 {
-    internal enum StatusCode
-    {
-        Completed = 200,
-        InProgress = 202,
-        NotFound = 404,
-        BadRequest = 400
-    }
-
     public class Program
     {
         // DTDL interface used: https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/Thermostat.json
@@ -43,20 +32,33 @@ namespace Thermostat
         private static readonly string s_deviceRegistrationId = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_DEVICE_ID");
         private static readonly string s_deviceSymmetricKey = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_DEVICE_KEY");
 
-        private static readonly Random s_random = new Random();
-
-        private static DeviceClient s_deviceClient;
         private static ILogger s_logger;
 
-        private static double s_temperature = 0d;
-        private static double s_maxTemp = 0d;
-
-        // Dictionary to hold the temperature updates sent over.
-        // NOTE: Memory constrained devices should leverage storage capabilities of an external service to store this information and perform computation.
-        // See https://docs.microsoft.com/en-us/azure/event-grid/compare-messaging-services for more details.
-        private static readonly Dictionary<DateTimeOffset, double> s_temperatureReadings = new Dictionary<DateTimeOffset, double>();
-
         public static async Task Main(string[] _)
+        {
+            s_logger = InitializeConsoleDebugLogger();
+
+            if (string.IsNullOrWhiteSpace(s_deviceSecurityType))
+            {
+                throw new ArgumentNullException("Device security type needs to be specified, please set the environment variable \"IOTHUB_DEVICE_SECURITY_TYPE\".");
+            }
+
+            s_logger.LogInformation("Press Control+C to quit the sample.");
+            using var cts = new CancellationTokenSource();
+            Console.CancelKeyPress += (sender, eventArgs) =>
+            {
+                eventArgs.Cancel = true;
+                cts.Cancel();
+                s_logger.LogInformation("Sample execution cancellation requested; will exit.");
+            };
+
+            s_logger.LogDebug($"Set up the device client.");
+            using DeviceClient deviceClient = await SetupDeviceClientAsync(s_deviceSecurityType, cts.Token);
+            var sample = new ThermostatSample(deviceClient, s_logger);
+            await sample.PerformOperationsAsync(cts.Token);
+        }
+
+        private static ILogger InitializeConsoleDebugLogger()
         {
             ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
             {
@@ -67,42 +69,31 @@ namespace Thermostat
                     options.TimestampFormat = "[MM/dd/yyyy HH:mm:ss]";
                 });
             });
-            s_logger = loggerFactory.CreateLogger<Program>();
 
-            await RunSampleAsync();
+            return loggerFactory.CreateLogger<ThermostatSample>();
         }
 
-        private static async Task RunSampleAsync()
+        private static async Task<DeviceClient> SetupDeviceClientAsync(string deviceSecurityType, CancellationToken cancellationToken)
         {
-            // This sample follows the following workflow:
-            // -> Initialize device client instance.
-            // -> Set handler to receive "targetTemperature" updates, and send the received update over reported property.
-            // -> Set handler to receive "getMaxMinReport" command, and send the generated report as command response.
-            // -> Periodically send "temperature" over telemetry.
-            // -> Send "maxTempSinceLastReboot" over property update, when a new max temperature is set.
-
-            if (string.IsNullOrWhiteSpace(s_deviceSecurityType))
-            {
-                throw new ArgumentNullException("Device security type needs to be specified, please set the environment variable \"IOTHUB_DEVICE_SECURITY_TYPE\".");
-            }
-
-            s_logger.LogDebug($"Initialize the device client.");
-            switch (s_deviceSecurityType.ToLowerInvariant())
+            DeviceClient deviceClient;
+            switch (deviceSecurityType.ToLowerInvariant())
             {
                 case "dps":
+                    s_logger.LogDebug($"Initializing via DPS");
                     if (ValidateArgsForDpsFlow())
                     {
-                        DeviceRegistrationResult dpsRegistrationResult = await ProvisionDeviceAsync();
+                        DeviceRegistrationResult dpsRegistrationResult = await ProvisionDeviceAsync(cancellationToken);
                         var authMethod = new DeviceAuthenticationWithRegistrySymmetricKey(dpsRegistrationResult.DeviceId, s_deviceSymmetricKey);
-                        InitializeDeviceClient(dpsRegistrationResult.AssignedHub, authMethod);
+                        deviceClient = InitializeDeviceClient(dpsRegistrationResult.AssignedHub, authMethod);
                         break;
                     }
                     throw new ArgumentException("Required environment variables are not set for DPS flow, please recheck your environment.");
 
                 case "connectionstring":
+                    s_logger.LogDebug($"Initializing via IoT Hub connection string");
                     if (ValidateArgsForIotHubFlow())
                     {
-                        InitializeDeviceClient(s_deviceConnectionString);
+                        deviceClient = InitializeDeviceClient(s_deviceConnectionString);
                         break;
                     }
                     throw new ArgumentException("Required environment variables are not set for IoT Hub flow, please recheck your environment.");
@@ -111,33 +102,11 @@ namespace Thermostat
                     throw new ArgumentException($"Unrecognized value for IOTHUB_DEVICE_SECURITY_TYPE received: {s_deviceSecurityType}." +
                         $" It should be either \"DPS\" or \"connectionString\" (case-insensitive).");
             }
-
-            s_logger.LogDebug($"Set handler to receive \"targetTemperature\" updates.");
-            await s_deviceClient.SetDesiredPropertyUpdateCallbackAsync(TargetTemperatureUpdateCallbackAsync, s_deviceClient);
-
-            s_logger.LogDebug($"Set handler for \"getMaxMinReport\" command.");
-            await s_deviceClient.SetMethodHandlerAsync("getMaxMinReport", HandleMaxMinReportCommandAsync, s_deviceClient);
-
-            bool temperatureReset = true;
-            await Task.Run(async () =>
-            {
-                while (true)
-                {
-                    if (temperatureReset)
-                    {
-                        // Generate a random value between 5.0°C and 45.0°C for the current temperature reading.
-                        s_temperature = Math.Round(s_random.NextDouble() * 40.0 + 5.0, 1);
-                        temperatureReset = false;
-                    }
-
-                    await SendTemperatureAsync();
-                    await Task.Delay(5 * 1000);
-                }
-            });
+            return deviceClient;
         }
 
         // Provision a device via DPS, by sending the PnP model Id as DPS payload.
-        private static async Task<DeviceRegistrationResult> ProvisionDeviceAsync()
+        private static async Task<DeviceRegistrationResult> ProvisionDeviceAsync(CancellationToken cancellationToken)
         {
             SecurityProvider symmetricKeyProvider = new SecurityProviderSymmetricKey(s_deviceRegistrationId, s_deviceSymmetricKey, null);
             ProvisioningTransportHandler mqttTransportHandler = new ProvisioningTransportHandlerMqtt();
@@ -147,156 +116,43 @@ namespace Thermostat
             {
                 JsonData = $"{{ \"modelId\": \"{ModelId}\" }}",
             };
-            return await pdc.RegisterAsync(pnpPayload);
+            return await pdc.RegisterAsync(pnpPayload, cancellationToken);
         }
 
         // Initialize the device client instance using connection string based authentication, over Mqtt protocol (TCP, with fallback over Websocket) and setting the ModelId into ClientOptions.
         // This method also sets a connection status change callback, that will get triggered any time the device's connection status changes.
-        private static void InitializeDeviceClient(string deviceConnectionString)
+        private static DeviceClient InitializeDeviceClient(string deviceConnectionString)
         {
             var options = new ClientOptions
             {
                 ModelId = ModelId,
             };
-            s_deviceClient = DeviceClient.CreateFromConnectionString(deviceConnectionString, TransportType.Mqtt, options);
-            s_deviceClient.SetConnectionStatusChangesHandler((status, reason) =>
+
+            var deviceClient = DeviceClient.CreateFromConnectionString(deviceConnectionString, TransportType.Mqtt, options);
+            deviceClient.SetConnectionStatusChangesHandler((status, reason) =>
             {
                 s_logger.LogDebug($"Connection status change registered - status={status}, reason={reason}.");
             });
+
+            return deviceClient;
         }
 
         // Initialize the device client instance using symmetric key based authentication, over Mqtt protocol (TCP, with fallback over Websocket) and setting the ModelId into ClientOptions.
         // This method also sets a connection status change callback, that will get triggered any time the device's connection status changes.
-        private static void InitializeDeviceClient(string hostname, IAuthenticationMethod authenticationMethod)
+        private static DeviceClient InitializeDeviceClient(string hostname, IAuthenticationMethod authenticationMethod)
         {
             var options = new ClientOptions
             {
                 ModelId = ModelId,
             };
-            s_deviceClient = DeviceClient.Create(hostname, authenticationMethod, TransportType.Mqtt, options);
-            s_deviceClient.SetConnectionStatusChangesHandler((status, reason) =>
+            
+            var deviceClient = DeviceClient.Create(hostname, authenticationMethod, TransportType.Mqtt, options);
+            deviceClient.SetConnectionStatusChangesHandler((status, reason) =>
             {
                 s_logger.LogDebug($"Connection status change registered - status={status}, reason={reason}.");
             });
-        }
 
-        // The desired property update callback, which receives the target temperature as a desired property update,
-        // and updates the current temperature value over telemetry and reported property update.
-        private static async Task TargetTemperatureUpdateCallbackAsync(TwinCollection desiredProperties, object userContext)
-        {
-            string propertyName = "targetTemperature";
-
-            (bool targetTempUpdateReceived, double targetTemperature) = GetPropertyFromTwin<double>(desiredProperties, propertyName);
-            if (targetTempUpdateReceived)
-            {
-                s_logger.LogDebug($"Property: Received - {{ \"{propertyName}\": {targetTemperature}°C }}.");
-
-                string jsonPropertyPending = $"{{ \"{propertyName}\": {{ \"value\": {s_temperature}, \"ac\": {(int)StatusCode.InProgress}, \"av\": {desiredProperties.Version} }} }}";
-                var reportedPropertyPending = new TwinCollection(jsonPropertyPending);
-                await s_deviceClient.UpdateReportedPropertiesAsync(reportedPropertyPending);
-                s_logger.LogDebug($"Property: Update - {{\"{propertyName}\": {targetTemperature}°C }} is {StatusCode.InProgress}.");
-
-                // Update Temperature in 2 steps
-                double step = (targetTemperature - s_temperature) / 2d;
-                for (int i = 1; i <= 2; i++)
-                {
-                    s_temperature = Math.Round(s_temperature + step, 1);
-                    await Task.Delay(6 * 1000);
-                }
-
-                string jsonProperty = $"{{ \"{propertyName}\": {{ \"value\": {s_temperature}, \"ac\": {(int)StatusCode.Completed}, \"av\": {desiredProperties.Version}, \"ad\": \"Successfully updated target temperature\" }} }}";
-                var reportedProperty = new TwinCollection(jsonProperty);
-                await s_deviceClient.UpdateReportedPropertiesAsync(reportedProperty);
-                s_logger.LogDebug($"Property: Update - {{\"{propertyName}\": {s_temperature}°C }} is {StatusCode.Completed}.");
-            }
-            else
-            {
-                s_logger.LogDebug($"Property: Received an unrecognized property update from service.");
-            }
-        }
-
-        private static async Task SendTemperatureAsync()
-        {
-            await SendTemperatureTelemetryAsync();
-
-            double maxTemp = s_temperatureReadings.Values.Max<double>();
-            if (maxTemp > s_maxTemp)
-            {
-                s_maxTemp = maxTemp;
-                await UpdateMaxTemperatureSinceLastRebootAsync();
-            }
-        }
-
-        private static async Task SendTemperatureTelemetryAsync()
-        {
-            string telemetryName = "temperature";
-
-            string telemetryPayload = $"{{ \"{telemetryName}\": {s_temperature} }}";
-            var message = new Message(Encoding.UTF8.GetBytes(telemetryPayload))
-            {
-                ContentEncoding = "utf-8",
-                ContentType = "application/json",
-            };
-
-            await s_deviceClient.SendEventAsync(message);
-            s_logger.LogDebug($"Telemetry: Sent - {{ \"{telemetryName}\": {s_temperature}°C }}.");
-
-            s_temperatureReadings.Add(DateTimeOffset.Now, s_temperature);
-        }
-
-        private static async Task UpdateMaxTemperatureSinceLastRebootAsync()
-        {
-            string propertyName = "maxTempSinceLastReboot";
-
-            var reportedProperties = new TwinCollection();
-            reportedProperties[propertyName] = s_maxTemp;
-
-            await s_deviceClient.UpdateReportedPropertiesAsync(reportedProperties);
-            s_logger.LogDebug($"Property: Update - {{ \"{propertyName}\": {s_maxTemp}°C }} is {StatusCode.Completed}.");
-        }
-
-        // The callback to handle "getMaxMinReport" command. This method will returns the max, min and average temperature from the specified time to the current time.
-        private static async Task<MethodResponse> HandleMaxMinReportCommandAsync(MethodRequest request, object userContext)
-        {
-            try
-            {
-                DateTime since = JsonConvert.DeserializeObject<DateTime>(request.DataAsJson);
-                var sinceInDateTimeOffset = new DateTimeOffset(since);
-                s_logger.LogDebug($"Command: Received - Generating max, min and avg temperature report since {sinceInDateTimeOffset.LocalDateTime}.");
-
-                var filteredReadings = s_temperatureReadings.Where(i => i.Key > sinceInDateTimeOffset).ToDictionary(i => i.Key, i => i.Value);
-
-                if (filteredReadings != null && filteredReadings.Any())
-                {
-                    var report = new
-                    {
-                        maxTemp = filteredReadings.Values.Max<double>(),
-                        minTemp = filteredReadings.Values.Min<double>(),
-                        avgTemp = filteredReadings.Values.Average(),
-                        startTime = filteredReadings.Keys.Min().DateTime,
-                        endTime = filteredReadings.Keys.Max().DateTime,
-                    };
-
-                    s_logger.LogDebug($"Command: MaxMinReport since {sinceInDateTimeOffset.LocalDateTime}:" +
-                        $" maxTemp={report.maxTemp}, minTemp={report.minTemp}, avgTemp={report.avgTemp}, startTime={report.startTime}, endTime={report.endTime}");
-
-                    byte[] responsePayload = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(report));
-                    return await Task.FromResult(new MethodResponse(responsePayload, (int)StatusCode.Completed));
-                }
-
-                s_logger.LogDebug($"Command: No relevant readings found since {sinceInDateTimeOffset.LocalDateTime}, cannot generate any report.");
-            }
-            catch (JsonReaderException ex)
-            {
-                s_logger.LogDebug($"Command input is invalid: {ex.Message}.");
-                return await Task.FromResult(new MethodResponse((int)StatusCode.BadRequest));
-            }
-            return await Task.FromResult(new MethodResponse((int)StatusCode.NotFound));
-        }
-
-        private static (bool, T) GetPropertyFromTwin<T>(TwinCollection collection, string propertyName)
-        {
-            return collection.Contains(propertyName) ? (true, (T)collection[propertyName]) : (false, default);
+            return deviceClient;
         }
 
         private static bool ValidateArgsForDpsFlow()

--- a/iothub/device/samples/PnpDeviceSamples/Thermostat/Program.cs
+++ b/iothub/device/samples/PnpDeviceSamples/Thermostat/Program.cs
@@ -36,7 +36,7 @@ namespace Thermostat
 
             if (!parameters.Validate())
             {
-                s_logger.LogError("Required parameters are not set, please recheck required variables by running \"dotnet run -- --help\"");
+                s_logger.LogError("Required parameters are not set. Please recheck required variables by using \"--help\"");
                 Environment.Exit(1);
             }
 
@@ -74,7 +74,7 @@ namespace Thermostat
         private static async Task<DeviceClient> SetupDeviceClientAsync(Parameters parameters, CancellationToken cancellationToken)
         {
             DeviceClient deviceClient;
-            switch (parameters.DeviceProvisioningType.ToLowerInvariant())
+            switch (parameters.DeviceSecurityType.ToLowerInvariant())
             {
                 case "dps":
                     s_logger.LogDebug($"Initializing via DPS");
@@ -83,14 +83,14 @@ namespace Thermostat
                     deviceClient = InitializeDeviceClient(dpsRegistrationResult.AssignedHub, authMethod);
                     break;
 
-                case "hubconnectionstring":
+                case "connectionstring":
                     s_logger.LogDebug($"Initializing via IoT Hub connection string");
                     deviceClient = InitializeDeviceClient(parameters.PrimaryConnectionString);
                     break;
 
                 default:
-                    throw new ArgumentException($"Unrecognized value for device provisioning received: {parameters.DeviceProvisioningType}." +
-                        $" It should be either \"dps\" or \"hubConnectionString\" (case-insensitive).");
+                    throw new ArgumentException($"Unrecognized value for device provisioning received: {parameters.DeviceSecurityType}." +
+                        $" It should be either \"dps\" or \"connectionString\" (case-insensitive).");
             }
             return deviceClient;
         }

--- a/iothub/device/samples/PnpDeviceSamples/Thermostat/Program.cs
+++ b/iothub/device/samples/PnpDeviceSamples/Thermostat/Program.cs
@@ -7,10 +7,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Provisioning.Client;
+using Microsoft.Azure.Devices.Provisioning.Client.Transport;
 using Microsoft.Azure.Devices.Shared;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Thermostat
 {
@@ -27,7 +28,21 @@ namespace Thermostat
         // DTDL interface used: https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/Thermostat.json
         private const string ModelId = "dtmi:com:example:Thermostat;1";
 
+        // This environment variable indicates if DPS or IoT Hub connection string will be used to provision the device.
+        // Expected values: (case-insensitive)
+        // "DPS" - The sample will use DPS to provision the device.
+        // "connectionString" - The sample will use IoT Hub connection string to provision the device.
+        private static readonly string s_deviceSecurityType = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_SECURITY_TYPE");
+
+        // Required if IOTHUB_DEVICE_SECURITY_TYPE is set to "connectionString".
         private static readonly string s_deviceConnectionString = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_CONNECTION_STRING");
+
+        // Required if IOTHUB_DEVICE_SECURITY_TYPE is set to "DPS".
+        private static readonly string s_dpsEndpoint = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_ENDPOINT");
+        private static readonly string s_dpsIdScope = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_ID_SCOPE");
+        private static readonly string s_deviceRegistrationId = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_DEVICE_ID");
+        private static readonly string s_deviceSymmetricKey = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_DPS_DEVICE_KEY");
+
         private static readonly Random s_random = new Random();
 
         private static DeviceClient s_deviceClient;
@@ -66,8 +81,36 @@ namespace Thermostat
             // -> Periodically send "temperature" over telemetry.
             // -> Send "maxTempSinceLastReboot" over property update, when a new max temperature is set.
 
+            if (string.IsNullOrWhiteSpace(s_deviceSecurityType))
+            {
+                throw new ArgumentNullException("Device security type needs to be specified, please set the environment variable \"IOTHUB_DEVICE_SECURITY_TYPE\".");
+            }
+
             s_logger.LogDebug($"Initialize the device client.");
-            InitializeDeviceClientAsync();
+            switch (s_deviceSecurityType.ToLowerInvariant())
+            {
+                case "dps":
+                    if (ValidateArgsForDpsFlow())
+                    {
+                        DeviceRegistrationResult dpsRegistrationResult = await ProvisionDeviceAsync();
+                        var authMethod = new DeviceAuthenticationWithRegistrySymmetricKey(dpsRegistrationResult.DeviceId, s_deviceSymmetricKey);
+                        InitializeDeviceClientAsync(dpsRegistrationResult.AssignedHub, authMethod);
+                        break;
+                    }
+                    throw new ArgumentException("Required environment variables are not set for DPS flow, please recheck your environment.");
+
+                case "connectionstring":
+                    if (ValidateArgsForIotHubFlow())
+                    {
+                        InitializeDeviceClientAsync(s_deviceConnectionString);
+                        break;
+                    }
+                    throw new ArgumentException("Required environment variables are not set for IoT Hub flow, please recheck your environment.");
+
+                default:
+                    throw new ArgumentException($"Unrecognized value for IOTHUB_DEVICE_SECURITY_TYPE received: {s_deviceSecurityType}." +
+                        $" It should be either \"DPS\" or \"connectionString\" (case-insensitive).");
+            }
 
             s_logger.LogDebug($"Set handler to receive \"targetTemperature\" updates.");
             await s_deviceClient.SetDesiredPropertyUpdateCallbackAsync(TargetTemperatureUpdateCallbackAsync, s_deviceClient);
@@ -93,15 +136,44 @@ namespace Thermostat
             });
         }
 
-        // Initialize the device client instance over Mqtt protocol (TCP, with fallback over Websocket), setting the ModelId into ClientOptions.
+        // Provision a device via DPS, by sending the PnP model Id as DPS payload.
+        private static async Task<DeviceRegistrationResult> ProvisionDeviceAsync()
+        {
+            SecurityProvider symmetricKeyProvider = new SecurityProviderSymmetricKey(s_deviceRegistrationId, s_deviceSymmetricKey, null);
+            ProvisioningTransportHandler mqttTransportHandler = new ProvisioningTransportHandlerMqtt();
+            var pdc = ProvisioningDeviceClient.Create(s_dpsEndpoint, s_dpsIdScope, symmetricKeyProvider, mqttTransportHandler);
+
+            var pnpPayload = new ProvisioningRegistrationAdditionalData
+            {
+                JsonData = $"{{ \"modelId\": \"{ModelId}\" }}",
+            };
+            return await pdc.RegisterAsync(pnpPayload);
+        }
+
+        // Initialize the device client instance using connection string based authentication, over Mqtt protocol (TCP, with fallback over Websocket) and setting the ModelId into ClientOptions.
         // This method also sets a connection status change callback, that will get triggered any time the device's connection status changes.
-        private static void InitializeDeviceClientAsync()
+        private static void InitializeDeviceClientAsync(string deviceConnectionString)
         {
             var options = new ClientOptions
             {
                 ModelId = ModelId,
             };
-            s_deviceClient = DeviceClient.CreateFromConnectionString(s_deviceConnectionString, TransportType.Mqtt, options);
+            s_deviceClient = DeviceClient.CreateFromConnectionString(deviceConnectionString, TransportType.Mqtt, options);
+            s_deviceClient.SetConnectionStatusChangesHandler((status, reason) =>
+            {
+                s_logger.LogDebug($"Connection status change registered - status={status}, reason={reason}.");
+            });
+        }
+
+        // Initialize the device client instance using symmetric key based authentication, over Mqtt protocol (TCP, with fallback over Websocket) and setting the ModelId into ClientOptions.
+        // This method also sets a connection status change callback, that will get triggered any time the device's connection status changes.
+        private static void InitializeDeviceClientAsync(string hostname, IAuthenticationMethod authenticationMethod)
+        {
+            var options = new ClientOptions
+            {
+                ModelId = ModelId,
+            };
+            s_deviceClient = DeviceClient.Create(hostname, authenticationMethod, TransportType.Mqtt, options);
             s_deviceClient.SetConnectionStatusChangesHandler((status, reason) =>
             {
                 s_logger.LogDebug($"Connection status change registered - status={status}, reason={reason}.");
@@ -225,6 +297,19 @@ namespace Thermostat
         private static (bool, T) GetPropertyFromTwin<T>(TwinCollection collection, string propertyName)
         {
             return collection.Contains(propertyName) ? (true, (T)collection[propertyName]) : (false, default);
+        }
+
+        private static bool ValidateArgsForDpsFlow()
+        {
+            return !string.IsNullOrWhiteSpace(s_dpsEndpoint)
+                && !string.IsNullOrWhiteSpace(s_dpsIdScope)
+                && !string.IsNullOrWhiteSpace(s_deviceRegistrationId)
+                && !string.IsNullOrWhiteSpace(s_deviceSymmetricKey);
+        }
+
+        private static bool ValidateArgsForIotHubFlow()
+        {
+            return !string.IsNullOrWhiteSpace(s_deviceConnectionString);
         }
     }
 }

--- a/iothub/device/samples/PnpDeviceSamples/Thermostat/Program.cs
+++ b/iothub/device/samples/PnpDeviceSamples/Thermostat/Program.cs
@@ -94,7 +94,7 @@ namespace Thermostat
                     {
                         DeviceRegistrationResult dpsRegistrationResult = await ProvisionDeviceAsync();
                         var authMethod = new DeviceAuthenticationWithRegistrySymmetricKey(dpsRegistrationResult.DeviceId, s_deviceSymmetricKey);
-                        InitializeDeviceClientAsync(dpsRegistrationResult.AssignedHub, authMethod);
+                        InitializeDeviceClient(dpsRegistrationResult.AssignedHub, authMethod);
                         break;
                     }
                     throw new ArgumentException("Required environment variables are not set for DPS flow, please recheck your environment.");
@@ -102,7 +102,7 @@ namespace Thermostat
                 case "connectionstring":
                     if (ValidateArgsForIotHubFlow())
                     {
-                        InitializeDeviceClientAsync(s_deviceConnectionString);
+                        InitializeDeviceClient(s_deviceConnectionString);
                         break;
                     }
                     throw new ArgumentException("Required environment variables are not set for IoT Hub flow, please recheck your environment.");
@@ -152,7 +152,7 @@ namespace Thermostat
 
         // Initialize the device client instance using connection string based authentication, over Mqtt protocol (TCP, with fallback over Websocket) and setting the ModelId into ClientOptions.
         // This method also sets a connection status change callback, that will get triggered any time the device's connection status changes.
-        private static void InitializeDeviceClientAsync(string deviceConnectionString)
+        private static void InitializeDeviceClient(string deviceConnectionString)
         {
             var options = new ClientOptions
             {
@@ -167,7 +167,7 @@ namespace Thermostat
 
         // Initialize the device client instance using symmetric key based authentication, over Mqtt protocol (TCP, with fallback over Websocket) and setting the ModelId into ClientOptions.
         // This method also sets a connection status change callback, that will get triggered any time the device's connection status changes.
-        private static void InitializeDeviceClientAsync(string hostname, IAuthenticationMethod authenticationMethod)
+        private static void InitializeDeviceClient(string hostname, IAuthenticationMethod authenticationMethod)
         {
             var options = new ClientOptions
             {

--- a/iothub/device/samples/PnpDeviceSamples/Thermostat/Thermostat.csproj
+++ b/iothub/device/samples/PnpDeviceSamples/Thermostat/Thermostat.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.27.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.28.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
   </ItemGroup>
 </Project>

--- a/iothub/device/samples/PnpDeviceSamples/Thermostat/Thermostat.csproj
+++ b/iothub/device/samples/PnpDeviceSamples/Thermostat/Thermostat.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.28.0" />
     <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.3.0" />

--- a/iothub/device/samples/PnpDeviceSamples/Thermostat/ThermostatSample.cs
+++ b/iothub/device/samples/PnpDeviceSamples/Thermostat/ThermostatSample.cs
@@ -173,7 +173,7 @@ namespace Thermostat
             string telemetryName = "temperature";
 
             string telemetryPayload = $"{{ \"{telemetryName}\": {_temperature} }}";
-            var message = new Message(Encoding.UTF8.GetBytes(telemetryPayload))
+            using var message = new Message(Encoding.UTF8.GetBytes(telemetryPayload))
             {
                 ContentEncoding = "utf-8",
                 ContentType = "application/json",

--- a/iothub/device/samples/PnpDeviceSamples/Thermostat/ThermostatSample.cs
+++ b/iothub/device/samples/PnpDeviceSamples/Thermostat/ThermostatSample.cs
@@ -1,0 +1,200 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Shared;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Thermostat
+{
+    internal enum StatusCode
+    {
+        Completed = 200,
+        InProgress = 202,
+        NotFound = 404,
+        BadRequest = 400
+    }
+
+    public class ThermostatSample
+    {
+        private readonly Random _random = new Random();
+
+        private double _temperature = 0d;
+        private double _maxTemp = 0d;
+
+        // Dictionary to hold the temperature updates sent over.
+        // NOTE: Memory constrained devices should leverage storage capabilities of an external service to store this information and perform computation.
+        // See https://docs.microsoft.com/en-us/azure/event-grid/compare-messaging-services for more details.
+        private readonly Dictionary<DateTimeOffset, double> _temperatureReadingsDateTimeOffset = new Dictionary<DateTimeOffset, double>();
+
+        private readonly DeviceClient _deviceClient;
+        private readonly ILogger _logger;
+
+        public ThermostatSample(DeviceClient deviceClient, ILogger logger)
+        {
+            _deviceClient = deviceClient ?? throw new ArgumentNullException($"{nameof(deviceClient)} cannot be null.");
+            _logger = logger ?? LoggerFactory.Create(builer => builer.AddConsole()).CreateLogger<ThermostatSample>();
+        }
+
+        public async Task PerformOperationsAsync(CancellationToken cancellationToken)
+        {
+            // This sample follows the following workflow:
+            // -> Set handler to receive "targetTemperature" updates, and send the received update over reported property.
+            // -> Set handler to receive "getMaxMinReport" command, and send the generated report as command response.
+            // -> Periodically send "temperature" over telemetry.
+            // -> Send "maxTempSinceLastReboot" over property update, when a new max temperature is set.
+
+            _logger.LogDebug($"Set handler to receive \"targetTemperature\" updates.");
+            await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(TargetTemperatureUpdateCallbackAsync, _deviceClient, cancellationToken);
+
+            _logger.LogDebug($"Set handler for \"getMaxMinReport\" command.");
+            await _deviceClient.SetMethodHandlerAsync("getMaxMinReport", HandleMaxMinReportCommandAsync, _deviceClient, cancellationToken);
+
+            bool temperatureReset = true;
+            await Task.Run(async () =>
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    if (temperatureReset)
+                    {
+                        // Generate a random value between 5.0°C and 45.0°C for the current temperature reading.
+                        _temperature = Math.Round(_random.NextDouble() * 40.0 + 5.0, 1);
+                        temperatureReset = false;
+                    }
+
+                    await SendTemperatureAsync();
+                    await Task.Delay(5 * 1000);
+                }
+            });
+        }
+
+        // The desired property update callback, which receives the target temperature as a desired property update,
+        // and updates the current temperature value over telemetry and reported property update.
+        private async Task TargetTemperatureUpdateCallbackAsync(TwinCollection desiredProperties, object userContext)
+        {
+            string propertyName = "targetTemperature";
+
+            (bool targetTempUpdateReceived, double targetTemperature) = GetPropertyFromTwin<double>(desiredProperties, propertyName);
+            if (targetTempUpdateReceived)
+            {
+                _logger.LogDebug($"Property: Received - {{ \"{propertyName}\": {targetTemperature}°C }}.");
+
+                string jsonPropertyPending = $"{{ \"{propertyName}\": {{ \"value\": {_temperature}, \"ac\": {(int)StatusCode.InProgress}, \"av\": {desiredProperties.Version} }} }}";
+                var reportedPropertyPending = new TwinCollection(jsonPropertyPending);
+                await _deviceClient.UpdateReportedPropertiesAsync(reportedPropertyPending);
+                _logger.LogDebug($"Property: Update - {{\"{propertyName}\": {targetTemperature}°C }} is {StatusCode.InProgress}.");
+
+                // Update Temperature in 2 steps
+                double step = (targetTemperature - _temperature) / 2d;
+                for (int i = 1; i <= 2; i++)
+                {
+                    _temperature = Math.Round(_temperature + step, 1);
+                    await Task.Delay(6 * 1000);
+                }
+
+                string jsonProperty = $"{{ \"{propertyName}\": {{ \"value\": {_temperature}, \"ac\": {(int)StatusCode.Completed}, \"av\": {desiredProperties.Version}, \"ad\": \"Successfully updated target temperature\" }} }}";
+                var reportedProperty = new TwinCollection(jsonProperty);
+                await _deviceClient.UpdateReportedPropertiesAsync(reportedProperty);
+                _logger.LogDebug($"Property: Update - {{\"{propertyName}\": {_temperature}°C }} is {StatusCode.Completed}.");
+            }
+            else
+            {
+                _logger.LogDebug($"Property: Received an unrecognized property update from service.");
+            }
+        }
+
+        private static (bool, T) GetPropertyFromTwin<T>(TwinCollection collection, string propertyName)
+        {
+            return collection.Contains(propertyName) ? (true, (T)collection[propertyName]) : (false, default);
+        }
+
+        // The callback to handle "getMaxMinReport" command. This method will returns the max, min and average temperature from the specified time to the current time.
+        private async Task<MethodResponse> HandleMaxMinReportCommandAsync(MethodRequest request, object userContext)
+        {
+            try
+            {
+                DateTime sinceInUtc = JsonConvert.DeserializeObject<DateTime>(request.DataAsJson);
+                var sinceInDateTimeOffset = new DateTimeOffset(sinceInUtc);
+                _logger.LogDebug($"Command: Received - Generating max, min and avg temperature report since {sinceInDateTimeOffset.LocalDateTime}.");
+
+                var filteredReadings = _temperatureReadingsDateTimeOffset.Where(i => i.Key > sinceInDateTimeOffset).ToDictionary(i => i.Key, i => i.Value);
+
+                if (filteredReadings != null && filteredReadings.Any())
+                {
+                    var report = new
+                    {
+                        maxTemp = filteredReadings.Values.Max<double>(),
+                        minTemp = filteredReadings.Values.Min<double>(),
+                        avgTemp = filteredReadings.Values.Average(),
+                        startTime = filteredReadings.Keys.Min(),
+                        endTime = filteredReadings.Keys.Max(),
+                    };
+
+                    _logger.LogDebug($"Command: MaxMinReport since {sinceInDateTimeOffset.LocalDateTime}:" +
+                        $" maxTemp={report.maxTemp}, minTemp={report.minTemp}, avgTemp={report.avgTemp}, startTime={report.startTime.LocalDateTime}, endTime={report.endTime.LocalDateTime}");
+
+                    byte[] responsePayload = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(report));
+                    return await Task.FromResult(new MethodResponse(responsePayload, (int)StatusCode.Completed));
+                }
+
+                _logger.LogDebug($"Command: No relevant readings found since {sinceInDateTimeOffset.LocalDateTime}, cannot generate any report.");
+            }
+            catch (JsonReaderException ex)
+            {
+                _logger.LogDebug($"Command input is invalid: {ex.Message}.");
+                return await Task.FromResult(new MethodResponse((int)StatusCode.BadRequest));
+            }
+            return await Task.FromResult(new MethodResponse((int)StatusCode.NotFound));
+        }
+
+        // Send temperature updates over telemetry. The sample also sends the value of max temperature since last reboot over reported property update.
+        private async Task SendTemperatureAsync()
+        {
+            await SendTemperatureTelemetryAsync();
+
+            double maxTemp = _temperatureReadingsDateTimeOffset.Values.Max<double>();
+            if (maxTemp > _maxTemp)
+            {
+                _maxTemp = maxTemp;
+                await UpdateMaxTemperatureSinceLastRebootAsync();
+            }
+        }
+
+        // Send temperature update over telemetry.
+        private async Task SendTemperatureTelemetryAsync()
+        {
+            string telemetryName = "temperature";
+
+            string telemetryPayload = $"{{ \"{telemetryName}\": {_temperature} }}";
+            var message = new Message(Encoding.UTF8.GetBytes(telemetryPayload))
+            {
+                ContentEncoding = "utf-8",
+                ContentType = "application/json",
+            };
+
+            await _deviceClient.SendEventAsync(message);
+            _logger.LogDebug($"Telemetry: Sent - {{ \"{telemetryName}\": {_temperature}°C }}.");
+
+            _temperatureReadingsDateTimeOffset.Add(DateTimeOffset.Now, _temperature);
+        }
+
+        // Send temperature over reported property update.
+        private async Task UpdateMaxTemperatureSinceLastRebootAsync()
+        {
+            string propertyName = "maxTempSinceLastReboot";
+
+            var reportedProperties = new TwinCollection();
+            reportedProperties[propertyName] = _maxTemp;
+
+            await _deviceClient.UpdateReportedPropertiesAsync(reportedProperties);
+            _logger.LogDebug($"Property: Update - {{ \"{propertyName}\": {_maxTemp}°C }} is {StatusCode.Completed}.");
+        }
+    }
+}


### PR DESCRIPTION
This PR currently has the DPS flow for the Thermostat sample. Once I get a sign-off on the approach, I'll implement the same for the TemperatureController sample as well.

Passing in env var via command line -> defaults to env variable:
![image](https://user-images.githubusercontent.com/22563986/93146185-00b22b00-f6a3-11ea-8c03-57057b0d2fac.png)
