### PR TITLE
Add logs to AmqpServiceClient

### DIFF
--- a/common/src/Logging.Common.cs
+++ b/common/src/Logging.Common.cs
@@ -62,10 +62,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Enter(object thisOrContextObject, FormattableString formattableString = null, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(formattableString);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(formattableString);
+
                 Log.Enter(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
             }
         }
@@ -79,10 +80,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Enter(object thisOrContextObject, object arg0, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(arg0);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(arg0);
+
                 Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)})");
             }
         }
@@ -95,11 +97,12 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Enter(object thisOrContextObject, object arg0, object arg1, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(arg0);
-            DebugValidateArg(arg1);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(arg0);
+                DebugValidateArg(arg1);
+
                 Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)})");
             }
         }
@@ -113,12 +116,13 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Enter(object thisOrContextObject, object arg0, object arg1, object arg2, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(arg0);
-            DebugValidateArg(arg1);
-            DebugValidateArg(arg2);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(arg0);
+                DebugValidateArg(arg1);
+                DebugValidateArg(arg2);
+
                 Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)}, {Format(arg2)})");
             }
         }
@@ -140,10 +144,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Exit(object thisOrContextObject, FormattableString formattableString = null, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(formattableString);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(formattableString);
+
                 Log.Exit(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
             }
         }
@@ -157,10 +162,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Exit(object thisOrContextObject, object arg0, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(arg0);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(arg0);
+
                 Log.Exit(IdOf(thisOrContextObject), memberName, Format(arg0).ToString());
             }
         }
@@ -173,11 +179,12 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Exit(object thisOrContextObject, object arg0, object arg1, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(arg0);
-            DebugValidateArg(arg1);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(arg0);
+                DebugValidateArg(arg1);
+
                 Log.Exit(IdOf(thisOrContextObject), memberName, $"{Format(arg0)}, {Format(arg1)}");
             }
         }
@@ -191,12 +198,13 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Exit(object thisOrContextObject, object arg0, object arg1, object arg2, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(arg0);
-            DebugValidateArg(arg1);
-            DebugValidateArg(arg2);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(arg0);
+                DebugValidateArg(arg1);
+                DebugValidateArg(arg2);
+
                 Log.Exit(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)}, {Format(arg2)})");
             }
         }
@@ -218,10 +226,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Info(object thisOrContextObject, FormattableString formattableString = null, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(formattableString);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(formattableString);
+
                 Log.Info(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
             }
         }
@@ -235,10 +244,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Info(object thisOrContextObject, object message, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(message);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(message);
+
                 Log.Info(IdOf(thisOrContextObject), memberName, Format(message).ToString());
             }
         }
@@ -260,10 +270,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Error(object thisOrContextObject, FormattableString formattableString, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(formattableString);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(formattableString);
+
                 Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
             }
         }
@@ -277,10 +288,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Error(object thisOrContextObject, object message, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(message);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(message);
+
                 Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
             }
         }
@@ -420,10 +432,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Associate(object first, object second, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(first);
-            DebugValidateArg(second);
             if (IsEnabled)
             {
+                DebugValidateArg(first);
+                DebugValidateArg(second);
+
                 Log.Associate(IdOf(first), memberName, IdOf(first), IdOf(second));
             }
         }
@@ -436,11 +449,12 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Associate(object thisOrContextObject, object first, object second, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(first);
-            DebugValidateArg(second);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(first);
+                DebugValidateArg(second);
+
                 Log.Associate(IdOf(thisOrContextObject), memberName, IdOf(first), IdOf(second));
             }
         }

--- a/iothub/device/src/Message.cs
+++ b/iothub/device/src/Message.cs
@@ -33,6 +33,9 @@ namespace Microsoft.Azure.Devices.Client
             Properties = new ReadOnlyDictionary45<string, string>(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), this);
             SystemProperties = new ReadOnlyDictionary45<string, object>(new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase), this);
             InitializeWithStream(Stream.Null, true);
+
+            // Set the default value for MessageId.
+            SystemProperties[MessageSystemPropertyNames.MessageId] = Guid.NewGuid().ToString();
         }
 
         /// <summary>
@@ -88,7 +91,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </remarks>
         public string MessageId
         {
-            get => GetSystemProperty<string>(MessageSystemPropertyNames.MessageId) ?? Guid.NewGuid().ToString();
+            get => GetSystemProperty<string>(MessageSystemPropertyNames.MessageId);
             set => SystemProperties[MessageSystemPropertyNames.MessageId] = value;
         }
 

