### PR TITLE
Add an API to set a callback for receiving C2D messages (amqp)

### DIFF
--- a/e2e/test/Helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/Helpers/TestDeviceCallbackHandler.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
     public class TestDeviceCallbackHandler : IDisposable
     {
         private readonly DeviceClient _deviceClient;
+        private readonly TestDevice _testDevice;
         private readonly MsTestLogger _logger;
 
         private readonly SemaphoreSlim _methodCallbackSemaphore = new SemaphoreSlim(0, 1);
@@ -28,9 +29,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         private ExceptionDispatchInfo _receiveMessageExceptionDispatch;
         private Message _expectedMessageSentByService = null;
 
-        public TestDeviceCallbackHandler(DeviceClient deviceClient, MsTestLogger logger)
+        public TestDeviceCallbackHandler(DeviceClient deviceClient, TestDevice testDevice, MsTestLogger logger)
         {
             _deviceClient = deviceClient;
+            _testDevice = testDevice;
             _logger = logger;
         }
 
@@ -53,7 +55,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                 {
                     try
                     {
-                        _logger.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: DeviceClient callback method: {request.Name} {request.ResponseTimeout}.");
+                        _logger.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: DeviceClient {_testDevice.Id} callback method: {request.Name} {request.ResponseTimeout}.");
                         request.Name.Should().Be(methodName, "The expected method name should match what was sent from service");
                         request.DataAsJson.Should().Be(expectedServiceRequestJson, "The expected method data should match what was sent from service");
 
@@ -88,7 +90,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(
                 (patch, context) =>
                 {
-                    _logger.Trace($"{nameof(SetTwinPropertyUpdateCallbackHandlerAsync)}: DeviceClient callback twin: DesiredProperty: {patch}, {context}");
+                    _logger.Trace($"{nameof(SetTwinPropertyUpdateCallbackHandlerAsync)}: DeviceClient {_testDevice.Id} callback twin: DesiredProperty: {patch}, {context}");
 
                     try
                     {
@@ -121,7 +123,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             await _deviceClient.SetReceiveMessageHandlerAsync(
                 async (receivedMessage, context) =>
                 {
-                    _logger.Trace($"{nameof(SetMessageReceiveCallbackHandlerAsync)}: DeviceClient received message with Id: {receivedMessage.MessageId}.");
+                    _logger.Trace($"{nameof(SetMessageReceiveCallbackHandlerAsync)}: DeviceClient {_testDevice.Id} received message with Id: {receivedMessage.MessageId}.");
 
                     try
                     {

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageReceiveFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageReceiveFaultInjectionPoolAmqpTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
 using Microsoft.Azure.Devices.E2ETests.Helpers.Templates;
@@ -21,7 +23,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_TcpConnectionLossReceiveRecovery_SingleConnection_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -36,7 +38,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_TcpConnectionLossReceiveRecovery_SingleConnection_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -51,7 +53,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_TcpConnectionLossReceiveRecovery_SingleConnection_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -67,7 +69,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_TcpConnectionLossReceiveRecovery_SingleConnection_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -83,7 +85,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_AmqpConnectionLossReceiveRecovery_SingleConnection_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -98,7 +100,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_AmqpConnectionLossReceiveRecovery_SingleConnection_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -113,7 +115,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IotHubSak_AmqpConnectionLossReceiveRecovery_SingleConnection_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -129,7 +131,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_AmqpConnectionLossReceiveRecovery_SingleConnection_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -146,7 +148,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_AmqpSessionLossReceiveRecovery_SingleConnection_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -162,7 +164,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_AmqpSessionLossReceiveRecovery_SingleConnection_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -178,7 +180,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_AmqpSessionLossReceiveRecovery_SingleConnection_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -195,7 +197,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_AmqpSessionLossReceiveRecovery_SingleConnection_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -211,7 +213,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_AmqpC2DLinkDropReceiveRecovery_SingleConnection_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -226,7 +228,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_AmqpC2DLinkDropReceiveRecovery_SingleConnection_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -241,7 +243,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_AmqpC2DLinkDropReceiveRecovery_SingleConnection_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -257,7 +259,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_AmqpC2DLinkDropReceiveRecovery_SingleConnection_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -273,7 +275,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_GracefulShutdownReceiveRecovery_SingleConnection_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -288,7 +290,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_GracefulShutdownReceiveRecovery_SingleConnection_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -303,7 +305,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_GracefulShutdownReceiveRecovery_SingleConnection_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -319,7 +321,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_GracefulShutdownReceiveRecovery_SingleConnection_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.SingleConnection_PoolSize,
@@ -333,7 +335,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_TcpConnectionLossReceiveRecovery_MultipleConnections_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -346,7 +348,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_TcpConnectionLossReceiveRecovery_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -359,7 +361,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_TcpConnectionLossReceiveRecovery_MultipleConnections_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -373,7 +375,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_TcpConnectionLossReceiveRecovery_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -387,7 +389,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_AmqpConnectionLossReceiveRecovery_MultipleConnections_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -400,7 +402,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_AmqpConnectionLossReceiveRecovery_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -413,7 +415,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IotHubSak_AmqpConnectionLossReceiveRecovery_MultipleConnections_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -427,7 +429,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_AmqpConnectionLossReceiveRecovery_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -442,7 +444,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_AmqpSessionLossReceiveRecovery_MultipleConnections_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -456,7 +458,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_AmqpSessionLossReceiveRecovery_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -470,7 +472,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_AmqpSessionLossReceiveRecovery_MultipleConnections_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -485,7 +487,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_AmqpSessionLossReceiveRecovery_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -500,7 +502,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestCategory("LongRunning")]
         public async Task Message_DeviceSak_AmqpC2DLinkDropReceiveRecovery_MultipleConnections_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -513,7 +515,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_AmqpC2DLinkDropReceiveRecovery_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -526,7 +528,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_AmqpC2DLinkDropReceiveRecovery_MultipleConnections_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -540,7 +542,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_AmqpC2DLinkDropReceiveRecovery_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -554,7 +556,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_GracefulShutdownReceiveRecovery_MultipleConnections_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -567,7 +569,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_DeviceSak_GracefulShutdownReceiveRecovery_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -580,7 +582,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_GracefulShutdownReceiveRecovery_MultipleConnections_Amqp()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -594,7 +596,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_GracefulShutdownReceiveRecovery_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessageRecoveryPoolOverAmqp(
+            await ReceiveMessageRecoveryPoolOverAmqpAsync(
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
@@ -605,7 +607,282 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
-        private async Task ReceiveMessageRecoveryPoolOverAmqp(
+        [LoggedTestMethod]
+        public async Task Message_DeviceSak_TcpConnectionLossReceiveUsingCallbackRecovery_MultipleConnections_Amqp()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_Tcp,
+                    FaultInjection.FaultCloseReason_Boom)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_DeviceSak_TcpConnectionLossReceiveUsingCallbackRecovery_MultipleConnections_AmqpWs()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_Tcp,
+                    FaultInjection.FaultCloseReason_Boom)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_IoTHubSak_TcpConnectionLossReceiveUsingCallbackRecovery_MultipleConnections_Amqp()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_Tcp,
+                    FaultInjection.FaultCloseReason_Boom,
+                    authScope: ConnectionStringAuthScope.IoTHub)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_IoTHubSak_TcpConnectionLossReceiveUsingCallbackRecovery_MultipleConnections_AmqpWs()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_Tcp,
+                    FaultInjection.FaultCloseReason_Boom,
+                    authScope: ConnectionStringAuthScope.IoTHub)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_DeviceSak_AmqpConnectionLossReceiveUsingCallbackRecovery_MultipleConnections_Amqp()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_AmqpConn,
+                    "")
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_DeviceSak_AmqpConnectionLossReceiveUsingCallbackRecovery_MultipleConnections_AmqpWs()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_AmqpConn,
+                    "")
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_IotHubSak_AmqpConnectionLossReceiveUsingCallbackRecovery_MultipleConnections_Amqp()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_AmqpConn,
+                    "",
+                    authScope: ConnectionStringAuthScope.IoTHub)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_IoTHubSak_AmqpConnectionLossReceiveUsingCallbackRecovery_MultipleConnections_AmqpWs()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_AmqpConn,
+                    "",
+                    authScope: ConnectionStringAuthScope.IoTHub)
+                .ConfigureAwait(false);
+        }
+
+        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
+        [LoggedTestMethod]
+        public async Task Message_DeviceSak_AmqpSessionLossReceiveUsingCallbackRecovery_MultipleConnections_Amqp()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_AmqpSess,
+                    "")
+                .ConfigureAwait(false);
+        }
+
+        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
+        [LoggedTestMethod]
+        public async Task Message_DeviceSak_AmqpSessionLossReceiveUsingCallbackRecovery_MultipleConnections_AmqpWs()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_AmqpSess,
+                    "")
+                .ConfigureAwait(false);
+        }
+
+        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
+        [LoggedTestMethod]
+        public async Task Message_IoTHubSak_AmqpSessionLossReceiveUsingCallbackRecovery_MultipleConnections_Amqp()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_AmqpSess,
+                    "",
+                    authScope: ConnectionStringAuthScope.IoTHub)
+                .ConfigureAwait(false);
+        }
+
+        // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
+        [LoggedTestMethod]
+        public async Task Message_IoTHubSak_AmqpSessionLossReceiveUsingCallbackRecovery_MultipleConnections_AmqpWs()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_AmqpSess,
+                    "",
+                    authScope: ConnectionStringAuthScope.IoTHub)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        [TestCategory("LongRunning")]
+        public async Task Message_DeviceSak_AmqpC2DLinkDropReceiveUsingCallbackRecovery_MultipleConnections_Amqp()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_AmqpC2D,
+                    FaultInjection.FaultCloseReason_Boom)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_DeviceSak_AmqpC2DLinkDropReceiveUsingCallbackRecovery_MultipleConnections_AmqpWs()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_AmqpC2D,
+                    FaultInjection.FaultCloseReason_Boom)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_IoTHubSak_AmqpC2DLinkDropReceiveUsingCallbackRecovery_MultipleConnections_Amqp()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_AmqpC2D,
+                    FaultInjection.FaultCloseReason_Boom,
+                    authScope: ConnectionStringAuthScope.IoTHub)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_IoTHubSak_AmqpC2DLinkDropReceiveUsingCallbackRecovery_MultipleConnections_AmqpWs()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_AmqpC2D,
+                    FaultInjection.FaultCloseReason_Boom,
+                    authScope: ConnectionStringAuthScope.IoTHub)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_DeviceSak_GracefulShutdownReceiveUsingCallbackRecovery_MultipleConnections_Amqp()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_GracefulShutdownAmqp,
+                    FaultInjection.FaultCloseReason_Bye)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_DeviceSak_GracefulShutdownReceiveUsingCallbackRecovery_MultipleConnections_AmqpWs()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_GracefulShutdownAmqp,
+                    FaultInjection.FaultCloseReason_Bye)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_IoTHubSak_GracefulShutdownReceiveUsingCallbackRecovery_MultipleConnections_Amqp()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_GracefulShutdownAmqp,
+                    FaultInjection.FaultCloseReason_Bye,
+                    authScope: ConnectionStringAuthScope.IoTHub)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_IoTHubSak_GracefulShutdownReceiveUsingCallbackRecovery_MultipleConnections_AmqpWs()
+        {
+            await ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    PoolingOverAmqp.MultipleConnections_PoolSize,
+                    PoolingOverAmqp.MultipleConnections_DevicesCount,
+                    FaultInjection.FaultType_GracefulShutdownAmqp,
+                    FaultInjection.FaultCloseReason_Bye,
+                    authScope: ConnectionStringAuthScope.IoTHub)
+                .ConfigureAwait(false);
+        }
+
+        private async Task ReceiveMessageRecoveryPoolOverAmqpAsync(
             TestDeviceType type,
             Client.TransportType transport,
             int poolSize,
@@ -618,9 +895,9 @@ namespace Microsoft.Azure.Devices.E2ETests
             string proxyAddress = null)
         {
             // Initialize the service client
-            ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
 
-            Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
+            async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
                 (Message msg, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage(Logger);
                 Logger.Trace($"{nameof(FaultInjectionPoolAmqpTests)}: Sending message to device {testDevice.Id}: payload='{payload}' p1Value='{p1Value}'");
@@ -632,9 +909,9 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
                 await MessageReceiveE2ETests.VerifyReceivedC2DMessageAsync(transport, deviceClient, testDevice.Id, msg, payload, Logger)
                 .ConfigureAwait(false);
-            };
+            }
 
