### PR TITLE
fix(devices-client): Add a comment to clarify why semi-colons is allowed in the SDK

### DIFF
--- a/iothub/device/src/Common/Extensions/CommonExtensions.cs
+++ b/iothub/device/src/Common/Extensions/CommonExtensions.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Azure.Devices.Client.Extensions
                 throw new ArgumentException("Malformed Token");
             }
 
-            // This regex allows semi-colons to be part of the allowed characters for device names. Although new devices are not allowed to have semi-colons in the name,
-            // some legacy devices still have them and so this name validation cannot be changed.
+            // This regex allows semi-colons to be part of the allowed characters for device names. Although new devices are not
+            // allowed to have semi-colons in the name, some legacy devices still have them and so this name validation cannot be changed.
             IEnumerable<string[]> parts = new Regex($"(?:^|{kvpDelimiter})([^{kvpDelimiter}{kvpSeparator}]*){kvpSeparator}")
                 .Matches(valuePairString)
                 .Cast<Match>()

--- a/iothub/device/src/Common/Extensions/CommonExtensions.cs
+++ b/iothub/device/src/Common/Extensions/CommonExtensions.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Azure.Devices.Client.Extensions
                 throw new ArgumentException("Malformed Token");
             }
 
+            // This regex allows semi-colons to be part of the allowed characters for device names. Although new devices are not allowed to have semi-colons in the name,
+            // some legacy devices still have them and so this name validation cannot be changed.
             IEnumerable<string[]> parts = new Regex($"(?:^|{kvpDelimiter})([^{kvpDelimiter}{kvpSeparator}]*){kvpSeparator}")
                 .Matches(valuePairString)
                 .Cast<Match>()

--- a/iothub/device/src/Common/Extensions/CommonExtensions.cs
+++ b/iothub/device/src/Common/Extensions/CommonExtensions.cs
@@ -61,10 +61,15 @@ namespace Microsoft.Azure.Devices.Client.Extensions
                 throw new ArgumentException("Malformed Token");
             }
 
-            IEnumerable<string[]> parts = valuePairString
-                .Split(kvpDelimiter)
-                .Where(p => p.Trim().Length > 0)
-                .Select(p => p.Split(new char[] { kvpSeparator }, 2));
+            IEnumerable<string[]> parts = new Regex($"(?:^|{kvpDelimiter})([^{kvpDelimiter}{kvpSeparator}]*){kvpSeparator}")
+                .Matches(valuePairString)
+                .Cast<Match>()
+                .Select(m => new string[] {
+                    m.Result("$1"),
+                    valuePairString.Substring(
+                        m.Index + m.Value.Length,
+                        (m.NextMatch().Success ? m.NextMatch().Index : valuePairString.Length) - (m.Index + m.Value.Length))
+                });
 
             if (!parts.Any() || parts.Any(p => p.Length != 2))
             {

--- a/iothub/device/src/Common/Extensions/CommonExtensions.cs
+++ b/iothub/device/src/Common/Extensions/CommonExtensions.cs
@@ -61,15 +61,10 @@ namespace Microsoft.Azure.Devices.Client.Extensions
                 throw new ArgumentException("Malformed Token");
             }
 