--- a/iothub/device/src/Message.cs
+++ b/iothub/device/src/Message.cs
@@ -28,24 +28,29 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Default constructor with no body data
         /// </summary>
-        public Message()
+        /// <param name="setDefaultMessageId">A flag indicating if the MessageId should be set to a random GUID.</param>
+        public Message(bool setDefaultMessageId = false)
         {
             Properties = new ReadOnlyDictionary45<string, string>(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), this);
             SystemProperties = new ReadOnlyDictionary45<string, object>(new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase), this);
             InitializeWithStream(Stream.Null, true);
 
-            // Set the default value for MessageId.
-            SystemProperties[MessageSystemPropertyNames.MessageId] = Guid.NewGuid().ToString();
+            if (setDefaultMessageId)
+            {
+                // Set the default value for MessageId.
+                SystemProperties[MessageSystemPropertyNames.MessageId] = Guid.NewGuid().ToString();
+            }
         }
 
         /// <summary>
         /// Constructor which uses the argument stream as the body stream.
         /// </summary>
-        /// <param name="stream">a stream which will be used as body stream.</param>
         /// <remarks>User is expected to own the disposing of the stream when using this constructor.</remarks>
+        /// <param name="stream">A stream which will be used as body stream.</param>
+        /// <param name="setDefaultMessageId">A flag indicating if the MessageId should be set to a random GUID.</param>
         // UWP cannot expose a method with System.IO.Stream in signature. TODO: consider adding an IRandomAccessStream overload
