### PR TITLE
Add an API to set a callback for receiving C2D messages (mqtt)

### DIFF
--- a/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
 using Microsoft.Azure.Devices.E2ETests.Helpers.Templates;
@@ -148,54 +149,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         }
 
         [LoggedTestMethod]
-        public async Task Message_DeviceReceiveMessageWithLessTimeout_Amqp()
-        {
-            await ReceiveMessageWithTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only, s_oneSecond).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveMessageWithMoreTimeout_Amqp()
-        {
-            await ReceiveMessageWithTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only, s_twentySeconds).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveMessageWithLessTimeout_AmqpWs()
-        {
-            await ReceiveMessageWithTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_WebSocket_Only, s_oneSecond).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveMessageWithMoreTimeout_AmqpWs()
-        {
-            await ReceiveMessageWithTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_WebSocket_Only, s_twentySeconds).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveMessageWithLessTimeout_Mqtt()
-        {
-            await ReceiveMessageWithTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only, s_oneSecond).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveMessageWithMoreTimeout_Mqtt()
-        {
-            await ReceiveMessageWithTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only, s_twentySeconds).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveMessageWithLessTimeout_MqttWs()
-        {
-            await ReceiveMessageWithTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only, s_oneSecond).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveMessageWithMoreTimeout_MqttWs()
-        {
-            await ReceiveMessageWithTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only, s_twentySeconds).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
         public async Task Message_DeviceReceiveMessageOperationTimeout_Amqp()
         {
             await ReceiveMessageInOperationTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
@@ -219,12 +172,60 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await ReceiveMessageInOperationTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
         }
 
+        [LoggedTestMethod]
+        public async Task DeviceReceiveMessageUsingCallback_Mqtt()
+        {
+            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceReceiveMessageUsingCallback_MqttWs()
+        {
+            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only);
+        }
+
+        [LoggedTestMethod]
+        public async Task X509_DeviceReceiveMessageUsingCallback_Mqtt()
+        {
+            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.X509, Client.TransportType.Mqtt_Tcp_Only);
+        }
+
+        [LoggedTestMethod]
+        public async Task X509_DeviceReceiveMessageUsingCallback_MqttWs()
+        {
+            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.X509, Client.TransportType.Mqtt_WebSocket_Only);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceReceiveMessageUsingCallbackAndUnsubscribe_Mqtt()
+        {
+            await ReceiveSingleMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceReceiveMessageUsingCallbackAndUnsubscribe_MqttWs()
+        {
+            await ReceiveSingleMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only);
+        }
+
+        [LoggedTestMethod]
+        public async Task X509_DeviceReceiveMessageUsingCallbackAndUnsubscribe_Mqtt()
+        {
+            await ReceiveSingleMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.X509, Client.TransportType.Mqtt_Tcp_Only);
+        }
+
+        [LoggedTestMethod]
+        public async Task X509_DeviceReceiveMessageUsingCallbackAndUnsubscribe_MqttWs()
+        {
+            await ReceiveSingleMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.X509, Client.TransportType.Mqtt_WebSocket_Only);
+        }
+
         public static (Message message, string payload, string p1Value) ComposeC2dTestMessage(MsTestLogger logger)
         {
-            var payload = Guid.NewGuid().ToString();
-            var messageId = Guid.NewGuid().ToString();
-            var p1Value = Guid.NewGuid().ToString();
-            var userId = Guid.NewGuid().ToString();
+            string payload = Guid.NewGuid().ToString();
+            string messageId = Guid.NewGuid().ToString();
+            string p1Value = Guid.NewGuid().ToString();
+            string userId = Guid.NewGuid().ToString();
 
             logger.Trace($"{nameof(ComposeC2dTestMessage)}: messageId='{messageId}' userId='{userId}' payload='{payload}' p1Value='{p1Value}'");
             var message = new Message(Encoding.UTF8.GetBytes(payload))
@@ -279,9 +280,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                         // ignore exception from CompleteAsync
                     }
 
-                    Assert.AreEqual(receivedMessage.MessageId, message.MessageId, "Recieved message Id is not what was sent by service");
-                    Assert.AreEqual(receivedMessage.UserId, message.UserId, "Recieved user Id is not what was sent by service");
-                    Assert.AreEqual(receivedMessage.To, receivedMessageDestination, "Recieved message destination is not what was sent by service");
+                    Assert.AreEqual(receivedMessage.MessageId, message.MessageId, "Received message Id is not what was sent by service");
+                    Assert.AreEqual(receivedMessage.UserId, message.UserId, "Received user Id is not what was sent by service");
+                    Assert.AreEqual(receivedMessage.To, receivedMessageDestination, "Received message destination is not what was sent by service");
 
                     string messageData = Encoding.ASCII.GetString(receivedMessage.GetBytes());
                     logger.Trace($"{nameof(VerifyReceivedC2DMessageAsync)}: Received message: for {deviceId}: {messageData}");
@@ -358,13 +359,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             Logger.Trace($"{nameof(ReceiveMessageInOperationTimeoutAsync)} - calling OpenAsync() for transport={transport}");
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
-            if (transport == Client.TransportType.Mqtt_Tcp_Only
-                || transport == Client.TransportType.Mqtt_WebSocket_Only)
-            {
-                // Dummy ReceiveAsync to ensure mqtt subscription registration before SendAsync() is called on service client.
-                await deviceClient.ReceiveAsync(s_fiveSeconds).ConfigureAwait(false);
-            }
-
             try
             {
                 deviceClient.OperationTimeoutInMilliseconds = Convert.ToUInt32(s_oneMinute.TotalMilliseconds);
@@ -393,25 +387,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             }
         }
 
-        private async Task ReceiveMessageWithTimeoutAsync(TestDeviceType type, Client.TransportType transport, TimeSpan timeout)
-        {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
-
-            await deviceClient.OpenAsync().ConfigureAwait(false);
-
-            if (transport == Client.TransportType.Mqtt_Tcp_Only
-                || transport == Client.TransportType.Mqtt_WebSocket_Only)
-            {
-                // Dummy ReceiveAsync to ensure mqtt subscription registration before SendAsync() is called on service client.
-                await deviceClient.ReceiveAsync(s_fiveSeconds).ConfigureAwait(false);
-            }
-
-            await ReceiveMessageWithTimeoutCheckAsync(deviceClient, timeout).ConfigureAwait(false);
-
-            await deviceClient.CloseAsync().ConfigureAwait(false);
-        }
-
         private async Task ReceiveSingleMessageAsync(TestDeviceType type, Client.TransportType transport)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
@@ -419,15 +394,18 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
+            await serviceClient.OpenAsync().ConfigureAwait(false);
 
+            // For Mqtt - the device needs to have subscribed to the devicebound topic, in order for IoT Hub to deliver messages to the device.
+            // For this reason we will make a "fake" ReceiveAsync() call, which will result in the device subscribing to the c2d topic.
+            // Note: We need this "fake" ReceiveAsync() call even though we (SDK default) CONNECT with a CleanSession flag set to 0.
+            // This is because this test device is newly created, and it has never subscribed to IoT hub c2d topic. 
+            // Hence, IoT hub doesn't know about its CleanSession preference yet.
             if (transport == Client.TransportType.Mqtt_Tcp_Only
                 || transport == Client.TransportType.Mqtt_WebSocket_Only)
             {
-                // Dummy ReceiveAsync to ensure mqtt subscription registration before SendAsync() is called on service client.
                 await deviceClient.ReceiveAsync(s_fiveSeconds).ConfigureAwait(false);
             }
-
-            await serviceClient.OpenAsync().ConfigureAwait(false);
 
             (Message msg, string payload, string p1Value) = ComposeC2dTestMessage(Logger);
             using (msg)
@@ -447,15 +425,18 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
+            await serviceClient.OpenAsync().ConfigureAwait(false);
 
+            // For Mqtt - the device needs to have subscribed to the devicebound topic, in order for IoT Hub to deliver messages to the device.
+            // For this reason we will make a "fake" ReceiveAsync() call, which will result in the device subscribing to the c2d topic.
+            // Note: We need this "fake" ReceiveAsync() call even though we (SDK default) CONNECT with a CleanSession flag set to 0.
+            // This is because this test device is newly created, and it has never subscribed to IoT hub c2d topic. 
+            // Hence, IoT hub doesn't know about its CleanSession preference yet.
             if (transport == Client.TransportType.Mqtt_Tcp_Only
                 || transport == Client.TransportType.Mqtt_WebSocket_Only)
             {
-                // Dummy ReceiveAsync to ensure mqtt subscription registration before SendAsync() is called on service client.
                 await deviceClient.ReceiveAsync(s_fiveSeconds).ConfigureAwait(false);
             }
-
-            await serviceClient.OpenAsync().ConfigureAwait(false);
 
             (Message msg, string payload, string p1Value) = ComposeC2dTestMessage(Logger);
             using (msg)
@@ -501,32 +482,89 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             }
         }
 
-        private static async Task ReceiveMessageWithTimeoutCheckAsync(DeviceClient dc, TimeSpan timeout)
+        private async Task ReceiveSingleMessageUsingCallbackAsync(TestDeviceType type, Client.TransportType transport)
         {
-            while (true)
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
+            using var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, Logger);
+
+            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            await serviceClient.OpenAsync().ConfigureAwait(false);
+
+            (Message msg, string payload, string p1Value) = ComposeC2dTestMessage(Logger);
+            using (msg)
             {
-                var sw = new Stopwatch();
-                try
-                {
-                    sw.Start();
-                    Client.Message message = await dc.ReceiveAsync(timeout).ConfigureAwait(false);
-                    sw.Stop();
+                await deviceClient.OpenAsync().ConfigureAwait(false);
+                await testDeviceCallbackHandler.SetMessageReceiveCallbackHandlerAsync().ConfigureAwait(false);
+                testDeviceCallbackHandler.ExpectedMessageSentByService = msg;
 
-                    if (message == null)
-                    {
-                        break;
-                    }
-
-                    await dc.CompleteAsync(message).ConfigureAwait(false);
-                }
-                finally
-                {
-                    if (sw.Elapsed > (timeout + s_fiveSeconds))
-                    {
-                        Assert.Fail("ReceiveAsync did not return in Operation Timeout time.");
-                    }
-                }
+                using var cts = new CancellationTokenSource(s_oneMinute);
+                await Task
+                    .WhenAll(
+                        serviceClient.SendAsync(testDevice.Id, msg),
+                        testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts.Token))
+                    .ConfigureAwait(false);
             }
+
+            await deviceClient.CloseAsync().ConfigureAwait(false);
+            await serviceClient.CloseAsync().ConfigureAwait(false);
+        }
+
+        private async Task ReceiveSingleMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType type, Client.TransportType transport)
+        {
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
+            using var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, Logger);
+
+            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            await serviceClient.OpenAsync().ConfigureAwait(false);
+
+            (Message firstMessage, string payload, _) = ComposeC2dTestMessage(Logger);
+
+            // First set a callback on the device client to receive C2D messages.
+            await deviceClient.OpenAsync().ConfigureAwait(false);
+            await testDeviceCallbackHandler.SetMessageReceiveCallbackHandlerAsync().ConfigureAwait(false);
+
+            // Now, send a message to the device from the service.
+            testDeviceCallbackHandler.ExpectedMessageSentByService = firstMessage;
+            await serviceClient.SendAsync(testDevice.Id, firstMessage).ConfigureAwait(false);
+            Logger.Trace($"Sent C2D message from service, messageId={firstMessage.MessageId}");
+
+            // The message should be received on the callback, while a call to ReceiveAsync() should return null.
+            using var cts = new CancellationTokenSource(s_oneMinute);
+            Client.Message receivedMessage = await deviceClient.ReceiveAsync(s_oneMinute).ConfigureAwait(false);
+            await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts.Token).ConfigureAwait(false);
+            receivedMessage.Should().BeNull();
+
+            // Now unsubscribe from receiving c2d messages over the callback.
+            await deviceClient.SetReceiveMessageHandlerAsync(null, deviceClient).ConfigureAwait(false);
+
+            // For Mqtt - since we have explicitly unsubscribed, we will need to resubscribe again
+            // before the device can begin receiving c2d messages.
+            if (transport == Client.TransportType.Mqtt_Tcp_Only
+                || transport == Client.TransportType.Mqtt_WebSocket_Only)
+            {
+                await deviceClient.ReceiveAsync(s_fiveSeconds).ConfigureAwait(false);
+            }
+
+            // Send a message to the device from the service.
+            (Message secondMessage, _, _) = ComposeC2dTestMessage(Logger);
+            await serviceClient.SendAsync(testDevice.Id, secondMessage).ConfigureAwait(false);
+            Logger.Trace($"Sent C2D message from service, messageId={secondMessage.MessageId}");
+
+            // This time, the message should not be received on the callback, rather it should be received on a call to ReceiveAsync().
+            Func<Task> receiveMessageOverCallback = async () =>
+            {
+                await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts.Token).ConfigureAwait(false);
+            };
+            Client.Message message = await deviceClient.ReceiveAsync(s_oneMinute).ConfigureAwait(false);
+            message.MessageId.Should().Be(secondMessage.MessageId);
+            receiveMessageOverCallback.Should().Throw<OperationCanceledException>();
+
+            firstMessage.Dispose();
+            secondMessage.Dispose();
+            await deviceClient.CloseAsync().ConfigureAwait(false);
+            await serviceClient.CloseAsync().ConfigureAwait(false);
         }
     }
 }

