### PR TITLE
Updates to PnP APIs

### DIFF
--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -22,8 +22,8 @@
     <Compile Remove="iothub\service\RegistryManagerImportDevicesTests.cs" />
     <Compile Remove="iothub\service\RegistryManagerExportDevicesTests.cs" />
     <Compile Remove="iothub\service\DigitalTwinClientE2ETests.cs" />
-    <Compile Remove="helpers\digitaltwins\ThermostatTwin.cs" />
-    <Compile Remove="helpers\digitaltwins\TemperatureControllerTwin.cs" />
+    <Compile Remove="helpers\digitaltwins\models\ThermostatTwin.cs" />
+    <Compile Remove="helpers\digitaltwins\models\TemperatureControllerTwin.cs" />
   </ItemGroup>
 
   <!-- All Platforms -->

--- a/iothub/service/src/DigitalTwin/DigitalTwin.json
+++ b/iothub/service/src/DigitalTwin/DigitalTwin.json
@@ -127,7 +127,7 @@
           {
             "name": "payload",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "description": "The Request Payload",
               "type": "object"
@@ -208,7 +208,7 @@
           {
             "name": "payload",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "description": "The Request Payload",
               "type": "object"

--- a/iothub/service/src/DigitalTwin/DigitalTwin.json
+++ b/iothub/service/src/DigitalTwin/DigitalTwin.json
@@ -1,270 +1,270 @@
 {
-    "swagger": "2.0",
-    "info": {
-        "version": "2020-09-30",
-        "title": "IotHub Gateway Service APIs"
-    },
-    "host": "fully-qualified-iothubname.azure-devices.net",
-    "schemes": [
-        "https"
-    ],
-    "paths": {
-        "/digitaltwins/{id}": {
-            "get": {
-                "summary": "Gets a digital twin.",
-                "operationId": "DigitalTwin_GetDigitalTwin",
-                "consumes": [],
-                "produces": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "description": "Digital Twin ID.",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "$ref": "#/parameters/api-version"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns the digital twin object",
-                        "schema": {
-                            "type": "object"
-                        },
-                        "headers": {
-                            "ETag": {
-                                "description": "Weak Etag",
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "summary": "Updates a digital twin.",
-                "operationId": "DigitalTwin_UpdateDigitalTwin",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "description": "Digital Twin ID.",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "digitalTwinPatch",
-                        "in": "body",
-                        "description": "json-patch contents to update.",
-                        "required": true,
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "object"
-                            }
-                        }
-                    },
-                    {
-                        "name": "If-Match",
-                        "in": "header",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "$ref": "#/parameters/api-version"
-                    }
-                ],
-                "responses": {
-                    "202": {
-                        "description": "Accepted",
-                        "headers": {
-                            "ETag": {
-                                "description": "Weak Etag of the modified resource",
-                                "type": "string"
-                            },
-                            "Location": {
-                                "description": "URI of the digital twin",
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/digitaltwins/{id}/commands/{commandName}": {
-            "post": {
-                "summary": "Invoke a digital twin root level command.",
-                "description": "Invoke a digital twin root level command.",
-                "operationId": "DigitalTwin_InvokeRootLevelCommand",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "commandName",
-                        "in": "path",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "payload",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "description": "The Request Payload",
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "$ref": "#/parameters/api-version"
-                    },
-                    {
-                        "name": "connectTimeoutInSeconds",
-                        "in": "query",
-                        "description": "Maximum interval of time, in seconds, that the digital twin command will wait for the answer.",
-                        "required": false,
-                        "type": "integer",
-                        "format": "int32"
-                    },
-                    {
-                        "name": "responseTimeoutInSeconds",
-                        "in": "query",
-                        "description": "Maximum interval of time, in seconds, that the digital twin command will wait for the answer.",
-                        "required": false,
-                        "type": "integer",
-                        "format": "int32"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns the digital twin command response payload",
-                        "schema": {
-                            "description": "The Response Payload",
-                            "type": "object"
-                        },
-                        "headers": {
-                            "x-ms-command-statuscode": {
-                                "description": "Device Generated Status Code for this Operation",
-                                "type": "integer",
-                                "format": "int32"
-                            },
-                            "x-ms-request-id": {
-                                "description": "Server Generated Request Id (GUID), to uniquely identify this request in the service",
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/digitaltwins/{id}/components/{componentPath}/commands/{commandName}": {
-            "post": {
-                "summary": "Invoke a digital twin command.",
-                "description": "Invoke a digital twin command.",
-                "operationId": "DigitalTwin_InvokeComponentCommand",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "componentPath",
-                        "in": "path",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "commandName",
-                        "in": "path",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "payload",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "description": "The Request Payload",
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "$ref": "#/parameters/api-version"
-                    },
-                    {
-                        "name": "connectTimeoutInSeconds",
-                        "in": "query",
-                        "description": "Maximum interval of time, in seconds, that the digital twin command will wait for the answer.",
-                        "required": false,
-                        "type": "integer",
-                        "format": "int32"
-                    },
-                    {
-                        "name": "responseTimeoutInSeconds",
-                        "in": "query",
-                        "description": "Maximum interval of time, in seconds, that the digital twin command will wait for the answer.",
-                        "required": false,
-                        "type": "integer",
-                        "format": "int32"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns the digital twin command response payload",
-                        "schema": {
-                            "description": "The Response Payload",
-                            "type": "object"
-                        },
-                        "headers": {
-                            "x-ms-command-statuscode": {
-                                "description": "Device Generated Status Code for this Operation",
-                                "type": "integer",
-                                "format": "int32"
-                            },
-                            "x-ms-request-id": {
-                                "description": "Server Generated Request Id (GUID), to uniquely identify this request in the service",
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    },
-    "parameters": {
-        "api-version": {
-            "name": "api-version",
-            "in": "query",
-            "description": "Version of the Api.",
+  "swagger": "2.0",
+  "info": {
+    "version": "2020-09-30",
+    "title": "IotHub Gateway Service APIs"
+  },
+  "host": "fully-qualified-iothubname.azure-devices.net",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/digitaltwins/{id}": {
+      "get": {
+        "summary": "Gets a digital twin.",
+        "operationId": "DigitalTwin_GetDigitalTwin",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Digital Twin ID.",
             "required": true,
-            "type": "string",
-            "default": "2020-09-30"
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the digital twin object",
+            "schema": {
+              "type": "object"
+            },
+            "headers": {
+              "ETag": {
+                "description": "Weak Etag",
+                "type": "string"
+              }
+            }
+          }
         }
+      },
+      "patch": {
+        "summary": "Updates a digital twin.",
+        "operationId": "DigitalTwin_UpdateDigitalTwin",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Digital Twin ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "digitalTwinPatch",
+            "in": "body",
+            "description": "json-patch contents to update.",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "headers": {
+              "ETag": {
+                "description": "Weak Etag of the modified resource",
+                "type": "string"
+              },
+              "Location": {
+                "description": "URI of the digital twin",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/digitaltwins/{id}/commands/{commandName}": {
+      "post": {
+        "summary": "Invoke a digital twin root level command.",
+        "description": "Invoke a digital twin root level command.",
+        "operationId": "DigitalTwin_InvokeRootLevelCommand",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "commandName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "payload",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "description": "The Request Payload",
+              "type": "object"
+            }
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "connectTimeoutInSeconds",
+            "in": "query",
+            "description": "Maximum interval of time, in seconds, that the digital twin command will wait for the answer.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "responseTimeoutInSeconds",
+            "in": "query",
+            "description": "Maximum interval of time, in seconds, that the digital twin command will wait for the answer.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the digital twin command response payload",
+            "schema": {
+              "description": "The Response Payload",
+              "type": "object"
+            },
+            "headers": {
+              "x-ms-command-statuscode": {
+                "description": "Device Generated Status Code for this Operation",
+                "type": "integer",
+                "format": "int32"
+              },
+              "x-ms-request-id": {
+                "description": "Server Generated Request Id (GUID), to uniquely identify this request in the service",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/digitaltwins/{id}/components/{componentPath}/commands/{commandName}": {
+      "post": {
+        "summary": "Invoke a digital twin command.",
+        "description": "Invoke a digital twin command.",
+        "operationId": "DigitalTwin_InvokeComponentCommand",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "componentPath",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "commandName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "payload",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "description": "The Request Payload",
+              "type": "object"
+            }
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "connectTimeoutInSeconds",
+            "in": "query",
+            "description": "Maximum interval of time, in seconds, that the digital twin command will wait for the answer.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "responseTimeoutInSeconds",
+            "in": "query",
+            "description": "Maximum interval of time, in seconds, that the digital twin command will wait for the answer.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the digital twin command response payload",
+            "schema": {
+              "description": "The Response Payload",
+              "type": "object"
+            },
+            "headers": {
+              "x-ms-command-statuscode": {
+                "description": "Device Generated Status Code for this Operation",
+                "type": "integer",
+                "format": "int32"
+              },
+              "x-ms-request-id": {
+                "description": "Server Generated Request Id (GUID), to uniquely identify this request in the service",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     }
+  },
+  "parameters": {
+    "api-version": {
+      "name": "api-version",
+      "in": "query",
+      "description": "Version of the Api.",
+      "required": true,
+      "type": "string",
+      "default": "2020-09-30"
+    }
+  }
 }

--- a/iothub/service/src/DigitalTwin/DigitalTwin.json
+++ b/iothub/service/src/DigitalTwin/DigitalTwin.json
@@ -127,7 +127,7 @@
                     {
                         "name": "payload",
                         "in": "body",
-                        "required": false,
+                        "required": true,
                         "schema": {
                             "description": "The Request Payload",
                             "type": "object"
@@ -208,7 +208,7 @@
                     {
                         "name": "payload",
                         "in": "body",
-                        "required": false,
+                        "required": true,
                         "schema": {
                             "description": "The Request Payload",
                             "type": "object"

--- a/iothub/service/src/DigitalTwin/Generated/DigitalTwin.cs
+++ b/iothub/service/src/DigitalTwin/Generated/DigitalTwin.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Azure.Devices.Generated
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>> InvokeRootLevelCommandWithHttpMessagesAsync(string id, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>> InvokeRootLevelCommandWithHttpMessagesAsync(string id, string commandName, string payload = default, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (id == null)
             {
@@ -624,7 +624,7 @@ namespace Microsoft.Azure.Devices.Generated
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse<string,DigitalTwinInvokeComponentCommandHeaders>> InvokeComponentCommandWithHttpMessagesAsync(string id, string componentPath, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<string,DigitalTwinInvokeComponentCommandHeaders>> InvokeComponentCommandWithHttpMessagesAsync(string id, string componentPath, string commandName, string payload = default, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (id == null)
             {

--- a/iothub/service/src/DigitalTwin/Generated/DigitalTwin.cs
+++ b/iothub/service/src/DigitalTwin/Generated/DigitalTwin.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Azure.Devices.Generated
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>> InvokeRootLevelCommandWithHttpMessagesAsync(string id, string commandName, string payload, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>> InvokeRootLevelCommandWithHttpMessagesAsync(string id, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (id == null)
             {
@@ -429,10 +429,6 @@ namespace Microsoft.Azure.Devices.Generated
             if (commandName == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "commandName");
-            }
-            if (payload == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "payload");
             }
             string apiVersion = "2020-09-30";
             // Tracing
@@ -628,7 +624,7 @@ namespace Microsoft.Azure.Devices.Generated
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse<string,DigitalTwinInvokeComponentCommandHeaders>> InvokeComponentCommandWithHttpMessagesAsync(string id, string componentPath, string commandName, string payload, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<string,DigitalTwinInvokeComponentCommandHeaders>> InvokeComponentCommandWithHttpMessagesAsync(string id, string componentPath, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (id == null)
             {
@@ -641,10 +637,6 @@ namespace Microsoft.Azure.Devices.Generated
             if (commandName == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "commandName");
-            }
-            if (payload == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "payload");
             }
             string apiVersion = "2020-09-30";
             // Tracing

--- a/iothub/service/src/DigitalTwin/Generated/DigitalTwin.cs
+++ b/iothub/service/src/DigitalTwin/Generated/DigitalTwin.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Azure.Devices.Generated
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>> InvokeRootLevelCommandWithHttpMessagesAsync(string id, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>> InvokeRootLevelCommandWithHttpMessagesAsync(string id, string commandName, string payload, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (id == null)
             {
@@ -429,6 +429,10 @@ namespace Microsoft.Azure.Devices.Generated
             if (commandName == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "commandName");
+            }
+            if (payload == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "payload");
             }
             string apiVersion = "2020-09-30";
             // Tracing
@@ -624,7 +628,7 @@ namespace Microsoft.Azure.Devices.Generated
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse<string,DigitalTwinInvokeComponentCommandHeaders>> InvokeComponentCommandWithHttpMessagesAsync(string id, string componentPath, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<string,DigitalTwinInvokeComponentCommandHeaders>> InvokeComponentCommandWithHttpMessagesAsync(string id, string componentPath, string commandName, string payload, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (id == null)
             {
@@ -637,6 +641,10 @@ namespace Microsoft.Azure.Devices.Generated
             if (commandName == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "commandName");
+            }
+            if (payload == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "payload");
             }
             string apiVersion = "2020-09-30";
             // Tracing

--- a/iothub/service/src/DigitalTwin/Generated/DigitalTwinExtensions.cs
+++ b/iothub/service/src/DigitalTwin/Generated/DigitalTwinExtensions.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.Generated
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<object> InvokeRootLevelCommandAsync(this IDigitalTwin operations, string id, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<object> InvokeRootLevelCommandAsync(this IDigitalTwin operations, string id, string commandName, string payload = default, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.InvokeRootLevelCommandWithHttpMessagesAsync(id, commandName, payload, connectTimeoutInSeconds, responseTimeoutInSeconds, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Devices.Generated
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<object> InvokeComponentCommandAsync(this IDigitalTwin operations, string id, string componentPath, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<object> InvokeComponentCommandAsync(this IDigitalTwin operations, string id, string componentPath, string commandName, string payload = default, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.InvokeComponentCommandWithHttpMessagesAsync(id, componentPath, commandName, payload, connectTimeoutInSeconds, responseTimeoutInSeconds, null, cancellationToken).ConfigureAwait(false))
                 {

--- a/iothub/service/src/DigitalTwin/Generated/DigitalTwinExtensions.cs
+++ b/iothub/service/src/DigitalTwin/Generated/DigitalTwinExtensions.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.Generated
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<object> InvokeRootLevelCommandAsync(this IDigitalTwin operations, string id, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<object> InvokeRootLevelCommandAsync(this IDigitalTwin operations, string id, string commandName, string payload, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.InvokeRootLevelCommandWithHttpMessagesAsync(id, commandName, payload, connectTimeoutInSeconds, responseTimeoutInSeconds, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Devices.Generated
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<object> InvokeComponentCommandAsync(this IDigitalTwin operations, string id, string componentPath, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<object> InvokeComponentCommandAsync(this IDigitalTwin operations, string id, string componentPath, string commandName, string payload, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.InvokeComponentCommandWithHttpMessagesAsync(id, componentPath, commandName, payload, connectTimeoutInSeconds, responseTimeoutInSeconds, null, cancellationToken).ConfigureAwait(false))
                 {

--- a/iothub/service/src/DigitalTwin/Generated/DigitalTwinExtensions.cs
+++ b/iothub/service/src/DigitalTwin/Generated/DigitalTwinExtensions.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.Generated
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<object> InvokeRootLevelCommandAsync(this IDigitalTwin operations, string id, string commandName, string payload, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<object> InvokeRootLevelCommandAsync(this IDigitalTwin operations, string id, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.InvokeRootLevelCommandWithHttpMessagesAsync(id, commandName, payload, connectTimeoutInSeconds, responseTimeoutInSeconds, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Devices.Generated
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<object> InvokeComponentCommandAsync(this IDigitalTwin operations, string id, string componentPath, string commandName, string payload, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<object> InvokeComponentCommandAsync(this IDigitalTwin operations, string id, string componentPath, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.InvokeComponentCommandWithHttpMessagesAsync(id, componentPath, commandName, payload, connectTimeoutInSeconds, responseTimeoutInSeconds, null, cancellationToken).ConfigureAwait(false))
                 {

--- a/iothub/service/src/DigitalTwin/Generated/IDigitalTwin.cs
+++ b/iothub/service/src/DigitalTwin/Generated/IDigitalTwin.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Devices.Generated
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>> InvokeRootLevelCommandWithHttpMessagesAsync(string id, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>> InvokeRootLevelCommandWithHttpMessagesAsync(string id, string commandName, string payload, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Invoke a digital twin command.
         /// </summary>
@@ -136,6 +136,6 @@ namespace Microsoft.Azure.Devices.Generated
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<HttpOperationResponse<string,DigitalTwinInvokeComponentCommandHeaders>> InvokeComponentCommandWithHttpMessagesAsync(string id, string componentPath, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<string,DigitalTwinInvokeComponentCommandHeaders>> InvokeComponentCommandWithHttpMessagesAsync(string id, string componentPath, string commandName, string payload, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/iothub/service/src/DigitalTwin/Generated/IDigitalTwin.cs
+++ b/iothub/service/src/DigitalTwin/Generated/IDigitalTwin.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Devices.Generated
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>> InvokeRootLevelCommandWithHttpMessagesAsync(string id, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>> InvokeRootLevelCommandWithHttpMessagesAsync(string id, string commandName, string payload = default, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Invoke a digital twin command.
         /// </summary>
@@ -136,6 +136,6 @@ namespace Microsoft.Azure.Devices.Generated
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<HttpOperationResponse<string,DigitalTwinInvokeComponentCommandHeaders>> InvokeComponentCommandWithHttpMessagesAsync(string id, string componentPath, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<string,DigitalTwinInvokeComponentCommandHeaders>> InvokeComponentCommandWithHttpMessagesAsync(string id, string componentPath, string commandName, string payload = default, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/iothub/service/src/DigitalTwin/Generated/IDigitalTwin.cs
+++ b/iothub/service/src/DigitalTwin/Generated/IDigitalTwin.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Devices.Generated
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>> InvokeRootLevelCommandWithHttpMessagesAsync(string id, string commandName, string payload, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>> InvokeRootLevelCommandWithHttpMessagesAsync(string id, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Invoke a digital twin command.
         /// </summary>
@@ -136,6 +136,6 @@ namespace Microsoft.Azure.Devices.Generated
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<HttpOperationResponse<string,DigitalTwinInvokeComponentCommandHeaders>> InvokeComponentCommandWithHttpMessagesAsync(string id, string componentPath, string commandName, string payload, int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<string,DigitalTwinInvokeComponentCommandHeaders>> InvokeComponentCommandWithHttpMessagesAsync(string id, string componentPath, string commandName, string payload = default(object), int? connectTimeoutInSeconds = default(int?), int? responseTimeoutInSeconds = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/iothub/service/src/DigitalTwin/generateCode.ps1
+++ b/iothub/service/src/DigitalTwin/generateCode.ps1
@@ -8,6 +8,18 @@ try {
 			Remove-Item $_.FullName
 		}
 
+	# TEMPORARY: Until https://msazure.visualstudio.com/One/_workitems/edit/8354260 is resolved.
+    # Update the swagger json file to accept payload as "optional" for invoke command APIs.
+    $swaggerJson = Get-Content .\DigitalTwin.json -raw | ConvertFrom-Json
+    $commandRestPath = '/digitaltwins/{id}/commands/{commandName}'
+    $commandParameters = $swaggerJson.paths.$commandRestPath.post.parameters
+    Foreach ($parameter in $commandParameters) {
+        #if ($parameter.name -eq 'payload') {
+        #    $parameter.required = $false
+        #}
+    }
+    $swaggerJson | ConvertTo-Json -Depth 10 | Set-Content .\DigitalTwin.json
+
 	#Generate the base code from the swagger file that is defined in this folder's README
 	autorest
 

--- a/iothub/service/src/DigitalTwin/generateCode.ps1
+++ b/iothub/service/src/DigitalTwin/generateCode.ps1
@@ -14,9 +14,16 @@ try {
     $commandRestPath = '/digitaltwins/{id}/commands/{commandName}'
     $commandParameters = $swaggerJson.paths.$commandRestPath.post.parameters
     Foreach ($parameter in $commandParameters) {
-        #if ($parameter.name -eq 'payload') {
-        #    $parameter.required = $false
-        #}
+        if ($parameter.name -eq 'payload') {
+            $parameter.required = $false
+        }
+    }
+	$componentCommandRestPath = '/digitaltwins/{id}/components/{componentPath}/commands/{commandName}'
+    $componentCommandParameters = $swaggerJson.paths.$componentCommandRestPath.post.parameters
+    Foreach ($parameter in $componentCommandParameters) {
+        if ($parameter.name -eq 'payload') {
+            $parameter.required = $false
+        }
     }
     $swaggerJson | ConvertTo-Json -Depth 10 | Set-Content .\DigitalTwin.json
 

--- a/iothub/service/src/DigitalTwin/generateCode.ps1
+++ b/iothub/service/src/DigitalTwin/generateCode.ps1
@@ -67,7 +67,7 @@ try {
 			$IDigitalTwinInterfaceClassCode = $IDigitalTwinInterfaceClassCode -replace 'IList<object> digitalTwinPatch', 'string digitalTwinPatch'
 			$IDigitalTwinInterfaceClassCode = $IDigitalTwinInterfaceClassCode -replace 'Task<HttpOperationResponse<object,DigitalTwinGetDigitalTwinHeaders>>', 'Task<HttpOperationResponse<string,DigitalTwinGetHeaders>>'
 			$IDigitalTwinInterfaceClassCode = $IDigitalTwinInterfaceClassCode -replace 'Task<HttpOperationHeaderResponse<DigitalTwinUpdateDigitalTwinHeaders>>', 'Task<HttpOperationHeaderResponse<DigitalTwinUpdateHeaders>>'
-			$IDigitalTwinInterfaceClassCode = $IDigitalTwinInterfaceClassCode -replace 'object payload', 'string payload'
+			$IDigitalTwinInterfaceClassCode = $IDigitalTwinInterfaceClassCode -replace 'object payload = default\(object\)', 'string payload = default'
 			$IDigitalTwinInterfaceClassCode = $IDigitalTwinInterfaceClassCode -replace 'Task<HttpOperationResponse<object,DigitalTwinInvokeRootLevelCommandHeaders>>', 'Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>>'
 			$IDigitalTwinInterfaceClassCode = $IDigitalTwinInterfaceClassCode -replace 'Task<HttpOperationResponse<object,DigitalTwinInvokeComponentCommandHeaders>>', 'Task<HttpOperationResponse<string,DigitalTwinInvokeComponentCommandHeaders>>'
 			[IO.File]::WriteAllText($_.FullName, ($IDigitalTwinInterfaceClassCode -join "`r`n"))
@@ -87,7 +87,7 @@ try {
 			$DigitalTwinClassCode = $DigitalTwinClassCode -replace 'Task<HttpOperationHeaderResponse<DigitalTwinUpdateDigitalTwinHeaders>>' , 'Task<HttpOperationHeaderResponse<DigitalTwinUpdateHeaders>>'
 			$DigitalTwinClassCode = $DigitalTwinClassCode -replace 'new HttpOperationHeaderResponse<DigitalTwinUpdateDigitalTwinHeaders>', 'new HttpOperationHeaderResponse<DigitalTwinUpdateHeaders>'
 			$DigitalTwinClassCode = $DigitalTwinClassCode -replace '_httpResponse.GetHeadersAsJson\(\).ToObject<DigitalTwinUpdateDigitalTwinHeaders>', '_httpResponse.GetHeadersAsJson().ToObject<DigitalTwinUpdateHeaders>'
-			$DigitalTwinClassCode = $DigitalTwinClassCode -replace 'object payload', 'string payload'
+			$DigitalTwinClassCode = $DigitalTwinClassCode -replace 'object payload = default\(object\)', 'string payload = default'
 			$DigitalTwinClassCode = $DigitalTwinClassCode -replace '_requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject\(payload, Client.SerializationSettings\);', '_requestContent = payload;'
 			$DigitalTwinClassCode = $DigitalTwinClassCode -replace 'Task<HttpOperationResponse<object,DigitalTwinInvokeRootLevelCommandHeaders>>' , 'Task<HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>>'
 			$DigitalTwinClassCode = $DigitalTwinClassCode -replace 'new HttpOperationResponse<object,DigitalTwinInvokeRootLevelCommandHeaders>', 'new HttpOperationResponse<string,DigitalTwinInvokeRootLevelCommandHeaders>'
@@ -102,7 +102,7 @@ try {
 			$DigitalTwinExtensionsClassCode = ($_ | Get-Content)
 			$DigitalTwinExtensionsClassCode = $DigitalTwinExtensionsClassCode -replace 'IList<object> digitalTwinPatch', 'string digitalTwinPatch'
 			$DigitalTwinExtensionsClassCode = $DigitalTwinExtensionsClassCode -replace 'Task<DigitalTwinUpdateDigitalTwinHeaders>' , 'Task<DigitalTwinUpdateHeaders>'
-			$DigitalTwinExtensionsClassCode = $DigitalTwinExtensionsClassCode -replace 'object payload', 'string payload'
+			$DigitalTwinExtensionsClassCode = $DigitalTwinExtensionsClassCode -replace 'object payload = default\(object\)', 'string payload = default'
 			[IO.File]::WriteAllText($_.FullName, ($DigitalTwinExtensionsClassCode -join "`r`n"))
 		}
 


### PR DESCRIPTION
Powershell script generates json doc with 2 spaces by default, so there are a lot of whitespace changes in the json doc.
View diff by hiding whitespace changes.

~This PR also add an optional delegating handlers to the client intializer factory method. The user can set proxy, retry, tracing settings etc to the http pipeline via delegating handlers.~ - removed this. This will be added in the next PR.