### PR TITLE
Fix(device-Service-Provisioning) Upgrade AMQP libary nuget package - Re-enable tests

### DIFF
--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -757,8 +757,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         }
 
         // Note: This test takes 3 minutes.
-        // TODO: azabbasi - Investigate the failure reason and re-enable test.
-        [Ignore("Skipping test due to failures in .net core/ Linux")]
         [LoggedTestMethod]
         [TestCategory("LongRunning")]
         public async Task ProvisioningDeviceClient_InvalidGlobalAddress_Register_Amqp_Fail()
@@ -795,10 +793,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             using SecurityProvider security = await CreateSecurityProviderFromName(attestationType, enrollmentType, groupId, null, AllocationPolicy.Hashed, null, null).ConfigureAwait(false);
 
             ProvisioningDeviceClient provClient = ProvisioningDeviceClient.Create(
-InvalidGlobalAddress,
-Configuration.Provisioning.IdScope,
-security,
-transport);
+                InvalidGlobalAddress,
+                Configuration.Provisioning.IdScope,
+                security,
+                transport);
 
             using var cts = new CancellationTokenSource(FailingTimeoutMiliseconds);
 

--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -52,7 +52,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetty.Codecs.Mqtt" Version="0.6.0" />
     <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.4" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />
   </ItemGroup>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -118,7 +118,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.4" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -91,7 +91,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.4" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.7" />
     <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Upgrade Microsoft.Azure.Amqp Library from 2.4.4 to 2.4.7
- Re-enable the flaky test

We have an e2e test that has been failing on Linux for a while. The issue seems to be that the underlying AMQP library is not throwing timeout exceptions sometimes during 
`await tcpInitiator.ConnectTaskAsync(timeout).ConfigureAwait(false);`

Looking into the release notes from the Amqp library, it appears they have issued a fix for this problem: https://github.com/Azure/azure-amqp/releases/tag/v2.4.7