--- a/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
@@ -172,6 +173,58 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
         }
 
+        [LoggedTestMethod]
+        public async Task Message_TcpConnectionLossReceiveWithCallbackRecovery_Mqtt()
+        {
+            await 
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Mqtt_Tcp_Only,
+                    FaultInjection.FaultType_Tcp,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_TcpConnectionLossReceiveWithCallbackRecovery_MqttWs()
+        {
+            await 
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Mqtt_WebSocket_Only,
+                    FaultInjection.FaultType_Tcp,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_GracefulShutdownReceiveWithCallbackRecovery_Mqtt()
+        {
+            await 
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Mqtt_Tcp_Only,
+                    FaultInjection.FaultType_GracefulShutdownMqtt,
+                    FaultInjection.FaultCloseReason_Bye,
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_GracefulShutdownReceiveWithCallbackRecovery_MqttWs()
+        {
+            await 
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Mqtt_WebSocket_Only,
+                    FaultInjection.FaultType_GracefulShutdownMqtt,
+                    FaultInjection.FaultCloseReason_Bye,
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
         private async Task ReceiveMessageRecovery(
             TestDeviceType type,
             Client.TransportType transport,
@@ -180,33 +233,37 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             int delayInSec,
             string proxyAddress = null)
         {
-            using (ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString))
+            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice)
             {
-                Func<DeviceClient, TestDevice, Task> init = async (deviceClient, testDevice) =>
+                await serviceClient.OpenAsync().ConfigureAwait(false);
+
+                // For Mqtt - the device needs to have subscribed to the devicebound topic, in order for IoT Hub to deliver messages to the device.
+                // For this reason we will make a "fake" ReceiveAsync() call, which will result in the device subscribing to the c2d topic.
+                // Note: We need this "fake" ReceiveAsync() call even though we (SDK default) CONNECT with a CleanSession flag set to 0.
+                // This is because this test device is newly created, and it has never subscribed to IoT hub c2d topic. 
+                // Hence, IoT hub doesn't know about its CleanSession preference yet.
+                if (transport == Client.TransportType.Mqtt_Tcp_Only ||
+                    transport == Client.TransportType.Mqtt_WebSocket_Only)
                 {
-                    await serviceClient.OpenAsync().ConfigureAwait(false);
+                    await deviceClient.ReceiveAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                }
+            }
 
-                    if (transport == Client.TransportType.Mqtt_Tcp_Only ||
-                        transport == Client.TransportType.Mqtt_WebSocket_Only)
-                    {
-                        // Dummy ReceiveAsync to ensure mqtt subscription registration before SendAsync() is called on service client.
-                        await deviceClient.ReceiveAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
-                    }
-                };
+            async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice)
+            {
+                (Message message, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage(Logger);
+                await serviceClient.SendAsync(testDevice.Id, message).ConfigureAwait(false);
+                await MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, testDevice.Id, message, payload, Logger).ConfigureAwait(false);
+            }
 
-                Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
-                {
-                    (Message message, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage(Logger);
-                    await serviceClient.SendAsync(testDevice.Id, message).ConfigureAwait(false);
-                    await MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, testDevice.Id, message, payload, Logger).ConfigureAwait(false);
-                };
+            Task CleanupOperationAsync()
+            {
+                return serviceClient.CloseAsync();
+            }
 
-                Func<Task> cleanupOperation = () =>
-                {
-                    return serviceClient.CloseAsync();
-                };
-
-                await FaultInjection.TestErrorInjectionAsync(
+            await FaultInjection
+                .TestErrorInjectionAsync(
                     DevicePrefix,
                     type,
                     transport,
@@ -215,11 +272,63 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     reason,
                     delayInSec,
                     FaultInjection.DefaultDurationInSec,
-                    init,
-                    testOperation,
-                    cleanupOperation,
-                    Logger).ConfigureAwait(false);
+                    InitOperationAsync,
+                    TestOperationAsync,
+                    CleanupOperationAsync,
+                    Logger)
+                .ConfigureAwait(false);
+        }
+
+        private async Task ReceiveMessageWithCallbackRecoveryAsync(
+            TestDeviceType type,
+            Client.TransportType transport,
+            string faultType,
+            string reason,
+            int delayInSec,
+            string proxyAddress = null)
+        {
+            TestDeviceCallbackHandler testDeviceCallbackHandler = null;
+            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+
+            async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice)
+            {
+                await serviceClient.OpenAsync().ConfigureAwait(false);
+                testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, Logger);
+                await testDeviceCallbackHandler.SetMessageReceiveCallbackHandlerAsync().ConfigureAwait(false);
             }
+
+            async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice)
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                (Message message, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage(Logger);
+
+                testDeviceCallbackHandler.ExpectedMessageSentByService = message;
+                await serviceClient.SendAsync(testDevice.Id, message).ConfigureAwait(false);
+                await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts.Token).ConfigureAwait(false);
+            }
+
+            Task CleanupOperationAsync()
+            {
+                serviceClient.CloseAsync();
+                testDeviceCallbackHandler?.Dispose();
+                return Task.FromResult(true);
+            }
+
+            await FaultInjection
+                .TestErrorInjectionAsync(
+                    DevicePrefix,
+                    type,
+                    transport,
+                    proxyAddress,
+                    faultType,
+                    reason,
+                    delayInSec,
+                    FaultInjection.DefaultDurationInSec,
+                    InitOperationAsync,
+                    TestOperationAsync,
+                    CleanupOperationAsync,
+                    Logger)
+                .ConfigureAwait(false);
         }
     }
 }

--- a/iothub/device/src/ClientFactory.cs
+++ b/iothub/device/src/ClientFactory.cs
@@ -390,7 +390,7 @@ namespace Microsoft.Azure.Devices.Client
             // Make sure client options is initialized with the correct transport setting.
             EnsureOptionsIsSetup(builder.Certificate, ref options);
 
-            pipelineBuilder = pipelineBuilder ?? BuildPipeline();
+            pipelineBuilder ??= BuildPipeline();
 
             // Defer concrete InternalClient creation to OpenAsync
             var client = new InternalClient(iotHubConnectionString, transportSettings, pipelineBuilder, options);

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -326,6 +326,18 @@ namespace Microsoft.Azure.Devices.Client
         public Task<Message> ReceiveAsync(TimeSpan timeout) => InternalClient.ReceiveAsync(timeout);
 
         /// <summary>
+        /// Registers a new delegate for receiving a message from the device queue using the default timeout.
+        /// After handling a received message, a client should call <see cref="CompleteAsync(Message, CancellationToken)"/>,
+        /// <see cref="AbandonAsync(Message, CancellationToken)"/>, or <see cref="RejectAsync(Message, CancellationToken)"/>, and then dispose the message.
+        /// If a null delegate is passed, it will disable the callback triggered on receiving messages from the service.
+        /// <param name="messageHandler">The delegate to be used when a could to device message is received by the client.</param>
+        /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        /// </summary>
+        public Task SetReceiveMessageHandlerAsync(ReceiveMessageCallback messageHandler, object userContext, CancellationToken cancellationToken = default) =>
+            InternalClient.SetReceiveMessageHandlerAsync(messageHandler, userContext, cancellationToken);
+
+        /// <summary>
         /// Deletes a received message from the device queue
         /// </summary>
         /// <param name="lockToken">The message lockToken.</param>

--- a/iothub/device/src/IDelegatingHandler.cs
+++ b/iothub/device/src/IDelegatingHandler.cs
@@ -32,6 +32,10 @@ namespace Microsoft.Azure.Devices.Client
 
         Task<Message> ReceiveAsync(TimeoutHelper timeoutHelper);
 
+        Task EnableReceiveMessageAsync(CancellationToken cancellationToken);
+
+        Task DisableReceiveMessageAsync(CancellationToken cancellationToken);
+
         Task RejectAsync(string lockToken, CancellationToken cancellationToken);
 
         Task AbandonAsync(string lockToken, CancellationToken cancellationToken);

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -58,14 +58,24 @@ namespace Microsoft.Azure.Devices.Client
     public delegate Task DesiredPropertyUpdateCallback(TwinCollection desiredProperties, object userContext);
 
     /// <summary>
+    /// Delegate that gets called when a message is received on a <see cref="DeviceClient"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is set using <see cref="DeviceClient.SetReceiveMessageHandlerAsync(ReceiveMessageCallback, object, CancellationToken)"/>.
+    /// </remarks>
+    /// <param name="message">The received message.</param>
+    /// <param name="userContext">Context object passed in when the callback was registered.</param>
+    public delegate Task ReceiveMessageCallback(Message message, object userContext);
+
+    /// <summary>
     /// Delegate that gets called when a message is received on a <see cref="ModuleClient"/>.
     /// </summary>
     /// <remarks>
-    /// This is set on <see cref="ModuleClient.SetInputMessageHandlerAsync(string, MessageHandler, object, CancellationToken)"/>
+    /// This is set using <see cref="ModuleClient.SetInputMessageHandlerAsync(string, MessageHandler, object, CancellationToken)"/>
     /// and <see cref="ModuleClient.SetMessageHandlerAsync(MessageHandler, object, CancellationToken)"/>.
     /// </remarks>
-    /// <param name="message">The message received</param>
-    /// <param name="userContext">The context object passed in</param>
+    /// <param name="message">The received message.</param>
+    /// <param name="userContext">Context object passed in when the callback was registered.</param>
     /// <returns>MessageResponse</returns>
     public delegate Task<MessageResponse> MessageHandler(Message message, object userContext);
 
@@ -97,7 +107,8 @@ namespace Microsoft.Azure.Devices.Client
     internal class InternalClient : IDisposable
     {
         private readonly SemaphoreSlim _methodsDictionarySemaphore = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _receiveSemaphore = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _deviceReceiveMessageSemaphore = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _moduleReceiveMessageSemaphore = new SemaphoreSlim(1, 1);
         private readonly ProductInfo _productInfo = new ProductInfo();
         private readonly HttpTransportHandler _fileUploadHttpTransportHandler;
         private readonly ITransportSettings[] _transportSettings;
@@ -119,6 +130,8 @@ namespace Microsoft.Azure.Devices.Client
         private ConnectionStatus _lastConnectionStatus = ConnectionStatus.Disconnected;
         private ConnectionStatusChangeReason _lastConnectionStatusChangeReason = ConnectionStatusChangeReason.Client_Close;
 
+        private volatile Tuple<ReceiveMessageCallback, object> _deviceReceiveMessageCallback;
+
         private bool _twinPatchSubscribedWithService = false;
         private object _twinPatchCallbackContext = null;
 
@@ -127,7 +140,9 @@ namespace Microsoft.Azure.Devices.Client
 
         internal delegate Task OnMethodCalledDelegate(MethodRequestInternal methodRequestInternal);
 
-        internal delegate Task OnReceiveEventMessageCalledDelegate(string input, Message message);
+        internal delegate Task OnDeviceMessageReceivedDelegate(Message message);
+
+        internal delegate Task OnModuleEventMessageReceivedDelegate(string input, Message message);
 
         public InternalClient(IotHubConnectionString iotHubConnectionString, ITransportSettings[] transportSettings, IDeviceClientPipelineBuilder pipelineBuilder, ClientOptions options)
         {
@@ -146,7 +161,8 @@ namespace Microsoft.Azure.Devices.Client
             pipelineContext.Set<OnMethodCalledDelegate>(OnMethodCalledAsync);
             pipelineContext.Set<Action<TwinCollection>>(OnReportedStatePatchReceived);
             pipelineContext.Set<ConnectionStatusChangesHandler>(OnConnectionStatusChanged);
-            pipelineContext.Set<OnReceiveEventMessageCalledDelegate>(OnReceiveEventMessageCalledAsync);
+            pipelineContext.Set<OnModuleEventMessageReceivedDelegate>(OnModuleEventMessageReceivedAsync);
+            pipelineContext.Set<OnDeviceMessageReceivedDelegate>(OnDeviceMessageReceivedAsync);
             pipelineContext.Set(_productInfo);
             pipelineContext.Set(options);
 
@@ -977,7 +993,8 @@ namespace Microsoft.Azure.Devices.Client
                     // will throw this SemaphoreFullException since it was never grabbed in the first place
                     if (Logging.IsEnabled)
                     {
-                        Logging.Info(this, "SemaphoreFullException thrown while releasing methods dictionary semaphore, but will be ignored since that means the semaphore is available for other threads to grab again anyways");
+                        Logging.Info(this, "SemaphoreFullException thrown while releasing methods dictionary semaphore," +
+                            " but will be ignored since that means the semaphore is available for other threads to grab again anyways");
                     }
                 }
             }
@@ -1273,6 +1290,130 @@ namespace Microsoft.Azure.Devices.Client
             }
         }
 
