### PR TITLE
Fix(ServiceClient): Fix issue with IOThreadTimer nullref.

### DIFF
--- a/iothub/service/src/AmqpFeedbackReceiver.cs
+++ b/iothub/service/src/AmqpFeedbackReceiver.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Devices
 
         Task<ReceivingAmqpLink> CreateReceivingLinkAsync(TimeSpan timeout)
         {
-            return this.iotHubConnection.CreateReceivingLink(this.receivingPath, timeout, 0);
+            return this.iotHubConnection.CreateReceivingLinkAsync(this.receivingPath, timeout, 0);
         }
 
         public override Task CompleteAsync(FeedbackBatch feedback)

--- a/iothub/service/src/AmqpFileNotificationReceiver.cs
+++ b/iothub/service/src/AmqpFileNotificationReceiver.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Devices
 
         Task<ReceivingAmqpLink> CreateReceivingLinkAsync(TimeSpan timeout)
         {
-            return this.Connection.CreateReceivingLink(this.receivingPath, timeout, 0);
+            return this.Connection.CreateReceivingLinkAsync(this.receivingPath, timeout, 0);
         }
 
         public override Task CompleteAsync(FileNotification fileNotification)

--- a/iothub/service/src/AmqpServiceClient.cs
+++ b/iothub/service/src/AmqpServiceClient.cs
@@ -243,14 +243,9 @@ namespace Microsoft.Azure.Devices
                     throw AmqpErrorMapper.GetExceptionFromOutcome(outcome);
                 }
             }
-            catch (Exception exception)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                if (exception.IsFatal())
-                {
-                    throw;
-                }
-
-                throw AmqpClientHelper.ToIotHubClientContract(exception);
+                throw AmqpClientHelper.ToIotHubClientContract(ex);
             }
         }
 

--- a/iothub/service/src/IotHubConnection.cs
+++ b/iothub/service/src/IotHubConnection.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices
         private static readonly AmqpVersion s_amqpVersion_1_0_0 = new AmqpVersion(1, 0, 0);
         private static readonly TimeSpan s_refreshTokenBuffer = TimeSpan.FromMinutes(2);
         private static readonly TimeSpan s_refreshTokenRetryInterval = TimeSpan.FromSeconds(30);
-        private static readonly Lazy<bool> s_disableServerCertificateValidation = new Lazy<bool>(InitializeDisableServerCertificateValidation);
+        private static readonly Lazy<bool> s_shouldDisableServerCertificateValidation = new Lazy<bool>(InitializeDisableServerCertificateValidation);
 
         private readonly AccessRights _accessRights;
         private readonly FaultTolerantAmqpObject<AmqpSession> _faultTolerantSession;
@@ -423,7 +423,7 @@ namespace Microsoft.Azure.Devices
             SslPolicyErrors sslPolicyErrors)
         {
             return sslPolicyErrors == SslPolicyErrors.None 
-                || (s_disableServerCertificateValidation.Value 
+                || (s_shouldDisableServerCertificateValidation.Value 
                     && sslPolicyErrors == SslPolicyErrors.RemoteCertificateNameMismatch);
         }
 

--- a/iothub/service/src/IotHubConnection.cs
+++ b/iothub/service/src/IotHubConnection.cs
@@ -47,14 +47,15 @@ namespace Microsoft.Azure.Devices
 
         public IotHubConnection(IotHubConnectionString connectionString, AccessRights accessRights, bool useWebSocketOnly, ServiceClientTransportSettings transportSettings)
         {
+#if !NET451
+            _refreshTokenTimer = new IOThreadTimerSlim(s => ((IotHubConnection)s).OnRefreshTokenAsync(), this);
+#else
+            _refreshTokenTimer = new IOThreadTimer(s => ((IotHubConnection)s).OnRefreshTokenAsync(), this, false);
+#endif
+
             ConnectionString = connectionString;
             _accessRights = accessRights;
             _faultTolerantSession = new FaultTolerantAmqpObject<AmqpSession>(CreateSessionAsync, CloseConnection);
-#if !NET451
-            _refreshTokenTimer = new IOThreadTimerSlim(s => ((IotHubConnection)s).OnRefreshToken(), this, false);
-#else
-            _refreshTokenTimer = new IOThreadTimer(s => ((IotHubConnection)s).OnRefreshToken(), this, false);
-#endif
             _useWebSocketOnly = useWebSocketOnly;
             _transportSettings = transportSettings;
         }
@@ -76,22 +77,16 @@ namespace Microsoft.Azure.Devices
             return _faultTolerantSession.CloseAsync();
         }
 