-            IEnumerable<string[]> parts = new Regex($"(?:^|{kvpDelimiter})([^{kvpDelimiter}{kvpSeparator}]*){kvpSeparator}")
-                .Matches(valuePairString)
-                .Cast<Match>()
-                .Select(m => new string[] {
-                    m.Result("$1"),
-                    valuePairString.Substring(
-                        m.Index + m.Value.Length,
-                        (m.NextMatch().Success ? m.NextMatch().Index : valuePairString.Length) - (m.Index + m.Value.Length))
-                });
+            IEnumerable<string[]> parts = valuePairString
+                .Split(kvpDelimiter)
+                .Where(p => p.Trim().Length > 0)
+                .Select(p => p.Split(new char[] { kvpSeparator }, 2));
 
             if (!parts.Any() || parts.Any(p => p.Length != 2))
             {

--- a/iothub/device/tests/ConnectionString/DeviceClientConnectionStringTests.cs
+++ b/iothub/device/tests/ConnectionString/DeviceClientConnectionStringTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
         [ExpectedException(typeof(FormatException))]
         public void DeviceClientConnectionStringInvalidCharacterTest()
         {
-            // The device Id has a semicolon, which is a character that is not allowed
+            // The device name has a semi-colon, which is a character that is not allowed in a device Id
             string connectionString = "HostName=acme.azure-devices.net;SharedAccessKey=dGVzdFN0cmluZzE=;DeviceId=device;1";
             var deviceClient = DeviceClient.CreateFromConnectionString(connectionString);
         }

--- a/iothub/device/tests/ConnectionString/DeviceClientConnectionStringTests.cs
+++ b/iothub/device/tests/ConnectionString/DeviceClientConnectionStringTests.cs
@@ -97,6 +97,15 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
         }
 
         [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void DeviceClientConnectionStringInvalidCharacterTest()
+        {
+            // The device name has a semi-colon, which is a character that is not allowed in a device Id
+            string connectionString = "HostName=acme.azure-devices.net;SharedAccessKey=dGVzdFN0cmluZzE=;DeviceId=device;1";
+            var deviceClient = DeviceClient.CreateFromConnectionString(connectionString);
+        }
+
+        [TestMethod]
         [Ignore] // TODO #583
         public void DeviceClientConnectionStringX509CertificateAmqpTest()
         {
@@ -267,7 +276,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             const string gatewayHostName = "gateway.acme.azure-devices.net";
             const string transparentGatewayHostName = "test";
             const string deviceId = "device1";
-            const string deviceIdSplChar = "device1-.+%_#*?!(),=@;$'";
+            const string deviceIdSplChar = "device1-.+%_#*?!(),=@$'";
             const string sharedAccessKey = "dGVzdFN0cmluZzE=";
             const string sharedAccessKeyName = "AllAccessKey";
             const string credentialScope = "Device";

--- a/iothub/device/tests/ConnectionString/DeviceClientConnectionStringTests.cs
+++ b/iothub/device/tests/ConnectionString/DeviceClientConnectionStringTests.cs
@@ -97,15 +97,6 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
         }
 
         [TestMethod]
-        [ExpectedException(typeof(FormatException))]
-        public void DeviceClientConnectionStringInvalidCharacterTest()
-        {
-            // The device name has a semi-colon, which is a character that is not allowed in a device Id
-            string connectionString = "HostName=acme.azure-devices.net;SharedAccessKey=dGVzdFN0cmluZzE=;DeviceId=device;1";
-            var deviceClient = DeviceClient.CreateFromConnectionString(connectionString);
-        }
-
-        [TestMethod]
         [Ignore] // TODO #583
         public void DeviceClientConnectionStringX509CertificateAmqpTest()
         {
@@ -276,7 +267,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             const string gatewayHostName = "gateway.acme.azure-devices.net";
             const string transparentGatewayHostName = "test";
             const string deviceId = "device1";
-            const string deviceIdSplChar = "device1-.+%_#*?!(),=@$'";
+            const string deviceIdSplChar = "device1-.+%_#*?!(),=@;$'";
             const string sharedAccessKey = "dGVzdFN0cmluZzE=";
             const string sharedAccessKeyName = "AllAccessKey";
             const string credentialScope = "Device";

--- a/iothub/device/tests/ConnectionString/DeviceClientConnectionStringTests.cs
+++ b/iothub/device/tests/ConnectionString/DeviceClientConnectionStringTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
         [ExpectedException(typeof(FormatException))]
         public void DeviceClientConnectionStringInvalidCharacterTest()
         {
-            // The device name has a semi-colon, which is a character that is not allowed in a device Id
+            // The device Id has a semicolon, which is a character that is not allowed
             string connectionString = "HostName=acme.azure-devices.net;SharedAccessKey=dGVzdFN0cmluZzE=;DeviceId=device;1";
             var deviceClient = DeviceClient.CreateFromConnectionString(connectionString);
         }


### PR DESCRIPTION
At some point, IoT Hub allowed semicolons in device names as part of the connection strings. Based on that, this PR was made:
https://github.com/Azure/azure-iot-sdk-csharp/commit/9dde3fee9e88fbc53ef1b9a0dbeee7dcfa9e7e6b

Since then, IoT reverted on this change. And now IoT does not allow semicolons. The SDK did not make the change to reflect that. Here's the change in documentation on when this happened:
https://github.com/MicrosoftDocs/azure-docs/commit/237b82518c01bc4cd9e3d98fc3d6b96ae2c3f487

This PR addresses this issue:
#1620 

The logic change in this change is similar to how the service client does it. I am not sure why the original PR did not make the change on the service side.
