### PR TITLE
Fix cross target framework dependency management

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -49,10 +49,6 @@
     <common>$(RootDir)\common\src</common>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <SupportsNetStandard20AndAbove Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">true</SupportsNetStandard20AndAbove>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="DotNetty.Codecs.Mqtt" Version="0.6.0" />
     <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
@@ -95,7 +91,7 @@
   </ItemGroup>
 
   <!-- NetStandard 2.1, NetStandard 2.0 and net472 -->
-  <ItemGroup Condition="'$(SupportsNetStandard20AndAbove)' == 'true'">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
     <Compile Include="$(Common)\DefaultWebProxySettings.cs" />
     <Compile Include="ModernDotNet\Common\IOThreadTimerSlim.cs" />
     <Compile Include="ModernDotNet\HsmAuthentication\Transport\HttpUdsMessageHandler.cs" />
@@ -103,7 +99,7 @@
     <Compile Include="ModernDotNet\HsmAuthentication\Transport\HttpRequestResponseSerializer.cs" />
     <Compile Include="ModernDotNet\HsmAuthentication\Transport\UnixDomainSocketEndPoint.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(SupportsNetStandard20AndAbove)' == 'true'">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
   </ItemGroup>

--- a/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
+++ b/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
@@ -14,15 +14,11 @@
     <DefaultItemExcludes>HsmAuthentication/**;$(DefaultItemExcludes)</DefaultItemExcludes>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <SupportsNetStandard20AndAbove Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">true</SupportsNetStandard20AndAbove>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(SupportsNetStandard20AndAbove)' == 'true'">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
     <Compile Include="HsmAuthentication\**" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SupportsNetStandard20AndAbove)' == 'true'">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
     <Compile Remove="ClientWebSocketTransportTests.cs" />
     <Compile Remove="Mqtt\ClientWebSocketChannelTests.cs" />
   </ItemGroup>

--- a/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
@@ -14,7 +14,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Azure.Devices
 {
     /// <summary>
-    /// /// The Digital Twins Service Client contains methods to retrieve and update digital twin information, and invoke commands on a digital twin device.
+    /// The Digital Twins Service Client contains methods to retrieve and update digital twin information, and invoke commands on a digital twin device.
     /// </summary>
     public class DigitalTwinClient : IDisposable
     {

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -38,10 +38,6 @@
     <PackageTags>IoT Microsoft Azure IoTHub Service Client SDK Manage Devices .NET</PackageTags>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <SupportsNetStandard20AndAbove Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">true</SupportsNetStandard20AndAbove>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Include="$(RootDir)\LICENSE" Pack="true" PackagePath="" />
     <None Include="$(RootDir)\shared\icons\nugetIcon.png" Pack="true" PackagePath="" />
@@ -154,12 +150,12 @@
   </ItemGroup>
 
   <!-- NetStandard 2.1, NetStandard 2.0 and net472 -->
-  <ItemGroup Condition="'$(SupportsNetStandard20AndAbove)' == 'true'">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
     <Compile Include="$(Common)\DefaultWebProxySettings.cs" />
     <Compile Include="ModernDotNet\Common\IOThreadTimerSlim.cs" />
     <Compile Include="DigitalTwin\**\*.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(SupportsNetStandard20AndAbove)' == 'true'">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />


### PR DESCRIPTION
Since net451 is the only tfm < ns2.0 that we target, Instead of adding an explicit check for each supported tfm greater than ns2.0, we can simply check if the tfm != net451.

Fix for #1562 , #1592 