### PR TITLE
Add additional logging to service client

### DIFF
--- a/common/src/Logging.Common.cs
+++ b/common/src/Logging.Common.cs
@@ -62,10 +62,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Enter(object thisOrContextObject, FormattableString formattableString = null, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(formattableString);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(formattableString);
+
                 Log.Enter(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
             }
         }
@@ -79,10 +80,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Enter(object thisOrContextObject, object arg0, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(arg0);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(arg0);
+
                 Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)})");
             }
         }
@@ -95,11 +97,12 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Enter(object thisOrContextObject, object arg0, object arg1, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(arg0);
-            DebugValidateArg(arg1);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(arg0);
+                DebugValidateArg(arg1);
+
                 Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)})");
             }
         }
@@ -113,12 +116,13 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Enter(object thisOrContextObject, object arg0, object arg1, object arg2, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(arg0);
-            DebugValidateArg(arg1);
-            DebugValidateArg(arg2);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(arg0);
+                DebugValidateArg(arg1);
+                DebugValidateArg(arg2);
+
                 Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)}, {Format(arg2)})");
             }
         }
@@ -140,10 +144,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Exit(object thisOrContextObject, FormattableString formattableString = null, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(formattableString);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(formattableString);
+
                 Log.Exit(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
             }
         }
@@ -157,10 +162,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Exit(object thisOrContextObject, object arg0, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(arg0);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(arg0);
+
                 Log.Exit(IdOf(thisOrContextObject), memberName, Format(arg0).ToString());
             }
         }
@@ -173,11 +179,12 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Exit(object thisOrContextObject, object arg0, object arg1, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(arg0);
-            DebugValidateArg(arg1);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(arg0);
+                DebugValidateArg(arg1);
+
                 Log.Exit(IdOf(thisOrContextObject), memberName, $"{Format(arg0)}, {Format(arg1)}");
             }
         }
@@ -191,12 +198,13 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Exit(object thisOrContextObject, object arg0, object arg1, object arg2, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(arg0);
-            DebugValidateArg(arg1);
-            DebugValidateArg(arg2);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(arg0);
+                DebugValidateArg(arg1);
+                DebugValidateArg(arg2);
+
                 Log.Exit(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)}, {Format(arg2)})");
             }
         }
@@ -218,10 +226,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Info(object thisOrContextObject, FormattableString formattableString = null, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(formattableString);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(formattableString);
+
                 Log.Info(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
             }
         }
@@ -235,10 +244,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Info(object thisOrContextObject, object message, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(message);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(message);
+
                 Log.Info(IdOf(thisOrContextObject), memberName, Format(message).ToString());
             }
         }
@@ -260,10 +270,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Error(object thisOrContextObject, FormattableString formattableString, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(formattableString);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(formattableString);
+
                 Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
             }
         }
@@ -277,10 +288,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Error(object thisOrContextObject, object message, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(message);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(message);
+
                 Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
             }
         }
@@ -420,10 +432,11 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Associate(object first, object second, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(first);
-            DebugValidateArg(second);
             if (IsEnabled)
             {
+                DebugValidateArg(first);
+                DebugValidateArg(second);
+
                 Log.Associate(IdOf(first), memberName, IdOf(first), IdOf(second));
             }
         }
@@ -436,11 +449,12 @@ namespace Microsoft.Azure.Devices.Shared
         [NonEvent]
         public static void Associate(object thisOrContextObject, object first, object second, [CallerMemberName] string memberName = null)
         {
-            DebugValidateArg(thisOrContextObject);
-            DebugValidateArg(first);
-            DebugValidateArg(second);
             if (IsEnabled)
             {
+                DebugValidateArg(thisOrContextObject);
+                DebugValidateArg(first);
+                DebugValidateArg(second);
+
                 Log.Associate(IdOf(thisOrContextObject), memberName, IdOf(first), IdOf(second));
             }
         }

--- a/iothub/service/src/AmqpServiceClient.cs
+++ b/iothub/service/src/AmqpServiceClient.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Devices
         // This call is executed over AMQP.
         public async override Task SendAsync(string deviceId, Message message, TimeSpan? timeout = null)
         {
-            Logging.Enter(this, $"Sending message with Id [{message?.MessageId}] for device [{deviceId}]", nameof(SendAsync));
+            Logging.Enter(this, $"Sending message with Id [{message?.MessageId}] for device {deviceId}", nameof(SendAsync));
 
             if (string.IsNullOrWhiteSpace(deviceId))
             {
@@ -137,12 +137,12 @@ namespace Microsoft.Azure.Devices
             }
             catch (Exception ex) when (!(ex is TimeoutException) && !ex.IsFatal())
             {
-                Logging.Error(this, $"SendAsync threw an exception: {ex.Message}", nameof(SendAsync));
+                Logging.Error(this, $"SendAsync threw an exception: {ex}", nameof(SendAsync));
                 throw AmqpClientHelper.ToIotHubClientContract(ex);
             }
             finally
             {
-                Logging.Exit(this, $"Sending message {message?.MessageId} for device {deviceId}", nameof(SendAsync));
+                Logging.Exit(this, $"Sending message [{message?.MessageId}] for device {deviceId}", nameof(SendAsync));
             }
         }
 
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.Devices
             }
             catch (Exception ex)
             {
-                Logging.Error(this, $"PurgeMessageQueueAsync threw an exception: {ex.Message}", nameof(PurgeMessageQueueAsync));
+                Logging.Error(this, $"PurgeMessageQueueAsync threw an exception: {ex}", nameof(PurgeMessageQueueAsync));
                 throw;
             }
             finally
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.Devices
             }
             catch (Exception ex)
             {
-                Logging.Error(this, $"{nameof(GetServiceStatisticsAsync)} threw an exception: {ex.Message}", nameof(GetServiceStatisticsAsync));
+                Logging.Error(this, $"{nameof(GetServiceStatisticsAsync)} threw an exception: {ex}", nameof(GetServiceStatisticsAsync));
                 throw;
             }
             finally
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.Devices
             }
             catch (Exception ex)
             {
-                Logging.Error(this, $"{nameof(InvokeDeviceMethodAsync)} threw an exception: {ex.Message}", nameof(InvokeDeviceMethodAsync));
+                Logging.Error(this, $"{nameof(InvokeDeviceMethodAsync)} threw an exception: {ex}", nameof(InvokeDeviceMethodAsync));
                 throw;
             }
             finally