-        public Message(Stream stream)
-            : this()
+        public Message(Stream stream, bool setDefaultMessageId = false)
+            : this(setDefaultMessageId)
         {
             if (stream != null)
             {
@@ -54,17 +59,15 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Constructor which uses the input byte array as the body
+        /// Constructor which uses the input byte array as the body.
         /// </summary>
-        /// <param name="byteArray">a byte array which will be used to
-        /// form the body stream</param>
-        /// <remarks>user should treat the input byte array as immutable when
-        /// sending the message.</remarks>
-        public Message(
-            byte[] byteArray)
-            : this(new MemoryStream(byteArray))
+        /// <remarks>User should treat the input byte array as immutable when sending the message.</remarks>
+        /// <param name="byteArray">A byte array which will be used to form the body stream.</param>
+        /// <param name="setDefaultMessageId">A flag indicating if the MessageId should be set to a random GUID.</param>
+        public Message(byte[] byteArray, bool setDefaultMessageId = false)
+            : this(new MemoryStream(byteArray), setDefaultMessageId)
         {
-            // reset the owning of the steams
+            // reset the owning of the streams
             _ownsBodyStream = true;
         }
 
@@ -72,10 +75,11 @@ namespace Microsoft.Azure.Devices.Client
         /// This constructor is only used on the Gateway http path so that
         /// we can clean up the stream.
         /// </summary>
-        /// <param name="stream"></param>
-        /// <param name="ownStream"></param>
-        internal Message(Stream stream, bool ownStream)
-            : this(stream)
+        /// <param name="stream">A stream which will be used as body stream.</param>
+        /// <param name="ownStream">A flag indicating that the client library will dispose the stream when the Message is disposed.</param>
+        /// <param name="setDefaultMessageId">A flag indicating if the MessageId should be set to a random GUID.</param>
+        internal Message(Stream stream, bool ownStream, bool setDefaultMessageId = false)
+            : this(stream, setDefaultMessageId)
         {
             _ownsBodyStream = ownStream;
         }
@@ -86,9 +90,6 @@ namespace Microsoft.Azure.Devices.Client
         /// + {'-', ':', '/', '\', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '$', '''}.
         /// Non-alphanumeric characters are from URN RFC.
         /// </summary>
-        /// <remarks>
-        /// If this value is not supplied by the user, the device client will set this to a new GUID.
-        /// </remarks>
         public string MessageId
         {
             get => GetSystemProperty<string>(MessageSystemPropertyNames.MessageId);
@@ -343,12 +344,14 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Clones an existing <see cref="Message"/> instance and sets content body defined by <paramref name="byteArray"/> on it.
         /// </summary>
+        /// <remarks>
+        /// The cloned message has the message <see cref="MessageId" /> as the original message.
+        /// User should treat the input byte array as immutable when sending the message.
+        /// </remarks>
         /// <param name="byteArray">Message content to be set after clone.</param>
         /// <returns>A new instance of <see cref="Message"/> with body content defined by <paramref name="byteArray"/>,
         /// and user/system properties of the cloned <see cref="Message"/> instance.
         /// </returns>
-        /// <remarks>user should treat the input byte array as immutable when
-        /// sending the message.</remarks>
         public Message CloneWithBody(in byte[] byteArray)
         {
             var result = new Message(byteArray);

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTMessageConverter.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTMessageConverter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 throw Fx.Exception.ArgumentNull(nameof(AmqpMessage));
             }
             Stream stream = amqpMessage.BodyStream;
-            Message message = new Message(stream, ownStream: true);
+            Message message = new Message(stream, StreamDisposalOwnership.Library);
             UpdateMessageHeaderAndProperties(amqpMessage, message);
             return message;
         }

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTMessageConverter.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTMessageConverter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 throw Fx.Exception.ArgumentNull(nameof(AmqpMessage));
             }
             Stream stream = amqpMessage.BodyStream;
-            Message message = new Message(stream, true);
+            Message message = new Message(stream, ownStream: true);
             UpdateMessageHeaderAndProperties(amqpMessage, message);
             return message;
         }

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -782,7 +782,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             {
                 var bodyStream = new ReadOnlyByteBufferStream(publish.Payload, true);
 
-                message = new Message(bodyStream, true);
+                message = new Message(bodyStream, ownStream: true);
 
                 PopulateMessagePropertiesFromPacket(message, publish);
 

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -782,7 +782,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             {
                 var bodyStream = new ReadOnlyByteBufferStream(publish.Payload, true);
 
-                message = new Message(bodyStream, ownStream: true);
+                message = new Message(bodyStream, StreamDisposalOwnership.Library);
 
                 PopulateMessagePropertiesFromPacket(message, publish);
 

--- a/iothub/service/src/AmqpServiceClient.cs
+++ b/iothub/service/src/AmqpServiceClient.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Devices
         // This call is executed over AMQP.
         public async override Task SendAsync(string deviceId, Message message, TimeSpan? timeout = null)
         {
-            Logging.Enter(this, $"Sending message with Id [{message?.MessageId}] for device [{deviceId}]", nameof(SendAsync));
+            Logging.Enter(this, $"Sending message with Id [{message?.MessageId}] for device {deviceId}", nameof(SendAsync));
 
             if (string.IsNullOrWhiteSpace(deviceId))
             {
@@ -137,12 +137,12 @@ namespace Microsoft.Azure.Devices
             }
             catch (Exception ex) when (!(ex is TimeoutException) && !ex.IsFatal())
             {
-                Logging.Error(this, $"SendAsync threw an exception: {ex.Message}", nameof(SendAsync));
+                Logging.Error(this, $"SendAsync threw an exception: {ex}", nameof(SendAsync));
                 throw AmqpClientHelper.ToIotHubClientContract(ex);
             }
             finally
             {
-                Logging.Exit(this, $"Sending message {message?.MessageId} for device {deviceId}", nameof(SendAsync));
+                Logging.Exit(this, $"Sending message [{message?.MessageId}] for device {deviceId}", nameof(SendAsync));
             }
         }
 
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.Devices
             }
             catch (Exception ex)
             {
-                Logging.Error(this, $"PurgeMessageQueueAsync threw an exception: {ex.Message}", nameof(PurgeMessageQueueAsync));
+                Logging.Error(this, $"PurgeMessageQueueAsync threw an exception: {ex}", nameof(PurgeMessageQueueAsync));
                 throw;
             }
             finally
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.Devices
             }
             catch (Exception ex)
             {
-                Logging.Error(this, $"{nameof(GetServiceStatisticsAsync)} threw an exception: {ex.Message}", nameof(GetServiceStatisticsAsync));
+                Logging.Error(this, $"{nameof(GetServiceStatisticsAsync)} threw an exception: {ex}", nameof(GetServiceStatisticsAsync));
                 throw;
             }
             finally
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.Devices
             }
             catch (Exception ex)
             {
-                Logging.Error(this, $"{nameof(InvokeDeviceMethodAsync)} threw an exception: {ex.Message}", nameof(InvokeDeviceMethodAsync));
+                Logging.Error(this, $"{nameof(InvokeDeviceMethodAsync)} threw an exception: {ex}", nameof(InvokeDeviceMethodAsync));
                 throw;
             }
             finally
