### PR TITLE
Bump release versions numbers

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.31.1</Version>
+    <Version>1.31.2</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.27.1</Version>
+    <Version>1.27.2</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,6 +1,6 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.31.1
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.27.1
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.31.2
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.27.2
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.25.1
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.1
 provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.1


### PR DESCRIPTION
## Microsoft.Azure.Devices.Client 1.31.2

### Bug Fixes:

- Fix issue with .NET Standard 5 preview throwing "Not Supported Exception" (https://github.com/Azure/azure-iot-sdk-csharp/issues/1592)
- Fix cross target framework dependency management (https://github.com/Azure/azure-iot-sdk-csharp/issues/1562)

## Microsoft.Azure.Devices 1.27.2

### Bug Fixes:

- Fix cross target framework dependency management (https://github.com/Azure/azure-iot-sdk-csharp/issues/1562)
- Fix issue where NullReference exceptions are missing full stack traces.
