### PR TITLE
Bump versions for 2020-11-05 release

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.33.0</Version>
+    <Version>1.33.1</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.28.0</Version>
+    <Version>1.28.1</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,6 +1,6 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.33.0
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.28.0
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.33.1
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.28.1
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.26.0
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.2
 provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.3


### PR DESCRIPTION
Draft release notes:

## Microsoft.Azure.Devices.Client 1.33.1
### Bug fixes:
- Fix bug where setting a callback for receiving C2D messages after having previously called `ReceiveAsync()` would not work on AMQP.
- Fix incorrect connection status being reported if the client is disconnected immediately after initialization (#1646 ).

## Microsoft.Azure.Devices 1.28.1
- Add logging to `RegistryManager`.