-            Func<IList<DeviceClient>, Task> cleanupOperation = async (deviceClients) =>
+            async Task CleanupOperationAsync(IList<DeviceClient> deviceClients)
             {
                 await serviceClient.CloseAsync()
                 .ConfigureAwait(false);
@@ -644,7 +921,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 {
                     deviceClient.Dispose();
                 }
-            };
+            }
 
             await FaultInjectionPoolingOverAmqp
                 .TestFaultInjectionPoolAmqpAsync(
@@ -657,9 +934,74 @@ namespace Microsoft.Azure.Devices.E2ETests
                     reason,
                     delayInSec,
                     durationInSec,
-                    (d, t) => { return Task.FromResult(false); },
-                    testOperation,
-                    cleanupOperation,
+                    (d, t, h) => { return Task.FromResult(false); },
+                    TestOperationAsync,
+                    CleanupOperationAsync,
+                    authScope,
+                    Logger)
+                .ConfigureAwait(false);
+        }
+
+        private async Task ReceiveMessageUsingCallbackRecoveryPoolOverAmqpAsync(
+            TestDeviceType type,
+            Client.TransportType transport,
+            int poolSize,
+            int devicesCount,
+            string faultType,
+            string reason,
+            int delayInSec = FaultInjection.DefaultDelayInSec,
+            int durationInSec = FaultInjection.DefaultDurationInSec,
+            ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device,
+            string proxyAddress = null)
+        {
+            // Initialize the service client
+            var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+
+            async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler testDeviceCallbackHandler)
+            {
+                await testDeviceCallbackHandler.SetMessageReceiveCallbackHandlerAsync().ConfigureAwait(false);
+            }
+
+            async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler testDeviceCallbackHandler)
+            {
+                var timeout = TimeSpan.FromSeconds(20);
+                using var cts = new CancellationTokenSource(timeout);
+
+                (Message msg, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage(Logger);
+                testDeviceCallbackHandler.ExpectedMessageSentByService = msg;
+                await serviceClient.SendAsync(testDevice.Id, msg).ConfigureAwait(false);
+                Logger.Trace($"{nameof(FaultInjectionPoolAmqpTests)}: Sent message to device {testDevice.Id}: payload='{payload}' p1Value='{p1Value}'");
+
+                Client.Message receivedMessage = await deviceClient.ReceiveAsync(timeout).ConfigureAwait(false);
+                await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts.Token).ConfigureAwait(false);
+                receivedMessage.Should().BeNull();
+            }
+
+            async Task CleanupOperationAsync(IList<DeviceClient> deviceClients)
+            {
+                await serviceClient.CloseAsync().ConfigureAwait(false);
+                serviceClient.Dispose();
+
+                foreach (DeviceClient deviceClient in deviceClients)
+                {
+                    deviceClient.Dispose();
+                }
+            }
+
+            await FaultInjectionPoolingOverAmqp
+                .TestFaultInjectionPoolAmqpAsync(
+                    MessageReceive_DevicePrefix,
+                    transport,
+                    proxyAddress,
+                    poolSize,
+                    devicesCount,
+                    faultType,
+                    reason,
+                    delayInSec,
+                    durationInSec,
+                    InitOperationAsync,
+                    TestOperationAsync,
+                    CleanupOperationAsync,
                     authScope,
                     Logger)
                 .ConfigureAwait(false);

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -881,7 +881,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device,
             string proxyAddress = null)
         {
-            Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
+            async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
                 Logger.Trace($"{nameof(FaultInjectionPoolAmqpTests)}: Preparing to send message for device {testDevice.Id}");
                 await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -890,9 +890,9 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 Logger.Trace($"{nameof(FaultInjectionPoolAmqpTests)}.{testDevice.Id}: payload='{payload}' p1Value='{p1Value}'");
                 await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
-            };
+            }
 
-            Func<IList<DeviceClient>, Task> cleanupOperation = (deviceClients) =>
+            Task CleanupOperationAsync(IList<DeviceClient> deviceClients)
             {
                 foreach (DeviceClient deviceClient in deviceClients)
                 {
@@ -900,7 +900,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 }
 
                 return Task.FromResult(0);
-            };
+            }
 
             await FaultInjectionPoolingOverAmqp
                 .TestFaultInjectionPoolAmqpAsync(
@@ -913,9 +913,9 @@ namespace Microsoft.Azure.Devices.E2ETests
                     reason,
                     delayInSec,
                     durationInSec,
-                    (d, t) => { return Task.FromResult(false); },
-                    testOperation,
-                    cleanupOperation,
+                    (d, t, h) => { return Task.FromResult(false); },
+                    TestOperationAsync,
+                    CleanupOperationAsync,
                     authScope,
                     Logger)
                 .ConfigureAwait(false);

--- a/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
@@ -423,7 +423,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice)
             {
                 await serviceClient.OpenAsync().ConfigureAwait(false);
-                testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, Logger);
+                testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
                 await testDeviceCallbackHandler.SetMessageReceiveCallbackHandlerAsync().ConfigureAwait(false);
             }
 

--- a/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
 using Microsoft.Azure.Devices.E2ETests.Helpers.Templates;
@@ -225,6 +226,135 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 .ConfigureAwait(false);
         }
 