@@ -289,7 +289,7 @@ namespace Microsoft.Azure.Devices
         // This call is executed over AMQP.
         public override async Task SendAsync(string deviceId, string moduleId, Message message)
         {
-            Logging.Enter(this, $"Sending message with Id [{message?.MessageId}] for device [{deviceId}], module [{moduleId}]", nameof(SendAsync));
+            Logging.Enter(this, $"Sending message with Id [{message?.MessageId}] for device {deviceId}, module {moduleId}", nameof(SendAsync));
 
             if (string.IsNullOrWhiteSpace(deviceId))
             {
@@ -328,12 +328,12 @@ namespace Microsoft.Azure.Devices
             }
             catch (Exception ex) when (!ex.IsFatal())
             {
-                Logging.Error(this, $"{nameof(SendAsync)} threw an exception: {ex.Message}", nameof(SendAsync));
+                Logging.Error(this, $"{nameof(SendAsync)} threw an exception: {ex}", nameof(SendAsync));
                 throw AmqpClientHelper.ToIotHubClientContract(ex);
             }
             finally
             {
-                Logging.Exit(this, $"Sending message with Id [{message?.MessageId}] for device [{deviceId}], module [{moduleId}]", nameof(SendAsync));
+                Logging.Exit(this, $"Sending message with Id [{message?.MessageId}] for device {deviceId}, module {moduleId}", nameof(SendAsync));
             }
         }
 

--- a/iothub/service/src/Message.cs
+++ b/iothub/service/src/Message.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Azure.Devices
             SystemProperties = new ReadOnlyDictionary45<string, object>(new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase), this);
             InitializeWithStream(Stream.Null, true);
             _serializedAmqpMessage = null;
+
+            // Set the default value for MessageId.
+            SystemProperties[MessageSystemPropertyNames.MessageId] = Guid.NewGuid().ToString();
         }
 
         /// <summary>
@@ -106,7 +109,7 @@ namespace Microsoft.Azure.Devices
         /// </remarks>
         public string MessageId
         {
-            get => GetSystemProperty<string>(MessageSystemPropertyNames.MessageId) ?? Guid.NewGuid().ToString();
+            get => GetSystemProperty<string>(MessageSystemPropertyNames.MessageId);
             set => SystemProperties[MessageSystemPropertyNames.MessageId] = value;
         }
 
@@ -131,12 +134,9 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// A string property in a response message that typically contains the MessageId of the request, in request-reply patterns.
         /// </summary>
-        /// <remarks>
-        /// If this value is not supplied by the user, the service client will set this to <see cref="MessageId"/>.
-        /// </remarks>
         public string CorrelationId
         {
-            get => GetSystemProperty<string>(MessageSystemPropertyNames.CorrelationId) ?? MessageId;
+            get => GetSystemProperty<string>(MessageSystemPropertyNames.CorrelationId);
             set => SystemProperties[MessageSystemPropertyNames.CorrelationId] = value;
         }
 
@@ -540,6 +540,8 @@ namespace Microsoft.Azure.Devices
                         _bodyStream.Dispose();
                         _bodyStream = null;
                     }
+
+                    _amqpMessageSemaphore?.Dispose();
                 }
 
                 _disposed = true;

--- a/iothub/service/src/Message.cs
+++ b/iothub/service/src/Message.cs
@@ -29,24 +29,29 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Default constructor with no body data
         /// </summary>
-        public Message()
+        /// <param name="setDefaultMessageId">A flag indicating if the MessageId should be set to a random GUID.</param>
+        public Message(bool setDefaultMessageId = false)
         {
             Properties = new ReadOnlyDictionary45<string, string>(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), this);
             SystemProperties = new ReadOnlyDictionary45<string, object>(new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase), this);
             InitializeWithStream(Stream.Null, true);
             _serializedAmqpMessage = null;
 
-            // Set the default value for MessageId.
-            SystemProperties[MessageSystemPropertyNames.MessageId] = Guid.NewGuid().ToString();
+            if (setDefaultMessageId)
+            {
+                // Set the default value for MessageId.
+                SystemProperties[MessageSystemPropertyNames.MessageId] = Guid.NewGuid().ToString();
+            }
         }
 
         /// <summary>
         /// Constructor which uses the argument stream as the body stream.
         /// </summary>
-        /// <param name="stream">a stream which will be used as body stream.</param>
         /// <remarks>User is expected to own the disposing of the stream when using this constructor.</remarks>
