### PR TITLE
build: Exclude running device stream tests in prod pipelines

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -368,6 +368,7 @@ try
         $verbosity = "normal"
         $testCategory = "TestCategory=E2E"
         
+        # Skip the Device Streaming tests when running on the production pipeline. Device Streaming features are not yet available in all regions.
         if ($skipDeviceStreamTests) 
         {
             $testCategory += "&TestCategory!=DeviceStreaming"

--- a/build.ps1
+++ b/build.ps1
@@ -171,7 +171,7 @@ Function RunTests($message, $framework = "*", $filterTestCategory = "*")
     Write-Host
     Write-Host -ForegroundColor Cyan $label
 
-    $runTestCmd = "dotnet test -t -s test.runsettings --verbosity $verbosity --configuration $configuration --logger trx"
+    $runTestCmd = "dotnet test -s test.runsettings --verbosity $verbosity --configuration $configuration --logger trx"
 
     if ($noBuildBeforeTesting)
     {

--- a/build.ps1
+++ b/build.ps1
@@ -171,7 +171,7 @@ Function RunTests($message, $framework = "*", $filterTestCategory = "*")
     Write-Host
     Write-Host -ForegroundColor Cyan $label
 
-    $runTestCmd = "dotnet test -s test.runsettings --verbosity $verbosity --configuration $configuration --logger trx"
+    $runTestCmd = "dotnet test -t -s test.runsettings --verbosity $verbosity --configuration $configuration --logger trx"
 
     if ($noBuildBeforeTesting)
     {

--- a/build.ps1
+++ b/build.ps1
@@ -72,7 +72,8 @@ Param(
     [switch] $skipIotHubTests,
     [switch] $skipDPSTests,
     [switch] $skipPnPTests,
-    [switch] $noBuildBeforeTesting
+    [switch] $noBuildBeforeTesting,
+    [switch] $skipDeviceStreamTests
 )
 
 Function CheckSignTools()
@@ -274,7 +275,14 @@ try
             Write-Host -ForegroundColor Cyan "Unit Test execution"
             Write-Host
 
-            RunTests "Unit tests" -filterTestCategory "TestCategory=Unit" -framework $framework
+            $testCategory = "TestCategory=Unit";
+
+            if ($skipDeviceStreamTests)
+            {
+                $testCategory += "&TestCategory!=DeviceStreaming";
+            }            
+
+            RunTests "Unit tests" -filterTestCategory $testCategory -framework $framework
         }
     }
 
@@ -311,6 +319,11 @@ try
         if ($skipPnPTests)
         {
             $testCategory += "&TestCategory!=PnP"
+        }
+
+        if ($skipDeviceStreamTests) 
+        {
+            $testCategory += "&TestCategory!=DeviceStreaming"
         }
 
         RunTests "PR tests" -filterTestCategory $testCategory -framework $framework

--- a/build.ps1
+++ b/build.ps1
@@ -275,14 +275,7 @@ try
             Write-Host -ForegroundColor Cyan "Unit Test execution"
             Write-Host
 
-            $testCategory = "TestCategory=Unit";
-
-            if ($skipDeviceStreamTests)
-            {
-                $testCategory += "&TestCategory!=DeviceStreaming";
-            }            
-
-            RunTests "Unit tests" -filterTestCategory $testCategory -framework $framework
+            RunTests "Unit tests" -filterTestCategory "TestCategory=Unit" -framework $framework
         }
     }
 
@@ -373,8 +366,14 @@ try
         # Override verbosity to display individual test execution.
         $oldVerbosity = $verbosity
         $verbosity = "normal"
+        $testCategory = "TestCategory=E2E"
+        
+        if ($skipDeviceStreamTests) 
+        {
+            $testCategory += "&TestCategory!=DeviceStreaming"
+        }
 
-        RunTests "E2E tests" -framework $framework "TestCategory=E2E"
+        RunTests "E2E tests" -framework $framework -filterTestCategory $testCategory
 
         $verbosity = $oldVerbosity
 

