### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Track1 .NET Azure IoT Hub and DPS SDKs
 
-@drwill-ms @timtay-microsoft @abhipsaMisra @vinagesh @azabbasi @bikamani @barustum @jamdavi
+*	@drwill-ms @timtay-microsoft @abhipsaMisra @vinagesh @azabbasi @bikamani @barustum @jamdavi


### PR DESCRIPTION
It requires an asterisk for the path

https://help.github.jp/enterprise/2.11/user/articles/about-codeowners/