+        /// <summary>
+        /// Registers a new delegate for receiving a message from the device queue using the default timeout.
+        /// If a delegate is already registered it will be replaced with the new delegate.
+        /// If a null delegate is passed, it will disable triggering any callback on receiving messages from the service.
+        /// <param name="messageHandler">The delegate to be used when a could to device message is received by the client.</param>
+        /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        /// </summary>
+        /// <returns>The task containing the event</returns>
+        public async Task SetReceiveMessageHandlerAsync(ReceiveMessageCallback messageHandler, object userContext, CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (Logging.IsEnabled)
+                {
+                    Logging.Enter(this, messageHandler, userContext, nameof(SetReceiveMessageHandlerAsync));
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Wait to acquire the _deviceReceiveMessageSemaphore. This ensures that concurrently invoked SetReceiveMessageHandlerAsync calls
+                // are invoked in a thread-safe manner.
+                await _deviceReceiveMessageSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                // If a ReceiveMessageCallback is already set on the DeviceClient, calling SetReceiveMessageHandlerAsync
+                // again will cause the delegate to be overwritten.
+                if (messageHandler != null)
+                {
+                    // If this is the first time the delegate is being registered, then the telemetry downlink will be enabled.
+                    await EnableReceiveMessageAsync(cancellationToken).ConfigureAwait(false);
+                    _deviceReceiveMessageCallback = new Tuple<ReceiveMessageCallback, object>(messageHandler, userContext);
+                }
+                else
+                {
+                    // If a null delegate is passed, it will disable the callback triggered on receiving messages from the service.
+                    _deviceReceiveMessageCallback = null;
+                    await DisableReceiveMessageAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                throw;
+            }
+            finally
+            {
+                try
+                {
+                    _deviceReceiveMessageSemaphore.Release();
+                }
+                catch (SemaphoreFullException)
+                {
+                    // this semaphore is typically grabbed at the start of the method, but if
+                    // this method is canceled while waiting to grab the semaphore, then this semaphore.release
+                    // will throw this SemaphoreFullException since it was never grabbed in the first place
+                    if (Logging.IsEnabled)
+                    {
+                        Logging.Info(this, "SemaphoreFullException thrown while releasing" +
+                        " message receiving semaphore, but will be ignored since that means the semaphore" +
+                        " is available for other threads to grab again anyways");
+                    }
+                }
+
+                if (Logging.IsEnabled)
+                {
+                    Logging.Exit(this, messageHandler, userContext, nameof(SetReceiveMessageHandlerAsync));
+                }
+            }
+        }
+
+        // Enable telemetry downlink for devices
+        private Task EnableReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            // The telemetry downlink needs to be enabled only for the first time that the _receiveMessageCallback delegate is set.
+            return _deviceReceiveMessageCallback == null
+                ? InnerHandler.EnableReceiveMessageAsync(cancellationToken)
+                : TaskHelpers.CompletedTask;
+        }
+
+        // Disable telemetry downlink for devices
+        private Task DisableReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            // The telemetry downlink should be disabled only after _receiveMessageCallback delegate has been removed.
+            return _deviceReceiveMessageCallback == null
+                ? InnerHandler.DisableReceiveMessageAsync(cancellationToken)
+                : TaskHelpers.CompletedTask;
+        }
+
+        /// <summary>
+        /// The delegate for handling c2d messages received
+        /// <param name="message">The message received</param>
+        /// </summary>
+        private async Task OnDeviceMessageReceivedAsync(Message message)
+        {
+            if (Logging.IsEnabled)
+            {
+                Logging.Enter(this, message, nameof(OnDeviceMessageReceivedAsync));
+            }
+
+            if (message == null)
+            {
+                return;
+            }
+
+            Tuple<ReceiveMessageCallback, object> callbackContextTuple = null;
+
+            try
+            {
+                // Wait to acquire the _deviceReceiveMessageSemaphore. This ensures that we get a reference to the latest callback set on the device client.
+                await _deviceReceiveMessageSemaphore.WaitAsync().ConfigureAwait(false);
+                callbackContextTuple = _deviceReceiveMessageCallback;
+                _deviceReceiveMessageSemaphore.Release();
+
+                await (callbackContextTuple?.Item1?.Invoke(message, callbackContextTuple.Item2) ?? TaskHelpers.CompletedTask).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (Logging.IsEnabled)
+                {
+                    Logging.Exit(this, message, nameof(OnDeviceMessageReceivedAsync));
+                }
+            }
+        }
+
         internal async Task<FileUploadSasUriResponse> GetFileUploadSasUriAsync(FileUploadSasUriRequest request, CancellationToken cancellationToken = default)
         {
             return await _fileUploadHttpTransportHandler.GetFileUploadSasUri(request, cancellationToken).ConfigureAwait(false);
@@ -1541,7 +1682,7 @@ namespace Microsoft.Azure.Devices.Client
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await _receiveSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                await _moduleReceiveMessageSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
                 if (messageHandler != null)
                 {
@@ -1574,7 +1715,7 @@ namespace Microsoft.Azure.Devices.Client
             {
                 try
                 {
-                    _receiveSemaphore.Release();
+                    _moduleReceiveMessageSemaphore.Release();
                 }
                 catch (SemaphoreFullException)
                 {
@@ -1636,7 +1777,7 @@ namespace Microsoft.Azure.Devices.Client
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await _receiveSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                await _moduleReceiveMessageSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 if (messageHandler != null)
                 {
                     // codes_SRS_DEVICECLIENT_33_003: [ It shall EnableEventReceiveAsync when called for the first time. ]
@@ -1654,7 +1795,7 @@ namespace Microsoft.Azure.Devices.Client
             {
                 try
                 {
-                    _receiveSemaphore.Release();
+                    _moduleReceiveMessageSemaphore.Release();
                 }
                 catch (SemaphoreFullException)
                 {
@@ -1679,11 +1820,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="input">The input on which a message is received</param>
         /// <param name="message">The message received</param>
         /// </summary>
-        internal async Task OnReceiveEventMessageCalledAsync(string input, Message message)
+        internal async Task OnModuleEventMessageReceivedAsync(string input, Message message)
         {
             if (Logging.IsEnabled)
             {
-                Logging.Enter(this, input, message, nameof(OnReceiveEventMessageCalledAsync));
+                Logging.Enter(this, input, message, nameof(OnModuleEventMessageReceivedAsync));
             }
 
             // codes_SRS_DEVICECLIENT_33_001: [ If the given eventMessageInternal argument is null, fail silently ]
@@ -1695,7 +1836,7 @@ namespace Microsoft.Azure.Devices.Client
             try
             {
                 Tuple<MessageHandler, object> callback = null;
-                await _receiveSemaphore.WaitAsync().ConfigureAwait(false);
+                await _moduleReceiveMessageSemaphore.WaitAsync().ConfigureAwait(false);
                 try
                 {
                     // codes_SRS_DEVICECLIENT_33_006: [ The OnReceiveEventMessageCalled shall get the default delegate if a delegate has not been assigned. ]
@@ -1708,14 +1849,14 @@ namespace Microsoft.Azure.Devices.Client
                 }
                 finally
                 {
-                    _receiveSemaphore.Release();
+                    _moduleReceiveMessageSemaphore.Release();
                 }
 
                 // codes_SRS_DEVICECLIENT_33_002: [ The OnReceiveEventMessageCalled shall invoke the specified delegate. ]
                 MessageResponse response = await (callback?.Item1?.Invoke(message, callback.Item2) ?? Task.FromResult(MessageResponse.Completed)).ConfigureAwait(false);
                 if (Logging.IsEnabled)
                 {
-                    Logging.Info(this, $"{nameof(MessageResponse)} = {response}", nameof(OnReceiveEventMessageCalledAsync));
+                    Logging.Info(this, $"{nameof(MessageResponse)} = {response}", nameof(OnModuleEventMessageReceivedAsync));
                 }
 
                 switch (response)
@@ -1736,20 +1877,24 @@ namespace Microsoft.Azure.Devices.Client
             {
                 if (Logging.IsEnabled)
                 {
-                    Logging.Exit(this, input, message, nameof(OnReceiveEventMessageCalledAsync));
+                    Logging.Exit(this, input, message, nameof(OnModuleEventMessageReceivedAsync));
                 }
             }
         }
 
+        // Enable telemetry downlink for modules
         private Task EnableEventReceiveAsync(CancellationToken cancellationToken)
         {
+            // The telemetry downlink needs to be enabled only for the first time that the _defaultEventCallback delegate is set.
             return _receiveEventEndpoints == null && _defaultEventCallback == null
                 ? InnerHandler.EnableEventReceiveAsync(cancellationToken)
                 : TaskHelpers.CompletedTask;
         }
 
+        // Disable telemetry downlink for modules
         private Task DisableEventReceiveAsync(CancellationToken cancellationToken)
         {
+            // The telemetry downlink should be disabled only after _defaultEventCallback delegate has been removed.
             return _receiveEventEndpoints == null && _defaultEventCallback == null
                 ? InnerHandler.DisableEventReceiveAsync(cancellationToken)
                 : TaskHelpers.CompletedTask;
@@ -1769,8 +1914,9 @@ namespace Microsoft.Azure.Devices.Client
         {
             InnerHandler?.Dispose();
             _methodsDictionarySemaphore?.Dispose();
-            _receiveSemaphore?.Dispose();
+            _moduleReceiveMessageSemaphore?.Dispose();
             _fileUploadHttpTransportHandler?.Dispose();
+            _deviceReceiveMessageSemaphore?.Dispose();
         }
 
         internal bool IsE2EDiagnosticSupportedProtocol()

--- a/iothub/device/src/Message.cs
+++ b/iothub/device/src/Message.cs
@@ -10,8 +10,6 @@ using System.Collections.Generic;
 
 namespace Microsoft.Azure.Devices.Client
 {
-    using DateTimeT = System.DateTime;
-
     /// <summary>
     /// The data structure represent the message that is used for interacting with IotHub.
     /// </summary>
@@ -85,9 +83,12 @@ namespace Microsoft.Azure.Devices.Client
         /// + {'-', ':', '/', '\', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '$', '''}.
         /// Non-alphanumeric characters are from URN RFC.
         /// </summary>
+        /// <remarks>
+        /// If this value is not supplied by the user, the device client will set this to a new GUID.
+        /// </remarks>
         public string MessageId
         {
-            get => GetSystemProperty<string>(MessageSystemPropertyNames.MessageId);
+            get => GetSystemProperty<string>(MessageSystemPropertyNames.MessageId) ?? Guid.NewGuid().ToString();
             set => SystemProperties[MessageSystemPropertyNames.MessageId] = value;
         }
 
@@ -103,9 +104,9 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// [Optional] The time when this message is considered expired
         /// </summary>
-        public DateTimeT ExpiryTimeUtc
+        public DateTime ExpiryTimeUtc
         {
-            get => GetSystemProperty<DateTimeT>(MessageSystemPropertyNames.ExpiryTimeUtc);
+            get => GetSystemProperty<DateTime>(MessageSystemPropertyNames.ExpiryTimeUtc);
             internal set => SystemProperties[MessageSystemPropertyNames.ExpiryTimeUtc] = value;
         }
 
@@ -153,11 +154,11 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Time when the message was received by the server
+        /// Date and time when the device-to-cloud message was received by the server.
         /// </summary>
-        public DateTimeT EnqueuedTimeUtc
+        public DateTime EnqueuedTimeUtc
         {
-            get => GetSystemProperty<DateTimeT>(MessageSystemPropertyNames.EnqueuedTime);
+            get => GetSystemProperty<DateTime>(MessageSystemPropertyNames.EnqueuedTime);
             internal set => SystemProperties[MessageSystemPropertyNames.EnqueuedTime] = value;
         }
 
@@ -198,9 +199,9 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Custom date property set by the originator of the message.
         /// </summary>
-        public DateTimeT CreationTimeUtc
+        public DateTime CreationTimeUtc
         {
-            get => GetSystemProperty<DateTimeT>(MessageSystemPropertyNames.CreationTimeUtc);
+            get => GetSystemProperty<DateTime>(MessageSystemPropertyNames.CreationTimeUtc);
             set => SystemProperties[MessageSystemPropertyNames.CreationTimeUtc] = value;
         }
 

--- a/iothub/device/src/Transport/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Transport/DefaultDelegatingHandler.cs
@@ -98,6 +98,18 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return InnerHandler.ReceiveAsync(timeoutHelper);
         }
 
+        public virtual Task EnableReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            return InnerHandler.EnableReceiveMessageAsync(cancellationToken);
+        }
+
+        public virtual Task DisableReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            return InnerHandler.DisableReceiveMessageAsync(cancellationToken);
+        }
+
         public virtual Task CompleteAsync(string lockToken, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();

--- a/iothub/device/src/Transport/ErrorDelegatingHandler.cs
+++ b/iothub/device/src/Transport/ErrorDelegatingHandler.cs
@@ -59,6 +59,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return ExecuteWithErrorHandlingAsync(() => base.ReceiveAsync(timeoutHelper));
         }
 
+        public override Task EnableReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            return ExecuteWithErrorHandlingAsync(() => base.EnableReceiveMessageAsync(cancellationToken));
+        }
+
+        public override Task DisableReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            return ExecuteWithErrorHandlingAsync(() => base.DisableReceiveMessageAsync(cancellationToken));
+        }
+
         public override Task EnableMethodsAsync(CancellationToken cancellationToken)
         {
             return ExecuteWithErrorHandlingAsync(() => base.EnableMethodsAsync(cancellationToken));

--- a/iothub/device/src/Transport/HttpTransportHandler.cs
+++ b/iothub/device/src/Transport/HttpTransportHandler.cs
@@ -317,6 +317,22 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
+        public override Task EnableReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new NotSupportedException("HTTP protocol does not support setting callbacks for receiving messages." +
+                " You can either call DeviceClient.ReceiveAsync() to wait and receive messages," +
+                " or set the callback over MQTT or AMQP.");
+        }
+
+        public override Task DisableReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new NotSupportedException("HTTP protocol does not support setting callbacks for receiving messages." +
+                " You can either call DeviceClient.ReceiveAsync() to wait and receive messages," +
+                " or set the callback over MQTT or AMQP.");
+        }
+
         public override Task CompleteAsync(string lockToken, CancellationToken cancellationToken)
         {
             IDictionary<string, string> customHeaders = PrepareCustomHeaders(
@@ -372,6 +388,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 cancellationToken);
         }
 
+        // This is for invoking methods from an edge module to another edge device or edge module.
         internal Task<MethodInvokeResponse> InvokeMethodAsync(MethodInvokeRequest methodInvokeRequest, Uri uri, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(_moduleId))

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -603,7 +603,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         {
             if (Logging.IsEnabled)
             {
-                Logging.Enter(this, context.Name, packetPassed, nameof(SubscribeAsync));
+                Logging.Enter(this, context.Name, packetPassed, packetPassed?.Requests?[0].TopicFilter, nameof(SubscribeAsync));
             }
 
             string topicFilter;
@@ -638,7 +638,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             if (Logging.IsEnabled)
             {
-                Logging.Exit(this, context.Name, packetPassed, nameof(SubscribeAsync));
+                Logging.Exit(this, context.Name, packetPassed, packetPassed?.Requests?[0].TopicFilter, nameof(SubscribeAsync));
             }
         }
 

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -393,7 +393,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, disconnectToken);
 
-            // -1 millisecond represents for SemaphoreSlim to wait indefinitely until either of the linked cancellation tokens have been cancelled.
+            // -1 millisecond represents for SemaphoreSlim to wait indefinitely until either of the linked cancellation tokens have been canceled.
             return await _receivingSemaphore.WaitAsync(TimeSpan.FromMilliseconds(-1), linkedCts.Token).ConfigureAwait(true);
         }
 

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -1,6 +1,22 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Net.Security;
+using System.Net.WebSockets;
+using System.Runtime.ExceptionServices;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
 using DotNetty.Buffers;
 using DotNetty.Codecs.Mqtt;
 using DotNetty.Codecs.Mqtt.Packets;
@@ -15,23 +31,6 @@ using Microsoft.Azure.Devices.Client.Extensions;
 using Microsoft.Azure.Devices.Client.TransientFaultHandling;
 using Microsoft.Azure.Devices.Shared;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Net.Security;
-using System.Net.WebSockets;
-using System.Runtime.ExceptionServices;
-using System.Security.Authentication;
-using System.Security.Cryptography.X509Certificates;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Web;
 
 //using TransportType = Microsoft.Azure.Devices.Client.TransportType;
 
@@ -61,6 +60,9 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         private readonly SemaphoreSlim _receivingSemaphore = new SemaphoreSlim(0);
         private readonly ConcurrentQueue<Message> _messageQueue;
+
+        private readonly SemaphoreSlim _deviceReceiveMessageSemaphore = new SemaphoreSlim(1, 1);
+        private bool _deviceReceiveMessageCallbackSet = false;
 
         private readonly TaskCompletionSource _connectCompletion = new TaskCompletionSource();
         private readonly TaskCompletionSource _subscribeCompletionSource = new TaskCompletionSource();
@@ -112,9 +114,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         private static readonly TimeSpan s_defaultTwinTimeout = TimeSpan.FromSeconds(60);
         private readonly Regex _twinResponseTopicRegex = new Regex(TwinResponseTopicPattern, RegexOptions.Compiled, s_regexTimeoutMilliseconds);
 
-        private readonly Func<MethodRequestInternal, Task> _messageListener;
+        private readonly Func<MethodRequestInternal, Task> _methodListener;
         private readonly Action<TwinCollection> _onDesiredStatePatchListener;
-        private readonly Func<string, Message, Task> _messageReceivedListener;
+        private readonly Func<string, Message, Task> _moduleMessageReceivedListener;
+        private readonly Func<Message, Task> _deviceMessageReceivedListener;
         private Action<Message> _twinResponseEvent;
 
         private readonly string _receiveEventMessageFilter;
@@ -129,11 +132,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             MqttTransportSettings settings,
             Func<MethodRequestInternal, Task> onMethodCallback = null,
             Action<TwinCollection> onDesiredStatePatchReceivedCallback = null,
-            Func<string, Message, Task> onReceiveCallback = null)
+            Func<string, Message, Task> onModuleMessageReceivedCallback = null,
+            Func<Message, Task> onDeviceMessageReceivedCallback = null)
             : this(context, iotHubConnectionString, settings, null)
         {
-            _messageListener = onMethodCallback;
-            _messageReceivedListener = onReceiveCallback;
+            _methodListener = onMethodCallback;
+            _deviceMessageReceivedListener = onDeviceMessageReceivedCallback;
+            _moduleMessageReceivedListener = onModuleMessageReceivedCallback;
             _onDesiredStatePatchListener = onDesiredStatePatchReceivedCallback;
         }
 
