### PR TITLE
Bump versions for 2020-01-11 release

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.1;netstandard2.0;net472;net451</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.28.0</Version>
+    <Version>1.30.0</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.6.3</Version>
+    <Version>1.7.0</Version>
     <Title>Microsoft Azure IoT Provisioning Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,5 +1,5 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.28.0
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.30.0
 iothub\service\src\Microsoft.Azure.Devices.csproj, 1.22.0
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.20.1
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.6.0
@@ -7,4 +7,4 @@ provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.A
 provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.2.4
 provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.3.0
 security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.2.3
-provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.6.3
+provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.7.0


### PR DESCRIPTION
Release notes:

# Microsoft.Azure.Devices.Client.1.30.0
- Remove unreferenced exceptions and their mappings
     * DeviceAlreadyExistsException
     * DeviceDisabledException
     * IotHubNotFoundException

# Microsoft.Azure.Devices.Provisioning.Service 1.7.0
- Add APIs to get device attestation mechanism

## Bug fixes:
- Fix GetFileUploadSasUriAsync API when using certificate authentication methods (https://github.com/Azure/azure-iot-sdk-csharp/issues/1527)