@@ -289,7 +289,7 @@ namespace Microsoft.Azure.Devices
         // This call is executed over AMQP.
         public override async Task SendAsync(string deviceId, string moduleId, Message message)
         {
-            Logging.Enter(this, $"Sending message with Id [{message?.MessageId}] for device [{deviceId}], module [{moduleId}]", nameof(SendAsync));
+            Logging.Enter(this, $"Sending message with Id [{message?.MessageId}] for device {deviceId}, module {moduleId}", nameof(SendAsync));
 
             if (string.IsNullOrWhiteSpace(deviceId))
             {
@@ -328,12 +328,12 @@ namespace Microsoft.Azure.Devices
             }
             catch (Exception ex) when (!ex.IsFatal())
             {
-                Logging.Error(this, $"{nameof(SendAsync)} threw an exception: {ex.Message}", nameof(SendAsync));
+                Logging.Error(this, $"{nameof(SendAsync)} threw an exception: {ex}", nameof(SendAsync));
                 throw AmqpClientHelper.ToIotHubClientContract(ex);
             }
             finally
             {
-                Logging.Exit(this, $"Sending message with Id [{message?.MessageId}] for device [{deviceId}], module [{moduleId}]", nameof(SendAsync));
+                Logging.Exit(this, $"Sending message with Id [{message?.MessageId}] for device {deviceId}, module {moduleId}", nameof(SendAsync));
             }
         }
 

--- a/iothub/service/src/AmqpServiceClient.cs
+++ b/iothub/service/src/AmqpServiceClient.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Devices
             }
             catch (Exception ex) when (!(ex is TimeoutException) && !ex.IsFatal())
             {
-                Logging.Error(this, $"SendAsync threw an exception: {ex}", nameof(SendAsync));
+                Logging.Error(this, $"{nameof(SendAsync)} threw an exception: {ex}", nameof(SendAsync));
                 throw AmqpClientHelper.ToIotHubClientContract(ex);
             }
             finally
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.Devices
             }
             catch (Exception ex)
             {
-                Logging.Error(this, $"PurgeMessageQueueAsync threw an exception: {ex}", nameof(PurgeMessageQueueAsync));
+                Logging.Error(this, $"{nameof(PurgeMessageQueueAsync)} threw an exception: {ex}", nameof(PurgeMessageQueueAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/Message.cs
+++ b/iothub/service/src/Message.cs
@@ -533,6 +533,7 @@ namespace Microsoft.Azure.Devices
                         // the amqpMessage will dispose the body stream so we don't
                         // need to dispose bodyStream twice.
                         _serializedAmqpMessage.Dispose();
+                        _serializedAmqpMessage = null;
                         _bodyStream = null;
                     }
                     else if (_bodyStream != null && _ownsBodyStream)

--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ For details on OS support see the following resources:
 | [Jobs](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs)                                  | :heavy_check_mark:        | HTTP | Use your backend app to perform job operation.                                                                           |
 | [File Upload](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-file-upload)                    | :heavy_check_mark:        | AMQP | Set up your backend app to receive file upload notifications. 
 | [Digital Twin Client](https://docs.microsoft.com/en-us/azure/iot-pnp/overview-iot-plug-and-play)              | :heavy_check_mark:        | HTTP | Set up your backend app to perform operations on plug and play devices.                                                      |
-| [IoT Hub Statistics](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-metrics)                          | :heavy_check_mark:        | HTTP | Get IoT Hub identity registry statistics; such as total device couent for device statistics, and connected device count for service statistics. |
+| [IoT Hub Statistics](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-metrics)                          | :heavy_check_mark:        | HTTP | Get IoT Hub identity registry statistics; such as total device count for device statistics, and connected device count for service statistics. |
 
 ### Provisioning Device SDK
 


### PR DESCRIPTION
From #1625 
Our log statements do not require a check for IsEnabled since that is already checked in the first implementation layer of the Logging class.

This is PR is just a sample on how the rest of the service client is going to look like when we are done with log instrumentations.