@@ -209,7 +214,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 EnsureValidState(throwIfNotOpen: false);
 
-                await OpenAsyncInternal(cancellationToken).ConfigureAwait(true);
+                await OpenAsyncInternalAsync(cancellationToken).ConfigureAwait(true);
             }
             finally
             {
@@ -256,77 +261,135 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         public override async Task<Message> ReceiveAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            Message message = null;
-
-            EnsureValidState();
-
-            if (State != TransportState.Receiving)
+            if (_deviceReceiveMessageCallbackSet)
             {
-                await SubscribeCloudToDeviceMessagesAsync().ConfigureAwait(true);
+                if (Logging.IsEnabled)
+                {
+                    Logging.Error(this, "Callback handler set for receiving c2d messages, ReceiveAsync() will now always return null", nameof(ReceiveAsync));
+                }
+                return null;
             }
+            else
+            {
+                try
+                {
+                    if (Logging.IsEnabled)
+                    {
+                        Logging.Enter(this, cancellationToken, $"Cancellation requested for ReceiveAsync(): {cancellationToken.IsCancellationRequested}",
+                            $"{nameof(ReceiveAsync)}");
+                    }
 
-            // -1 millisecond represents for SemaphoreSlim to wait indefinitely
-            bool hasMessage = await ReceiveMessageArrivalAsync(TimeSpan.FromMilliseconds(-1), cancellationToken).ConfigureAwait(true);
-            message = ProcessMessage(message, hasMessage);
+                    cancellationToken.ThrowIfCancellationRequested();
 
-            return message;
+                    Message message = null;
+                    EnsureValidState();
+
+                    if (State != TransportState.Receiving)
+                    {
+                        await SubscribeCloudToDeviceMessagesAsync().ConfigureAwait(true);
+                    }
+
+                    // -1 millisecond represents for SemaphoreSlim to wait indefinitely
+                    bool hasMessage = await ReceiveMessageArrivalAsync(TimeSpan.FromMilliseconds(-1), cancellationToken).ConfigureAwait(true);
+                    message = ProcessMessage(message, hasMessage);
+
+                    return message;
+                }
+                finally
+                {
+                    if (Logging.IsEnabled)
+                    {
+                        Logging.Exit(this, cancellationToken, $"Cancellation requested for ReceiveAsync(): {cancellationToken.IsCancellationRequested}",
+                            $"{nameof(ReceiveAsync)}");
+                    }
+                }
+            }
         }
 
         public override async Task<Message> ReceiveAsync(TimeoutHelper timeoutHelper)
         {
-            if (Logging.IsEnabled)
+            if (_deviceReceiveMessageCallbackSet)
             {
-                Logging.Enter(this, timeoutHelper, timeoutHelper.GetRemainingTime(), $"{nameof(ReceiveAsync)}");
+                if (Logging.IsEnabled)
+                {
+                    Logging.Error(this, "Callback handler set for receiving c2d messages, ReceiveAsync() will now always return null", nameof(ReceiveAsync));
+                }
+                return null;
             }
-
-            Message message = null;
-
-            EnsureValidState();
-
-            if (State != TransportState.Receiving)
+            else
             {
-                await SubscribeCloudToDeviceMessagesAsync().ConfigureAwait(true);
+                try
+                {
+                    if (Logging.IsEnabled)
+                    {
+                        Logging.Enter(this, timeoutHelper, $"Time remaining for ReceiveAsync(): {timeoutHelper.GetRemainingTime()}", $"{nameof(ReceiveAsync)}");
+                    }
+
+                    Message message = null;
+
+                    EnsureValidState();
+
+                    if (State != TransportState.Receiving)
+                    {
+                        await SubscribeCloudToDeviceMessagesAsync().ConfigureAwait(true);
+                    }
+
+                    TimeSpan timeout = timeoutHelper.GetRemainingTime();
+                    using var cts = new CancellationTokenSource(timeout);
+                    bool hasMessage = await ReceiveMessageArrivalAsync(timeout, cts.Token).ConfigureAwait(true);
+                    message = ProcessMessage(message, hasMessage);
+
+                    return message;
+                }
+                finally
+                {
+                    if (Logging.IsEnabled)
+                    {
+                        Logging.Exit(this, timeoutHelper, $"Time remaining for ReceiveAsync(): {timeoutHelper.GetRemainingTime()}", $"{nameof(ReceiveAsync)}");
+                    }
+                }
             }
-
-            TimeSpan timeout = timeoutHelper.GetRemainingTime();
-            using var cts = new CancellationTokenSource(timeout);
-            bool hasMessage = await ReceiveMessageArrivalAsync(timeout, cts.Token).ConfigureAwait(true);
-            message = ProcessMessage(message, hasMessage);
-
-            if (Logging.IsEnabled)
-            {
-                Logging.Exit(this, timeoutHelper, timeoutHelper.GetRemainingTime(), $"{nameof(ReceiveAsync)}");
-            }
-
-            return message;
         }
 
         private Message ProcessMessage(Message message, bool hasMessage)
         {
-            if (hasMessage)
+            try
             {
-                lock (_syncRoot)
+                if (Logging.IsEnabled)
                 {
-                    _messageQueue.TryDequeue(out message);
-                    message.LockToken = message.LockToken;
-                    if (_qos == QualityOfService.AtLeastOnce)
-                    {
-                        _completionQueue.Enqueue(message.LockToken);
-                    }
+                    Logging.Enter(this, message, $"hasMessage={hasMessage}", nameof(ProcessMessage));
+                }
 
-                    message.LockToken = _generationId + message.LockToken;
+                if (hasMessage)
+                {
+                    lock (_syncRoot)
+                    {
+                        _messageQueue.TryDequeue(out message);
+                        message.LockToken = message.LockToken;
+                        if (_qos == QualityOfService.AtLeastOnce)
+                        {
+                            _completionQueue.Enqueue(message.LockToken);
+                        }
+
+                        message.LockToken = _generationId + message.LockToken;
+                    }
+                }
+
+                return message;
+            }
+            finally
+            {
+                if (Logging.IsEnabled)
+                {
+                    Logging.Exit(this, message, $"hasMessage={hasMessage}", nameof(ProcessMessage));
                 }
             }
-
-            return message;
         }
 
         private async Task<bool> ReceiveMessageArrivalAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var disconnectToken = _disconnectAwaitersCancellationSource.Token;
+            CancellationToken disconnectToken = _disconnectAwaitersCancellationSource.Token;
             EnsureValidState();
 
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, disconnectToken);
@@ -453,7 +516,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
         }
 
-        private async Task HandleIncomingTwinPatch(Message message)
+        private async Task HandleIncomingTwinPatchAsync(Message message)
         {
             try
             {
@@ -461,7 +524,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 {
                     using var reader = new StreamReader(message.GetBodyStream(), System.Text.Encoding.UTF8);
                     string patch = reader.ReadToEnd();
-                    var props = JsonConvert.DeserializeObject<TwinCollection>(patch);
+                    TwinCollection props = JsonConvert.DeserializeObject<TwinCollection>(patch);
                     await Task.Run(() => _onDesiredStatePatchListener(props)).ConfigureAwait(true);
                 }
             }
@@ -471,14 +534,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
         }
 