-        public void SafeClose(Exception exception)
-        {
-            _faultTolerantSession.Close();
-        }
-
         public async Task<SendingAmqpLink> CreateSendingLinkAsync(string path, TimeSpan timeout)
         {
             var timeoutHelper = new TimeoutHelper(timeout);
 
-            AmqpSession session;
-            if (!_faultTolerantSession.TryGetOpenedObject(out session))
+            if (!_faultTolerantSession.TryGetOpenedObject(out AmqpSession session))
             {
                 session = await _faultTolerantSession.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
-            var linkAddress = ConnectionString.BuildLinkAddress(path);
+            Uri linkAddress = ConnectionString.BuildLinkAddress(path);
 
             var linkSettings = new AmqpLinkSettings
             {
@@ -113,17 +108,16 @@ namespace Microsoft.Azure.Devices
             return link;
         }
 
-        public async Task<ReceivingAmqpLink> CreateReceivingLink(string path, TimeSpan timeout, uint prefetchCount)
+        public async Task<ReceivingAmqpLink> CreateReceivingLinkAsync(string path, TimeSpan timeout, uint prefetchCount)
         {
             var timeoutHelper = new TimeoutHelper(timeout);
 
-            AmqpSession session;
-            if (!_faultTolerantSession.TryGetOpenedObject(out session))
+            if (!_faultTolerantSession.TryGetOpenedObject(out AmqpSession session))
             {
                 session = await _faultTolerantSession.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
-            var linkAddress = ConnectionString.BuildLinkAddress(path);
+            Uri linkAddress = ConnectionString.BuildLinkAddress(path);
 
             var linkSettings = new AmqpLinkSettings
             {
@@ -172,8 +166,8 @@ namespace Microsoft.Azure.Devices
             TransportBase transport;
             if (_useWebSocketOnly)
             {
-                // Try only Amqp transport over WebSocket
-                transport = await CreateClientWebSocketTransport(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                // Try only AMQP transport over WebSocket
+                transport = await CreateClientWebSocketTransportAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
             else
             {
@@ -194,10 +188,10 @@ namespace Microsoft.Azure.Devices
                         throw;
                     }
 
-                    // Amqp transport over TCP failed. Retry Amqp transport over WebSocket
+                    // AMQP transport over TCP failed. Retry AMQP transport over WebSocket
                     if (timeoutHelper.RemainingTime() != TimeSpan.Zero)
                     {
-                        transport = await CreateClientWebSocketTransport(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                        transport = await CreateClientWebSocketTransportAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                     }
                     else
                     {
@@ -295,7 +289,7 @@ namespace Microsoft.Azure.Devices
             return websocket;
         }
 
-        private async Task<TransportBase> CreateClientWebSocketTransport(TimeSpan timeout)
+        private async Task<TransportBase> CreateClientWebSocketTransportAsync(TimeSpan timeout)
         {
             var timeoutHelper = new TimeoutHelper(timeout);
             var websocketUri = new Uri(WebSocketConstants.Scheme + ConnectionString.HostName + ":" + WebSocketConstants.SecurePort + WebSocketConstants.UriSuffix);
@@ -398,7 +392,7 @@ namespace Microsoft.Azure.Devices
             ScheduleTokenRefresh(expiresAtUtc);
         }
 
-        private async void OnRefreshToken()
+        private async void OnRefreshTokenAsync()
         {
             if (_faultTolerantSession.TryGetOpenedObject(out AmqpSession amqpSession) && amqpSession != null && !amqpSession.IsClosing())
             {
@@ -428,17 +422,9 @@ namespace Microsoft.Azure.Devices
             X509Chain chain,
             SslPolicyErrors sslPolicyErrors)
         {
-            if (sslPolicyErrors == SslPolicyErrors.None)
-            {
-                return true;
-            }
-
-            if (s_disableServerCertificateValidation.Value && sslPolicyErrors == SslPolicyErrors.RemoteCertificateNameMismatch)
-            {
-                return true;
-            }
-
-            return false;
+            return sslPolicyErrors == SslPolicyErrors.None 
+                || (s_disableServerCertificateValidation.Value 
+                    && sslPolicyErrors == SslPolicyErrors.RemoteCertificateNameMismatch);
         }
 
         public static ArraySegment<byte> GetNextDeliveryTag(ref int deliveryTag)
@@ -456,7 +442,7 @@ namespace Microsoft.Azure.Devices
 
             if (!Guid.TryParse(lockToken, out Guid lockTokenGuid))
             {
-                throw new ArgumentException("Should be a valid Guid", nameof(lockToken));
+                throw new ArgumentException("Should be a valid GUID", nameof(lockToken));
             }
 
             var deliveryTag = new ArraySegment<byte>(lockTokenGuid.ToByteArray());
@@ -467,6 +453,7 @@ namespace Microsoft.Azure.Devices
         public void Dispose()
         {
             _faultTolerantSession.Dispose();
+            _refreshTokenTimer.Dispose();
         }
 
         private void ScheduleTokenRefresh(DateTime expiresAtUtc)

--- a/iothub/service/src/IotHubConnection.cs
+++ b/iothub/service/src/IotHubConnection.cs
@@ -453,7 +453,7 @@ namespace Microsoft.Azure.Devices
         public void Dispose()
         {
             _faultTolerantSession.Dispose();
-            _refreshTokenTimer.Dispose();
+            _refreshTokenTimer?.Dispose();
         }
 
         private void ScheduleTokenRefresh(DateTime expiresAtUtc)

--- a/iothub/service/src/IotHubConnection.cs
+++ b/iothub/service/src/IotHubConnection.cs
@@ -452,7 +452,7 @@ namespace Microsoft.Azure.Devices
         /// <inheritdoc/>
         public void Dispose()
         {
-            _faultTolerantSession.Dispose();
+            _faultTolerantSession?.Dispose();
             _refreshTokenTimer?.Dispose();
         }
 

--- a/iothub/service/src/ModernDotNet/Common/IOThreadTimerSlim.cs
+++ b/iothub/service/src/ModernDotNet/Common/IOThreadTimerSlim.cs
@@ -1,43 +1,52 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Threading;
+
 namespace Microsoft.Azure.Devices
 {
-    using System;
-    using System.Threading;
-
-    class IOThreadTimerSlim
+    internal class IOThreadTimerSlim : IDisposable
     {
-        Timer timer;
-        Action<object> callback;
-        object callbackState;
+        private Timer _timer;
+        private readonly Action<object> _callback;
+        private readonly object _callbackState;
 
-        private void CreateTimer()
+        public IOThreadTimerSlim(Action<object> callback, object callbackState)
         {
-            this.timer = new Timer((obj) => callback(obj), callbackState, TimeSpan.FromMilliseconds(-1), TimeSpan.FromMilliseconds(-1));
-        }
-
-        public IOThreadTimerSlim(Action<object> callback, object callbackState, bool isTypicallyCanceledShortlyAfterBeingSet)
-        {
-            this.callback = callback;
-            this.callbackState = callbackState;
+            _callback = callback;
+            _callbackState = callbackState;
             CreateTimer();
         }
 
         public void Set(TimeSpan timeFromNow)
         {
-            if (timer == null)
+            if (_timer == null)
             {
                 CreateTimer();
             }
-            timer.Change(timeFromNow, TimeSpan.FromMilliseconds(-1));
+            _timer.Change(timeFromNow, TimeSpan.FromMilliseconds(-1));
         }
 
         public bool Cancel()
         {
-            timer.Dispose();
-            timer = null;
+            if (_timer != null)
+            {
+                _timer.Dispose();
+                _timer = null;
+            }
+
             return true;
+        }
+
+        public void Dispose()
+        {
+            _timer.Dispose();
+        }
+
+        private void CreateTimer()
+        {
+            _timer = new Timer((obj) => _callback(obj), _callbackState, TimeSpan.FromMilliseconds(-1), TimeSpan.FromMilliseconds(-1));
         }
     }
 }

--- a/iothub/service/src/ModernDotNet/Common/IOThreadTimerSlim.cs
+++ b/iothub/service/src/ModernDotNet/Common/IOThreadTimerSlim.cs
@@ -25,23 +25,21 @@ namespace Microsoft.Azure.Devices
             {
                 CreateTimer();
             }
+
             _timer.Change(timeFromNow, TimeSpan.FromMilliseconds(-1));
         }
 
         public bool Cancel()
         {
-            if (_timer != null)
-            {
-                _timer.Dispose();
-                _timer = null;
-            }
+            _timer?.Dispose();
+            _timer = null;
 
             return true;
         }
 
         public void Dispose()
         {
-            _timer.Dispose();
+            _timer?.Dispose();
         }
 
         private void CreateTimer()

--- a/iothub/service/src/ModernDotNet/Common/IOThreadTimerSlim.cs
+++ b/iothub/service/src/ModernDotNet/Common/IOThreadTimerSlim.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Azure.Devices
         public void Dispose()
         {
             _timer?.Dispose();
+            _sem?.Dispose();
         }
 
         private void CreateTimer()

--- a/iothub/service/src/net451/Common/IOThreadTimer.cs
+++ b/iothub/service/src/net451/Common/IOThreadTimer.cs
@@ -10,9 +10,9 @@ using Microsoft.Azure.Devices.Common.Interop;
 
 namespace Microsoft.Azure.Devices.Common
 {
-    // IOThreadTimer has several characterstics that are important for performance:
+    // IOThreadTimer has several characteristics that are important for performance:
     // - Timers that expire benefit from being scheduled to run on IO threads using IOThreadScheduler.Schedule.
-    // - The timer "waiter" thread thread is only allocated if there are set timers.
+    // - The timer "waiter" thread is only allocated if there are set timers.
     // - The timer waiter thread itself is an IO thread, which allows it to go away if there is no need for it,
     //   and allows it to be reused for other purposes.
     // - After the timer count goes to zero, the timer waiter thread remains active for a bounded amount
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.Common
     //   waitable timer handle.
     // - Setting or canceling a timer does not typically involve any allocations.
 
-    internal class IOThreadTimer
+    internal class IOThreadTimer : IDisposable
     {
         private const int MaxSkewInMillisecondsDefault = 100;
         private static long s_systemTimeResolutionTicks = -1;
@@ -120,6 +120,11 @@ namespace Microsoft.Azure.Devices.Common
             }
 
             TimerManager.Value.Set(this, newDueTimeInTicks);
+        }
+
+        public void Dispose()
+        {
+            _timerGroup.Dispose();
         }
 
         [Fx.Tag.SynchronizationObject(Blocking = false, Scope = Fx.Tag.Strings.AppDomain)]


### PR DESCRIPTION
If the IOThreadTimer is canceled twice without being set in between the cancels, it will throw a nullref because there is no null check involved.