### PR TITLE
Add comments for DeviceClient, ModuleClient, MqttTransportSettings

### DIFF
--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -217,8 +217,8 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <summary>
         /// Stores the timeout used in the operation retries. Note that this value is ignored for operations
-        /// where a cancellation token is provided. For example, SendEventAsync(Message) will use this timeout, but
-        /// SendEventAsync(Message, CancellationToken) will not. The latter operation will only be canceled by the
+        /// where a cancellation token is provided. For example, <see cref="SendEventAsync(Message)"/> will use this timeout, but
+        /// <see cref="SendEventAsync(Message, CancellationToken)"/> will not. The latter operation will only be canceled by the
         /// provided cancellation token.
         /// </summary>
         // Codes_SRS_DEVICECLIENT_28_002: [This property shall be defaulted to 240000 (4 minutes).]
@@ -253,7 +253,8 @@ namespace Microsoft.Azure.Devices.Client
         /// Sets the retry policy used in the operation retries.
         /// The change will take effect after any in-progress operations.
         /// </summary>
-        /// <param name="retryPolicy">The retry policy. The default is new ExponentialBackoff(int.MaxValue, TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(100));</param>
+        /// <param name="retryPolicy">The retry policy. The default is
+        /// <c>new ExponentialBackoff(int.MaxValue, TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(100));</c></param>
         // Codes_SRS_DEVICECLIENT_28_001: [This property shall be defaulted to the exponential retry strategy with back-off
         // parameters for calculating delay in between retries.]
         public void SetRetryPolicy(IRetryPolicy retryPolicy)
@@ -287,13 +288,17 @@ namespace Microsoft.Azure.Devices.Client
         public Task CloseAsync(CancellationToken cancellationToken) => InternalClient.CloseAsync(cancellationToken);
 
         /// <summary>
-        /// Receive a message from the device queue using the default timeout. After handling a received message, a client should call Complete, Abandon, or Reject, and then dispose the message.
+        /// Receive a message from the device queue using the default timeout.
+        /// After handling a received message, a client should call <see cref="CompleteAsync(Message)"/>,
+        /// <see cref="AbandonAsync(Message)"/>, or <see cref="RejectAsync(Message)"/>, and then dispose the message.
         /// </summary>
         /// <returns>The receive message or null if there was no message until the default timeout</returns>
         public Task<Message> ReceiveAsync() => InternalClient.ReceiveAsync();
 
         /// <summary>
-        /// Receive a message from the device queue using the cancellation token. After handling a received message, a client should call Complete, Abandon, or Reject, and then dispose the message.
+        /// Receive a message from the device queue using the cancellation token.
+        /// After handling a received message, a client should call <see cref="CompleteAsync(Message, CancellationToken)"/>,
+        /// <see cref="AbandonAsync(Message, CancellationToken)"/>, or <see cref="RejectAsync(Message, CancellationToken)"/>, and then dispose the message.
         /// </summary>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
@@ -301,7 +306,9 @@ namespace Microsoft.Azure.Devices.Client
         public Task<Message> ReceiveAsync(CancellationToken cancellationToken) => InternalClient.ReceiveAsync(cancellationToken);
 
         /// <summary>
-        /// Receive a message from the device queue with the specified timeout. After handling a received message, a client should call Complete, Abandon, or Reject, and then dispose the message.
+        /// Receive a message from the device queue using the cancellation token.
+        /// After handling a received message, a client should call <see cref="CompleteAsync(Message, CancellationToken)"/>,
+        /// <see cref="AbandonAsync(Message, CancellationToken)"/>, or <see cref="RejectAsync(Message, CancellationToken)"/>, and then dispose the message.
         /// </summary>
         /// <returns>The receive message or null if there was no message until the specified time has elapsed</returns>
         public Task<Message> ReceiveAsync(TimeSpan timeout) => InternalClient.ReceiveAsync(timeout);

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client.Edge;
+using Microsoft.Azure.Devices.Client.Extensions;
 using Microsoft.Azure.Devices.Client.Transport;
 using Microsoft.Azure.Devices.Shared;
 
@@ -577,47 +578,57 @@ namespace Microsoft.Azure.Devices.Client
             InternalClient.SetMessageHandlerAsync(messageHandler, userContext, cancellationToken);
 
         /// <summary>
-        /// Interactively invokes a method on a device
+        /// Interactively invokes a method from an edge module to an edge device.
+        /// Both the edge module and the edge device need to be connected to the same edge hub.
         /// </summary>