-        private async Task HandleIncomingMethodPost(Message message)
+        private async Task HandleIncomingMethodPostAsync(Message message)
         {
             try
             {
                 string[] tokens = Regex.Split(message.MqttTopicName, "/", RegexOptions.Compiled, s_regexTimeoutMilliseconds);
 
                 using var mr = new MethodRequestInternal(tokens[3], tokens[4].Substring(6), message.GetBodyStream(), CancellationToken.None);
-                await Task.Run(() => _messageListener(mr)).ConfigureAwait(true);
+                await Task.Run(() => _methodListener(mr)).ConfigureAwait(true);
             }
             finally
             {
@@ -486,8 +549,36 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
         }
 
+        private async Task HandleIncomingMessagesAsync(Message message)
+        {
+            if (Logging.IsEnabled)
+            {
+                Logging.Enter(this, message, "Process c2d message via callback", nameof(HandleIncomingMessagesAsync));
+            }
+
+            try
+            {
+                using Message receivedMessage = ProcessMessage(message, true);
+                await (_deviceMessageReceivedListener?.Invoke(message) ?? TaskHelpers.CompletedTask).ConfigureAwait(false);
+            }
+            finally
+            {
+                message.Dispose();
+            }
+
+            if (Logging.IsEnabled)
+            {
+                Logging.Exit(this, message, "Process c2d message via callback", nameof(HandleIncomingMessagesAsync));
+            }
+        }
+
         public async void OnMessageReceived(Message message)
         {
+            if (Logging.IsEnabled)
+            {
+                Logging.Enter(this, message, nameof(OnMessageReceived));
+            }
+
             // Added Try-Catch to avoid unknown thread exception
             // after running for more than 24 hours
             try
@@ -495,32 +586,44 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 if ((State & TransportState.Open) == TransportState.Open)
                 {
                     string topic = message.MqttTopicName;
+                    if (Logging.IsEnabled)
+                    {
+                        Logging.Info(this, $"Received a message on topic: {topic}", nameof(OnMessageReceived));
+                    }
+
                     if (topic.StartsWith(TwinResponseTopicPrefix, StringComparison.OrdinalIgnoreCase))
                     {
                         _twinResponseEvent(message);
                     }
                     else if (topic.StartsWith(TwinPatchTopicPrefix, StringComparison.OrdinalIgnoreCase))
                     {
-                        await HandleIncomingTwinPatch(message).ConfigureAwait(true);
+                        await HandleIncomingTwinPatchAsync(message).ConfigureAwait(true);
                     }
                     else if (topic.StartsWith(MethodPostTopicPrefix, StringComparison.OrdinalIgnoreCase))
                     {
-                        await HandleIncomingMethodPost(message).ConfigureAwait(true);
+                        await HandleIncomingMethodPostAsync(message).ConfigureAwait(true);
                     }
                     else if (topic.StartsWith(_receiveEventMessagePrefix, StringComparison.OrdinalIgnoreCase))
                     {
-                        await HandleIncomingEventMessage(message).ConfigureAwait(true);
+                        await HandleIncomingEventMessageAsync(message).ConfigureAwait(true);
                     }
                     else if (topic.StartsWith(_deviceboundMessagePrefix, StringComparison.OrdinalIgnoreCase))
                     {
                         _messageQueue.Enqueue(message);
-                        _receivingSemaphore.Release();
+                        if (_deviceReceiveMessageCallbackSet)
+                        {
+                            await HandleIncomingMessagesAsync(message).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            _receivingSemaphore.Release();
+                        }
                     }
                     else
                     {
                         if (Logging.IsEnabled)
                         {
-                            Logging.Error(this, "Recevied mqtt message on an unrecognized topic, ignoring message. Topic: " + topic);
+                            Logging.Error(this, "Received mqtt message on an unrecognized topic, ignoring message. Topic: " + topic);
                         }
                     }
                 }
@@ -529,9 +632,16 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             {
                 OnError(ex);
             }
+            finally
+            {
+                if (Logging.IsEnabled)
+                {
+                    Logging.Exit(this, message, nameof(OnMessageReceived));
+                }
+            }
         }
 
-        private async Task HandleIncomingEventMessage(Message message)
+        private async Task HandleIncomingEventMessageAsync(Message message)
         {
             try
             {
@@ -551,7 +661,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     }
                 }
                 message.LockToken = _generationId + message.LockToken;
-                await (_messageReceivedListener?.Invoke(inputName, message) ?? TaskHelpers.CompletedTask).ConfigureAwait(true);
+                await (_moduleMessageReceivedListener?.Invoke(inputName, message) ?? TaskHelpers.CompletedTask).ConfigureAwait(true);
             }
             finally
             {
@@ -561,6 +671,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         public async void OnError(Exception exception)
         {
+            if (Logging.IsEnabled)
+            {
+                Logging.Enter(this, exception, nameof(OnError));
+            }
+
             try
             {
                 TransportState previousState = MoveToStateIfPossible(TransportState.Error, TransportState.Closed);
@@ -604,6 +719,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     Logging.Error(this, ex.ToString(), nameof(OnError));
                 }
             }
+            finally
+            {
+                if (Logging.IsEnabled)
+                {
+                    Logging.Exit(this, exception, nameof(OnError));
+                }
+            }
         }
 
         private TransportState MoveToStateIfPossible(TransportState destination, TransportState illegalStates)
@@ -627,7 +749,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         #endregion MQTT callbacks
 
-        private async Task OpenAsyncInternal(CancellationToken cancellationToken)
+        private async Task OpenAsyncInternalAsync(CancellationToken cancellationToken)
         {
             if (IsProxyConfigured())
             {
@@ -734,6 +856,78 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         private async Task SubscribeTwinResponsesAsync()
         {
             await _channel.WriteAsync(new SubscribePacket(0, new SubscriptionRequest(TwinResponseTopicFilter, QualityOfService.AtMostOnce))).ConfigureAwait(true);
+        }
+
+        public override async Task EnableReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            if (Logging.IsEnabled)
+            {
+                Logging.Enter(this, cancellationToken, nameof(EnableReceiveMessageAsync));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureValidState();
+
+            try
+            {
+                // Wait to grab the semaphore, and then enable c2d message subscription and set _deviceReceiveMessageCallbackSet to true.
+                // Once _deviceReceiveMessageCallbackSet is set to true, all received c2d messages will be returned on the callback,
+                // and not via the polling ReceiveAsync() call.
+                await _deviceReceiveMessageSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                if (State != TransportState.Receiving)
+                {
+                    await SubscribeCloudToDeviceMessagesAsync().ConfigureAwait(false);
+                }
+                _deviceReceiveMessageCallbackSet = true;
+            }
+            finally
+            {
+                _deviceReceiveMessageSemaphore.Release();
+                if (Logging.IsEnabled)
+                {
+                    Logging.Exit(this, cancellationToken, nameof(EnableReceiveMessageAsync));
+                }
+            }
+        }
+
+        public override async Task DisableReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            if (Logging.IsEnabled)
+            {
+                Logging.Enter(this, cancellationToken, nameof(DisableReceiveMessageAsync));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureValidState();
+
+            try
+            {
+                // Wait to grab the semaphore, and then unsubscriobe from c2d messages and set _deviceReceiveMessageCallbackSet to true.
+                // Once _deviceReceiveMessageCallbackSet is set to true, all received c2d messages will be returned on the callback,
+                // and not via the polling ReceiveAsync() call.
+                await _deviceReceiveMessageSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                // The TransportState is transitioned to Receiving only if the device is subscribed to _deviceboundMessageFilter.
+                // Only if the subscription has been previously set, we will send the unsubscribe packet.
+                if (State == TransportState.Receiving)
+                {
+                    // Update the TransportState from Receiving to Open.
+                    if (TryStateTransition(TransportState.Receiving, TransportState.Open))
+                    {
+                        await _channel.WriteAsync(new UnsubscribePacket(0, _deviceboundMessageFilter)).ConfigureAwait(true);
+                    }
+                }
+                _deviceReceiveMessageCallbackSet = false;
+            }
+            finally
+            {
+                _deviceReceiveMessageSemaphore.Release();
+                if (Logging.IsEnabled)
+                {
+                    Logging.Exit(this, cancellationToken, nameof(DisableReceiveMessageAsync));
+                }
+            }
         }
 
         public override async Task EnableMethodsAsync(CancellationToken cancellationToken)
@@ -931,7 +1125,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             EnsureValidState();
 
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_025:  `SendTwinPatchAsync` shall serialize the `reported` object into a JSON string
-            var body = JsonConvert.SerializeObject(reportedProperties);
+            string body = JsonConvert.SerializeObject(reportedProperties);
             var bodyStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(body));
 
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_022:  `SendTwinPatchAsync` shall allocate a `Message` object to hold the update request
@@ -1032,16 +1226,12 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                         //same as above, we will handle DotNetty.Transport.Channels.ConnectException
                         if (Logging.IsEnabled)
                         {
-                            Logging.Error(this, $"ConnectException trying to connect to {address.ToString()}: {ex.ToString()}", nameof(CreateChannelFactory));
+                            Logging.Error(this, $"ConnectException trying to connect to {address}: {ex}", nameof(CreateChannelFactory));
                         }
                     }
                 }
 
-                if (channel == null)
-                {
-                    throw new IotHubCommunicationException("MQTT channel open failed.");
-                }
-                return channel;
+                return channel ?? throw new IotHubCommunicationException("MQTT channel open failed.");
             };
         }
 
@@ -1143,12 +1333,9 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         private Task CleanupAsync()
         {
-            if (_cleanupFunc != null)
-            {
-                return _cleanupFunc();
-            }
-
-            return TaskHelpers.CompletedTask;
+            return _cleanupFunc != null
+                ? _cleanupFunc()
+                : TaskHelpers.CompletedTask;
         }
 
         private bool TryStateTransition(TransportState fromState, TransportState toState)

--- a/iothub/device/src/Transport/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Transport/RetryDelegatingHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         private RetryPolicy _internalRetryPolicy;
 
-        private readonly SemaphoreSlim _handlerLock = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _handlerSemaphore = new SemaphoreSlim(1, 1);
         private bool _openCalled;
         private bool _opened;
         private bool _methodsEnabled;
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
 
                             // Wait to acquire the _handlerLock. This ensures that concurrently invoked API calls are invoked in a thread-safe manner.
-                            await _handlerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                            await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
                             {
                                 // The telemetry downlink needs to be enabled only for the first time that the callback is set.
@@ -254,7 +254,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerLock.Release();
+                                _handlerSemaphore.Release();
                             }
                         },
                         cancellationToken)
@@ -286,7 +286,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
 
                             // Wait to acquire the _handlerLock. This ensures that concurrently invoked API calls are invoked in a thread-safe manner.
-                            await _handlerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                            await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
                             {
                                 // Ensure that a callback for receiving messages has been previously set.
@@ -296,7 +296,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerLock.Release();
+                                _handlerSemaphore.Release();
                             }
                         },
                         cancellationToken)
@@ -326,7 +326,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         {
                             await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
 
-                            await _handlerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                            await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
                             {
                                 Debug.Assert(!_methodsEnabled);
@@ -335,7 +335,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerLock.Release();
+                                _handlerSemaphore.Release();
                             }
                         },
                         cancellationToken)
@@ -364,7 +364,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         async () =>
                         {
                             await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
-                            await _handlerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                            await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
                             {
                                 Debug.Assert(_methodsEnabled);
@@ -373,7 +373,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerLock.Release();
+                                _handlerSemaphore.Release();
                             }
                         },
                         cancellationToken)
@@ -402,7 +402,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         async () =>
                         {
                             await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
-                            await _handlerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                            await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
                             {
                                 await base.EnableEventReceiveAsync(cancellationToken).ConfigureAwait(false);
@@ -411,7 +411,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerLock.Release();
+                                _handlerSemaphore.Release();
                             }
                         },
                         cancellationToken)
@@ -440,7 +440,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         async () =>
                         {
                             await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
-                            await _handlerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                            await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
                             {
                                 Debug.Assert(_eventsEnabled);
@@ -449,7 +449,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerLock.Release();
+                                _handlerSemaphore.Release();
                             }
                         },
                         cancellationToken)
@@ -478,7 +478,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         async () =>
                         {
                             await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
-                            await _handlerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                            await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
                             {
                                 Debug.Assert(!_twinEnabled);
@@ -487,7 +487,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerLock.Release();
+                                _handlerSemaphore.Release();
                             }
                         },
                         cancellationToken)
@@ -649,7 +649,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task CloseAsync(CancellationToken cancellationToken)
         {
-            await _handlerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 if (!_openCalled)
@@ -673,7 +673,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     Logging.Exit(this, cancellationToken, nameof(CloseAsync));
                 }
 
-                _handlerLock.Release();
+                _handlerSemaphore.Release();
             }
         }
 
@@ -687,7 +687,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 return;
             }
 
-            await _handlerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 if (!_opened)
@@ -720,7 +720,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
             finally
             {
-                _handlerLock.Release();
+                _handlerSemaphore.Release();
             }
         }
 
@@ -731,7 +731,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 return;
             }
 
-            bool gain = await _handlerLock.WaitAsync(timeoutHelper.GetRemainingTime()).ConfigureAwait(false);
+            bool gain = await _handlerSemaphore.WaitAsync(timeoutHelper.GetRemainingTime()).ConfigureAwait(false);
             if (!gain)
             {
                 throw new TimeoutException("Timed out to acquire handler lock.");
@@ -769,7 +769,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
             finally
             {
-                _handlerLock.Release();
+                _handlerSemaphore.Release();
             }
         }
 
@@ -875,7 +875,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 Logging.Info(this, "Transport disconnected: unexpected.", nameof(HandleDisconnectAsync));
             }
 
-            await _handlerLock.WaitAsync().ConfigureAwait(false);
+            await _handlerSemaphore.WaitAsync().ConfigureAwait(false);
             _opened = false;
 
             try
@@ -965,7 +965,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
             finally
             {
-                _handlerLock.Release();
+                _handlerSemaphore.Release();
             }
         }
 

