### PR TITLE
Re-enabling test that was disabled and passes now

### DIFF
--- a/iothub/device/tests/Amqp/AmqpTransportHandlerTests.cs
+++ b/iothub/device/tests/Amqp/AmqpTransportHandlerTests.cs
@@ -1,4 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information
 
 using System;
@@ -15,7 +17,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
     [TestCategory("Unit")]
     public class AmqpTransportHandlerTests
     {
-        private const string DumpyConnectionString = "HostName=Do.Not.Exist;SharedAccessKeyName=AllAccessKey;DeviceId=FakeDevice;SharedAccessKey=dGVzdFN0cmluZzE=";
+        private const string TestConnectionString = "HostName=Do.Not.Exist;SharedAccessKeyName=AllAccessKey;DeviceId=FakeDevice;SharedAccessKey=dGVzdFN0cmluZzE=";
 
         [TestMethod]
         public async Task AmqpTransportHandlerOpenAsyncTokenCancellationRequested()
@@ -59,31 +61,30 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
             await TestOperationCanceledByToken(token => CreateFromConnectionString().RejectAsync(Guid.NewGuid().ToString(), token)).ConfigureAwait(false);
         }
 
-        [Ignore] // TODO #584 Uncomment later once we support throwing exceptions on TransportSettingsChange
         [TestMethod]
         public void AmqpTransportHandler_RejectAmqpSettingsChange()
         {
-            //var amqpTransportHandler1 = new AmqpTransportHandler(new PipelineContext(), IotHubConnectionString.Parse(DumpyConnectionString), new AmqpTransportSettings(TransportType.Amqp_Tcp_Only, 60, new AmqpConnectionPoolSettings()
-            //{
-            //    Pooling = true,
-            //    MaxPoolSize = 10,
-            //    ConnectionIdleTimeout = TimeSpan.FromMinutes(1)
-            //}));
-            //
-            //try
-            //{
-            //    // Try to create a set AmqpTransportHandler with different connection pool settings.
-            //    var amqpTransportHandler2 = new AmqpTransportHandler(new PipelineContext(), IotHubConnectionString.Parse(DumpyConnectionString), new AmqpTransportSettings(TransportType.Amqp_Tcp_Only, 60, new AmqpConnectionPoolSettings()
-            //    {
-            //        Pooling = true,
-            //        MaxPoolSize = 7, // different pool size
-            //        ConnectionIdleTimeout = TimeSpan.FromMinutes(1)
-            //    }));
-            //}
-            //catch (ArgumentException ae)
-            //{
-            //    Assert.IsTrue(ae.Message.Contains("AmqpTransportSettings cannot be modified from the initial settings."), "Did not return the correct error message");
-            //}
+            var amqpTransportHandler1 = new AmqpTransportHandler(new PipelineContext(), new IotHubConnectionString(IotHubConnectionStringBuilder.Create(TestConnectionString)), new AmqpTransportSettings(TransportType.Amqp_Tcp_Only, 60, new AmqpConnectionPoolSettings()
+            {
+                Pooling = true,
+                MaxPoolSize = 10,
+                ConnectionIdleTimeout = TimeSpan.FromMinutes(1)
+            }));
+
+            try
+            {
+                // Try to create a set AmqpTransportHandler with different connection pool settings.
+                var amqpTransportHandler2 = new AmqpTransportHandler(new PipelineContext(), new IotHubConnectionString(IotHubConnectionStringBuilder.Create(TestConnectionString)), new AmqpTransportSettings(TransportType.Amqp_Tcp_Only, 60, new AmqpConnectionPoolSettings()
+                {
+                    Pooling = true,
+                    MaxPoolSize = 7, // different pool size
+                    ConnectionIdleTimeout = TimeSpan.FromMinutes(1)
+                }));
+            }
+            catch (ArgumentException ae)
+            {
+                Assert.IsTrue(ae.Message.Contains("AmqpTransportSettings cannot be modified from the initial settings."), "Did not return the correct error message");
+            }
         }
 
         private async Task TestOperationCanceledByToken(Func<CancellationToken, Task> asyncMethod)
@@ -103,7 +104,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
         {
             return new AmqpTransportHandler(
                 new PipelineContext(),
-                IotHubConnectionStringExtensions.Parse(DumpyConnectionString),
+                IotHubConnectionStringExtensions.Parse(TestConnectionString),
                 new AmqpTransportSettings(TransportType.Amqp_Tcp_Only));
         }
     }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->

https://github.com/Azure/azure-iot-sdk-csharp/issues/584