### PR TITLE
Bump package versions for 2020-10-15 release

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.31.2</Version>
+    <Version>1.32.0</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.27.2</Version>
+    <Version>1.27.3</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.13.1</Version>
+    <Version>1.13.2</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client AMQP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,9 +1,9 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.31.2
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.27.2
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.32.0
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.27.3
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.25.1
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.1
-provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.1
+provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.2
 provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.12.1
 provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.13.1
 security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.12.1


### PR DESCRIPTION
Release notes:

## Microsoft.Azure.Devices.Client 1.32.0
- Update Microsoft.Azure.Amqp version to 2.4.7.
- Set a default idle timeout of 2 minutes over AMQP (https://github.com/Azure/azure-iot-sdk-csharp/issues/1535)

### Bug fixes:
- Added QuotaExeededException as an inner exception to the DeviceMaximumQueueDepthExceededException that is incorrectly being mapped to a 403002 AMQP error code.

## Microsoft.Azure.Devices 1.27.3
- Update Microsoft.Azure.Amqp version to 2.4.7.

### Bug fixes:
- Fix issue with AmqpServiceClient throwing NRE during C2D messages.

## Microsoft.Azure.Devices.Provisioning.Transport.Amqp 1.13.2
- Update Microsoft.Azure.Amqp version to 2.4.7.