--- a/iothub/device/src/Transport/TransportHandlerFactory.cs
+++ b/iothub/device/src/Transport/TransportHandlerFactory.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
             IotHubConnectionString connectionString = context.Get<IotHubConnectionString>();
             InternalClient.OnMethodCalledDelegate onMethodCallback = context.Get<InternalClient.OnMethodCalledDelegate>();
             Action<TwinCollection> onDesiredStatePatchReceived = context.Get<Action<TwinCollection>>();
-            InternalClient.OnReceiveEventMessageCalledDelegate onReceiveCallback = context.Get<InternalClient.OnReceiveEventMessageCalledDelegate>();
+            InternalClient.OnModuleEventMessageReceivedDelegate onModuleEventReceivedCallback = context.Get<InternalClient.OnModuleEventMessageReceivedDelegate>();
+            InternalClient.OnDeviceMessageReceivedDelegate onDeviceMessageReceivedCallback = context.Get<InternalClient.OnDeviceMessageReceivedDelegate>();
 
             switch (transportSetting.GetTransportType())
             {
@@ -32,7 +33,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         transportSetting as AmqpTransportSettings,
                         new Func<MethodRequestInternal, Task>(onMethodCallback),
                         onDesiredStatePatchReceived,
-                        new Func<string, Message, Task>(onReceiveCallback));
+                        new Func<string, Message, Task>(onModuleEventReceivedCallback));
 
                 case TransportType.Http1:
                     return new HttpTransportHandler(context, connectionString, transportSetting as Http1TransportSettings);
@@ -45,7 +46,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         transportSetting as MqttTransportSettings,
                         new Func<MethodRequestInternal, Task>(onMethodCallback),
                         onDesiredStatePatchReceived,
-                        new Func<string, Message, Task>(onReceiveCallback));
+                        new Func<string, Message, Task>(onModuleEventReceivedCallback),
+                        new Func<Message, Task>(onDeviceMessageReceivedCallback));
 
                 default:
                     throw new InvalidOperationException("Unsupported Transport Setting {0}".FormatInvariant(transportSetting));

--- a/iothub/device/tests/HttpTransportHandlerTests.cs
+++ b/iothub/device/tests/HttpTransportHandlerTests.cs
@@ -7,11 +7,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Azure.Devices.Client.Test.Transport
 {
     using System.Collections.Generic;
-    using System.Net.Sockets;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Devices.Client.Transport;
+    using FluentAssertions;
     using Microsoft.Azure.Devices.Client.Test.ConnectionString;
+    using Microsoft.Azure.Devices.Client.Transport;
 
     [TestClass]
     [TestCategory("Unit")]
@@ -55,12 +55,46 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
             await TestOperationCanceledByToken(token => CreateFromConnectionString().RejectAsync(Guid.NewGuid().ToString(), token)).ConfigureAwait(false);
         }
 
+        [TestMethod]
+        public void HttpTransportHandler_EnableReceiveMessageAsync_ThrowsNotSupportedException()
+        {
+            // arrange
+            using var tokenSource = new CancellationTokenSource();
+            HttpTransportHandler mockTransport = CreateFromConnectionString();
+
+            // act
+            Func<Task> act = async () =>
+            {
+                await mockTransport.EnableReceiveMessageAsync(tokenSource.Token).ConfigureAwait(false);
+            };
+
+            // assert
+            act.Should().Throw<NotSupportedException>();
+        }
+
+        [TestMethod]
+        public void HttpTransportHandler_DisableReceiveMessageAsync_ThrowsNotSupportedException()
+        {
+            // arrange
+            using var tokenSource = new CancellationTokenSource();
+            HttpTransportHandler mockTransport = CreateFromConnectionString();
+
+            // act
+            Func<Task> act = async () =>
+            {
+                await mockTransport.DisableReceiveMessageAsync(tokenSource.Token).ConfigureAwait(false);
+            };
+
+            // assert
+            act.Should().Throw<NotSupportedException>();
+        }
+
         HttpTransportHandler CreateFromConnectionString()
         {
             return new HttpTransportHandler(new PipelineContext(), IotHubConnectionStringExtensions.Parse(DumpyConnectionString), new Http1TransportSettings());
         }
 
-        async Task TestOperationCanceledByToken(Func<CancellationToken, Task> asyncMethod)
+        private async Task TestOperationCanceledByToken(Func<CancellationToken, Task> asyncMethod)
         {
             using var tokenSource = new CancellationTokenSource();
             tokenSource.Cancel();

--- a/iothub/device/tests/MessageTests.cs
+++ b/iothub/device/tests/MessageTests.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Devices.Client.Test
     using System;
     using System.IO;
     using System.Text;
-
+    using FluentAssertions;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -222,6 +222,26 @@ namespace Microsoft.Azure.Devices.Client.Test
                     Assert.IsFalse(clone.SystemProperties.Keys.Contains(MessageSystemPropertyNames.UserId));
                 }
             }
+        }
+
+        [TestMethod]
+        public void MessageShouldAlwaysSetMessageIdByDefault()
+        {
+            using var message = new Message(Encoding.UTF8.GetBytes("test message"));
+            message.MessageId.Should().NotBeNullOrEmpty();
+        }
+
+        [TestMethod]
+        public void MessageShouldAllowMessageIdToBeUserSettable()
+        {
+            string messageId = Guid.NewGuid().ToString();
+            using var message = new Message(Encoding.UTF8.GetBytes("test message"))
+            {
+                MessageId = messageId,
+            };
+
+            message.MessageId.Should().NotBeNullOrEmpty();
+            message.MessageId.Should().Be(messageId, "MessageId should have the value set by user.");
         }
     }
 }

--- a/iothub/device/tests/ModuleClientTests.cs
+++ b/iothub/device/tests/ModuleClientTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.Devices.Client.Test
                     "custom data")
                 .ConfigureAwait(false);
 
-            await moduleClient.InternalClient.OnReceiveEventMessageCalledAsync(null, null).ConfigureAwait(false);
+            await moduleClient.InternalClient.OnModuleEventMessageReceivedAsync(null, null).ConfigureAwait(false);
             Assert.IsFalse(isMessageHandlerCalled);
         }
 
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.Devices.Client.Test
                 LockToken = "AnyLockToken",
             };
 
-            await moduleClient.InternalClient.OnReceiveEventMessageCalledAsync("endpoint1", testMessage).ConfigureAwait(false);
+            await moduleClient.InternalClient.OnModuleEventMessageReceivedAsync("endpoint1", testMessage).ConfigureAwait(false);
             Assert.IsTrue(isDefaultCallbackCalled);
             Assert.IsFalse(isSpecificCallbackCalled);
         }
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.Devices.Client.Test
                 LockToken = "AnyLockToken",
             };
 
-            await moduleClient.InternalClient.OnReceiveEventMessageCalledAsync("endpoint2", testMessage).ConfigureAwait(false);
+            await moduleClient.InternalClient.OnModuleEventMessageReceivedAsync("endpoint2", testMessage).ConfigureAwait(false);
             Assert.IsFalse(isDefaultCallbackCalled);
             Assert.IsTrue(isSpecificCallbackCalled);
         }

--- a/iothub/device/tests/MqttTransportHandlerTests.cs
+++ b/iothub/device/tests/MqttTransportHandlerTests.cs
@@ -644,15 +644,22 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
             await mockTransport.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             // act
-            Func<Task> act = async () =>
+            // The receivingSemaphore.WaitAsync(TimeSpan, CancellationToken) have the same timespan for both the timeout and the cancellation token.
+            // Based on some internal thread management, this call could either throw an OperationCancelledException, or cleanly fail to acquire the semaphore.
+            // Both of these scenarios should complete within the timeout specified.
+            try
             {
                 sw.Start();
-                await mockTransport.ReceiveAsync(timeout).ConfigureAwait(false);
-            };
+                Message receivedMessage = await mockTransport.ReceiveAsync(timeout).ConfigureAwait(false);
+                sw.Stop();
 
-            // assert
-            act.Should().Throw<OperationCanceledException>();
-            sw.Stop();
+                // assert
+                receivedMessage.Should().BeNull();
+            }
+            catch(OperationCanceledException)
+            {
+                sw.Stop();
+            }
 
             sw.Elapsed.Should().BeLessOrEqualTo(timeSpan + ReceiveTimeoutBuffer, "ReceiveAsync should throw within the timeout specified.");
         }

--- a/iothub/device/tests/MqttTransportHandlerTests.cs
+++ b/iothub/device/tests/MqttTransportHandlerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -10,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DotNetty.Codecs.Mqtt.Packets;
 using DotNetty.Transport.Channels;
+using FluentAssertions;
 using Microsoft.Azure.Devices.Client.Exceptions;
 using Microsoft.Azure.Devices.Client.Test.ConnectionString;
 using Microsoft.Azure.Devices.Client.Transport.Mqtt;
@@ -34,6 +36,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
         private const int statusSuccess = 200;
         private const int statusFailure = 400;
         private const string fakeResponseId = "fakeResponseId";
+        private static readonly TimeSpan ReceiveTimeoutBuffer = TimeSpan.FromSeconds(5);
         private delegate bool MessageMatcher(Message msg);
 
         [TestMethod]
@@ -551,6 +554,54 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
             Assert.IsTrue(t.IsCompleted);
         }
 