+        [LoggedTestMethod]
+        public async Task Message_TcpConnectionLossReceiveWithCallbackRecovery_Amqp()
+        {
+            await
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    FaultInjection.FaultType_Tcp,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_TcpConnectionLossReceiveWithCallbackRecovery_AmqpWs()
+        {
+            await
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    FaultInjection.FaultType_Tcp,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_AmqpConnectionLossReceiveWithCallbackRecovery_Amqp()
+        {
+            await
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    FaultInjection.FaultType_AmqpConn,
+                    "",
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_AmqpConnectionLossReceiveWithCallbackRecovery_AmqpWs()
+        {
+            await
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    FaultInjection.FaultType_AmqpConn, "",
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_AmqpSessionLossReceiveWithCallbackRecovery_Amqp()
+        {
+            await
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    FaultInjection.FaultType_AmqpSess,
+                    "",
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_AmqpSessionLossReceiveWithCallbackRecovery_AmqpWs()
+        {
+            await
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    FaultInjection.FaultType_AmqpSess,
+                    "",
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_AmqpC2DLinkDropReceiveWithCallbackRecovery_Amqp()
+        {
+            await
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    FaultInjection.FaultType_AmqpC2D,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_AmqpC2DLinkDropReceiveWithCallbackRecovery_AmqpWs()
+        {
+            await
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    FaultInjection.FaultType_AmqpD2C,
+                    FaultInjection.FaultCloseReason_Boom,
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_GracefulShutdownReceiveWithCallbackRecovery_Amqp()
+        {
+            await
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_Tcp_Only,
+                    FaultInjection.FaultType_GracefulShutdownAmqp,
+                    FaultInjection.FaultCloseReason_Bye,
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Message_GracefulShutdownReceiveWithCallbackRecovery_AmqpWs()
+        {
+            await
+                ReceiveMessageWithCallbackRecoveryAsync(
+                    TestDeviceType.Sasl,
+                    Client.TransportType.Amqp_WebSocket_Only,
+                    FaultInjection.FaultType_GracefulShutdownAmqp,
+                    FaultInjection.FaultCloseReason_Bye,
+                    FaultInjection.DefaultDelayInSec)
+                .ConfigureAwait(false);
+        }
+
         private async Task ReceiveMessageRecovery(
             TestDeviceType type,
             Client.TransportType transport,
@@ -299,12 +429,16 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice)
             {
-                using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                var timeout = TimeSpan.FromSeconds(20);
+                using var cts = new CancellationTokenSource(timeout);
                 (Message message, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage(Logger);
 
                 testDeviceCallbackHandler.ExpectedMessageSentByService = message;
                 await serviceClient.SendAsync(testDevice.Id, message).ConfigureAwait(false);
+
+                Client.Message receivedMessage = await deviceClient.ReceiveAsync(timeout).ConfigureAwait(false);
                 await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts.Token).ConfigureAwait(false);
+                receivedMessage.Should().BeNull();
             }
 
             Task CleanupOperationAsync()

--- a/e2e/test/iothub/messaging/MessageSendE2EPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/MessageSendE2EPoolAmqpTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             int devicesCount,
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device)
         {
-            Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
+            async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
                 Logger.Trace($"{nameof(MessageSendE2EPoolAmqpTests)}: Preparing to send message for device {testDevice.Id}");
                 await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 (Client.Message testMessage, string payload, string p1Value) = MessageSendE2ETests.ComposeD2cTestMessage(Logger);
                 Logger.Trace($"{nameof(MessageSendE2EPoolAmqpTests)}.{testDevice.Id}: messageId='{testMessage.MessageId}' payload='{payload}' p1Value='{p1Value}'");
                 await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
-            };
+            }
 
             await PoolingOverAmqp
                 .TestPoolAmqpAsync(
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     poolSize,
                     devicesCount,
                     null,
-                    testOperation,
+                    TestOperationAsync,
                     null,
                     authScope,
                     true,

--- a/e2e/test/iothub/method/FaultInjectionPoolAmqpTests.MethodFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/method/FaultInjectionPoolAmqpTests.MethodFaultInjectionPoolAmqpTests.cs
@@ -737,35 +737,36 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             var testDevicesWithCallbackHandler = new Dictionary<string, TestDeviceCallbackHandler>();
 
-            Func<DeviceClient, TestDevice, Task> initOperation = async (deviceClient, testDevice) =>
+            async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
-                var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, Logger);
+                var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
                 testDevicesWithCallbackHandler.Add(testDevice.Id, testDeviceCallbackHandler);
 
                 Logger.Trace($"{nameof(MethodE2EPoolAmqpTests)}: Setting method callback handler for device {testDevice.Id}");
                 await testDeviceCallbackHandler
                     .SetDeviceReceiveMethodAsync(MethodName, MethodE2ETests.DeviceResponseJson, MethodE2ETests.ServiceRequestJson)
                     .ConfigureAwait(false);
-            };
+            }
 
-            Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
+            async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
                 TestDeviceCallbackHandler testDeviceCallbackHandler = testDevicesWithCallbackHandler[testDevice.Id];
                 using var cts = new CancellationTokenSource(FaultInjection.RecoveryTimeMilliseconds);
 
                 Logger.Trace($"{nameof(MethodE2EPoolAmqpTests)}: Preparing to receive method for device {testDevice.Id}");
-                Task serviceSendTask = MethodE2ETests.ServiceSendMethodAndVerifyResponseAsync(
-                    testDevice.Id,
-                    MethodName,
-                    MethodE2ETests.DeviceResponseJson,
-                    MethodE2ETests.ServiceRequestJson,
-                    Logger);
+                Task serviceSendTask = MethodE2ETests
+                    .ServiceSendMethodAndVerifyResponseAsync(
+                        testDevice.Id,
+                        MethodName,
+                        MethodE2ETests.DeviceResponseJson,
+                        MethodE2ETests.ServiceRequestJson,
+                        Logger);
                 Task methodReceivedTask = testDeviceCallbackHandler.WaitForMethodCallbackAsync(cts.Token);
 
                 await Task.WhenAll(serviceSendTask, methodReceivedTask).ConfigureAwait(false);
-            };
+            }
 
-            Func<IList<DeviceClient>, Task> cleanupOperation = async (deviceClients) =>
+            async Task CleanupOperationAsync(IList<DeviceClient> deviceClients)
             {
                 foreach (DeviceClient deviceClient in deviceClients)
                 {
@@ -780,7 +781,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 testDevicesWithCallbackHandler.Clear();
                 await Task.FromResult<bool>(false).ConfigureAwait(false);
-            };
+            }
 
             await FaultInjectionPoolingOverAmqp
                 .TestFaultInjectionPoolAmqpAsync(
@@ -793,9 +794,9 @@ namespace Microsoft.Azure.Devices.E2ETests
                     reason,
                     delayInSec,
                     durationInSec,
-                    initOperation,
-                    testOperation,
-                    cleanupOperation,
+                    InitOperationAsync,
+                    TestOperationAsync,
+                    CleanupOperationAsync,
                     authScope,
                     Logger)
                 .ConfigureAwait(false);

--- a/e2e/test/iothub/method/MethodE2EPoolAmqpTests.cs
+++ b/e2e/test/iothub/method/MethodE2EPoolAmqpTests.cs
@@ -225,13 +225,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             Func<DeviceClient, string, MsTestLogger, Task<Task>> setDeviceReceiveMethod,
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device)
         {
-            Func<DeviceClient, TestDevice, Task> initOperation = async (deviceClient, testDevice) =>
+            async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
                 Logger.Trace($"{nameof(MethodE2EPoolAmqpTests)}: Setting method for device {testDevice.Id}");
                 Task methodReceivedTask = await setDeviceReceiveMethod(deviceClient, MethodName, Logger).ConfigureAwait(false);
-            };
+            }
 
-            Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
+            async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
                 Logger.Trace($"{nameof(MethodE2EPoolAmqpTests)}: Preparing to receive method for device {testDevice.Id}");
                 await MethodE2ETests
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                         MethodE2ETests.ServiceRequestJson,
                         Logger)
                     .ConfigureAwait(false);
-            };
+            }
 
             await PoolingOverAmqp
                 .TestPoolAmqpAsync(
@@ -250,8 +250,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     transport,
                     poolSize,
                     devicesCount,
-                    initOperation,
-                    testOperation,
+                    InitOperationAsync,
+                    TestOperationAsync,
                     null,
                     authScope,
                     true,

--- a/e2e/test/iothub/method/MethodFaultInjectionTests.cs
+++ b/e2e/test/iothub/method/MethodFaultInjectionTests.cs
@@ -253,16 +253,16 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             using var cts = new CancellationTokenSource(FaultInjection.RecoveryTimeMilliseconds);
 
             // Configure the callback and start accepting method calls.
-            Func<DeviceClient, TestDevice, Task> initOperation = async (deviceClient, testDevice) =>
+            async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice)
             {
-                testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, Logger);
+                testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
                 await testDeviceCallbackHandler
                     .SetDeviceReceiveMethodAsync(MethodName, DeviceResponseJson, ServiceRequestJson)
                     .ConfigureAwait(false);
-            };
+            }
 
             // Call the method from the service side and verify the device received the call.
-            Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
+            async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice)
             {
                 Task serviceSendTask = ServiceSendMethodAndVerifyResponseAsync(testDevice.Id, MethodName, DeviceResponseJson, ServiceRequestJson);
                 Task methodReceivedTask = testDeviceCallbackHandler.WaitForMethodCallbackAsync(cts.Token);
@@ -274,14 +274,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     completedTask.GetAwaiter().GetResult();
                     tasks.Remove(completedTask);
                 }
-            };
+            }
 
             // Cleanup references.
-            Func<Task> cleanupOperation = () =>
+            Task CleanupOperationAsync()
             {
                 testDeviceCallbackHandler?.Dispose();
                 return Task.FromResult(false);
-            };
+            }
 
             await FaultInjection
                 .TestErrorInjectionAsync(
@@ -293,9 +293,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     reason,
                     delayInSec,
                     FaultInjection.DefaultDelayInSec,
-                    initOperation,
-                    testOperation,
-                    cleanupOperation,
+                    InitOperationAsync,
+                    TestOperationAsync,
+                    CleanupOperationAsync,
                     Logger)
                 .ConfigureAwait(false);
         }

--- a/e2e/test/iothub/twin/FaultInjectionPoolAmqpTests.TwinFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/twin/FaultInjectionPoolAmqpTests.TwinFaultInjectionPoolAmqpTests.cs
@@ -1433,36 +1433,38 @@ namespace Microsoft.Azure.Devices.E2ETests
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device,
             string proxyAddress = null)
         {
-            Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
+            async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
                 Logger.Trace($"{nameof(TwinE2EPoolAmqpTests)}: Setting reported propery and verifying twin for device {testDevice.Id}");
                 await TwinE2ETests.Twin_DeviceSetsReportedPropertyAndGetsItBackAsync(deviceClient, Guid.NewGuid().ToString(), Logger).ConfigureAwait(false);
-            };
+            }
 
-            Func<IList<DeviceClient>, Task> cleanupOperation = async (deviceClients) =>
+            async Task CleanupOperationAsync(IList<DeviceClient> deviceClients)
             {
                 foreach (DeviceClient deviceClient in deviceClients)
                 {
                     deviceClient.Dispose();
                 }
                 await Task.FromResult<bool>(false).ConfigureAwait(false);
-            };
+            }
 
-            await FaultInjectionPoolingOverAmqp.TestFaultInjectionPoolAmqpAsync(
-                Twin_DevicePrefix,
-                transport,
-                proxyAddress,
-                poolSize,
-                devicesCount,
-                faultType,
-                reason,
-                delayInSec,
-                durationInSec,
-                (d, t) => { return Task.FromResult(false); },
-                testOperation,
-                cleanupOperation,
-                authScope,
-                Logger).ConfigureAwait(false);
+            await FaultInjectionPoolingOverAmqp
+                .TestFaultInjectionPoolAmqpAsync(
+                    Twin_DevicePrefix,
+                    transport,
+                    proxyAddress,
+                    poolSize,
+                    devicesCount,
+                    faultType,
+                    reason,
+                    delayInSec,
+                    durationInSec,
+                    (d, t, h) => { return Task.FromResult(false); },
+                    TestOperationAsync,
+                    CleanupOperationAsync,
+                    authScope,
+                    Logger)
+                .ConfigureAwait(false);
         }
 
         private async Task Twin_DeviceDesiredPropertyUpdateRecoveryPoolOverAmqp(
@@ -1481,9 +1483,9 @@ namespace Microsoft.Azure.Devices.E2ETests
             var twinPropertyMap = new Dictionary<string, List<string>>();
             var testDevicesWithCallbackHandler = new Dictionary<string, TestDeviceCallbackHandler>();
 
-            Func<DeviceClient, TestDevice, Task> initOperation = async (deviceClient, testDevice) =>
+            async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
-                var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, Logger);
+                var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
                 testDevicesWithCallbackHandler.Add(testDevice.Id, testDeviceCallbackHandler);
 
                 var propName = Guid.NewGuid().ToString();
@@ -1493,11 +1495,11 @@ namespace Microsoft.Azure.Devices.E2ETests
                 Logger.Trace($"{nameof(FaultInjectionPoolAmqpTests)}: Setting desired propery callback for device {testDevice.Id}");
                 Logger.Trace($"{nameof(Twin_DeviceDesiredPropertyUpdateRecoveryPoolOverAmqp)}: name={propName}, value={propValue}");
                 await testDeviceCallbackHandler.SetTwinPropertyUpdateCallbackHandlerAsync(propName).ConfigureAwait(false);
