### PR TITLE
fix(warnings): Change the severity of CA2208 to Suggestion

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -323,3 +323,5 @@ dotnet_diagnostic.CA1805.severity = warning
 dotnet_diagnostic.CA1834.severity = warning
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = warning
+# CA2208: Instantiate argument exceptions correctly
+dotnet_diagnostic.CA2208.severity = suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -323,5 +323,11 @@ dotnet_diagnostic.CA1805.severity = warning
 dotnet_diagnostic.CA1834.severity = warning
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = warning
+
 # CA2208: Instantiate argument exceptions correctly
+# CA2208 is suggesting that the argument that is passed to ArgumentNullException should match a name of a parameter
+# in the signature of the method that is throwing the exception. However, many of the CA2208 warning instances is
+# because the code throws an ArgumentNullException while passing in a property (or a field) on the object that is
+# passed into the method that is throwing the exception. A proper fix for this would be to throw an ArgumentException
+# instead. However, many of these instances are of a public method. So changing the exception being thrown is a breaking change.
 dotnet_diagnostic.CA2208.severity = suggestion


### PR DESCRIPTION
The reason why I changed the severity of CA2208 to a suggestion because all the instances of this warning look something like this:
``` csharp
public static byte[] SerializeRequest(HttpRequestMessage request)
        {
            if (request == null)
            {
                throw new ArgumentNullException(nameof(request));
            }
            if (request.RequestUri == null)
            {
                throw new ArgumentNullException(nameof(request.RequestUri));
            }
```

The culprit in this case is the second throw. CA2208 is telling us that the parameter that we pass in to ArgumentNullException should match a name of a parameter in the method signature. So in this case, the first throw does the correct thing. But not the second throw. A proper fix for this would be to not throw an ArgumentNullException, rather an ArgumentException. However, many of these instances are of a public method. So changing the exception being thrown is a breaking change.