+        [TestMethod]
+        public async Task MqttTransportHandler_ReceiveAsync_ThrowsWithSmallTimeout()
+        {
+            await TestReceiveOperationThrowsBasedOnTimeout(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task MqttTransportHandler_ReceiveAsync_ThrowsWithBigTimeout()
+        {
+            await TestReceiveOperationThrowsBasedOnTimeout(TimeSpan.FromSeconds(20)).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task MqttTransportHandler_EnableReceiveMessageAsync_SubscribesSuccessfully()
+        {
+            // arrange
+            string expectedTopicFilter = "devices/FakeDevice/messages/devicebound/#";
+            var transport = CreateTransportHandlerWithMockChannel(out IChannel channel, DummyModuleConnectionString);
+
+            // act
+            await transport.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+            await transport.EnableReceiveMessageAsync(CancellationToken.None).ConfigureAwait(false);
+
+            // assert
+            await channel
+                .Received()
+                .WriteAsync(Arg.Is<SubscribePacket>(msg => msg.Requests[0].TopicFilter.Equals(expectedTopicFilter))).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task MqttTransportHandler_DisableReceiveMessageAsync_UnsubscribesSuccessfully()
+        {
+            // arrange
+            IChannel channel;
+            string expectedTopicFilter = "devices/FakeDevice/messages/devicebound/#";
+            var transport = CreateTransportHandlerWithMockChannel(out channel);
+
+            // act
+            await transport.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+            await transport.EnableReceiveMessageAsync(CancellationToken.None).ConfigureAwait(false);
+            await transport.DisableReceiveMessageAsync(CancellationToken.None).ConfigureAwait(false);
+
+            // assert
+            await channel
+                .Received()
+                .WriteAsync(Arg.Is<UnsubscribePacket>(msg => System.Linq.Enumerable.ElementAt(msg.TopicFilters, 0).Equals(expectedTopicFilter))).ConfigureAwait(false);
+        }
+
         private string GetResponseTopic(string requestTopic, int status)
         {
             var index = requestTopic.IndexOf("=");
@@ -578,6 +629,32 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
                 Assert.Fail("Operation did not throw expected exception.");
             }
             catch (OperationCanceledException) { }
+        }
+
+        private async Task TestReceiveOperationThrowsBasedOnTimeout(TimeSpan timeSpan)
+        {
+            // arrange
+            var sw = new Stopwatch();
+            var timeout = new TimeoutHelper(timeSpan);
+            string expectedTopicFilter = "devices/FakeDevice/messages/devicebound/#";
+            var mockTransport = CreateTransportHandlerWithMockChannel(out IChannel channel);
+            channel
+                .WriteAsync(Arg.Is<SubscribePacket>(msg => msg.Requests[0].TopicFilter.Equals(expectedTopicFilter)))
+                .Returns(x => { return TaskHelpers.CompletedTask; });
+            await mockTransport.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+
+            // act
+            Func<Task> act = async () =>
+            {
+                sw.Start();
+                await mockTransport.ReceiveAsync(timeout).ConfigureAwait(false);
+            };
+
+            // assert
+            act.Should().Throw<OperationCanceledException>();
+            sw.Stop();
+
+            sw.Elapsed.Should().BeLessOrEqualTo(timeSpan + ReceiveTimeoutBuffer, "ReceiveAsync should throw within the timeout specified.");
         }
 
         private MqttTransportHandler CreateTransportHandlerWithMockChannel(out IChannel channel, string connectionString = DummyConnectionString)

--- a/iothub/service/src/Message.cs
+++ b/iothub/service/src/Message.cs
@@ -1,40 +1,40 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+
+using Microsoft.Azure.Devices.Common;
+using Microsoft.Azure.Devices.Common.Exceptions;
+using Microsoft.Azure.Amqp;
+
 namespace Microsoft.Azure.Devices
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
-    using System.IO;
-    using System.Threading;
-
-    using Microsoft.Azure.Devices.Common;
-    using Microsoft.Azure.Devices.Common.Exceptions;
-    using Microsoft.Azure.Amqp;
-
     /// <summary>
     /// The data structure represent the message that is used for interacting with IotHub.
     /// </summary>
     public sealed class Message : IDisposable, IReadOnlyIndicator
     {
-        private readonly object messageLock = new object();
-        private volatile Stream bodyStream;
-        private AmqpMessage serializedAmqpMessage;
-        private bool disposed;
-        private bool ownsBodyStream;
-        private int getBodyCalled;
-        private long sizeInBytesCalled;
+        private readonly object _messageLock = new object();
+        private volatile Stream _bodyStream;
+        private AmqpMessage _serializedAmqpMessage;
+        private bool _disposed;
+        private bool _ownsBodyStream;
+        private int _getBodyCalled;
+        private long _sizeInBytesCalled;
 
         /// <summary>
         /// Default constructor with no body data
         /// </summary>
         public Message()
         {
-            this.Properties = new ReadOnlyDictionary45<string, string>(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), this);
-            this.SystemProperties = new ReadOnlyDictionary45<string, object>(new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase), this);
-            this.InitializeWithStream(Stream.Null, true);
-            this.serializedAmqpMessage = null;
+            Properties = new ReadOnlyDictionary45<string, string>(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), this);
+            SystemProperties = new ReadOnlyDictionary45<string, object>(new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase), this);
+            InitializeWithStream(Stream.Null, true);
+            _serializedAmqpMessage = null;
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Devices
         {
             if (stream != null)
             {
-                this.InitializeWithStream(stream, false);
+                InitializeWithStream(stream, false);
             }
         }
 
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Devices
             : this(new MemoryStream(byteArray))
         {
             // reset the owning of the steams
-            this.ownsBodyStream = true;
+            _ownsBodyStream = true;
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Devices
 
             MessageConverter.UpdateMessageHeaderAndProperties(amqpMessage, this);
             Stream stream = amqpMessage.BodyStream;
-            this.InitializeWithStream(stream, true);
+            InitializeWithStream(stream, true);
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices
         internal Message(Stream stream, bool ownStream)
             : this(stream)
         {
-            this.ownsBodyStream = ownStream;
+            _ownsBodyStream = ownStream;
         }
 
         /// <summary>
@@ -101,17 +101,13 @@ namespace Microsoft.Azure.Devices
         /// + {'-', ':', '/', '\', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '$', '''}.
         /// Non-alphanumeric characters are from URN RFC.
         /// </summary>
+        /// <remarks>
+        /// If this value is not supplied by the user, the service client will set this to a new GUID.
+        /// </remarks>
         public string MessageId
         {
-            get
-            {
-                return this.GetSystemProperty<string>(MessageSystemPropertyNames.MessageId);
-            }
-
-            set
-            {
-                this.SystemProperties[MessageSystemPropertyNames.MessageId] = value;
-            }
+            get => GetSystemProperty<string>(MessageSystemPropertyNames.MessageId) ?? Guid.NewGuid().ToString();
+            set => SystemProperties[MessageSystemPropertyNames.MessageId] = value;
         }
 
         /// <summary>
@@ -119,15 +115,8 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         public string To
         {
-            get
-            {
-                return this.GetSystemProperty<string>(MessageSystemPropertyNames.To);
-            }
-
-            set
-            {
-                this.SystemProperties[MessageSystemPropertyNames.To] = value;
-            }
+            get => GetSystemProperty<string>(MessageSystemPropertyNames.To);
+            set => SystemProperties[MessageSystemPropertyNames.To] = value;
         }
 
         /// <summary>
@@ -135,93 +124,64 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         public DateTime ExpiryTimeUtc
         {
-            get
-            {
-                return this.GetSystemProperty<DateTime>(MessageSystemPropertyNames.ExpiryTimeUtc);
-            }
-
-            set
-            {
-                this.SystemProperties[MessageSystemPropertyNames.ExpiryTimeUtc] = value;
-            }
+            get => GetSystemProperty<DateTime>(MessageSystemPropertyNames.ExpiryTimeUtc);
+            set => SystemProperties[MessageSystemPropertyNames.ExpiryTimeUtc] = value;
         }
 
         /// <summary>
-        /// Used in message responses and feedback
+        /// A string property in a response message that typically contains the MessageId of the request, in request-reply patterns.
         /// </summary>
+        /// <remarks>
+        /// If this value is not supplied by the user, the service client will set this to <see cref="MessageId"/>.
+        /// </remarks>
         public string CorrelationId
         {
-            get
-            {
-                return this.GetSystemProperty<string>(MessageSystemPropertyNames.CorrelationId);
-            }
-
-            set
-            {
-                this.SystemProperties[MessageSystemPropertyNames.CorrelationId] = value;
-            }
+            get => GetSystemProperty<string>(MessageSystemPropertyNames.CorrelationId) ?? MessageId;
+            set => SystemProperties[MessageSystemPropertyNames.CorrelationId] = value;
         }
 
         /// <summary>
-        /// Indicates whether consumption or expiration of the message should post data to the feedback queue
+        /// Used in cloud-to-device messages to request IoT Hub to generate feedback messages as a result of the consumption of the message by the device.
         /// </summary>
+        /// <remarks>
+        /// Possible values:
+        /// <para>none (default): no feedback message is generated.</para>
+        /// <para>positive: receive a feedback message if the message was completed.</para>
+        /// <para>negative: receive a feedback message if the message expired (or maximum delivery count was reached) without being completed by the device.</para>
+        /// <para>full: both positive and negative.</para>
+        /// </remarks>
         [SuppressMessage("Microsoft.Design", "CA1065:DoNotRaiseExceptionsInUnexpectedLocations", Justification = "This should never happen. If it does, the client should crash.")]
         public DeliveryAcknowledgement Ack
         {
             get
             {
-                string deliveryAckAsString = this.GetSystemProperty<string>(MessageSystemPropertyNames.Ack);
+                string deliveryAckAsString = GetSystemProperty<string>(MessageSystemPropertyNames.Ack);
 
                 if (!string.IsNullOrWhiteSpace(deliveryAckAsString))
                 {
-                    switch (deliveryAckAsString)
+                    return deliveryAckAsString switch
                     {
-                        case "none":
-                            return DeliveryAcknowledgement.None;
-
-                        case "positive":
-                            return DeliveryAcknowledgement.PositiveOnly;
-
-                        case "negative":
-                            return DeliveryAcknowledgement.NegativeOnly;
-
-                        case "full":
-                            return DeliveryAcknowledgement.Full;
-
-                        default:
-                            throw new IotHubException("Invalid Delivery Ack mode");
-                    }
+                        "none" => DeliveryAcknowledgement.None,
+                        "positive" => DeliveryAcknowledgement.PositiveOnly,
+                        "negative" => DeliveryAcknowledgement.NegativeOnly,
+                        "full" => DeliveryAcknowledgement.Full,
+                        _ => throw new IotHubException("Invalid Delivery Ack mode"),
+                    };
                 }
 
                 return DeliveryAcknowledgement.None;
             }
             set
             {
-                string valueToSet;
-
-                switch (value)
+                string valueToSet = value switch
                 {
-                    case DeliveryAcknowledgement.None:
-                        valueToSet = "none";
-                        break;
-
-                    case DeliveryAcknowledgement.PositiveOnly:
-                        valueToSet = "positive";
-                        break;
-
-                    case DeliveryAcknowledgement.NegativeOnly:
-                        valueToSet = "negative";
-                        break;
-
-                    case DeliveryAcknowledgement.Full:
-                        valueToSet = "full";
-                        break;
-
-                    default:
-                        throw new IotHubException("Invalid Delivery Ack mode");
-                }
-
-                this.SystemProperties[MessageSystemPropertyNames.Ack] = valueToSet;
+                    DeliveryAcknowledgement.None => "none",
+                    DeliveryAcknowledgement.PositiveOnly => "positive",
+                    DeliveryAcknowledgement.NegativeOnly => "negative",
+                    DeliveryAcknowledgement.Full => "full",
+                    _ => throw new IotHubException("Invalid Delivery Ack mode"),
+                };
+                SystemProperties[MessageSystemPropertyNames.Ack] = valueToSet;
             }
         }
 
@@ -230,15 +190,8 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         internal ulong SequenceNumber
         {
-            get
-            {
-                return this.GetSystemProperty<ulong>(MessageSystemPropertyNames.SequenceNumber);
-            }
-
-            set
-            {
-                this.SystemProperties[MessageSystemPropertyNames.SequenceNumber] = value;
-            }
+            get => GetSystemProperty<ulong>(MessageSystemPropertyNames.SequenceNumber);
+            set => SystemProperties[MessageSystemPropertyNames.SequenceNumber] = value;
         }
 
         /// <summary>
@@ -246,15 +199,8 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         public string LockToken
         {
-            get
-            {
-                return this.GetSystemProperty<string>(MessageSystemPropertyNames.LockToken);
-            }
-
-            internal set
-            {
-                this.SystemProperties[MessageSystemPropertyNames.LockToken] = value;
-            }
+            get => GetSystemProperty<string>(MessageSystemPropertyNames.LockToken);
+            set => SystemProperties[MessageSystemPropertyNames.LockToken] = value;
         }
 
         /// <summary>
@@ -262,15 +208,8 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         internal DateTime EnqueuedTimeUtc
         {
-            get
-            {
-                return this.GetSystemProperty<DateTime>(MessageSystemPropertyNames.EnqueuedTime);
-            }
-
-            set
-            {
-                this.SystemProperties[MessageSystemPropertyNames.EnqueuedTime] = value;
-            }
+            get => GetSystemProperty<DateTime>(MessageSystemPropertyNames.EnqueuedTime);
+            set => SystemProperties[MessageSystemPropertyNames.EnqueuedTime] = value;
         }
 
         /// <summary>
@@ -278,15 +217,8 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         internal uint DeliveryCount
         {
-            get
-            {
-                return this.GetSystemProperty<byte>(MessageSystemPropertyNames.DeliveryCount);
-            }
-
-            set
-            {
-                this.SystemProperties[MessageSystemPropertyNames.DeliveryCount] = (byte)value;
-            }
+            get => GetSystemProperty<byte>(MessageSystemPropertyNames.DeliveryCount);
+            set => SystemProperties[MessageSystemPropertyNames.DeliveryCount] = (byte)value;
         }
 
         /// <summary>
@@ -295,15 +227,8 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         public string UserId
         {
-            get
-            {
-                return this.GetSystemProperty<string>(MessageSystemPropertyNames.UserId);
-            }
-
-            set
-            {
-                this.SystemProperties[MessageSystemPropertyNames.UserId] = value;
-            }
+            get => GetSystemProperty<string>(MessageSystemPropertyNames.UserId);
+            set => SystemProperties[MessageSystemPropertyNames.UserId] = value;
         }
 
         /// <summary>
@@ -311,15 +236,8 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         public string MessageSchema
         {
-            get
-            {
-                return this.GetSystemProperty<string>(MessageSystemPropertyNames.MessageSchema);
-            }
-
-            set
-            {
-                this.SystemProperties[MessageSystemPropertyNames.MessageSchema] = value;
-            }
+            get => GetSystemProperty<string>(MessageSystemPropertyNames.MessageSchema);
+            set => SystemProperties[MessageSystemPropertyNames.MessageSchema] = value;
         }
 
         /// <summary>
@@ -327,15 +245,8 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         public DateTime CreationTimeUtc
         {
-            get
-            {
-                return this.GetSystemProperty<DateTime>(MessageSystemPropertyNames.CreationTimeUtc);
-            }
-
-            set
-            {
-                this.SystemProperties[MessageSystemPropertyNames.CreationTimeUtc] = value;
-            }
+            get => GetSystemProperty<DateTime>(MessageSystemPropertyNames.CreationTimeUtc);
+            set => SystemProperties[MessageSystemPropertyNames.CreationTimeUtc] = value;
         }
 
         /// <summary>
@@ -343,15 +254,8 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         public string ContentType
         {
-            get
-            {
-                return this.GetSystemProperty<string>(MessageSystemPropertyNames.ContentType);
-            }
-
-            set
-            {
-                this.SystemProperties[MessageSystemPropertyNames.ContentType] = value;
-            }
+            get => GetSystemProperty<string>(MessageSystemPropertyNames.ContentType);
+            set => SystemProperties[MessageSystemPropertyNames.ContentType] = value;
         }
 
         /// <summary>
@@ -359,15 +263,8 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         public string ContentEncoding
         {
-            get
-            {
-                return this.GetSystemProperty<string>(MessageSystemPropertyNames.ContentEncoding);
-            }
-
-            set
-            {
-                this.SystemProperties[MessageSystemPropertyNames.ContentEncoding] = value;
-            }
+            get => GetSystemProperty<string>(MessageSystemPropertyNames.ContentEncoding);
+            set => SystemProperties[MessageSystemPropertyNames.ContentEncoding] = value;
         }
 
         /// <summary>
@@ -380,29 +277,17 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         internal IDictionary<string, object> SystemProperties { get; private set; }
 
-        bool IReadOnlyIndicator.IsReadOnly
-        {
-            get
-            {
-                return Interlocked.Read(ref this.sizeInBytesCalled) == 1;
-            }
-        }
+        bool IReadOnlyIndicator.IsReadOnly => Interlocked.Read(ref _sizeInBytesCalled) == 1;
 