-            };
+            }
 
-            Func<DeviceClient, TestDevice, Task> testOperation = async (deviceClient, testDevice) =>
+            async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
-                var testDeviceCallbackHandler = testDevicesWithCallbackHandler[testDevice.Id];
+                TestDeviceCallbackHandler testDeviceCallbackHandler = testDevicesWithCallbackHandler[testDevice.Id];
                 using var cts = new CancellationTokenSource(FaultInjection.RecoveryTimeMilliseconds);
 
                 List<string> twinProperties = twinPropertyMap[testDevice.Id];
@@ -1511,9 +1513,9 @@ namespace Microsoft.Azure.Devices.E2ETests
                 Task twinReceivedTask = testDeviceCallbackHandler.WaitForTwinCallbackAsync(cts.Token);
 
                 await Task.WhenAll(serviceSendTask, twinReceivedTask).ConfigureAwait(false);
-            };
+            }
 
-            Func<IList<DeviceClient>, Task> cleanupOperation = async (deviceClients) =>
+            async Task CleanupOperationAsync(IList<DeviceClient> deviceClients)
             {
                 foreach (DeviceClient deviceClient in deviceClients)
                 {
@@ -1529,23 +1531,25 @@ namespace Microsoft.Azure.Devices.E2ETests
                 twinPropertyMap.Clear();
                 testDevicesWithCallbackHandler.Clear();
                 await Task.FromResult<bool>(false).ConfigureAwait(false);
-            };
+            }
 
-            await FaultInjectionPoolingOverAmqp.TestFaultInjectionPoolAmqpAsync(
-                Twin_DevicePrefix,
-                transport,
-                proxyAddress,
-                poolSize,
-                devicesCount,
-                faultType,
-                reason,
-                delayInSec,
-                durationInSec,
-                initOperation,
-                testOperation,
-                cleanupOperation,
-                authScope,
-                Logger).ConfigureAwait(false);
+            await FaultInjectionPoolingOverAmqp
+                .TestFaultInjectionPoolAmqpAsync(
+                    Twin_DevicePrefix,
+                    transport,
+                    proxyAddress,
+                    poolSize,
+                    devicesCount,
+                    faultType,
+                    reason,
+                    delayInSec,
+                    durationInSec,
+                    InitOperationAsync,
+                    TestOperationAsync,
+                    CleanupOperationAsync,
+                    authScope,
+                    Logger)
+                .ConfigureAwait(false);
         }
     }
 }

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
@@ -35,9 +35,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         public AmqpUnit CreateAmqpUnit(
             DeviceIdentity deviceIdentity,
-            Func<MethodRequestInternal, Task> methodHandler,
+            Func<MethodRequestInternal, Task> onMethodCallback,
             Action<Twin, string, TwinCollection> twinMessageListener,
-            Func<string, Message, Task> eventListener,
+            Func<string, Message, Task> onModuleMessageReceivedCallback,
+            Func<Message, Task> onDeviceMessageReceivedCallback,
             Action onUnitDisconnected)
         {
             if (Logging.IsEnabled)
@@ -48,9 +49,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             var amqpUnit = new AmqpUnit(
                 deviceIdentity,
                 this,
-                methodHandler,
+                onMethodCallback,
                 twinMessageListener,
-                eventListener,
+                onModuleMessageReceivedCallback,
+                onDeviceMessageReceivedCallback,
                 onUnitDisconnected);
             lock (_unitsLock)
             {

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
@@ -17,9 +17,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         public AmqpUnit CreateAmqpUnit(
             DeviceIdentity deviceIdentity,
-            Func<MethodRequestInternal, Task> methodHandler,
+            Func<MethodRequestInternal, Task> onMethodCallback,
             Action<Twin, string, TwinCollection> twinMessageListener,
-            Func<string, Message, Task> eventListener,
+            Func<string, Message, Task> onModuleMessageReceivedCallback,
+            Func<Message, Task> onDeviceMessageReceivedCallback,
             Action onUnitDisconnected)
         {
             if (Logging.IsEnabled)
@@ -41,7 +42,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                     Logging.Exit(this, deviceIdentity, $"{nameof(CreateAmqpUnit)}");
                 }
 
-                return amqpConnectionHolder.CreateAmqpUnit(deviceIdentity, methodHandler, twinMessageListener, eventListener, onUnitDisconnected);
+                return amqpConnectionHolder.CreateAmqpUnit(
+                    deviceIdentity,
+                    onMethodCallback,
+                    twinMessageListener,
+                    onModuleMessageReceivedCallback,
+                    onDeviceMessageReceivedCallback,
+                    onUnitDisconnected);
             }
             else
             {
@@ -50,7 +57,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                     Logging.Exit(this, deviceIdentity, $"{nameof(CreateAmqpUnit)}");
                 }
 
-                return new AmqpConnectionHolder(deviceIdentity).CreateAmqpUnit(deviceIdentity, methodHandler, twinMessageListener, eventListener, onUnitDisconnected);
+                return new AmqpConnectionHolder(deviceIdentity)
+                    .CreateAmqpUnit(
+                        deviceIdentity,
+                        onMethodCallback,
+                        twinMessageListener,
+                        onModuleMessageReceivedCallback,
+                        onDeviceMessageReceivedCallback,
+                        onUnitDisconnected);
             }
         }
 

--- a/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
@@ -6,9 +6,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.Devices.Shared;
 using Microsoft.Azure.Devices.Client.Transport.AmqpIoT;
-using Microsoft.Azure.Devices.Client.Exceptions;
+using Microsoft.Azure.Devices.Shared;
 
 namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 {
@@ -19,7 +18,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
         private const int ResponseTimeoutInSeconds = 300;
         private readonly TimeSpan _operationTimeout;
         private readonly AmqpUnit _amqpUnit;
-        private readonly Action<TwinCollection> _desiredPropertyListener;
+        private readonly Action<TwinCollection> _onDesiredStatePatchListener;
         private readonly object _lock = new object();
         private ConcurrentDictionary<string, TaskCompletionSource<Twin>> _twinResponseCompletions = new ConcurrentDictionary<string, TaskCompletionSource<Twin>>();
         private bool _closed;
@@ -35,10 +34,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             catch (Exception ex)
             {
                 // Do not throw from static ctor.
-                if (Logging.IsEnabled)
-                {
-                    Logging.Error(null, ex, nameof(AmqpTransportHandler));
-                }
+                Logging.Error(null, ex, nameof(AmqpTransportHandler));
             }
         }
 
@@ -46,26 +42,25 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             IPipelineContext context,
             IotHubConnectionString connectionString,
             AmqpTransportSettings transportSettings,
-            Func<MethodRequestInternal, Task> methodHandler = null,
-            Action<TwinCollection> desiredPropertyListener = null,
-            Func<string, Message, Task> eventListener = null)
+            Func<MethodRequestInternal, Task> onMethodCallback = null,
+            Action<TwinCollection> onDesiredStatePatchReceivedCallback = null,
+            Func<string, Message, Task> onModuleMessageReceivedCallback = null,
+            Func<Message, Task> onDeviceMessageReceivedCallback = null)
             : base(context, transportSettings)
         {
             _operationTimeout = transportSettings.OperationTimeout;
-            _desiredPropertyListener = desiredPropertyListener;
+            _onDesiredStatePatchListener = onDesiredStatePatchReceivedCallback;
             var deviceIdentity = new DeviceIdentity(connectionString, transportSettings, context.Get<ProductInfo>(), context.Get<ClientOptions>());
             _amqpUnit = AmqpUnitManager.GetInstance().CreateAmqpUnit(
                 deviceIdentity,
-                methodHandler,
+                onMethodCallback,
                 TwinMessageListener,
-                eventListener,
+                onModuleMessageReceivedCallback,
+                onDeviceMessageReceivedCallback,
                 OnDisconnected
             );
 
-            if (Logging.IsEnabled)
-            {
-                Logging.Associate(this, _amqpUnit, $"{nameof(_amqpUnit)}");
-            }
+            Logging.Associate(this, _amqpUnit, $"{nameof(_amqpUnit)}");
         }
 
         private void OnDisconnected()
@@ -87,10 +82,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         public override async Task OpenAsync(TimeoutHelper timeoutHelper)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, timeoutHelper, $"{nameof(OpenAsync)}");
-            }
+            Logging.Enter(this, timeoutHelper, $"{nameof(OpenAsync)}");
 
             lock (_lock)
             {
@@ -108,19 +100,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, timeoutHelper, $"{nameof(OpenAsync)}");
-                }
+                Logging.Exit(this, timeoutHelper, $"{nameof(OpenAsync)}");
             }
         }
 
         public override async Task OpenAsync(CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, cancellationToken, $"{nameof(OpenAsync)}");
-            }
+            Logging.Enter(this, cancellationToken, $"{nameof(OpenAsync)}");
 
             cancellationToken.ThrowIfCancellationRequested();
             lock (_lock)
@@ -139,19 +125,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, cancellationToken, $"{nameof(OpenAsync)}");
-                }
+                Logging.Exit(this, cancellationToken, $"{nameof(OpenAsync)}");
             }
         }
 
         public override async Task CloseAsync(CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, $"{nameof(CloseAsync)}");
-            }
+            Logging.Enter(this, $"{nameof(CloseAsync)}");
 
             lock (_lock)
             {
@@ -166,10 +146,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             finally
             {
                 OnTransportClosedGracefully();
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, $"{nameof(CloseAsync)}");
-                }
+                Logging.Exit(this, $"{nameof(CloseAsync)}");
             }
         }
 
@@ -179,10 +156,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         public override async Task SendEventAsync(Message message, CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, message, cancellationToken, $"{nameof(SendEventAsync)}");
-            }
+            Logging.Enter(this, message, cancellationToken, $"{nameof(SendEventAsync)}");
 
             try
             {
@@ -196,19 +170,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, message, cancellationToken, $"{nameof(SendEventAsync)}");
-                }
+                Logging.Exit(this, message, cancellationToken, $"{nameof(SendEventAsync)}");
             }
         }
 
         public override async Task SendEventAsync(IEnumerable<Message> messages, CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, messages, cancellationToken, $"{nameof(SendEventAsync)}");