-        /// <param name="deviceId">Device Id</param>
-        /// <param name="methodRequest">Device method parameters (pass-through to device)</param>
-        /// <returns>Method result</returns>
+        /// <param name="deviceId">The unique identifier of the edge device to invoke the method on.</param>
+        /// <param name="methodRequest">The details of the method to invoke.</param>
+        /// <returns>The result of the method invocation.</returns>
         public Task<MethodResponse> InvokeMethodAsync(string deviceId, MethodRequest methodRequest) =>
             InvokeMethodAsync(deviceId, methodRequest, CancellationToken.None);
 
         /// <summary>
-        /// Interactively invokes a method on device
+        /// Interactively invokes a method from an edge module to an edge device.
+        /// Both the edge module and the edge device need to be connected to the same edge hub.
         /// </summary>
-        /// <param name="deviceId">Device Id</param>
-        /// <param name="methodRequest">Device method parameters (pass-through to device)</param>
-        /// <param name="cancellationToken">Cancellation Token</param>
+        /// <param name="deviceId">The unique identifier of the edge device to invoke the method on.</param>
+        /// <param name="methodRequest">The details of the method to invoke.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <returns>Method result</returns>
-        public Task<MethodResponse> InvokeMethodAsync(string deviceId, MethodRequest methodRequest, CancellationToken cancellationToken) =>
-            InvokeMethodAsync(GetDeviceMethodUri(deviceId), methodRequest, cancellationToken);
+        /// <returns>The result of the method invocation.</returns>
+        public Task<MethodResponse> InvokeMethodAsync(string deviceId, MethodRequest methodRequest, CancellationToken cancellationToken)
+        {
+            methodRequest.ThrowIfNull(nameof(methodRequest));
+            return InvokeMethodAsync(GetDeviceMethodUri(deviceId), methodRequest, cancellationToken);
+        }
 
         /// <summary>
-        /// Interactively invokes a method on a module
+        /// Interactively invokes a method from an edge module to a different edge module.
+        /// Both of the edge modules need to be connected to the same edge hub.
         /// </summary>
-        /// <param name="deviceId">Device Id</param>
-        /// <param name="moduleId">Module Id</param>
-        /// <param name="methodRequest">Module method parameters</param>
+        /// <param name="deviceId">The unique identifier of the device.</param>
+        /// <param name="moduleId">The unique identifier of the edge module to invoke the method on.</param>
+        /// <param name="methodRequest">The details of the method to invoke.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <returns>Method result</returns>
+        /// <returns>The result of the method invocation.</returns>
         public Task<MethodResponse> InvokeMethodAsync(string deviceId, string moduleId, MethodRequest methodRequest) =>
             InvokeMethodAsync(deviceId, moduleId, methodRequest, CancellationToken.None);
 
         /// <summary>
-        /// Interactively invokes a method on module
+        /// Interactively invokes a method from an edge module to a different edge module.
+        /// Both of the edge modules need to be connected to the same edge hub.
         /// </summary>
-        /// <param name="deviceId">Device Id</param>
-        /// <param name="moduleId">Module Id</param>
-        /// <param name="methodRequest">Module method parameters.</param>
-        /// <param name="cancellationToken">Cancellation Token</param>
+        /// <param name="deviceId">The unique identifier of the device.</param>
+        /// <param name="moduleId">The unique identifier of the edge module to invoke the method on.</param>
+        /// <param name="methodRequest">The details of the method to invoke.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <returns>Method result</returns>
-        public Task<MethodResponse> InvokeMethodAsync(string deviceId, string moduleId, MethodRequest methodRequest, CancellationToken cancellationToken) =>
-            InvokeMethodAsync(GetModuleMethodUri(deviceId, moduleId), methodRequest, cancellationToken);
+        /// <returns>The result of the method invocation.</returns>
+        public Task<MethodResponse> InvokeMethodAsync(string deviceId, string moduleId, MethodRequest methodRequest, CancellationToken cancellationToken)
+        {
+            methodRequest.ThrowIfNull(nameof(methodRequest));
+            return InvokeMethodAsync(GetModuleMethodUri(deviceId, moduleId), methodRequest, cancellationToken);
+        }
 
         private async Task<MethodResponse> InvokeMethodAsync(Uri uri, MethodRequest methodRequest, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
This PR adds/updates the comments in :
- `DeviceClient`, marking code blocks with appropriate tags.
- `ModuleClient`, explaining the use-case for `InvokeMethod` APIs (since they are edge-specific). Usually we would expect these APIs to be present as a part of `ServiceClient` (they exist in the `ServiceClient` as well, currently).
- `MqttTransportSettings` - there are a bunch of properties here that are unused in the client library. This PR call them out as such. The long-term plan is to either hook them to the library (if applicable), or mark them as deprecated.