-        internal Stream BodyStream
-        {
-            get
-            {
-                return this.bodyStream;
-            }
-        }
+        internal Stream BodyStream => _bodyStream;
 
         internal AmqpMessage SerializedAmqpMessage
         {
             get
             {
-                lock (this.messageLock)
+                lock (_messageLock)
                 {
-                    return this.serializedAmqpMessage;
+                    return _serializedAmqpMessage;
                 }
             }
         }
@@ -419,23 +304,23 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ObjectDisposedException">throws if the event data has already been disposed.</exception>
         public Message Clone()
         {
-            this.ThrowIfDisposed();
-            if (this.serializedAmqpMessage != null)
+            ThrowIfDisposed();
+            if (_serializedAmqpMessage != null)
             {
-                return new Message(this.serializedAmqpMessage);
+                return new Message(_serializedAmqpMessage);
             }
 
             var message = new Message();
-            if (this.bodyStream != null)
+            if (_bodyStream != null)
             {
                 // The new Message always owns the cloned stream.
-                message = new Message(CloneStream(this.bodyStream))
+                message = new Message(CloneStream(_bodyStream))
                 {
-                    ownsBodyStream = true
+                    _ownsBodyStream = true
                 };
             }
 
-            foreach (KeyValuePair<string, object> systemProperty in this.SystemProperties)
+            foreach (KeyValuePair<string, object> systemProperty in SystemProperties)
             {
                 // MessageId would already be there.
                 if (message.SystemProperties.ContainsKey(systemProperty.Key))
@@ -448,7 +333,7 @@ namespace Microsoft.Azure.Devices
                 }
             }
 
-            foreach (KeyValuePair<string, string> property in this.Properties)
+            foreach (KeyValuePair<string, string> property in Properties)
             {
                 message.Properties.Add(property);
             }
@@ -461,7 +346,7 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         public void Dispose()
         {
-            this.Dispose(true);
+            Dispose(true);
         }
 
         /// <summary>
@@ -473,14 +358,9 @@ namespace Microsoft.Azure.Devices
         /// <remarks>This method can only be called once and afterwards method will throw <see cref="InvalidOperationException"/>.</remarks>
         public Stream GetBodyStream()
         {
-            this.ThrowIfDisposed();
-            this.SetGetBodyCalled();
-            if (this.bodyStream != null)
-            {
-                return this.bodyStream;
-            }
-
-            return Stream.Null;
+            ThrowIfDisposed();
+            SetGetBodyCalled();
+            return _bodyStream ?? Stream.Null;
         }
 
         /// <summary>
@@ -491,15 +371,18 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ObjectDisposedException">throws if the event data has already been disposed.</exception>
         public byte[] GetBytes()
         {
-            this.ThrowIfDisposed();
-            this.SetGetBodyCalled();
-            if (this.bodyStream == null)
+            ThrowIfDisposed();
+            SetGetBodyCalled();
+            if (_bodyStream == null)
             {
+#if NET451
                 return new byte[] { };
+#else
+                return Array.Empty<byte>();
+#endif
             }
 
-            BufferListStream listStream;
-            if ((listStream = this.bodyStream as BufferListStream) != null)
+            if (_bodyStream is BufferListStream listStream)
             {
                 // We can trust Amqp bufferListStream.Length;
                 var bytes = new byte[listStream.Length];
@@ -508,17 +391,17 @@ namespace Microsoft.Azure.Devices
             }
 
             // This is just fail safe code in case we are not using the Amqp protocol.
-            return ReadFullStream(this.bodyStream);
+            return ReadFullStream(_bodyStream);
         }
 
         internal AmqpMessage ToAmqpMessage(bool setBodyCalled = true)
         {
-            this.ThrowIfDisposed();
-            if (this.serializedAmqpMessage == null)
+            ThrowIfDisposed();
+            if (_serializedAmqpMessage == null)
             {
-                lock (this.messageLock)
+                lock (_messageLock)
                 {
-                    if (this.serializedAmqpMessage == null)
+                    if (_serializedAmqpMessage == null)
                     {
                         // Interlocked exchange two variable does allow for a small period
                         // where one is set while the other is not. Not sure if it is worth
@@ -527,34 +410,34 @@ namespace Microsoft.Azure.Devices
                         // readonly because the amqpMessage has been serialized.
                         if (setBodyCalled)
                         {
-                            this.SetGetBodyCalled();
+                            SetGetBodyCalled();
                         }
 
-                        this.SetSizeInBytesCalled();
-                        this.serializedAmqpMessage = this.bodyStream == null
+                        SetSizeInBytesCalled();
+                        _serializedAmqpMessage = _bodyStream == null
                             ? AmqpMessage.Create()
-                            : AmqpMessage.Create(this.bodyStream, false);
-                        this.serializedAmqpMessage = this.PopulateAmqpMessageForSend(this.serializedAmqpMessage);
+                            : AmqpMessage.Create(_bodyStream, false);
+                        _serializedAmqpMessage = PopulateAmqpMessageForSend(_serializedAmqpMessage);
                     }
                 }
             }
 
-            return this.serializedAmqpMessage;
+            return _serializedAmqpMessage;
         }
 
         // Test hook only
         internal void ResetGetBodyCalled()
         {
-            Interlocked.Exchange(ref this.getBodyCalled, 0);
-            if (this.bodyStream != null && this.bodyStream.CanSeek)
+            Interlocked.Exchange(ref _getBodyCalled, 0);
+            if (_bodyStream != null && _bodyStream.CanSeek)
             {
-                this.bodyStream.Seek(0, SeekOrigin.Begin);
+                _bodyStream.Seek(0, SeekOrigin.Begin);
             }
         }
 
         private void SetGetBodyCalled()
         {
-            if (1 == Interlocked.Exchange(ref this.getBodyCalled, 1))
+            if (1 == Interlocked.Exchange(ref _getBodyCalled, 1))
             {
                 throw Fx.Exception.AsError(new InvalidOperationException(ApiResources.MessageBodyConsumed));
             }
@@ -562,41 +445,35 @@ namespace Microsoft.Azure.Devices
 
         private void SetSizeInBytesCalled()
         {
-            Interlocked.Exchange(ref this.sizeInBytesCalled, 1);
+            Interlocked.Exchange(ref _sizeInBytesCalled, 1);
         }
 
         private void InitializeWithStream(Stream stream, bool ownsStream)
         {
             // This method should only be used in constructor because
             // this has no locking on the bodyStream.
-            this.bodyStream = stream;
-            this.ownsBodyStream = ownsStream;
+            _bodyStream = stream;
+            _ownsBodyStream = ownsStream;
         }
 
         private static byte[] ReadFullStream(Stream inputStream)
         {
-            using (var ms = new MemoryStream())
-            {
-                inputStream.CopyTo(ms);
-                return ms.ToArray();
-            }
+            using var ms = new MemoryStream();
+            inputStream.CopyTo(ms);
+            return ms.ToArray();
         }
 
         private static Stream CloneStream(Stream originalStream)
         {
             if (originalStream != null)
             {
-                MemoryStream memoryStream;
-
-                ICloneable cloneable;
-
-                if ((memoryStream = originalStream as MemoryStream) != null)
+                if (originalStream is MemoryStream memoryStream)
                 {
                     // Note: memoryStream.GetBuffer() doesn't work
                     return new MemoryStream(memoryStream.ToArray(), 0, (int)memoryStream.Length, false, true);
                 }
 
-                if ((cloneable = originalStream as ICloneable) != null)
+                if (originalStream is ICloneable cloneable)
                 {
                     return (Stream)cloneable.Clone();
                 }
@@ -620,17 +497,14 @@ namespace Microsoft.Azure.Devices
 
         private T GetSystemProperty<T>(string key)
         {
-            if (this.SystemProperties.ContainsKey(key))
-            {
-                return (T)this.SystemProperties[key];
-            }
-
-            return default(T);
+            return SystemProperties.ContainsKey(key)
+                ? (T)SystemProperties[key]
+                : default;
         }
 
         private void ThrowIfDisposed()
         {
-            if (this.disposed)
+            if (_disposed)
             {
                 throw Fx.Exception.ObjectDisposed(ApiResources.MessageDisposed);
             }
@@ -638,27 +512,27 @@ namespace Microsoft.Azure.Devices
 
         private void Dispose(bool disposing)
         {
-            if (!this.disposed)
+            if (!_disposed)
             {
                 if (disposing)
                 {
-                    if (this.serializedAmqpMessage != null)
+                    if (_serializedAmqpMessage != null)
                     {
                         // in the receive scenario, this.bodyStream is a reference
                         // to serializedAmqpMessage.BodyStream, and we assume disposing
                         // the amqpMessage will dispose the body stream so we don't
                         // need to dispose bodyStream twice.
-                        this.serializedAmqpMessage.Dispose();
-                        this.bodyStream = null;
+                        _serializedAmqpMessage.Dispose();
+                        _bodyStream = null;
                     }
-                    else if (this.bodyStream != null && this.ownsBodyStream)
+                    else if (_bodyStream != null && _ownsBodyStream)
                     {
-                        this.bodyStream.Dispose();
-                        this.bodyStream = null;
+                        _bodyStream.Dispose();
+                        _bodyStream = null;
                     }
                 }
 
-                this.disposed = true;
+                _disposed = true;
             }
         }
     }

--- a/iothub/service/tests/MessageTests.cs
+++ b/iothub/service/tests/MessageTests.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
-
+using FluentAssertions;
 using Microsoft.Azure.Devices;
 using Microsoft.Azure.Devices.Common;
 using Microsoft.Azure.Devices.Common.Exceptions;
@@ -147,6 +147,55 @@ namespace Microsoft.Azure.Devices.Api.Test
             message.Headers.Add(CommonConstants.IotHubErrorCode, ErrorCode.BulkRegistryOperationFailure.ToString());
             bool isMappedToException = HttpClientHelper.IsMappedToException(message);
             Assert.IsFalse(isMappedToException, "BulkRegistryOperationFailures should not be mapped to exceptions");
+        }
+
+        [TestMethod]
+        public void MessageShouldAlwaysSetMessageIdByDefault()
+        {
+            using var message = new Message(Encoding.UTF8.GetBytes("test message"));
+            message.MessageId.Should().NotBeNullOrEmpty();
+        }
+
+        [TestMethod]
+        public void MessageShouldAllowMessageIdToBeUserSettable()
+        {
+            string messageId = Guid.NewGuid().ToString();
+            using var message = new Message(Encoding.UTF8.GetBytes("test message"))
+            {
+                MessageId = messageId,
+            };
+
+            message.MessageId.Should().NotBeNullOrEmpty();
+            message.MessageId.Should().Be(messageId, "MessageId should have the value set by user.");
+        }
+
+        [TestMethod]
+        public void MessageShouldSetMessageIdToCorrelationIdByDefault()
+        {
+            string messageId = Guid.NewGuid().ToString();
+            using var message = new Message(Encoding.UTF8.GetBytes("test message"))
+            {
+                MessageId = messageId,
+            };
+
+            message.CorrelationId.Should().NotBeNullOrEmpty();
+            message.CorrelationId.Should().Be(messageId, "Default value of correlation Id should be the MessageId.");
+        }
+
+        [TestMethod]
+        public void MessageShouldAllowCorrelationIdToBeUserSettable()
+        {
+            string messageId = Guid.NewGuid().ToString();
+            string correlationId = Guid.NewGuid().ToString();
+            using var message = new Message(Encoding.UTF8.GetBytes("test message"))
+            {
+                MessageId = messageId,
+                CorrelationId = correlationId,
+            };
+
+            message.CorrelationId.Should().NotBeNullOrEmpty();
+            message.CorrelationId.Should().NotBe(messageId, "CorrelationId should have the value set by user.");
+            message.CorrelationId.Should().Be(correlationId, "CorrelationId should have the value set by user.");
         }
     }
 }


### PR DESCRIPTION
Currently we can receive C2D messages on a device client only by calling `ReceiveAsync()` and waiting on the Task.
This PR adds another API using which you can set a callback to be triggered whenever the device receives C2D  messages.

This PR adds the implementation for MQTT, the implementation for AMQP will follow in the next PR.

Issue: #1289 

```csharp
public Task SetReceiveMessageHandlerAsync(ReceiveMessageCallback messageHandler, object userContext, CancellationToken cancellationToken = default(CancellationToken));
public delegate Task ReceiveMessageCallback(Message message, object userContext);
```

Behavior over different transport protocols:
- Http -
 ```csharp
throw new NotSupportedException("HTTP protocol does not support setting callbacks for receiving messages." +
                " You can either call DeviceClient.ReceiveAsync() to wait and receive messages," +
                " or set the callback over MQTT or AMQP.");
```
- Mqtt - 
    - enable callback - subscribe to `devices/{device_id}/messages/devicebound/#` as a Topic Filter.
    - disable callback - unsubscribe from `devices/{device_id}/messages/devicebound/#` topic.
    - once callback is enabled, `public Task<Message> ReceiveAsync();` will not work anymore 
        - it will always return null.
        - we will log the following statement:
```csharp
Logging.Error(this, "Callback handler set for receiving c2d messages, ReceiveAsync() will now always return null", nameof(ReceiveAsync));
```
   - returning `null` instead of throwing an exception will make writing application code easier for our users, else they will need to keep track of their transport protocol used (http only supports `ReceiveAsync()`), and also the latest state (whether they are polling, or have subscribed to a callback). The drawback is that they will need to maintain the processing code for received messages in 2 places.