### PR TITLE
fix(iot-service): Fix Message disposal behavior

### DIFF
--- a/e2e/test/Helpers/templates/FaultInjection.cs
+++ b/e2e/test/Helpers/templates/FaultInjection.cs
@@ -67,9 +67,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
 
         public static bool FaultShouldDisconnect(string faultType)
         {
-            return (faultType != FaultType_Auth) &&
-                (faultType != FaultType_Throttle) &&
-                (faultType != FaultType_QuotaExceeded);
+            return faultType != FaultType_Auth
+                && faultType != FaultType_Throttle
+                && faultType != FaultType_QuotaExceeded;
         }
 
         // Fault timings:
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                 // For disconnect type faults, the device should disconnect and recover.
                 if (FaultShouldDisconnect(faultType))
                 {
-                    logger.Trace($"{nameof(FaultInjection)}: Confirming fault injection has been actived.");
+                    logger.Trace($"{nameof(FaultInjection)}: Confirming fault injection has been activated.");
                     // Check that service issued the fault to the faulting device
                     bool isFaulted = false;
                     for (int i = 0; i < LatencyTimeBufferInSec; i++)
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                     }
 
                     Assert.IsTrue(isFaulted, $"The device {testDevice.Id} did not get faulted with fault type: {faultType}");
-                    logger.Trace($"{nameof(FaultInjection)}: Confirmed fault injection has been actived.");
+                    logger.Trace($"{nameof(FaultInjection)}: Confirmed fault injection has been activated.");
 
                     // Check the device is back online
                     logger.Trace($"{nameof(FaultInjection)}: Confirming device back online.");

--- a/iothub/device/src/Message.cs
+++ b/iothub/device/src/Message.cs
@@ -64,8 +64,7 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// This constructor is only used on the Gateway http path so that
-        /// we can clean up the stream.
+        /// This constructor is only used on the Gateway HTTP path so that we can clean up the stream.
         /// </summary>
         /// <param name="stream">A stream which will be used as body stream.</param>
         /// <param name="streamDisposalResponsibility">Indicates if the stream passed in should be disposed by the client library, or by the calling application.</param>

--- a/iothub/service/src/AmqpServiceClient.cs
+++ b/iothub/service/src/AmqpServiceClient.cs
@@ -153,10 +153,6 @@ namespace Microsoft.Azure.Devices
                 Logging.Error(this, $"{nameof(SendAsync)} threw an exception: {ex}", nameof(SendAsync));
                 throw AmqpClientHelper.ToIotHubClientContract(ex);
             }
-            catch (Exception)
-            {
-                throw;
-            }
             finally
             {
                 Logging.Exit(this, $"Sending message [{message?.MessageId}] for device {deviceId}", nameof(SendAsync));
@@ -357,10 +353,6 @@ namespace Microsoft.Azure.Devices
             {
                 Logging.Error(this, $"{nameof(SendAsync)} threw an exception: {ex}", nameof(SendAsync));
                 throw AmqpClientHelper.ToIotHubClientContract(ex);
-            }
-            catch (Exception)
-            {
-                throw;
             }
             finally
             {

--- a/iothub/service/src/AmqpServiceClient.cs
+++ b/iothub/service/src/AmqpServiceClient.cs
@@ -124,6 +124,11 @@ namespace Microsoft.Azure.Devices
                 message.MessageId = Guid.NewGuid().ToString();
             }
 
+            if (message.IsBodyCalled)
+            {
+                message.ResetBody();
+            }
+
             timeout ??= OperationTimeout;
 
             using AmqpMessage amqpMessage = MessageConverter.MessageToAmqpMessage(message);
@@ -146,16 +151,10 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex) when (!(ex is TimeoutException) && !ex.IsFatal())
             {
                 Logging.Error(this, $"{nameof(SendAsync)} threw an exception: {ex}", nameof(SendAsync));
-                // In case of an exception we need to reset the GetBodyCalled property,
-                // so that the send operation can be attempted for the same message again.
-                message.ResetGetBodyCalled();
                 throw AmqpClientHelper.ToIotHubClientContract(ex);
             }
             catch (Exception)
             {
-                // In case of an exception we need to reset the GetBodyCalled property,
-                // so that the send operation can be attempted for the same message again.
-                message.ResetGetBodyCalled();
                 throw;
             }
             finally
@@ -329,6 +328,11 @@ namespace Microsoft.Azure.Devices
                 message.MessageId = Guid.NewGuid().ToString();
             }
 
+            if (message.IsBodyCalled)
+            {
+                message.ResetBody();
+            }
+
             using AmqpMessage amqpMessage = MessageConverter.MessageToAmqpMessage(message);
             amqpMessage.Properties.To = "/devices/" + WebUtility.UrlEncode(deviceId) + "/modules/" + WebUtility.UrlEncode(moduleId) + "/messages/deviceBound";
             try
@@ -352,17 +356,10 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex) when (!ex.IsFatal())
             {
                 Logging.Error(this, $"{nameof(SendAsync)} threw an exception: {ex}", nameof(SendAsync));
-
-                // In case of an exception we need to reset the GetBodyCalled property,
-                // so that the send operation can be attempted for the same message again.
-                message.ResetGetBodyCalled();
                 throw AmqpClientHelper.ToIotHubClientContract(ex);
             }
             catch (Exception)
             {
-                // In case of an exception we need to reset the GetBodyCalled property,
-                // so that the send operation can be attempted for the same message again.
-                message.ResetGetBodyCalled();
                 throw;
             }
             finally


### PR DESCRIPTION
Our `Message` class on the service client contained a reference to the actual `AmqpMessage` which is sent when `SentAsync()` was called. Since the `AmqpMessage` is disposed after each Send attempt, resending the same IoT Hub message (on network failure etc) would result in us attempting to resend the same disposed Amqp message, resulting in an `ObjectDisposedException`. 

This PR removes the AmqpMessage from being a property of IoT Hub message, resulting in us being able to manage their lifetimes independently.

Is is very surprising however that no one has reported this issue yet. With our current code, if you attempt to resend the same message instance multiple times, you will always get an `ObjectDisposedException`.

You can use the sample [here](https://github.com/Azure-Samples/azure-iot-samples-csharp/pull/155) to test this behavior (simulate network disconnect to have the sdk resend the same Message multiple times).

Even this fails:
```csharp
private async Task SendSameMessage()
{
    var message = new Message(Encoding.UTF8.GetBytes("test"));

    for (int i = 0; i < 5; i++)
    {
        await _serviceClient.SendAsync(_deviceId, message);
        Console.WriteLine($"done {i}");
    }
}
```