### PR TITLE
Bump API version for LTS_2020-08 patch

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.28.0</Version>
+    <Version>1.28.1</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,5 +1,5 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.28.0
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.28.1
 iothub\service\src\Microsoft.Azure.Devices.csproj, 1.22.0
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.20.1
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.6.0


### PR DESCRIPTION
release notes:

## Microsoft.Azure.Devices.Client.1.28.1

### Bug fixes:
- Fix GetFileUploadSasUriAsync API when using certificate authentication methods (https://github.com/Azure/azure-iot-sdk-csharp/issues/1527)