--- a/e2e/test/iothub/DeviceStreamingE2ETests.cs
+++ b/e2e/test/iothub/DeviceStreamingE2ETests.cs
@@ -1,20 +1,16 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Azure.Devices.Client;
-using Microsoft.Azure.Devices.Client.Exceptions;
-using Microsoft.Azure.Devices.E2ETests.Helpers;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.Tracing;
 using System.Linq;
-using System.Net;
 using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Client.Exceptions;
+using Microsoft.Azure.Devices.E2ETests.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ClientDeviceStreamingRequest = Microsoft.Azure.Devices.Client.DeviceStreamRequest;
 using ServiceDeviceStreamingRequest = Microsoft.Azure.Devices.DeviceStreamRequest;
 
@@ -22,11 +18,14 @@ namespace Microsoft.Azure.Devices.E2ETests
 {
     [TestClass]
     [TestCategory("IoTHub-E2E")]
+    [TestCategory("DeviceStreaming")]
     public partial class DeviceStreamingTests : E2EMsTestBase, IDisposable
     {
         private readonly string DevicePrefix = $"{nameof(DeviceStreamingTests)}_";
         private readonly string ModulePrefix = $"{nameof(DeviceStreamingTests)}_";
         private static string ProxyServerAddress = Configuration.IoTHub.ProxyServerAddress;
+
+        #region Device Streaming
 
         #region Device Client Tests
 
@@ -265,6 +264,8 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         #endregion Module Client Tests
+
+        #endregion Device Streaming
 
         #region Private Methods
 

--- a/e2e/test/iothub/DeviceStreamingE2ETests.cs
+++ b/e2e/test/iothub/DeviceStreamingE2ETests.cs
@@ -17,7 +17,8 @@ using ServiceDeviceStreamingRequest = Microsoft.Azure.Devices.DeviceStreamReques
 namespace Microsoft.Azure.Devices.E2ETests
 {
     [TestClass]
-    [TestCategory("IoTHub-E2E")]
+    [TestCategory("E2E")]
+    [TestCategory("IoTHub")]
     [TestCategory("DeviceStreaming")]
     public partial class DeviceStreamingTests : E2EMsTestBase, IDisposable
     {

--- a/iothub/device/tests/DeviceClientTests.cs
+++ b/iothub/device/tests/DeviceClientTests.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Azure.Devices.Client.Transport.Mqtt;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSubstitute;
 using System;
 using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Devices.Client.Transport.Mqtt;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
 
 namespace Microsoft.Azure.Devices.Client.Test
 {
@@ -18,9 +18,6 @@ namespace Microsoft.Azure.Devices.Client.Test
     {
         private const string fakeConnectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;SharedAccessKey=dGVzdFN0cmluZzE=";
         private const string fakeConnectionStringWithModuleId = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;SharedAccessKey=dGVzdFN0cmluZzE=;ModuleId=mod1";
-
-        const string fakeDeviceStreamSGWUrl = "wss://sgw.eastus2euap-001.streams.azure-devices.net/bridges/iot-sdks-tcpstreaming/E2E_DeviceStreamingTests_Sasl_f88fd19b-ed0d-496b-b32c-6346ca61d289/E2E_DeviceStreamingTests_b82c9ec4-4fb3-432a-bfb5-af484966a7d4c002f7a841b8/3a6a2eba4b525c38bfcb";
-        const string fakeDeviceStreamAuthToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1NDgzNTU0ODEsImp0aSI6InFfdlllQkF4OGpmRW5tTWFpOHhSNTM2QkpxdTZfRlBOa2ZWSFJieUc4bUUiLCJpb3RodWIRrcy10Y3BzdHJlYW1pbmciOiJpb3Qtc2ifQ.X_HIb53nDsCT2SZ0P4-vnA_Wz94jxYRLbk_5nvP9bj8";
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
@@ -1255,101 +1252,5 @@ namespace Microsoft.Azure.Devices.Client.Test
             DeviceClient client = DeviceClient.CreateFromConnectionString(fakeConnectionString);
             await client.AbandonAsync((string)null, CancellationToken.None);
         }
-        
-        #region Device Streaming
-        [TestMethod]
-        public async Task DeviceClientWaitForDeviceStreamRequestAsync()
-        {
-            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
-
-            var innerHandler = Substitute.For<IDelegatingHandler>();
-            deviceClient.InnerHandler = innerHandler;
-
-            CancellationToken ct = new CancellationToken();
-            
-            Task<DeviceStreamRequest> requestTask = deviceClient.WaitForDeviceStreamRequestAsync(ct);
-
-            await innerHandler.Received().EnableStreamsAsync(ct).ConfigureAwait(false);
-            await innerHandler.Received().WaitForDeviceStreamRequestAsync(ct).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task DeviceClientWaitForDeviceStreamRequestAsyncNoCancellationToken()
-        {
-            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
-
-            var innerHandler = Substitute.For<IDelegatingHandler>();
-            deviceClient.InnerHandler = innerHandler;
-
-            Task<DeviceStreamRequest> requestTask = deviceClient.WaitForDeviceStreamRequestAsync();
-
-            await innerHandler.Received().EnableStreamsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
-            await innerHandler.Received().WaitForDeviceStreamRequestAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task DeviceClientAcceptDeviceStreamRequestAsync()
-        {
-            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
-
-            var innerHandler = Substitute.For<IDelegatingHandler>();
-            deviceClient.InnerHandler = innerHandler;
-
-            CancellationToken ct = new CancellationToken();
-
-            DeviceStreamRequest request = new DeviceStreamRequest("1", "StreamA", new Uri(fakeDeviceStreamSGWUrl), fakeDeviceStreamAuthToken);
-
-            Task acceptTask = deviceClient.AcceptDeviceStreamRequestAsync(request, ct);
-
-            await innerHandler.Received().AcceptDeviceStreamRequestAsync(request, ct).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task DeviceClientAcceptDeviceStreamRequestAsyncNoCancellationToken()
-        {
-            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
-
-            var innerHandler = Substitute.For<IDelegatingHandler>();
-            deviceClient.InnerHandler = innerHandler;
-
-            DeviceStreamRequest request = new DeviceStreamRequest("1", "StreamA", new Uri(fakeDeviceStreamSGWUrl), fakeDeviceStreamAuthToken);
-
-            Task acceptTask = deviceClient.AcceptDeviceStreamRequestAsync(request);
-
-            await innerHandler.Received().AcceptDeviceStreamRequestAsync(request, Arg.Any<CancellationToken>()).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task DeviceClientRejectDeviceStreamRequestAsync()
-        {
-            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
-
-            var innerHandler = Substitute.For<IDelegatingHandler>();
-            deviceClient.InnerHandler = innerHandler;
-
-            CancellationToken ct = new CancellationToken();
-
-            DeviceStreamRequest request = new DeviceStreamRequest("1", "StreamA", new Uri(fakeDeviceStreamSGWUrl), fakeDeviceStreamAuthToken);
-
-            Task acceptTask = deviceClient.RejectDeviceStreamRequestAsync(request, ct);
-
-            await innerHandler.Received().RejectDeviceStreamRequestAsync(request, ct).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task DeviceClientRejectDeviceStreamRequestAsyncNoCancellationToken()
-        {
-            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
-
-            var innerHandler = Substitute.For<IDelegatingHandler>();
-            deviceClient.InnerHandler = innerHandler;
-
-            DeviceStreamRequest request = new DeviceStreamRequest("1", "StreamA", new Uri(fakeDeviceStreamSGWUrl), fakeDeviceStreamAuthToken);
-
-            Task acceptTask = deviceClient.RejectDeviceStreamRequestAsync(request);
-
-            await innerHandler.Received().RejectDeviceStreamRequestAsync(request, Arg.Any<CancellationToken>()).ConfigureAwait(false);
-        }
-        #endregion Device Streaming
     }
 }

--- a/iothub/device/tests/DeviceStreamingTests.cs
+++ b/iothub/device/tests/DeviceStreamingTests.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace Microsoft.Azure.Devices.Client.Test
+{
+    [TestClass]
+    [TestCategory("DeviceStreaming")]
+    [TestCategory("Unit")]
+    public class DeviceStreamingTests
+    {
+        private const string fakeConnectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;SharedAccessKey=dGVzdFN0cmluZzE=";
+
+        const string fakeDeviceStreamSGWUrl = "wss://sgw.eastus2euap-001.streams.azure-devices.net/bridges/iot-sdks-tcpstreaming/E2E_DeviceStreamingTests_Sasl_f88fd19b-ed0d-496b-b32c-6346ca61d289/E2E_DeviceStreamingTests_b82c9ec4-4fb3-432a-bfb5-af484966a7d4c002f7a841b8/3a6a2eba4b525c38bfcb";
+        const string fakeDeviceStreamAuthToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1NDgzNTU0ODEsImp0aSI6InFfdlllQkF4OGpmRW5tTWFpOHhSNTM2QkpxdTZfRlBOa2ZWSFJieUc4bUUiLCJpb3RodWIRrcy10Y3BzdHJlYW1pbmciOiJpb3Qtc2ifQ.X_HIb53nDsCT2SZ0P4-vnA_Wz94jxYRLbk_5nvP9bj8";
+
+        #region Device Streaming
+        [TestMethod]
+        public async Task DeviceClientWaitForDeviceStreamRequestAsync()
+        {
+            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+
+            var innerHandler = Substitute.For<IDelegatingHandler>();
+            deviceClient.InnerHandler = innerHandler;
+
+            CancellationToken ct = new CancellationToken();
+            
+            Task<DeviceStreamRequest> requestTask = deviceClient.WaitForDeviceStreamRequestAsync(ct);
+
+            await innerHandler.Received().EnableStreamsAsync(ct).ConfigureAwait(false);
+            await innerHandler.Received().WaitForDeviceStreamRequestAsync(ct).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task DeviceClientWaitForDeviceStreamRequestAsyncNoCancellationToken()
+        {
+            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+
+            var innerHandler = Substitute.For<IDelegatingHandler>();
+            deviceClient.InnerHandler = innerHandler;
+
+            Task<DeviceStreamRequest> requestTask = deviceClient.WaitForDeviceStreamRequestAsync();
+
+            await innerHandler.Received().EnableStreamsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
+            await innerHandler.Received().WaitForDeviceStreamRequestAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task DeviceClientAcceptDeviceStreamRequestAsync()
+        {
+            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+
+            var innerHandler = Substitute.For<IDelegatingHandler>();
+            deviceClient.InnerHandler = innerHandler;
+
+            CancellationToken ct = new CancellationToken();
+
+            DeviceStreamRequest request = new DeviceStreamRequest("1", "StreamA", new Uri(fakeDeviceStreamSGWUrl), fakeDeviceStreamAuthToken);
+
+            Task acceptTask = deviceClient.AcceptDeviceStreamRequestAsync(request, ct);
+
+            await innerHandler.Received().AcceptDeviceStreamRequestAsync(request, ct).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task DeviceClientAcceptDeviceStreamRequestAsyncNoCancellationToken()
+        {
+            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+
+            var innerHandler = Substitute.For<IDelegatingHandler>();
+            deviceClient.InnerHandler = innerHandler;
+
+            DeviceStreamRequest request = new DeviceStreamRequest("1", "StreamA", new Uri(fakeDeviceStreamSGWUrl), fakeDeviceStreamAuthToken);
+
+            Task acceptTask = deviceClient.AcceptDeviceStreamRequestAsync(request);
+
+            await innerHandler.Received().AcceptDeviceStreamRequestAsync(request, Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task DeviceClientRejectDeviceStreamRequestAsync()
+        {
+            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+
+            var innerHandler = Substitute.For<IDelegatingHandler>();
+            deviceClient.InnerHandler = innerHandler;
+
+            CancellationToken ct = new CancellationToken();
+
+            DeviceStreamRequest request = new DeviceStreamRequest("1", "StreamA", new Uri(fakeDeviceStreamSGWUrl), fakeDeviceStreamAuthToken);
+
+            Task acceptTask = deviceClient.RejectDeviceStreamRequestAsync(request, ct);
+
+            await innerHandler.Received().RejectDeviceStreamRequestAsync(request, ct).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task DeviceClientRejectDeviceStreamRequestAsyncNoCancellationToken()
+        {
+            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(fakeConnectionString);
+
+            var innerHandler = Substitute.For<IDelegatingHandler>();
+            deviceClient.InnerHandler = innerHandler;
+
+            DeviceStreamRequest request = new DeviceStreamRequest("1", "StreamA", new Uri(fakeDeviceStreamSGWUrl), fakeDeviceStreamAuthToken);
+
+            Task acceptTask = deviceClient.RejectDeviceStreamRequestAsync(request);
+
+            await innerHandler.Received().RejectDeviceStreamRequestAsync(request, Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+        #endregion Device Streaming
+    }
+}

--- a/vsts/determine_tests_to_run.ps1
+++ b/vsts/determine_tests_to_run.ps1
@@ -39,6 +39,14 @@ function ShouldSkipPnPTests
 	return $false
 }
 
+function ShouldSkipDeviceStreamTests
+{
+	return ($env:SOURCE_BRANCH_NAME -and `
+		$env:SOURCE_BRANCH_NAME.toLower() -eq 'preview' -and `
+		$env:PIPELINE_ENVIRONMENT -and `
+		$env:PIPELINE_ENVIRONMENT.toLower() -eq 'prod')
+}
+
 # $folderNames is an array of strings where each string is the name of a folder within the codebase to look for in the git diff between the source and target branches
 # For instance, $folderNames can be "iothub", "common", "shared" if you want to see if any changes happened within the iothub folder, the common folder, or in the shared folder
 function DoChangesAffectAnyOfFolders($folderNames) 

--- a/vsts/determine_tests_to_run.ps1
+++ b/vsts/determine_tests_to_run.ps1
@@ -41,10 +41,46 @@ function ShouldSkipPnPTests
 
 function ShouldSkipDeviceStreamTests
 {
-	Write-Host "TARGET_BRANCH: " $env:TARGET_BRANCH
-	Write-Host "SOURCE_BRANCH_NAME:" $env:SOURCE_BRANCH_NAME
-	Write-Host "PIPELINE_ENVIRONMENT:" $env:PIPELINE_ENVIRONMENT
-	Write-Host "PIPELINE_ENVIRONMENT (NO-ENV):" $(PIPELINE-ENVIRONMENT)
+	if ($env:SOURCE_BRANCH_NAME)
+	{
+		Write-Host "SOURCE_BRANCH_NAME is defined"
+		Write-Host "SOURCE_BRANCH_NAME:" $env:SOURCE_BRANCH_NAME
+	}
+
+	if ($env:TARGET_BRANCH)
+	{
+		Write-Host "TARGET_BRANCH is defined"
+		Write-Host "TARGET_BRANCH:" $env:TARGET_BRANCH
+	}
+
+	if ($env:PIPELINE_ENVIRONMENT)
+	{
+		Write-Host "PIPELINE_ENVIRONMENT is defined"
+		Write-Host "PIPELINE_ENVIRONMENT:" $env:PIPELINE_ENVIRONMENT
+	}
+
+	if ($env:SOURCE_BRANCH_NAME -and `
+		$env:SOURCE_BRANCH_NAME.toLower() -eq 'donotrunstreamingtestsinprod' -and `
+		$env:PIPELINE_ENVIRONMENT -and `
+		$env:PIPELINE_ENVIRONMENT.toLower() -eq 'prod')
+	{
+		Write-Host "-------TRUE with source_branch_name---------"
+	}
+	else 
+	{
+		Write-Host "-------FALSE---------"
+	}
+
+	if ($env:SOURCE_BRANCH_NAME -and $env:SOURCE_BRANCH_NAME.toLower() -eq 'donotrunstreamingtestsinprod' -and $env:PIPELINE_ENVIRONMENT -and $env:PIPELINE_ENVIRONMENT.toLower() -eq 'prod')
+	{
+		Write-Host "-------TRUE AGAIN WITH SOURCE_BRANCH_NAME---------"
+	}
+
+	if ($env:Build.SourceBranchName)
+	{
+		Write-Host "Build.SourceBranchName is defined"
+		Write-Host "Build.SourceBranchName:" $env:Build.SourceBranchName
+	}
 
 	return ($env:SOURCE_BRANCH_NAME -and `
 		$env:SOURCE_BRANCH_NAME.toLower() -eq 'donotrunstreamingtestsinprod' -and `

--- a/vsts/determine_tests_to_run.ps1
+++ b/vsts/determine_tests_to_run.ps1
@@ -42,7 +42,7 @@ function ShouldSkipPnPTests
 function ShouldSkipDeviceStreamTests
 {
 	return ($env:SOURCE_BRANCH_NAME -and `
-		$env:SOURCE_BRANCH_NAME.toLower() -eq 'donotrunstreamingtestsinprod' -and `
+		$env:SOURCE_BRANCH_NAME.toLower() -eq 'preview' -and `
 		$env:PIPELINE_ENVIRONMENT -and `
 		$env:PIPELINE_ENVIRONMENT.toLower() -eq 'prod')
 }

--- a/vsts/determine_tests_to_run.ps1
+++ b/vsts/determine_tests_to_run.ps1
@@ -41,8 +41,11 @@ function ShouldSkipPnPTests
 
 function ShouldSkipDeviceStreamTests
 {
+	Write-Host "SOURCE_BRANCH_NAME:" $env:SOURCE_BRANCH_NAME
+	Write-Host "PIPELINE_ENVIRONMENT:" $env:PIPELINE_ENVIRONMENT
+
 	return ($env:SOURCE_BRANCH_NAME -and `
-		$env:SOURCE_BRANCH_NAME.toLower() -eq 'doNotRunStreamingTestsInProd' -and `
+		$env:SOURCE_BRANCH_NAME.toLower() -eq 'donotrunstreamingtestsinprod' -and `
 		$env:PIPELINE_ENVIRONMENT -and `
 		$env:PIPELINE_ENVIRONMENT.toLower() -eq 'prod')
 }

--- a/vsts/determine_tests_to_run.ps1
+++ b/vsts/determine_tests_to_run.ps1
@@ -41,47 +41,6 @@ function ShouldSkipPnPTests
 
 function ShouldSkipDeviceStreamTests
 {
-	if ($env:SOURCE_BRANCH_NAME)
-	{
-		Write-Host "SOURCE_BRANCH_NAME is defined"
-		Write-Host "SOURCE_BRANCH_NAME:" $env:SOURCE_BRANCH_NAME
-	}
-
-	if ($env:TARGET_BRANCH)
-	{
-		Write-Host "TARGET_BRANCH is defined"
-		Write-Host "TARGET_BRANCH:" $env:TARGET_BRANCH
-	}
-
-	if ($env:PIPELINE_ENVIRONMENT)
-	{
-		Write-Host "PIPELINE_ENVIRONMENT is defined"
-		Write-Host "PIPELINE_ENVIRONMENT:" $env:PIPELINE_ENVIRONMENT
-	}
-
-	if ($env:SOURCE_BRANCH_NAME -and `
-		$env:SOURCE_BRANCH_NAME.toLower() -eq 'donotrunstreamingtestsinprod' -and `
-		$env:PIPELINE_ENVIRONMENT -and `
-		$env:PIPELINE_ENVIRONMENT.toLower() -eq 'prod')
-	{
-		Write-Host "-------TRUE with source_branch_name---------"
-	}
-	else 
-	{
-		Write-Host "-------FALSE---------"
-	}
-
-	if ($env:SOURCE_BRANCH_NAME -and $env:SOURCE_BRANCH_NAME.toLower() -eq 'donotrunstreamingtestsinprod' -and $env:PIPELINE_ENVIRONMENT -and $env:PIPELINE_ENVIRONMENT.toLower() -eq 'prod')
-	{
-		Write-Host "-------TRUE AGAIN WITH SOURCE_BRANCH_NAME---------"
-	}
-
-	if ($env:Build.SourceBranchName)
-	{
-		Write-Host "Build.SourceBranchName is defined"
-		Write-Host "Build.SourceBranchName:" $env:Build.SourceBranchName
-	}
-
 	return ($env:SOURCE_BRANCH_NAME -and `
 		$env:SOURCE_BRANCH_NAME.toLower() -eq 'donotrunstreamingtestsinprod' -and `
 		$env:PIPELINE_ENVIRONMENT -and `

--- a/vsts/determine_tests_to_run.ps1
+++ b/vsts/determine_tests_to_run.ps1
@@ -42,7 +42,7 @@ function ShouldSkipPnPTests
 function ShouldSkipDeviceStreamTests
 {
 	return ($env:SOURCE_BRANCH_NAME -and `
-		$env:SOURCE_BRANCH_NAME.toLower() -eq 'preview' -and `
+		$env:SOURCE_BRANCH_NAME.toLower() -eq 'doNotRunStreamingTestsInProd' -and `
 		$env:PIPELINE_ENVIRONMENT -and `
 		$env:PIPELINE_ENVIRONMENT.toLower() -eq 'prod')
 }

--- a/vsts/determine_tests_to_run.ps1
+++ b/vsts/determine_tests_to_run.ps1
@@ -41,8 +41,10 @@ function ShouldSkipPnPTests
 
 function ShouldSkipDeviceStreamTests
 {
+	Write-Host "TARGET_BRANCH: " $env:TARGET_BRANCH
 	Write-Host "SOURCE_BRANCH_NAME:" $env:SOURCE_BRANCH_NAME
 	Write-Host "PIPELINE_ENVIRONMENT:" $env:PIPELINE_ENVIRONMENT
+	Write-Host "PIPELINE_ENVIRONMENT (NO-ENV):" $(PIPELINE-ENVIRONMENT)
 
 	return ($env:SOURCE_BRANCH_NAME -and `
 		$env:SOURCE_BRANCH_NAME.toLower() -eq 'donotrunstreamingtestsinprod' -and `

--- a/vsts/gatedBuild.ps1
+++ b/vsts/gatedBuild.ps1
@@ -19,6 +19,13 @@ docker ps -a
 . .\vsts\determine_tests_to_run.ps1
 
 $runTestCmd = ".\build.ps1 -clean -build -configuration DEBUG -framework $env:FRAMEWORK -noBuildBeforeTesting"
+
+if (ShouldSkipDeviceStreamTests)
+{
+	Write-Host "Will skip Device Stream tests"
+	$runTestCmd += " -skipDeviceStreamTests"
+}
+
 if (IsPullRequestBuild)
 {
 	Write-Host "Pull request build detected, will run pr tests"

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -181,7 +181,7 @@ jobs:
           E2E_IKEY: $(E2E-IKEY)
           TARGET_BRANCH: $(System.PullRequest.TargetBranch)
           FRAMEWORK: $(FRAMEWORK)
-          SOURCE_BRANCH_NAME: $(SourceBranchName)
+          SOURCE_BRANCH_NAME: $(Build.SourceBranchName)
           PIPELINE_ENVIRONMENT: $(PIPELINE-ENVIRONMENT)
 
       - task: CopyFiles@2

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -88,7 +88,7 @@ jobs:
           E2E_IKEY: $(E2E-IKEY)
           TARGET_BRANCH: $(System.PullRequest.TargetBranch)
           FRAMEWORK: $(FRAMEWORK)
-          SOURCE_BRANCH_NAME: $(SourceBranchName)
+          SOURCE_BRANCH_NAME: $(Build.SourceBranchName)
           PIPELINE_ENVIRONMENT: $(PIPELINE-ENVIRONMENT)
 
       - task: CopyFiles@2

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -88,6 +88,8 @@ jobs:
           E2E_IKEY: $(E2E-IKEY)
           TARGET_BRANCH: $(System.PullRequest.TargetBranch)
           FRAMEWORK: $(FRAMEWORK)
+          SOURCE_BRANCH_NAME: $(SourceBranchName)
+          PIPELINE_ENVIRONMENT: $(PIPELINE-ENVIRONMENT)
 
       - task: CopyFiles@2
         displayName: "Copy files to the artifacts folder"
@@ -179,6 +181,8 @@ jobs:
           E2E_IKEY: $(E2E-IKEY)
           TARGET_BRANCH: $(System.PullRequest.TargetBranch)
           FRAMEWORK: $(FRAMEWORK)
+          SOURCE_BRANCH_NAME: $(SourceBranchName)
+          PIPELINE_ENVIRONMENT: $(PIPELINE-ENVIRONMENT)
 
       - task: CopyFiles@2
         displayName: "Copy TRX files to the artifacts folder"


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->
- Extract the device streaming unit tests into a separate test file
- Add a new test category for the device streaming tests
- Wrote logic in the build scripts to exclude the test category when running against the prod pipeline