-            }
+            Logging.Enter(this, messages, cancellationToken, $"{nameof(SendEventAsync)}");
 
             try
             {
@@ -218,36 +186,24 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, messages, cancellationToken, $"{nameof(SendEventAsync)}");
-                }
+                Logging.Exit(this, messages, cancellationToken, $"{nameof(SendEventAsync)}");
             }
         }
 
         public override async Task<Message> ReceiveAsync(TimeoutHelper timeoutHelper)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, timeoutHelper, timeoutHelper.GetRemainingTime(), $"{nameof(ReceiveAsync)}");
-            }
+            Logging.Enter(this, timeoutHelper, timeoutHelper.GetRemainingTime(), $"{nameof(ReceiveAsync)}");
 
             Message message = await _amqpUnit.ReceiveMessageAsync(timeoutHelper.GetRemainingTime()).ConfigureAwait(false);
 
-            if (Logging.IsEnabled)
-            {
-                Logging.Exit(this, timeoutHelper, timeoutHelper.GetRemainingTime(), $"{nameof(ReceiveAsync)}");
-            }
+            Logging.Exit(this, timeoutHelper, timeoutHelper.GetRemainingTime(), $"{nameof(ReceiveAsync)}");
 
             return message;
         }
 
         public override async Task<Message> ReceiveAsync(CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, cancellationToken, $"{nameof(ReceiveAsync)}");
-            }
+            Logging.Enter(this, cancellationToken, $"{nameof(ReceiveAsync)}");
 
             Message message;
             while (true)
@@ -260,12 +216,39 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                 }
             }
 
-            if (Logging.IsEnabled)
-            {
-                Logging.Exit(this, cancellationToken, cancellationToken, $"{nameof(ReceiveAsync)}");
-            }
+            Logging.Exit(this, cancellationToken, cancellationToken, $"{nameof(ReceiveAsync)}");
 
             return message;
+        }
+
+        public override async Task EnableReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            Logging.Enter(this, cancellationToken, $"{nameof(EnableReceiveMessageAsync)}");
+
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await _amqpUnit.EnableReceiveMessageAsync(_operationTimeout).ConfigureAwait(false);
+            }
+            finally
+            {
+                Logging.Exit(this, cancellationToken, $"{nameof(EnableReceiveMessageAsync)}");
+            }
+        }
+
+        public override async Task DisableReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            Logging.Enter(this, cancellationToken, $"{nameof(DisableReceiveMessageAsync)}");
+
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await _amqpUnit.DisableReceiveMessageAsync(_operationTimeout).ConfigureAwait(false);
+            }
+            finally
+            {
+                Logging.Exit(this, cancellationToken, $"{nameof(DisableReceiveMessageAsync)}");
+            }
         }
 
         #endregion Telemetry
@@ -274,10 +257,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         public override async Task EnableMethodsAsync(CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, cancellationToken, $"{nameof(EnableMethodsAsync)}");
-            }
+            Logging.Enter(this, cancellationToken, $"{nameof(EnableMethodsAsync)}");
 
             try
             {
@@ -287,10 +267,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, cancellationToken, $"{nameof(EnableMethodsAsync)}");
-                }
+                Logging.Exit(this, cancellationToken, $"{nameof(EnableMethodsAsync)}");
             }
         }
 
@@ -298,10 +275,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
         {
             try
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Enter(this, cancellationToken, $"{nameof(DisableMethodsAsync)}");
-                }
+                Logging.Enter(this, cancellationToken, $"{nameof(DisableMethodsAsync)}");
 
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -309,19 +283,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, cancellationToken, $"{nameof(DisableMethodsAsync)}");
-                }
+                Logging.Exit(this, cancellationToken, $"{nameof(DisableMethodsAsync)}");
             }
         }
 
         public override async Task SendMethodResponseAsync(MethodResponseInternal methodResponse, CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, methodResponse, cancellationToken, $"{nameof(SendMethodResponseAsync)}");
-            }
+            Logging.Enter(this, methodResponse, cancellationToken, $"{nameof(SendMethodResponseAsync)}");
 
             try
             {
@@ -334,10 +302,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, methodResponse, cancellationToken, $"{nameof(SendMethodResponseAsync)}");
-                }
+                Logging.Exit(this, methodResponse, cancellationToken, $"{nameof(SendMethodResponseAsync)}");
             }
         }
 
@@ -347,10 +312,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         public override async Task EnableTwinPatchAsync(CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, cancellationToken, $"{nameof(EnableTwinPatchAsync)}");
-            }
+            Logging.Enter(this, cancellationToken, $"{nameof(EnableTwinPatchAsync)}");
 
             try
             {
@@ -360,10 +322,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, cancellationToken, $"{nameof(EnableTwinPatchAsync)}");
-                }
+                Logging.Exit(this, cancellationToken, $"{nameof(EnableTwinPatchAsync)}");
             }
         }
 
@@ -371,10 +330,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
         {
             try
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Enter(this, cancellationToken, $"{nameof(DisableTwinPatchAsync)}");
-                }
+                Logging.Enter(this, cancellationToken, $"{nameof(DisableTwinPatchAsync)}");
 
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -382,19 +338,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, cancellationToken, $"{nameof(DisableTwinPatchAsync)}");
-                }
+                Logging.Exit(this, cancellationToken, $"{nameof(DisableTwinPatchAsync)}");
             }
         }
 
         public override async Task<Twin> SendTwinGetAsync(CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, cancellationToken, $"{nameof(SendTwinGetAsync)}");
-            }
+            Logging.Enter(this, cancellationToken, $"{nameof(SendTwinGetAsync)}");
 
             try
             {
@@ -408,19 +358,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, cancellationToken, $"{nameof(SendTwinGetAsync)}");
-                }
+                Logging.Exit(this, cancellationToken, $"{nameof(SendTwinGetAsync)}");
             }
         }
 
         public override async Task SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, reportedProperties, cancellationToken, $"{nameof(SendTwinPatchAsync)}");
-            }
+            Logging.Enter(this, reportedProperties, cancellationToken, $"{nameof(SendTwinPatchAsync)}");
 
             try
             {
@@ -429,19 +373,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, reportedProperties, cancellationToken, $"{nameof(SendTwinPatchAsync)}");
-                }
+                Logging.Exit(this, reportedProperties, cancellationToken, $"{nameof(SendTwinPatchAsync)}");
             }
         }
 
         private async Task<Twin> RoundTripTwinMessage(AmqpTwinMessageType amqpTwinMessageType, TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, cancellationToken, $"{nameof(RoundTripTwinMessage)}");
-            }
+            Logging.Enter(this, cancellationToken, $"{nameof(RoundTripTwinMessage)}");
 
             string correlationId = Guid.NewGuid().ToString();
             Twin response = null;
@@ -475,10 +413,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             finally
             {
                 _twinResponseCompletions.TryRemove(correlationId, out _);
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, cancellationToken, $"{nameof(RoundTripTwinMessage)}");
-                }
+                Logging.Exit(this, cancellationToken, $"{nameof(RoundTripTwinMessage)}");
             }
 
             return response;
@@ -490,10 +425,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         public override async Task EnableEventReceiveAsync(CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, cancellationToken, $"{nameof(EnableEventReceiveAsync)}");
-            }
+            Logging.Enter(this, cancellationToken, $"{nameof(EnableEventReceiveAsync)}");
 
             try
             {
@@ -503,10 +435,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, cancellationToken, $"{nameof(EnableEventReceiveAsync)}");
-                }
+                Logging.Exit(this, cancellationToken, $"{nameof(EnableEventReceiveAsync)}");
             }
         }
 
@@ -516,10 +445,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         public override Task CompleteAsync(string lockToken, CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, lockToken, cancellationToken, $"{nameof(CompleteAsync)}");
-            }
+            Logging.Enter(this, lockToken, cancellationToken, $"{nameof(CompleteAsync)}");
 
             try
             {
@@ -528,19 +454,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, lockToken, cancellationToken, $"{nameof(CompleteAsync)}");
-                }
+                Logging.Exit(this, lockToken, cancellationToken, $"{nameof(CompleteAsync)}");
             }
         }
 
         public override Task AbandonAsync(string lockToken, CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, lockToken, cancellationToken, $"{nameof(AbandonAsync)}");
-            }
+            Logging.Enter(this, lockToken, cancellationToken, $"{nameof(AbandonAsync)}");
 
             try
             {
@@ -549,19 +469,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, lockToken, cancellationToken, $"{nameof(AbandonAsync)}");
-                }
+                Logging.Exit(this, lockToken, cancellationToken, $"{nameof(AbandonAsync)}");
             }
         }
 
         public override Task RejectAsync(string lockToken, CancellationToken cancellationToken)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, lockToken, cancellationToken, $"{nameof(RejectAsync)}");
-            }
+            Logging.Enter(this, lockToken, cancellationToken, $"{nameof(RejectAsync)}");
 
             try
             {
@@ -570,19 +484,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, lockToken, cancellationToken, $"{nameof(RejectAsync)}");
-                }
+                Logging.Exit(this, lockToken, cancellationToken, $"{nameof(RejectAsync)}");
             }
         }
 
         private async Task DisposeMessageAsync(string lockToken, AmqpIoTDisposeActions outcome)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, outcome, $"{nameof(DisposeMessageAsync)}");
-            }
+            Logging.Enter(this, outcome, $"{nameof(DisposeMessageAsync)}");
 
             AmqpIoTOutcome disposeOutcome;
             try
@@ -598,10 +506,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, outcome, $"{nameof(DisposeMessageAsync)}");
-                }
+                Logging.Exit(this, outcome, $"{nameof(DisposeMessageAsync)}");
             }
         }
 
@@ -623,7 +528,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             else
             {
                 // It is a PATCH, just call the callback with the TwinCollection
-                _desiredPropertyListener(twinCollection);
+                _onDesiredStatePatchListener(twinCollection);
             }
         }
 
@@ -640,10 +545,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                     return;
                 }
 
