### PR TITLE
Set a default idle timeout of 2min over amqp

### DIFF
--- a/iothub/device/src/AmqpTransportSettings.cs
+++ b/iothub/device/src/AmqpTransportSettings.cs
@@ -43,6 +43,11 @@ namespace Microsoft.Azure.Devices.Client
         public static readonly TimeSpan DefaultOpenTimeout = TimeSpan.FromMinutes(1);
 
         /// <summary>
+        /// The default idle timeout
+        /// </summary>
+        public static readonly TimeSpan DefaultIdleTimeout = TimeSpan.FromMinutes(2);
+
+        /// <summary>
         /// The default prefetch count
         /// </summary>
         public const uint DefaultPrefetchCount = 50;
@@ -76,6 +81,7 @@ namespace Microsoft.Azure.Devices.Client
         {
             OperationTimeout = DefaultOperationTimeout;
             OpenTimeout = DefaultOpenTimeout;
+            IdleTimeout = DefaultIdleTimeout;
 
             PrefetchCount = prefetchCount <= 0
                 ? throw new ArgumentOutOfRangeException(nameof(prefetchCount), "Must be greater than zero")
@@ -103,7 +109,8 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Specify client-side heartbeat interval
+        /// Specify client-side heartbeat interval.
+        /// The default value is 2 minutes.
         /// </summary>
         public TimeSpan IdleTimeout { get; set; }
 

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             Closed = 16
         }
 
-        // Topic names for sending cloud-to-device messages
+        // Topic names for sending device-to-cloud messages
         private const string DeviceTelemetryTopicFormat = "devices/{0}/messages/events/";
         private const string ModuleTelemetryTopicFormat = "devices/{0}/modules/{1}/messages/events/";
 
@@ -397,6 +397,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         private static async void PingServer(object ctx)
         {
+            if (Logging.IsEnabled) Logging.Enter(ctx, $"Scheduled check to see if a ping request should be sent.", nameof(PingServer));
+
             var context = (IChannelHandlerContext)ctx;
             try
             {
@@ -408,6 +410,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 }
 
                 TimeSpan idleTime = DateTime.UtcNow - self._lastChannelActivityTime;
+                if (Logging.IsEnabled) Logging.Info(context, $"Idle time currently is {idleTime}.", nameof(PingServer));
 
                 if (idleTime > self._pingRequestInterval)
                 {
@@ -434,6 +437,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             {
                 ShutdownOnError(context, ex);
             }
+
+            if (Logging.IsEnabled) Logging.Exit(ctx, $"Scheduled check to see if a ping request should be sent.", nameof(PingServer));
         }
 
         private async Task ProcessConnectAckAsync(IChannelHandlerContext context, ConnAckPacket packet)

--- a/iothub/device/tests/TransportSettingsTests.cs
+++ b/iothub/device/tests/TransportSettingsTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Security.Cryptography.X509Certificates;
-using Microsoft.Azure.Devices.Client.ApiTest;
 using Microsoft.Azure.Devices.Client.Transport.Mqtt;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -146,7 +144,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        public void AmqpTransportSettings_TimeoutDefaultsAndOverrides()
+        public void AmqpTransportSettings_SetsDefaultTimeout()
         {
             // act
             var transportSetting = new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only, 200);
@@ -154,6 +152,32 @@ namespace Microsoft.Azure.Devices.Client.Test
             // assert
             Assert.AreEqual(AmqpTransportSettings.DefaultOpenTimeout, transportSetting.OpenTimeout, "Default OpenTimeout not set correctly");
             Assert.AreEqual(AmqpTransportSettings.DefaultOperationTimeout, transportSetting.OperationTimeout, "Default OperationTimeout not set correctly");
+            Assert.AreEqual(AmqpTransportSettings.DefaultIdleTimeout, transportSetting.IdleTimeout, "Default IdleTimeout not set correctly");
+            Assert.AreEqual(AmqpTransportSettings.DefaultOperationTimeout, transportSetting.DefaultReceiveTimeout, "Default DefaultReceiveTimeout not set correctly");
+        }
+
+        [TestMethod]
+        public void AmqpTransportSettings_OverridesDefaultTimeout()
+        {
+            // We want to test that the timeouts that we set on AmqpTransportSettings override the default timeouts.
+            // In order to test that, we need to ensure the test timeout values are different from the default timeout values.
+            // Adding a TimeSpan to the default timeout value is an easy way to achieve that.
+            var openTimeout = AmqpTransportSettings.DefaultOpenTimeout.Add(TimeSpan.FromMinutes(5));
+            var operationTimeout = AmqpTransportSettings.DefaultOperationTimeout.Add(TimeSpan.FromMinutes(5));
+            var idleTimeout = AmqpTransportSettings.DefaultIdleTimeout.Add(TimeSpan.FromMinutes(5));
+
+            // act
+            var transportSetting = new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only, 200)
+            {
+                OpenTimeout = openTimeout,
+                OperationTimeout = operationTimeout,
+                IdleTimeout = idleTimeout,
+            };
+
+            // assert
+            Assert.AreEqual(openTimeout, transportSetting.OpenTimeout, "OpenTimeout not set correctly");
+            Assert.AreEqual(operationTimeout, transportSetting.OperationTimeout, "OperationTimeout not set correctly");
+            Assert.AreEqual(idleTimeout, transportSetting.IdleTimeout, "IdleTimeout not set correctly");
         }
 
         [TestMethod]


