### PR TITLE
Update device and service SDK to refer to API version 2020-09-30, bring model Id changes to twin (from preview)

### DIFF
--- a/iothub/device/src/Common/Api/ClientApiVersionHelper.cs
+++ b/iothub/device/src/Common/Api/ClientApiVersionHelper.cs
@@ -6,15 +6,9 @@ namespace Microsoft.Azure.Devices.Client
     internal class ClientApiVersionHelper
     {
         internal const string ApiVersionQueryPrefix = "api-version=";
-        internal const string ApiVersionLatest = "2019-10-01";
-
-        // The preview API version has been added to enable support for plug and play features.
-        // This will be removed once the plug and play service goes GA.
-        internal const string ApiVersionPreview = "2020-05-31-preview";
+        internal const string ApiVersionLatest = "2020-09-30";
 
         public const string ApiVersionString = ApiVersionLatest;
         public const string ApiVersionQueryStringLatest = ApiVersionQueryPrefix + ApiVersionString;
-
-        public const string ApiVersionQueryStringPreview = ApiVersionQueryPrefix + ApiVersionPreview;
     }
 }

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTSession.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTSession.cs
@@ -209,8 +209,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
         {
             if (Logging.IsEnabled) Logging.Enter(typeof(AmqpIoTSession), deviceIdentity, $"{nameof(OpenSendingAmqpLinkAsync)}");
 
-            string serviceApiVersion = ClientApiVersionHelper.ApiVersionString;
-
             AmqpLinkSettings amqpLinkSettings = new AmqpLinkSettings
             {
                 LinkName = linkSuffix,
@@ -235,15 +233,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
 
             // This check is added to enable the device or module client to available plug and play features. For devices or modules that pass in the model Id,
-            // the SDK will enable plug and play features by using the PnP-enabled service API version, and setting the modelId to Amqp link settings.
-            // For devices or modules that do not have the model Id set, the SDK will use the GA service API version.
+            // the SDK will enable plug and play features by setting the modelId to Amqp link settings.
             if (!string.IsNullOrWhiteSpace(deviceIdentity.Options?.ModelId))
             {
                 amqpLinkSettings.AddProperty(AmqpIoTConstants.ModelId, deviceIdentity.Options.ModelId);
-                serviceApiVersion = ClientApiVersionHelper.ApiVersionPreview;
             }
 
-            amqpLinkSettings.AddProperty(AmqpIoTConstants.ApiVersion, serviceApiVersion);
+            amqpLinkSettings.AddProperty(AmqpIoTConstants.ApiVersion, ClientApiVersionHelper.ApiVersionString);
 
             try
             {

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     Debug.Assert(_mqttTransportSettings.ClientCertificate != null);
                 }
 
-                string usernameString = $"{this._iotHubHostName}/{id}/?{ClientApiVersionHelper.ApiVersionQueryStringLatest}&{DeviceClientTypeParam}={Uri.EscapeDataString(this._productInfo.ToString())}";
+                string usernameString = $"{_iotHubHostName}/{id}/?{ClientApiVersionHelper.ApiVersionQueryStringLatest}&{DeviceClientTypeParam}={Uri.EscapeDataString(_productInfo.ToString())}";
 
                 if (!_mqttTransportSettings.AuthenticationChain.IsNullOrWhiteSpace())
                 {

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -297,24 +297,18 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     Debug.Assert(_mqttTransportSettings.ClientCertificate != null);
                 }
 
-                // This check is added to enable the device or module client to available plug and play features. For devices or modules that pass in the model Id,
-                // the SDK will enable plug and play features by using the PnP-enabled service API version, and appending the model Id to the MQTT CONNECT packet (in the username).
-                // For devices or modules that do not have the model Id set, the SDK will use the GA service API version.
-                string serviceParams = null;
-                if (string.IsNullOrWhiteSpace(_options?.ModelId))
-                {
-                    serviceParams = ClientApiVersionHelper.ApiVersionQueryStringLatest;
-                }
-                else
-                {
-                    serviceParams = $"{ClientApiVersionHelper.ApiVersionQueryStringPreview}&{ModelIdParam}={_options.ModelId}";
-                }
-
-                string usernameString = $"{this._iotHubHostName}/{id}/?{serviceParams}&{DeviceClientTypeParam}={Uri.EscapeDataString(this._productInfo.ToString())}";
+                string usernameString = $"{this._iotHubHostName}/{id}/?{ClientApiVersionHelper.ApiVersionQueryStringLatest}&{DeviceClientTypeParam}={Uri.EscapeDataString(this._productInfo.ToString())}";
 
                 if (!_mqttTransportSettings.AuthenticationChain.IsNullOrWhiteSpace())
                 {
                     usernameString += $"&{AuthChainParam}={Uri.EscapeDataString(_mqttTransportSettings.AuthenticationChain)}";
+                }
+
+                // This check is added to enable the device or module client to available plug and play features. For devices or modules that pass in the model Id,
+                // the SDK will enable plug and play features by appending the model Id to the MQTT CONNECT packet (in the username).
+                if (!(_options?.ModelId).IsNullOrWhiteSpace())
+                {
+                    usernameString += $"&{ModelIdParam}={_options.ModelId}";
                 }
 
                 if (Logging.IsEnabled) Logging.Info(this, $"{nameof(usernameString)}={usernameString}", nameof(ConnectAsync));

--- a/iothub/device/tests/Mqtt/MqttIotHubAdapterTest.cs
+++ b/iothub/device/tests/Mqtt/MqttIotHubAdapterTest.cs
@@ -177,10 +177,9 @@ namespace Microsoft.Azure.Devices.Client.Test.Mqtt
         }
 
         [TestMethod]
-        public void SettingPnpModelIdShouldSetPreviewApiVersionAndModelIdOnConnectPacket()
+        public void SettingPnpModelIdShouldSetModelIdOnConnectPacket()
         {
             // arrange
-            string ApiVersionParam = "api-version";
             string ModelIdParam = "model-id";
             var passwordProvider = new Mock<IAuthorizationProvider>();
             var mqttIotHubEventHandler = new Mock<IMqttIotHubEventHandler>();
@@ -201,15 +200,13 @@ namespace Microsoft.Azure.Devices.Client.Test.Mqtt
             // Assert: the username should use the preview API version and have the model ID appended
             ConnectPacket connectPacket = messages.First().As<ConnectPacket>();
             NameValueCollection queryParams = ExtractQueryParamsFromConnectUsername(connectPacket.Username);
-            Assert.AreEqual(ClientApiVersionHelper.ApiVersionPreview, queryParams.Get(ApiVersionParam));
             Assert.AreEqual(options.ModelId, queryParams.Get(ModelIdParam));
         }
 
         [TestMethod]
-        public void NotSettingPnpModelIdShouldSetLatestApiVersionAndNoModelIdOnConnectPacket()
+        public void NotSettingPnpModelIdShouldNotSetModelIdOnConnectPacket()
         {
             // arrange
-            string ApiVersionParam = "api-version";
             string ModelIdParam = "model-id";
             var passwordProvider = new Mock<IAuthorizationProvider>();
             var mqttIotHubEventHandler = new Mock<IMqttIotHubEventHandler>();
@@ -230,7 +227,6 @@ namespace Microsoft.Azure.Devices.Client.Test.Mqtt
             // Assert: the username should use the GA API version and not have the model ID appended
             ConnectPacket connectPacket = messages.First().As<ConnectPacket>();
             NameValueCollection queryParams = ExtractQueryParamsFromConnectUsername(connectPacket.Username);
-            Assert.AreEqual(ClientApiVersionHelper.ApiVersionLatest, queryParams.Get(ApiVersionParam));
             Assert.IsFalse(queryParams.AllKeys.Contains(ModelIdParam));
         }
 

--- a/iothub/service/src/ClientApiVersionHelper.cs
+++ b/iothub/service/src/ClientApiVersionHelper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices
     internal class ClientApiVersionHelper
     {
         private const string ApiVersionQueryPrefix = "api-version=";
-        private const string ApiVersionDefault = "2020-03-13";
+        private const string ApiVersionDefault = "2020-09-30";
 
         /// <summary>
         /// The default API version to use for all data-plane service calls

--- a/shared/src/Twin.cs
+++ b/shared/src/Twin.cs
@@ -49,10 +49,12 @@ namespace Microsoft.Azure.Devices.Shared
         public string DeviceId { get; set; }
 
         /// <summary>
-        /// The DTDL model id of the device.
-        /// The value will be null for a non-pnp device.
-        /// The value will be null for a pnp device until the device connects and registers with the model id.
+        /// The DTDL model Id of the device.
         /// </summary>
+        /// <remarks>
+        /// The value will be null for a non-pnp device.
+        /// The value will be null for a pnp device until the device connects and registers with the model Id.
+        /// </remarks>
         public string ModelId { get; set; }
 
         /// <summary>

--- a/shared/src/Twin.cs
+++ b/shared/src/Twin.cs
@@ -49,6 +49,13 @@ namespace Microsoft.Azure.Devices.Shared
         public string DeviceId { get; set; }
 
         /// <summary>
+        /// The DTDL model id of the device.
+        /// The value will be null for a non-pnp device.
+        /// The value will be null for a pnp device until the device connects and registers with the model id.
+        /// </summary>
+        public string ModelId { get; set; }
+
+        /// <summary>
         /// Gets and sets the <see cref="Twin" /> Module Id.
         /// </summary>
         public string ModuleId { get; set; }

--- a/shared/src/TwinJsonConverter.cs
+++ b/shared/src/TwinJsonConverter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices.Shared
         private const string CloudToDeviceMessageCountTag = "cloudToDeviceMessageCount";
         private const string AuthenticationTypeTag = "authenticationType";
         private const string X509ThumbprintTag = "x509Thumbprint";
-        private const string ModelId = "digital-twin-model-id";
+        private const string ModelId = "modelId";
 
         /// <summary>
         /// Converts <see cref="Twin"/> to its equivalent Json representation.

--- a/shared/src/TwinJsonConverter.cs
+++ b/shared/src/TwinJsonConverter.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.Devices.Shared
         private const string CloudToDeviceMessageCountTag = "cloudToDeviceMessageCount";
         private const string AuthenticationTypeTag = "authenticationType";
         private const string X509ThumbprintTag = "x509Thumbprint";
+        private const string ModelId = "digital-twin-model-id";
 
         /// <summary>
         /// Converts <see cref="Twin"/> to its equivalent Json representation.
@@ -72,10 +73,16 @@ namespace Microsoft.Azure.Devices.Shared
 
             writer.WriteStartObject();
 
+            if (!string.IsNullOrWhiteSpace(twin.ModelId))
+            {
+                writer.WritePropertyName(ModelId);
+                writer.WriteValue(twin.ModelId);
+            }
+
             writer.WritePropertyName(DeviceIdJsonTag);
             writer.WriteValue(twin.DeviceId);
 
-            if (!string.IsNullOrEmpty(twin.ModuleId))
+            if (!string.IsNullOrWhiteSpace(twin.ModuleId))
             {
                 writer.WritePropertyName(ModuleIdJsonTag);
                 writer.WriteValue(twin.ModuleId);
@@ -93,7 +100,7 @@ namespace Microsoft.Azure.Devices.Shared
                 writer.WriteRawValue(JsonConvert.SerializeObject(twin.Status));
             }
 
-            if (!string.IsNullOrEmpty(twin.StatusReason))
+            if (!string.IsNullOrWhiteSpace(twin.StatusReason))
             {
                 writer.WritePropertyName(StatusReasonTag);
                 writer.WriteValue(twin.StatusReason);
@@ -215,6 +222,10 @@ namespace Microsoft.Azure.Devices.Shared
                 {
                     case DeviceIdJsonTag:
                         twin.DeviceId = reader.Value as string;
+                        break;
+
+                    case ModelId:
+                        twin.ModelId = reader.Value as string;
                         break;
 
                     case ModuleIdJsonTag:


### PR DESCRIPTION
- update the device and service SDK to refer to API version 2020-09-30.
- remove the if-else block added for using different API versions on device client, depending on if model Id was set or not.
- bring model Id changes to twin (from preview) 