### PR TITLE
Revert lockToken setter behavior from being public to internal

### DIFF
--- a/iothub/service/src/Message.cs
+++ b/iothub/service/src/Message.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.Devices
         public string LockToken
         {
             get => GetSystemProperty<string>(MessageSystemPropertyNames.LockToken);
-            set => SystemProperties[MessageSystemPropertyNames.LockToken] = value;
+            internal set => SystemProperties[MessageSystemPropertyNames.LockToken] = value;
         }
 
         /// <summary>


### PR DESCRIPTION
`Message.LockToken` was accidentally modified to `public` in PR: #1618 .
This PR reverts the change. 

![image](https://user-images.githubusercontent.com/22563986/97911061-89dafb00-1cff-11eb-839c-eb7e48af380c.png)