### PR DESCRIPTION
This PR was being tracked in #1545 , but git stopped updating the status, so I had to close it. On attempting to reopen the PR, git complained that there had been a force-push to the feature branch, so it didn't allow me to reopen the PR.

Fix for #1535 

**Adding context here:**

The previous behavior was the the idle timeout would be set only if the user sets this property on transport settings. If the idle timeout is not set, then the client no longer monitors for connection loss. This was resulting in the following behavior where ~20mins would go by without the disconnection having been detected.

On setting a default idle timeout of 2 mins, the client will now exhibit the following behavior:
- the client informs the service that it's idle timeout is 2 mins.
- as per amqp specs, the service now needs to respond with a ping at least once every 2 mins.
- in the event that 2mins go by without any communication, the amqp library at the client side will trigger a disconnect.
- the sdk will see a disconnection, and retry based on it's retry policy.

The reason for selecting an idle timeout of 2 mins is to ensure that a disconnection event is triggered before the default operation timeout is reached (4 minutes). Otherwise, if we set the default idle timeout for > 4minutes, an operation would timeout before a disconnection event was detected (i.e. in the event of a disconnection, the operation would be stuck for 4 minutes and then timeout, and then return the disconnection event). On setting it to < 4 minutes, a disconnection event would first be detected, and then the operation would timeout.

Note that this is different from the heartbeat protocol followed by Mqtt, where on establishing a keep-alive of 5mins from the client to the service, the client was responsible for sending across a ping request (which it would send if it had been idle for > (5mins/4 = 75 secs) and monitoring the ping response (wait for a max of 30 secs)). This resulted in the client taking about 2-3mins to detect a disconnection.

@kiranpradeep  We are unable to follow the c-sdk in taking into account this ratio (ping interval is 1/2 of the keep-alive interval). This is because the ping request-response logic is encapsulated by the azure-amqp library being used underneath, and those hooks are not available to us to modify.

**The effect of this change would be that the device client would be more proactive in detecting connection losses over Amqp.**
- If disconnection-reconnection duration is short enough (less than 2mins) = does not report any change in status = no change in behavior.
- If the disconnection-reconnection duration is > 2mins and < 20 mins (on Linux) = previously the device would simply be stuck in disconnected state, but not have reported it to the application. Now the device will return the "disconnected_retrying" status to the connection status change callback handler (after about 2-3 minutes). The device client will still have the responsibility of retrying and re-establishing the connection.
- If the disconnection-reconnection duration is > 20 mins = reports disconnection event = no change in behavior.