-                if (Logging.IsEnabled)
-                {
-                    Logging.Info(this, $"{nameof(disposing)}");
-                }
+                Logging.Info(this, $"{nameof(disposing)}");
 
                 if (disposing)
                 {

--- a/iothub/device/src/Transport/Amqp/AmqpUnit.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnit.cs
@@ -18,19 +18,23 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
         // If the first argument is set to true, we are disconnecting gracefully via CloseAsync.
         private readonly DeviceIdentity _deviceIdentity;
 
-        private readonly Func<MethodRequestInternal, Task> _methodHandler;
+        private readonly Func<MethodRequestInternal, Task> _onMethodCallback;
         private readonly Action<Twin, string, TwinCollection> _twinMessageListener;
-        private readonly Func<string, Message, Task> _eventListener;
+        private readonly Func<string, Message, Task> _onModuleMessageReceivedCallback;
+        private readonly Func<Message, Task> _onDeviceMessageReceivedCallback;
         private readonly IAmqpConnectionHolder _amqpConnectionHolder;
         private readonly Action _onUnitDisconnected;
         private volatile bool _disposed;
         private volatile bool _closed;
 
-        private readonly SemaphoreSlim _sessionLock = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _sessionSemaphore = new SemaphoreSlim(1, 1);
 
         private AmqpIoTSendingLink _messageSendingLink;
         private AmqpIoTReceivingLink _messageReceivingLink;
         private readonly SemaphoreSlim _messageReceivingLinkSemaphore = new SemaphoreSlim(1, 1);
+
+        private readonly SemaphoreSlim _messageReceivingCallbackSemaphore = new SemaphoreSlim(1, 1);
+        private bool _isDeviceReceiveMessageCallbackSet  = false;
 
         private AmqpIoTReceivingLink _eventReceivingLink;
         private readonly SemaphoreSlim _eventReceivingLinkSemaphore = new SemaphoreSlim(1, 1);
@@ -49,22 +53,21 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
         public AmqpUnit(
             DeviceIdentity deviceIdentity,
             IAmqpConnectionHolder amqpConnectionHolder,
-            Func<MethodRequestInternal, Task> methodHandler,
+            Func<MethodRequestInternal, Task> onMethodCallback,
             Action<Twin, string, TwinCollection> twinMessageListener,
-            Func<string, Message, Task> eventListener,
+            Func<string, Message, Task> onModuleMessageReceivedCallback,
+            Func<Message, Task> onDeviceMessageReceivedCallback,
             Action onUnitDisconnected)
         {
             _deviceIdentity = deviceIdentity;
-            _methodHandler = methodHandler;
+            _onMethodCallback = onMethodCallback;
             _twinMessageListener = twinMessageListener;
-            _eventListener = eventListener;
+            _onModuleMessageReceivedCallback = onModuleMessageReceivedCallback;
+            _onDeviceMessageReceivedCallback = onDeviceMessageReceivedCallback;
             _amqpConnectionHolder = amqpConnectionHolder;
             _onUnitDisconnected = onUnitDisconnected;
 
-            if (Logging.IsEnabled)
-            {
-                Logging.Associate(this, _deviceIdentity, $"{nameof(_deviceIdentity)}");
-            }
+            Logging.Associate(this, _deviceIdentity, $"{nameof(_deviceIdentity)}");
         }
 
         internal DeviceIdentity GetDeviceIdentity()
@@ -76,10 +79,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
 
         public async Task OpenAsync(TimeSpan timeout)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, timeout, $"{nameof(OpenAsync)}");
-            }
+            Logging.Enter(this, timeout, $"{nameof(OpenAsync)}");
 
             try
             {
@@ -88,10 +88,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, timeout, $"{nameof(OpenAsync)}");
-                }
+                Logging.Exit(this, timeout, $"{nameof(OpenAsync)}");
             }
         }
 
@@ -102,12 +99,9 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 throw new IotHubException("Device is now offline.", false);
             }
 
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, timeout, $"{nameof(EnsureSessionAsync)}");
-            }
+            Logging.Enter(this, timeout, $"{nameof(EnsureSessionAsync)}");
 
-            bool gain = await _sessionLock.WaitAsync(timeout).ConfigureAwait(false);
+            bool gain = await _sessionSemaphore.WaitAsync(timeout).ConfigureAwait(false);
             if (!gain)
             {
                 throw new TimeoutException();
@@ -120,18 +114,12 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                     _amqpIoTSession?.SafeClose();
 
                     _amqpIoTSession = await _amqpConnectionHolder.OpenSessionAsync(_deviceIdentity, timeout).ConfigureAwait(false);
-                    if (Logging.IsEnabled)
-                    {
-                        Logging.Associate(this, _amqpIoTSession, $"{nameof(_amqpIoTSession)}");
-                    }
+                    Logging.Associate(this, _amqpIoTSession, $"{nameof(_amqpIoTSession)}");
 
                     if (_deviceIdentity.AuthenticationModel == AuthenticationModel.SasIndividual)
                     {
                         _amqpAuthenticationRefresher = await _amqpConnectionHolder.CreateRefresherAsync(_deviceIdentity, timeout).ConfigureAwait(false);
-                        if (Logging.IsEnabled)
-                        {
-                            Logging.Associate(this, _amqpAuthenticationRefresher, $"{nameof(_amqpAuthenticationRefresher)}");
-                        }
+                        Logging.Associate(this, _amqpAuthenticationRefresher, $"{nameof(_amqpAuthenticationRefresher)}");
                     }
 
                     _amqpIoTSession.Closed += OnSessionDisconnected;
@@ -141,10 +129,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                         _amqpIoTSession.SafeClose();
                     };
 
-                    if (Logging.IsEnabled)
-                    {
-                        Logging.Associate(this, _messageSendingLink, $"{nameof(_messageSendingLink)}");
-                    }
+                    Logging.Associate(this, _messageSendingLink, $"{nameof(_messageSendingLink)}");
                 }
 
                 if (_disposed)
@@ -159,25 +144,19 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
             finally
             {
-                _sessionLock.Release();
+                _sessionSemaphore.Release();
             }
 
-            if (Logging.IsEnabled)
-            {
-                Logging.Exit(this, timeout, $"{nameof(EnsureSessionAsync)}");
-            }
+            Logging.Exit(this, timeout, $"{nameof(EnsureSessionAsync)}");
 
             return _amqpIoTSession;
         }
 
         public async Task CloseAsync(TimeSpan timeout)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, timeout, $"{nameof(CloseAsync)}");
-            }
+            Logging.Enter(this, timeout, $"{nameof(CloseAsync)}");
 
-            bool gain = await _sessionLock.WaitAsync(timeout).ConfigureAwait(false);
+            bool gain = await _sessionSemaphore.WaitAsync(timeout).ConfigureAwait(false);
             if (!gain)
             {
                 throw new TimeoutException();
@@ -200,21 +179,15 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             finally
             {
                 _closed = true;
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, timeout, $"{nameof(CloseAsync)}");
-                }
+                Logging.Exit(this, timeout, $"{nameof(CloseAsync)}");
 
-                _sessionLock.Release();
+                _sessionSemaphore.Release();
             }
         }
 
         private void Cleanup()
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, $"{nameof(Cleanup)}");
-            }
+            Logging.Enter(this, $"{nameof(Cleanup)}");
 
             _amqpIoTSession?.SafeClose();
             _amqpAuthenticationRefresher?.StopLoop();
@@ -223,27 +196,21 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 _amqpConnectionHolder?.Shutdown();
             }
 
-            if (Logging.IsEnabled)
-            {
-                Logging.Exit(this, $"{nameof(Cleanup)}");
-            }
+            Logging.Exit(this, $"{nameof(Cleanup)}");
         }
 
         #endregion Open-Close
 
         #region Message
 
-        private async Task EnsureMessageReceivingLinkAsync(TimeSpan timeout)
+        private async Task EnsureMessageReceivingLinkAsync(TimeSpan timeout, bool enableCallback = false)
         {
             if (_closed)
             {
                 throw new IotHubException("Device is now offline.", false);
             }
 
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, timeout, $"{nameof(EnsureMessageReceivingLinkAsync)}");
-            }
+            Logging.Enter(this, timeout, $"{nameof(EnsureMessageReceivingLinkAsync)}");
 
             AmqpIoTSession amqpIoTSession = await EnsureSessionAsync(timeout).ConfigureAwait(false);
             bool gain = await _messageReceivingLinkSemaphore.WaitAsync(timeout).ConfigureAwait(false);
@@ -264,28 +231,23 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                     {
                         amqpIoTSession.SafeClose();
                     };
-                    if (Logging.IsEnabled)
+                    if (enableCallback)
                     {
-                        Logging.Associate(this, this, _messageReceivingLink, $"{nameof(EnsureMessageReceivingLinkAsync)}");
+                        _messageReceivingLink.RegisterReceiveMessageListener(OnDeviceMessageReceived);
                     }
+                    Logging.Associate(this, this, _messageReceivingLink, $"{nameof(EnsureMessageReceivingLinkAsync)}");
                 }
             }
             finally
             {
                 _messageReceivingLinkSemaphore.Release();
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, timeout, $"{nameof(EnsureMessageReceivingLinkAsync)}");
-                }
+                Logging.Exit(this, timeout, $"{nameof(EnsureMessageReceivingLinkAsync)}");
             }
         }
 
         public async Task<AmqpIoTOutcome> SendMessagesAsync(IEnumerable<Message> messages, TimeSpan timeout)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, messages, timeout, $"{nameof(SendMessagesAsync)}");
-            }
+            Logging.Enter(this, messages, timeout, $"{nameof(SendMessagesAsync)}");
 
             await EnsureSessionAsync(timeout).ConfigureAwait(false);
             try
@@ -295,19 +257,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, messages, timeout, $"{nameof(SendMessagesAsync)}");
-                }
+                Logging.Exit(this, messages, timeout, $"{nameof(SendMessagesAsync)}");
             }
         }
 
         public async Task<AmqpIoTOutcome> SendMessageAsync(Message message, TimeSpan timeout)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, message, timeout, $"{nameof(SendMessageAsync)}");
-            }
+            Logging.Enter(this, message, timeout, $"{nameof(SendMessageAsync)}");
 
             await EnsureSessionAsync(timeout).ConfigureAwait(false);
             try
