### PR TITLE
Update XML comments, code cleanup and add missing internal constructors for Exceptions

### DIFF
--- a/common/src/service/FatalException.cs
+++ b/common/src/service/FatalException.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
+
 namespace Microsoft.Azure.Devices.Common
 {
-    using System;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Runtime.Serialization;
-
     [Serializable]
     [SuppressMessage(FxCop.Category.Design, "CA1064:ExceptionsShouldBePublic", Justification = "CSDMain Bug 43142")]
     internal class FatalException : Exception

--- a/iothub/service/src/Common/Exceptions/CallbackException.cs
+++ b/iothub/service/src/Common/Exceptions/CallbackException.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Runtime.Serialization;
+
 namespace Microsoft.Azure.Devices.Common
 {
-    using System;
-    using System.Runtime.Serialization;
-
     [Serializable]
     internal class CallbackException : FatalException
     {
@@ -24,6 +24,11 @@ namespace Microsoft.Azure.Devices.Common
 
         protected CallbackException(SerializationInfo info, StreamingContext context)
             : base(info, context)
+        {
+        }
+
+        internal CallbackException(string message)
+            : base(message)
         {
         }
     }

--- a/iothub/service/src/Common/Exceptions/DeviceAlreadyExistsException.cs
+++ b/iothub/service/src/Common/Exceptions/DeviceAlreadyExistsException.cs
@@ -6,30 +6,62 @@ using System.Runtime.Serialization;
 
 namespace Microsoft.Azure.Devices.Common.Exceptions
 {
+    /// <summary>
+    /// The exception that is thrown when an attempt is made to create a device that already exists in the hub.
+    /// </summary>
     [Serializable]
     public sealed class DeviceAlreadyExistsException : IotHubException
     {
+        /// <summary>
+        /// Creates an instance of <see cref="DeviceAlreadyExistsException"/> with the specified device Id, an empty error message
+        /// and marks it as non-transient.
+        /// </summary>
+        /// <param name="deviceId">The Id of the device that is already registered on IoT Hub.</param>
         public DeviceAlreadyExistsException(string deviceId)
             : this(deviceId, string.Empty)
         {
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="DeviceAlreadyExistsException"/> with the specified device Id and the service returned tracking Id
+        /// associated with this particular error, and marks it as non-transient.
+        /// </summary>
+        /// <param name="deviceId">The Id of the device that is already registered on IoT Hub.</param>
+        /// <param name="trackingId">The service returned tracking Id associated with this particular error.</param>
         public DeviceAlreadyExistsException(string deviceId, string trackingId)
-            : base("Device {0} already registered".FormatInvariant(deviceId), trackingId)
+            : base($"Device {deviceId} already registered", trackingId)
         {
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="DeviceAlreadyExistsException"/> with a specified error message and
+        /// a reference to the inner exception that caused this exception, and marks it as non-transient.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public DeviceAlreadyExistsException(string message, Exception innerException)
             : base(message, innerException)
         {
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="DeviceAlreadyExistsException"/> with a specified <see cref="ErrorCode"/>, error message and an
+        /// optional reference to the inner exception that caused this exception. This exception is marked as non-transient.
+        /// </summary>
+        /// <param name="code">The <see cref="ErrorCode"/> associated with the error.</param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public DeviceAlreadyExistsException(ErrorCode code, string message, Exception innerException = null)
             : base(code, message, innerException)
         {
         }
 
-        public DeviceAlreadyExistsException(SerializationInfo info, StreamingContext context)
+        internal DeviceAlreadyExistsException()
+            : base()
+        {
+        }
+
+        private DeviceAlreadyExistsException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }

--- a/iothub/service/src/Common/Exceptions/DeviceInvalidResultCountException.cs
+++ b/iothub/service/src/Common/Exceptions/DeviceInvalidResultCountException.cs
@@ -1,37 +1,57 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Runtime.Serialization;
+
 namespace Microsoft.Azure.Devices.Common.Exceptions
 {
-    using System;
-    using System.Runtime.Serialization;
-
+    /// <summary>
+    /// The exception that is thrown when the count of device results exceeds the specified maximum value.
+    /// Note: This exception is currently not thrown by the client library.
+    /// </summary>
     [Serializable]
     public sealed class DeviceInvalidResultCountException : IotHubException
     {
+        /// <summary>
+        /// Creates an instance of <see cref="DeviceInvalidResultCountException"/> with the value of the
+        /// maximum allowable count of device results.
+        /// </summary>
+        /// <param name="maximumResultCount">The maximum count of device results allowed.</param>
         public DeviceInvalidResultCountException(int maximumResultCount)
             : base("Number of device results must be between 0 and {0}".FormatInvariant(maximumResultCount))
         {
-            this.MaximumResultCount = maximumResultCount;
+            MaximumResultCount = maximumResultCount;
+        }
+
+        internal DeviceInvalidResultCountException()
+            : base()
+        {
+        }
+
+        internal DeviceInvalidResultCountException(string message)
+            : base(message)
+        {
+        }
+
+        internal DeviceInvalidResultCountException(string message, Exception innerException)
+            : base(message, innerException)
+        {
         }
 
         private DeviceInvalidResultCountException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            this.MaximumResultCount = info.GetInt32("MaximumResultCount");
+            MaximumResultCount = info.GetInt32("MaximumResultCount");
         }
 
-        internal int MaximumResultCount
-        {
-            get;
-            private set;
-        }
+        internal int MaximumResultCount { get; private set; }
 
         /// <inheritdoc />
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue("MaximumResultCount", this.MaximumResultCount);
+            info.AddValue("MaximumResultCount", MaximumResultCount);
         }
     }
 }

--- a/iothub/service/src/Common/Exceptions/DeviceMaximumQueueDepthExceededException.cs
+++ b/iothub/service/src/Common/Exceptions/DeviceMaximumQueueDepthExceededException.cs
@@ -1,38 +1,68 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.Serialization;
+
 namespace Microsoft.Azure.Devices.Common.Exceptions
 {
-    using System;
-    using System.Runtime.Serialization;
-
+    /// <summary>
+    /// The exception that is thrown when an attempt to enqueue a message fails because the message queue for the device is already full.
+    /// </summary>
     [Serializable]
     public sealed class DeviceMaximumQueueDepthExceededException : IotHubException
     {
+        /// <summary>
+        /// Creates an instance of <see cref="DeviceMaximumQueueDepthExceededException"/> with the specified value of the maximum queue depth
+        /// and marks it as non-transient.
+        /// </summary>
+        /// <param name="maximumQueueDepth"></param>
         public DeviceMaximumQueueDepthExceededException(int maximumQueueDepth)
             : this(maximumQueueDepth, null)
         {
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="DeviceMaximumQueueDepthExceededException"/> with the specified value of the maximum queue depth
+        /// and the service returned tracking Id associated with this particular error, and marks it as non-transient.
+        /// </summary>
+        /// <param name="maximumQueueDepth">The maximum number of messages that can be enqueued to the message queue.</param>
+        /// <param name="trackingId">The service returned tracking Id associated with this particular error.</param>
         public DeviceMaximumQueueDepthExceededException(int maximumQueueDepth, string trackingId)
-            : base("Device Queue depth cannot exceed {0} messages".FormatInvariant(maximumQueueDepth), trackingId)
+            : base($"Device Queue depth cannot exceed {maximumQueueDepth} messages", trackingId)
         {
-            this.MaximumQueueDepth = maximumQueueDepth;
+            MaximumQueueDepth = maximumQueueDepth;
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="DeviceMaximumQueueDepthExceededException"/> with a specified error message and marks it as non-transient.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
         public DeviceMaximumQueueDepthExceededException(string message)
             : base(message)
         {
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="DeviceMaximumQueueDepthExceededException"/> with a specified error message and
+        /// a reference to the inner exception that caused this exception, and marks it as non-transient.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public DeviceMaximumQueueDepthExceededException(string message, Exception innerException)
             : base(message, innerException)
+        {
+        }
+
+        internal DeviceMaximumQueueDepthExceededException()
+            : base()
         {
         }
 
         private DeviceMaximumQueueDepthExceededException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            this.MaximumQueueDepth = info.GetInt32("MaximumQueueDepth");
+            MaximumQueueDepth = info.GetInt32("MaximumQueueDepth");
         }
 
         internal int MaximumQueueDepth
@@ -45,7 +75,7 @@ namespace Microsoft.Azure.Devices.Common.Exceptions
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue("MaximumQueueDepth", this.MaximumQueueDepth);
+            info.AddValue("MaximumQueueDepth", MaximumQueueDepth);
         }
     }
 }

--- a/iothub/service/src/Common/Exceptions/IotHubException.cs
+++ b/iothub/service/src/Common/Exceptions/IotHubException.cs
@@ -12,30 +12,11 @@ namespace Microsoft.Azure.Devices.Common.Exceptions
     [Serializable]
     public class IotHubException : Exception
     {
-        private const string IotHubExceptionDefaultMessage = "An IoT Hub exception has occurred.";
         private const string IsTransientValueSerializationStoreName = "IotHubException-IsTransient";
         private const string TrackingIdSerializationStoreName = "IoTHubException-TrackingId";
 
         /// <summary>
-        /// Indicates if the error is transient and should be retried.
-        /// </summary>
-        public bool IsTransient { get; private set; }
-
-        /// <summary>
-        /// The service returned tracking Id associated with this particular error.
-        /// </summary>
-        public string TrackingId { get; set; }
-
-        /// <summary>
-        /// Creates an instance of <see cref="IotHubException"/> with the default error message and mark it as non-transient.
-        /// </summary>
-        public IotHubException()
-            : this(IotHubExceptionDefaultMessage, false)
-        {
-        }
-
-        /// <summary>
-        /// Creates an instance of <see cref="IotHubException"/> with the supplied error message and mark it as non-transient.
+        /// Creates an instance of <see cref="IotHubException"/> with the supplied error message and marks it as non-transient.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
         public IotHubException(string message)
@@ -44,7 +25,7 @@ namespace Microsoft.Azure.Devices.Common.Exceptions
         }
 
         /// <summary>
-        /// Creates an instance of <see cref="IotHubException"/> with the supplied error message and tracking Id, and mark it as non-transient.
+        /// Creates an instance of <see cref="IotHubException"/> with the supplied error message and tracking Id, and marks it as non-transient.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
         /// <param name="trackingId">The service returned tracking Id associated with this particular error.</param>
@@ -85,7 +66,7 @@ namespace Microsoft.Azure.Devices.Common.Exceptions
 
         /// <summary>
         /// Creates an instance of <see cref="IotHubException"/> with a specified error message and
-        /// a reference to the inner exception that caused this exception, and mark it as non-transient.
+        /// a reference to the inner exception that caused this exception, and marks it as non-transient.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
@@ -166,6 +147,29 @@ namespace Microsoft.Azure.Devices.Common.Exceptions
         }
 
         /// <summary>
+        /// Creates an instance of <see cref="IotHubException"/> with an empty error message and marks it as non-transient.
+        /// </summary>
+        protected IotHubException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Indicates if the error is transient and should be retried.
+        /// </summary>
+        public bool IsTransient { get; private set; }
+
+        /// <summary>
+        /// The service returned tracking Id associated with this particular error.
+        /// </summary>
+        public string TrackingId { get; set; }
+
+        /// <summary>
+        /// The <see cref="ErrorCode"/> associated with the exception.
+        /// </summary>
+        public ErrorCode Code { get; private set; }
+
+        /// <summary>
         /// Sets the <see cref="IsTransient"/> and <see cref="TrackingId"/> information to the <see cref="SerializationInfo"/>.
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
@@ -175,15 +179,6 @@ namespace Microsoft.Azure.Devices.Common.Exceptions
             base.GetObjectData(info, context);
             info.AddValue(IsTransientValueSerializationStoreName, IsTransient);
             info.AddValue(TrackingIdSerializationStoreName, TrackingId);
-        }
-
-        /// <summary>
-        /// The <see cref="ErrorCode"/> associated with the exception.
-        /// </summary>
-        public ErrorCode Code
-        {
-            get;
-            private set;
         }
     }
 }

--- a/iothub/service/src/Common/Exceptions/ThrottlingException.cs
+++ b/iothub/service/src/Common/Exceptions/ThrottlingException.cs
@@ -2,24 +2,60 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Azure.Devices.Common.Exceptions
 {
+    /// <summary>
+    /// The exception that is thrown when the rate of incoming requests exceeds the throttling limit set by IoT Hub.
+    /// </summary>
     [Serializable]
     public class ThrottlingException : IotHubException
     {
+        /// <summary>
+        /// Creates an instance of <see cref="ThrottlingException"/> with a specified error message and marks it as non-transient.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
         public ThrottlingException(string message)
             : base(message)
         {
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="ThrottlingException"/> with a specified <see cref="ErrorCode"/>, error message
+        /// and marks it as non-transient.
+        /// </summary>
+        /// <param name="code">The <see cref="ErrorCode"/> associated with the error.</param>
+        /// <param name="message">The message that describes the error.</param>
         public ThrottlingException(ErrorCode code, string message)
             : base(code, message)
         {
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="ThrottlingException"/> with a specified error message and
+        /// a reference to the inner exception that caused this exception, and marks it as non-transient.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception.</param>
         public ThrottlingException(string message, Exception inner)
             : base(message, inner)
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="ThrottlingException"/> with the <see cref="SerializationInfo"/>
+        /// and <see cref="StreamingContext"/> associated with the exception.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected ThrottlingException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
+        internal ThrottlingException()
+            : base()
         {
         }
     }


### PR DESCRIPTION
CA1032: Implement standard exception constructors
Cause: A type extends System.Exception but doesn't declare all the required constructors.

https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1032

Also added XML comments for public methods and properties (CS1591).