-        public Message(Stream stream)
-            : this()
+        /// <param name="stream">a stream which will be used as body stream.</param>
+        /// <param name="setDefaultMessageId">A flag indicating if the MessageId should be set to a random GUID.</param>
+        public Message(Stream stream, bool setDefaultMessageId = false)
+            : this(setDefaultMessageId)
         {
             if (stream != null)
             {
@@ -55,26 +60,25 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <summary>
-        /// Constructor which uses the input byte array as the body
+        /// Constructor which uses the input byte array as the body.
         /// </summary>
-        /// <param name="byteArray">a byte array which will be used to
-        /// form the body stream</param>
-        /// <remarks>user should treat the input byte array as immutable when
-        /// sending the message.</remarks>
-        public Message(byte[] byteArray)
-            : this(new MemoryStream(byteArray))
+        /// <remarks>User should treat the input byte array as immutable when sending the message.</remarks>
+        /// <param name="byteArray">A byte array which will be used to form the body stream.</param>
+        /// <param name="setDefaultMessageId">A flag indicating if the MessageId should be set to a random GUID.</param>
+        public Message(byte[] byteArray, bool setDefaultMessageId = false)
+            : this(new MemoryStream(byteArray), setDefaultMessageId)
         {
             // reset the owning of the steams
             _ownsBodyStream = true;
         }
 
         /// <summary>
-        /// This constructor is only used in the receive path from Amqp path,
-        /// or in Cloning from a Message that has serialized.
+        /// This constructor is only used in the receive path from AMQP path, or in cloning from a Message that has serialized.
         /// </summary>
-        /// <param name="amqpMessage"></param>
-        internal Message(AmqpMessage amqpMessage)
-            : this()
+        /// <param name="amqpMessage">The AMQP message received, or the message to be cloned.</param>
+        /// <param name="setDefaultMessageId">A flag indicating if the MessageId should be set to a random GUID.</param>
+        internal Message(AmqpMessage amqpMessage, bool setDefaultMessageId = false)
+            : this(setDefaultMessageId)
         {
             if (amqpMessage == null)
             {
@@ -87,13 +91,13 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <summary>
-        /// This constructor is only used on the Gateway http path so that
-        /// we can clean up the stream.
+        /// This constructor is only used on the Gateway http path so that we can clean up the stream.
         /// </summary>
-        /// <param name="stream"></param>
-        /// <param name="ownStream"></param>
-        internal Message(Stream stream, bool ownStream)
-            : this(stream)
+        /// <param name="stream">A stream which will be used as body stream.</param>
+        /// <param name="ownStream">A flag indicating that the client library will dispose the stream when the Message is disposed.</param>
+        /// <param name="setDefaultMessageId">A flag indicating if the MessageId should be set to a random GUID.</param>
+        internal Message(Stream stream, bool ownStream, bool setDefaultMessageId = false)
+            : this(stream, setDefaultMessageId)
         {
             _ownsBodyStream = ownStream;
         }

--- a/iothub/service/src/Message.cs
+++ b/iothub/service/src/Message.cs
@@ -533,6 +533,7 @@ namespace Microsoft.Azure.Devices
                         // the amqpMessage will dispose the body stream so we don't
                         // need to dispose bodyStream twice.
                         _serializedAmqpMessage.Dispose();
+                        _serializedAmqpMessage = null;
                         _bodyStream = null;
                     }
                     else if (_bodyStream != null && _ownsBodyStream)

--- a/iothub/service/tests/MessageTests.cs
+++ b/iothub/service/tests/MessageTests.cs
@@ -125,16 +125,16 @@ namespace Microsoft.Azure.Devices.Api.Test
         [TestMethod]
         public void DisposingOwnedStreamTest()
         {
-            // ownStream = true
+            // Library should dispose the stream.
             var ms = new MemoryStream(Encoding.UTF8.GetBytes("Hello, World!"));
-            var msg = new Message(ms, ownStream: true);
+            var msg = new Message(ms, StreamDisposalOwnership.Library);
             msg.Dispose();
 
             TestAssert.Throws<ObjectDisposedException>(() => ms.Write(Encoding.UTF8.GetBytes("howdy"), 0, 5));
 
-            // ownStream = false
+            // User will dispose the stream.
             ms = new MemoryStream(Encoding.UTF8.GetBytes("Hello, World!"));
-            msg = new Message(ms, ownStream: false);
+            msg = new Message(ms, StreamDisposalOwnership.User);
             msg.Dispose();
 
             ms.Write(Encoding.UTF8.GetBytes("howdy"), 0, 5);
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Devices.Api.Test
             using var emptyBodyMessage = new Message();
             using var byteBodyMessage = new Message(messageByteArray);
             using var streamMessage = new Message(ms);
-            using var libraryManagedStreamMessage = new Message(ms, ownStream: true);
+            using var libraryManagedStreamMessage = new Message(ms, StreamDisposalOwnership.Library);
 
             // assert
             emptyBodyMessage.MessageId.Should().BeNull();
@@ -179,10 +179,10 @@ namespace Microsoft.Azure.Devices.Api.Test
             using var ms = new MemoryStream(messageByteArray);
 
             // act
-            using var emptyBodyMessage = new Message(setDefaultMessageId: true);
-            using var byteBodyMessage = new Message(messageByteArray, setDefaultMessageId: true);
-            using var streamMessage = new Message(ms, setDefaultMessageId: true);
-            using var libraryManagedStreamMessage = new Message(ms, ownStream: true, setDefaultMessageId: true);
+            using var emptyBodyMessage = new Message(true);
+            using var byteBodyMessage = new Message(messageByteArray, true);
+            using var streamMessage = new Message(ms, true);
+            using var libraryManagedStreamMessage = new Message(ms, StreamDisposalOwnership.Library, true);
 
             // assert
             emptyBodyMessage.MessageId.Should().NotBeNullOrEmpty();

--- a/iothub/service/tests/MessageTests.cs
+++ b/iothub/service/tests/MessageTests.cs
@@ -168,34 +168,5 @@ namespace Microsoft.Azure.Devices.Api.Test
             message.MessageId.Should().NotBeNullOrEmpty();
             message.MessageId.Should().Be(messageId, "MessageId should have the value set by user.");
         }
-
-        [TestMethod]
-        public void MessageShouldSetMessageIdToCorrelationIdByDefault()
-        {
-            string messageId = Guid.NewGuid().ToString();
-            using var message = new Message(Encoding.UTF8.GetBytes("test message"))
-            {
-                MessageId = messageId,
-            };
-
-            message.CorrelationId.Should().NotBeNullOrEmpty();
-            message.CorrelationId.Should().Be(messageId, "Default value of correlation Id should be the MessageId.");
-        }
-
-        [TestMethod]
-        public void MessageShouldAllowCorrelationIdToBeUserSettable()
-        {
-            string messageId = Guid.NewGuid().ToString();
-            string correlationId = Guid.NewGuid().ToString();
-            using var message = new Message(Encoding.UTF8.GetBytes("test message"))
-            {
-                MessageId = messageId,
-                CorrelationId = correlationId,
-            };
-
-            message.CorrelationId.Should().NotBeNullOrEmpty();
-            message.CorrelationId.Should().NotBe(messageId, "CorrelationId should have the value set by user.");
-            message.CorrelationId.Should().Be(correlationId, "CorrelationId should have the value set by user.");
-        }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ For details on OS support see the following resources:
 | [Jobs](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs)                                  | :heavy_check_mark:        | HTTP | Use your backend app to perform job operation.                                                                           |
 | [File Upload](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-file-upload)                    | :heavy_check_mark:        | AMQP | Set up your backend app to receive file upload notifications. 
 | [Digital Twin Client](https://docs.microsoft.com/en-us/azure/iot-pnp/overview-iot-plug-and-play)              | :heavy_check_mark:        | HTTP | Set up your backend app to perform operations on plug and play devices.                                                      |
-| [IoT Hub Statistics](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-metrics)                          | :heavy_check_mark:        | HTTP | Get IoT Hub identity registry statistics; such as total device couent for device statistics, and connected device count for service statistics. |
+| [IoT Hub Statistics](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-metrics)                          | :heavy_check_mark:        | HTTP | Get IoT Hub identity registry statistics; such as total device count for device statistics, and connected device count for service statistics. |
 
 ### Provisioning Device SDK
 


### PR DESCRIPTION
Our log statements do not require a check for IsEnabled since that is already checked in the first implementation layer of the Logging class.

This is PR is just a sample on how the rest of the service client is going to look like when we are done with log instrumentations.

I've also updated the MessageId default behavior implementation in this PR -> we now take in a flag `setDefaultMessageId` in `Message` constructors. If set to true, the client library will set the MessageId to a GUID.