@@ -317,19 +273,19 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, message, timeout, $"{nameof(SendMessageAsync)}");
-                }
+                Logging.Exit(this, message, timeout, $"{nameof(SendMessageAsync)}");
             }
         }
 
         public async Task<Message> ReceiveMessageAsync(TimeSpan timeout)
         {
-            if (Logging.IsEnabled)
+            if (_isDeviceReceiveMessageCallbackSet )
             {
-                Logging.Enter(this, timeout, $"{nameof(ReceiveMessageAsync)}");
+                Logging.Error(this, "Callback handler set for receiving c2d messages, ReceiveAsync() will now always return null", nameof(ReceiveMessageAsync));
+                return null;
             }
+
+            Logging.Enter(this, timeout, $"{nameof(ReceiveMessageAsync)}");
 
             await EnsureMessageReceivingLinkAsync(timeout).ConfigureAwait(false);
             try
@@ -339,19 +295,108 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
             finally
             {
-                if (Logging.IsEnabled)
+                Logging.Exit(this, timeout, $"{nameof(ReceiveMessageAsync)}");
+            }
+        }
+
+        public async Task EnableReceiveMessageAsync(TimeSpan timeout)
+        {
+            if (_closed)
+            {
+                throw new IotHubException("Device is now offline.", false);
+            }
+
+            Logging.Enter(this, timeout, $"{nameof(EnableReceiveMessageAsync)}");
+
+            try
+            {
+                // Wait to grab the semaphore, and then open the telemetry receiving link and set the callback,
+                // and set _isDeviceReceiveMessageCallbackSet  to true.
+                // Once _isDeviceReceiveMessageCallbackSet  is set to true, all received c2d messages will be returned on the callback,
+                // and not via the polling ReceiveAsync() call.
+                bool gain = await _messageReceivingCallbackSemaphore.WaitAsync(timeout).ConfigureAwait(false);
+                if (!gain)
                 {
-                    Logging.Exit(this, timeout, $"{nameof(ReceiveMessageAsync)}");
+                    throw new TimeoutException();
                 }
+                await EnsureMessageReceivingLinkAsync(timeout, true).ConfigureAwait(false);
+                _isDeviceReceiveMessageCallbackSet  = true;
+            }
+            finally
+            {
+                _messageReceivingCallbackSemaphore.Release();
+                Logging.Exit(this, timeout, $"{nameof(EnableReceiveMessageAsync)}");
+            }
+        }
+
+        public async Task DisableReceiveMessageAsync(TimeSpan timeout)
+        {
+            if (_closed)
+            {
+                throw new IotHubException("Device is now offline.", false);
+            }
+
+            Logging.Enter(this, timeout, $"{nameof(DisableReceiveMessageAsync)}");
+
+            try
+            {
+                // Wait to grab the semaphore, and then close the telemetry receiving link and set _isDeviceReceiveMessageCallbackSet  to false.
+                // Once _isDeviceReceiveMessageCallbackSet  is set to false, all received c2d messages can be returned via the polling ReceiveAsync() call.
+                bool gain = await _messageReceivingCallbackSemaphore.WaitAsync(timeout).ConfigureAwait(false);
+                if (!gain)
+                {
+                    throw new TimeoutException();
+                }
+                await DisableMessageReceivingLinkAsync(timeout).ConfigureAwait(false);
+                _isDeviceReceiveMessageCallbackSet  = false;
+            }
+            finally
+            {
+                _messageReceivingCallbackSemaphore.Release();
+                Logging.Exit(this, timeout, $"{nameof(DisableReceiveMessageAsync)}");
+            }
+        }
+
+        public async Task DisableMessageReceivingLinkAsync(TimeSpan timeout)
+        {
+            Logging.Enter(this, timeout, $"{nameof(DisableMessageReceivingLinkAsync)}");
+
+            Debug.Assert(_messageReceivingLink != null);
+
+            bool gain = await _messageReceivingLinkSemaphore.WaitAsync(timeout).ConfigureAwait(false);
+            if (!gain)
+            {
+                throw new TimeoutException();
+            }
+
+            try
+            {
+                await _messageReceivingLink.CloseAsync(timeout).ConfigureAwait(false);
+            }
+            finally
+            {
+                _messageReceivingLinkSemaphore.Release();
+                Logging.Exit(this, timeout, $"{nameof(DisableMessageReceivingLinkAsync)}");
+            }
+        }
+
+        private void OnDeviceMessageReceived(Message message)
+        {
+            Logging.Enter(this, message, $"{nameof(OnDeviceMessageReceived)}");
+
+            try
+            {
+                _onDeviceMessageReceivedCallback?.Invoke(message);
+            }
+            finally
+            {
+                Logging.Exit(this, message, $"{nameof(OnDeviceMessageReceived)}");
             }
         }
 
         public async Task<AmqpIoTOutcome> DisposeMessageAsync(string lockToken, AmqpIoTDisposeActions disposeAction, TimeSpan timeout)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, lockToken, $"{nameof(DisposeMessageAsync)}");
-            }
+            Logging.Enter(this, lockToken, $"{nameof(DisposeMessageAsync)}");
 
             AmqpIoTOutcome disposeOutcome;
             if (_deviceIdentity.IotHubConnectionString.ModuleId.IsNullOrWhiteSpace())
@@ -364,10 +409,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 await EnableEventReceiveAsync(timeout).ConfigureAwait(false);
                 disposeOutcome = await _eventReceivingLink.DisposeMessageAsync(lockToken, AmqpIoTResultAdapter.GetResult(disposeAction), timeout).ConfigureAwait(false);
             }
-            if (Logging.IsEnabled)
-            {
-                Logging.Exit(this, lockToken, $"{nameof(DisposeMessageAsync)}");
-            }
+            Logging.Exit(this, lockToken, $"{nameof(DisposeMessageAsync)}");
 
             return disposeOutcome;
         }
@@ -383,10 +425,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 throw new IotHubException("Device is now offline.", false);
             }
 
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, timeout, $"{nameof(EnableEventReceiveAsync)}");
-            }
+            Logging.Enter(this, timeout, $"{nameof(EnableEventReceiveAsync)}");
 
             AmqpIoTSession amqpIoTSession = await EnsureSessionAsync(timeout).ConfigureAwait(false);
             bool gain = await _eventReceivingLinkSemaphore.WaitAsync(timeout).ConfigureAwait(false);
@@ -407,28 +446,19 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                         amqpIoTSession.SafeClose();
                     };
                     _eventReceivingLink.RegisterEventListener(OnEventsReceived);
-                    if (Logging.IsEnabled)
-                    {
-                        Logging.Associate(this, this, _eventReceivingLink, $"{nameof(EnableEventReceiveAsync)}");
-                    }
+                    Logging.Associate(this, this, _eventReceivingLink, $"{nameof(EnableEventReceiveAsync)}");
                 }
             }
             finally
             {
                 _eventReceivingLinkSemaphore.Release();
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, timeout, $"{nameof(EnableEventReceiveAsync)}");
-                }
+                Logging.Exit(this, timeout, $"{nameof(EnableEventReceiveAsync)}");
             }
         }
 
         public async Task<AmqpIoTOutcome> SendEventsAsync(IEnumerable<Message> messages, TimeSpan timeout)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, messages, timeout, $"{nameof(SendEventsAsync)}");
-            }
+            Logging.Enter(this, messages, timeout, $"{nameof(SendEventsAsync)}");
 
             try
             {
@@ -436,19 +466,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, messages, timeout, $"{nameof(SendEventsAsync)}");
-                }
+                Logging.Exit(this, messages, timeout, $"{nameof(SendEventsAsync)}");
             }
         }
 
         public async Task<AmqpIoTOutcome> SendEventAsync(Message message, TimeSpan timeout)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, message, timeout, $"{nameof(SendEventAsync)}");
-            }
+            Logging.Enter(this, message, timeout, $"{nameof(SendEventAsync)}");
 
             try
             {
@@ -456,16 +480,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, message, timeout, $"{nameof(SendEventAsync)}");
-                }
+                Logging.Exit(this, message, timeout, $"{nameof(SendEventAsync)}");
             }
         }
 
         public void OnEventsReceived(Message message)
         {
-            _eventListener?.Invoke(message.InputName, message);
+            _onModuleMessageReceivedCallback?.Invoke(message.InputName, message);
         }
 
         #endregion Event
@@ -479,10 +500,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 throw new IotHubException("Device is now offline.", false);
             }
 
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, timeout, $"{nameof(EnableMethodsAsync)}");
-            }
+            Logging.Enter(this, timeout, $"{nameof(EnableMethodsAsync)}");
 
             AmqpIoTSession amqpIoTSession = await EnsureSessionAsync(timeout).ConfigureAwait(false);
             bool gain = await _methodLinkSemaphore.WaitAsync(timeout).ConfigureAwait(false);
@@ -502,10 +520,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             finally
             {
                 _methodLinkSemaphore.Release();
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, timeout, $"{nameof(EnableMethodsAsync)}");
-                }
+                Logging.Exit(this, timeout, $"{nameof(EnableMethodsAsync)}");
             }
         }
 
@@ -521,19 +536,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                     amqpIoTSession.SafeClose();
                 };
                 _methodReceivingLink.RegisterMethodListener(OnMethodReceived);
-                if (Logging.IsEnabled)
-                {
-                    Logging.Associate(this, _methodReceivingLink, $"{nameof(_methodReceivingLink)}");
-                }
+                Logging.Associate(this, _methodReceivingLink, $"{nameof(_methodReceivingLink)}");
             }
         }
 
         public async Task DisableTwinLinksAsync(TimeSpan timeout)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, timeout, $"{nameof(DisableTwinLinksAsync)}");
-            }
+            Logging.Enter(this, timeout, $"{nameof(DisableTwinLinksAsync)}");
 
             Debug.Assert(_twinSendingLink != null);
             Debug.Assert(_twinReceivingLink != null);
@@ -566,20 +575,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, timeout, $"{nameof(DisableTwinLinksAsync)}");
-                }
+                Logging.Exit(this, timeout, $"{nameof(DisableTwinLinksAsync)}");
                 _twinLinksSemaphore.Release();
             }
         }
 
         public async Task DisableMethodsAsync(TimeSpan timeout)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, timeout, $"{nameof(DisableMethodsAsync)}");
-            }
+            Logging.Enter(this, timeout, $"{nameof(DisableMethodsAsync)}");
 
             Debug.Assert(_methodSendingLink != null);
             Debug.Assert(_methodReceivingLink != null);
@@ -606,10 +609,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, timeout, $"{nameof(DisableMethodsAsync)}");
-                }
+                Logging.Exit(this, timeout, $"{nameof(DisableMethodsAsync)}");
             }
         }
 
@@ -624,39 +624,27 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 {
                     amqpIoTSession.SafeClose();
                 };
-                if (Logging.IsEnabled)
-                {
-                    Logging.Associate(this, _methodSendingLink, $"{nameof(_methodSendingLink)}");
-                }
+                Logging.Associate(this, _methodSendingLink, $"{nameof(_methodSendingLink)}");
             }
         }
 
         private void OnMethodReceived(MethodRequestInternal methodRequestInternal)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, methodRequestInternal, $"{nameof(OnMethodReceived)}");
-            }
+            Logging.Enter(this, methodRequestInternal, $"{nameof(OnMethodReceived)}");
 
             try
             {
-                _methodHandler?.Invoke(methodRequestInternal);
+                _onMethodCallback?.Invoke(methodRequestInternal);
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, methodRequestInternal, $"{nameof(OnMethodReceived)}");
-                }
+                Logging.Exit(this, methodRequestInternal, $"{nameof(OnMethodReceived)}");
             }
         }
 
         public async Task<AmqpIoTOutcome> SendMethodResponseAsync(MethodResponseInternal methodResponse, TimeSpan timeout)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, methodResponse, $"{nameof(SendMethodResponseAsync)}");
-            }
+            Logging.Enter(this, methodResponse, $"{nameof(SendMethodResponseAsync)}");
 
             await EnableMethodsAsync(timeout).ConfigureAwait(false);
             Debug.Assert(_methodSendingLink != null);
@@ -667,10 +655,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, methodResponse, $"{nameof(SendMethodResponseAsync)}");
-                }
+                Logging.Exit(this, methodResponse, $"{nameof(SendMethodResponseAsync)}");
             }
         }
 
@@ -685,10 +670,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 throw new IotHubException("Device is now offline.", false);
             }
 
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, timeout, $"{nameof(EnableTwinLinksAsync)}");
-            }
+            Logging.Enter(this, timeout, $"{nameof(EnableTwinLinksAsync)}");
 
             AmqpIoTSession amqpIoTSession = await EnsureSessionAsync(timeout).ConfigureAwait(false);
             bool gain = await _twinLinksSemaphore.WaitAsync(timeout).ConfigureAwait(false);
@@ -709,10 +691,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             finally
             {
                 _twinLinksSemaphore.Release();
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, timeout, $"{nameof(EnableTwinLinksAsync)}");
-                }
+                Logging.Exit(this, timeout, $"{nameof(EnableTwinLinksAsync)}");
             }
         }
 
@@ -728,10 +707,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                     amqpIoTSession.SafeClose();
                 };
                 _twinReceivingLink.RegisterTwinListener(OnDesiredPropertyReceived);
-                if (Logging.IsEnabled)
-                {
-                    Logging.Associate(this, _twinReceivingLink, $"{nameof(_twinReceivingLink)}");
-                }
+                Logging.Associate(this, _twinReceivingLink, $"{nameof(_twinReceivingLink)}");
             }
         }
 
@@ -746,19 +722,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 {
                     amqpIoTSession.SafeClose();
                 };
-                if (Logging.IsEnabled)
-                {
-                    Logging.Associate(this, _twinSendingLink, $"{nameof(_twinSendingLink)}");
-                }
+                Logging.Associate(this, _twinSendingLink, $"{nameof(_twinSendingLink)}");
             }
         }
 
         private void OnDesiredPropertyReceived(Twin twin, string correlationId, TwinCollection twinCollection)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, twin, $"{nameof(OnDesiredPropertyReceived)}");
-            }
+            Logging.Enter(this, twin, $"{nameof(OnDesiredPropertyReceived)}");
 
             try
             {
@@ -766,19 +736,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, twin, $"{nameof(OnDesiredPropertyReceived)}");
-                }
+                Logging.Exit(this, twin, $"{nameof(OnDesiredPropertyReceived)}");
             }
         }
 
         public async Task SendTwinMessageAsync(AmqpTwinMessageType amqpTwinMessageType, string correlationId, TwinCollection reportedProperties, TimeSpan timeout)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, timeout, $"{nameof(SendTwinMessageAsync)}");
-            }
+            Logging.Enter(this, timeout, $"{nameof(SendTwinMessageAsync)}");
 
             await EnableTwinLinksAsync(timeout).ConfigureAwait(false);
             Debug.Assert(_twinSendingLink != null);
@@ -818,10 +782,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
             finally
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, timeout, $"{nameof(SendTwinMessageAsync)}");
-                }
+                Logging.Exit(this, timeout, $"{nameof(SendTwinMessageAsync)}");
             }
         }
 
@@ -831,36 +792,24 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
 
         public void OnConnectionDisconnected()
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, $"{nameof(OnConnectionDisconnected)}");
-            }
+            Logging.Enter(this, $"{nameof(OnConnectionDisconnected)}");
 
             _amqpAuthenticationRefresher?.StopLoop();
             _onUnitDisconnected();
 
-            if (Logging.IsEnabled)
-            {
-                Logging.Exit(this, $"{nameof(OnConnectionDisconnected)}");
-            }
+            Logging.Exit(this, $"{nameof(OnConnectionDisconnected)}");
         }
 
         private void OnSessionDisconnected(object o, EventArgs args)
         {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, o, $"{nameof(OnSessionDisconnected)}");
-            }
+            Logging.Enter(this, o, $"{nameof(OnSessionDisconnected)}");
 
             if (ReferenceEquals(o, _amqpIoTSession))
             {
                 _amqpAuthenticationRefresher?.StopLoop();
                 _onUnitDisconnected();
             }
-            if (Logging.IsEnabled)
-            {
-                Logging.Exit(this, o, $"{nameof(OnSessionDisconnected)}");
-            }
+            Logging.Exit(this, o, $"{nameof(OnSessionDisconnected)}");
         }
 
         #endregion Connectivity Event
@@ -884,10 +833,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
 
             if (disposing)
             {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Enter(this, disposing, $"{nameof(Dispose)}");
-                }
+                Logging.Enter(this, disposing, $"{nameof(Dispose)}");
 
                 Cleanup();
                 if (!_deviceIdentity.IsPooling())
@@ -895,10 +841,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                     _amqpConnectionHolder?.Dispose();
                 }
 
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, disposing, $"{nameof(Dispose)}");
-                }
+                _sessionSemaphore?.Dispose();
+                _messageReceivingLinkSemaphore?.Dispose();
+                _messageReceivingCallbackSemaphore?.Dispose();
+                _eventReceivingLinkSemaphore?.Dispose();
+                _methodLinkSemaphore?.Dispose();
+                _twinLinksSemaphore?.Dispose();
+
+                Logging.Exit(this, disposing, $"{nameof(Dispose)}");
             }
         }
 

--- a/iothub/device/src/Transport/Amqp/AmqpUnitManager.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnitManager.cs
@@ -28,17 +28,19 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         public AmqpUnit CreateAmqpUnit(
             DeviceIdentity deviceIdentity,
-            Func<MethodRequestInternal, Task> methodHandler,
+            Func<MethodRequestInternal, Task> onMethodCallback,
             Action<Twin, string, TwinCollection> twinMessageListener,
-            Func<string, Message, Task> eventListener,
+            Func<string, Message, Task> onModuleMessageReceivedCallback,
+            Func<Message, Task> onDeviceMessageReceivedCallback,
             Action onUnitDisconnected)
         {
             IAmqpUnitManager amqpConnectionPool = ResolveConnectionPool(deviceIdentity.IotHubConnectionString.HostName);
             return amqpConnectionPool.CreateAmqpUnit(
                 deviceIdentity,
-                methodHandler,
+                onMethodCallback,
                 twinMessageListener,
-                eventListener,
+                onModuleMessageReceivedCallback,
+                onDeviceMessageReceivedCallback,
                 onUnitDisconnected);
         }
 

--- a/iothub/device/src/Transport/Amqp/IAmqpUnitManager.cs
+++ b/iothub/device/src/Transport/Amqp/IAmqpUnitManager.cs
@@ -12,9 +12,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
     {
         AmqpUnit CreateAmqpUnit(
             DeviceIdentity deviceIdentity,
-            Func<MethodRequestInternal, Task> methodHandler,
+            Func<MethodRequestInternal, Task> onMethodCallback,
             Action<Twin, string, TwinCollection> twinMessageListener,
-            Func<string, Message, Task> eventListener,
+            Func<string, Message, Task> onModuleMessageReceivedCallback,
+            Func<Message, Task> onDeviceMessageReceivedCallback,
             Action onUnitDisconnected);
 
         void RemoveAmqpUnit(AmqpUnit amqpUnit);

--- a/iothub/device/src/Transport/TransportHandlerFactory.cs
+++ b/iothub/device/src/Transport/TransportHandlerFactory.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         transportSetting as AmqpTransportSettings,
                         new Func<MethodRequestInternal, Task>(onMethodCallback),
                         onDesiredStatePatchReceived,
-                        new Func<string, Message, Task>(onModuleEventReceivedCallback));
+                        new Func<string, Message, Task>(onModuleEventReceivedCallback),
+                        new Func<Message, Task>(onDeviceMessageReceivedCallback));
 
                 case TransportType.Http1:
                     return new HttpTransportHandler(context, connectionString, transportSetting as Http1TransportSettings);


### PR DESCRIPTION
Currently we can receive C2D messages on a device client only by calling `ReceiveAsync()` and waiting on the Task.
This PR adds another API using which you can set a callback to be triggered whenever the device receives C2D  messages.

The implementation for MQTT has been added already, this PR adds the implementation for AMQP.

Issue: #1289 

```csharp
public Task SetReceiveMessageHandlerAsync(ReceiveMessageCallback messageHandler, object userContext, CancellationToken cancellationToken = default(CancellationToken));
public delegate Task ReceiveMessageCallback(Message message, object userContext);
```

Behavior over different transport protocols:
- Amqp - 
     - enable callback - open the amqp message receiving link `/devices/<deviceID>/messages/devicebound link`.
    - disable callback - closethe amqp message receiving link `/devices/<deviceID>/messages/devicebound link`.
    - once callback is enabled, `public Task<Message> ReceiveAsync();` will not work anymore 
        - it will always return null.
        - we will log the following statement:
```csharp
Logging.Error(this, "Callback handler set for receiving c2d messages, ReceiveAsync() will now always return null", nameof(ReceiveAsync));
```
   - returning `null` instead of throwing an exception will make writing application code easier for our users, else they will need to keep track of their transport protocol used (http only supports `ReceiveAsync()`), and also the latest state (whether they are polling, or have subscribed to a callback). The drawback is that they will need to maintain the processing code for received messages in 2 places.