### PR TITLE
CS4014

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -11,7 +11,7 @@
     <OutputPath>.\bin\$(Configuration)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
 
-    <!-- Don't auto-compile platform specific files: -->
+    <!-- Don't auto-compile platform-specific files: -->
     <DefaultItemExcludes>ModernDotNet/**;net451/**;$(DefaultItemExcludes)</DefaultItemExcludes>
 
     <RootDir>$(MSBuildProjectDirectory)\..\..\..</RootDir>
@@ -51,11 +51,32 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetty.Codecs.Mqtt" Version="0.6.0" />
-    <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.7" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />
+    <Compile Include="$(Common)\Logging.Common.cs">
+      <LinkBase>Common</LinkBase>
+    </Compile>
+    <Compile Include="$(Common)\StreamDisposalResponsibility.cs">
+      <LinkBase>Common</LinkBase>
+    </Compile>
+    <Compile Include="$(Common)\DefaultWebProxySettings.cs">
+      <LinkBase>Common</LinkBase>
+    </Compile>
+  </ItemGroup>
+
+  <!-- All the "new" .NET targets -->
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
+    <Compile Include="ModernDotNet\Common\IOThreadTimerSlim.cs" />
+    <Compile Include="ModernDotNet\HsmAuthentication\Transport\HttpUdsMessageHandler.cs" />
+    <Compile Include="ModernDotNet\HsmAuthentication\Transport\HttpBufferedStream.cs" />
+    <Compile Include="ModernDotNet\HsmAuthentication\Transport\HttpRequestResponseSerializer.cs" />
+    <Compile Include="ModernDotNet\HsmAuthentication\Transport\UnixDomainSocketEndPoint.cs" />
+  </ItemGroup>
+
+  <!-- net451 only -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <Compile Include="net451\IotHubClientWebSocket.cs" />
+    <Compile Include="net451\Common\LegacyClientWebSocketTransport.cs" />
+    <Compile Include="net451\Common\IOThreadTimer.cs" />
+    <Compile Include="net451\Common\Interop\UnsafeNativeMethods.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -63,20 +84,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(Common)\Logging.Common.cs">
-      <Link>Common\Logging.Common.cs</Link>
-    </Compile>
-    <Compile Include="$(Common)\StreamDisposalResponsibility.cs" />
+    <PackageReference Include="DotNetty.Codecs.Mqtt" Version="0.6.0" />
+    <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />
   </ItemGroup>
 
-  <!-- Net451 -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Compile Include="$(Common)\DefaultWebProxySettings.cs" />
-    <Compile Include="net451\IotHubClientWebSocket.cs" />
-    <Compile Include="net451\Common\LegacyClientWebSocketTransport.cs" />
-    <Compile Include="net451\Common\IOThreadTimer.cs" />
-    <Compile Include="net451\Common\Interop\UnsafeNativeMethods.cs" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <Reference Include="System.Web" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Net.Http.WebRequest" />
@@ -85,25 +109,6 @@
     <Reference Include="System.Net.Http" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.3" />
     <PackageReference Include="Microsoft.Owin" Version="4.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <Reference Include="System.Web" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
-
-  <!-- NetStandard 2.1, NetStandard 2.0 and net472 -->
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
-    <Compile Include="$(Common)\DefaultWebProxySettings.cs" />
-    <Compile Include="ModernDotNet\Common\IOThreadTimerSlim.cs" />
-    <Compile Include="ModernDotNet\HsmAuthentication\Transport\HttpUdsMessageHandler.cs" />
-    <Compile Include="ModernDotNet\HsmAuthentication\Transport\HttpBufferedStream.cs" />
-    <Compile Include="ModernDotNet\HsmAuthentication\Transport\HttpRequestResponseSerializer.cs" />
-    <Compile Include="ModernDotNet\HsmAuthentication\Transport\UnixDomainSocketEndPoint.cs" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/iothub/device/src/net451/Common/LegacyClientWebSocketTransport.cs
+++ b/iothub/device/src/net451/Common/LegacyClientWebSocketTransport.cs
@@ -1,64 +1,57 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.IO;
+using System.Net;
+using System.Net.WebSockets;
+using System.Threading.Tasks;
+using Microsoft.Azure.Amqp;
+using Microsoft.Azure.Amqp.Transport;
+using Microsoft.Azure.Devices.Shared;
+
 namespace Microsoft.Azure.Devices.Client
 {
-    using System;
-    using System.IO;
-    using System.Net;
-    using System.Net.WebSockets;
-    using System.Threading.Tasks;
-    using Microsoft.Azure.Amqp;
-    using Microsoft.Azure.Amqp.Transport;
-    using Microsoft.Azure.Devices.Shared;
-
-    sealed class LegacyClientWebSocketTransport : TransportBase
+    internal sealed class LegacyClientWebSocketTransport : TransportBase
     {
-        const string ClientWebSocketTransportReadBufferTooSmall = "LegacyClientWebSocketTransport Read Buffer too small.";
-        const int MaxReadBufferSize = 256 * 1024; // Max Read buffer size is hard-coded to 256k
-        static readonly AsyncCallback onWriteComplete = OnWriteComplete;
+        private const string ClientWebSocketTransportReadBufferTooSmall = "LegacyClientWebSocketTransport Read Buffer too small.";
+        private const int MaxReadBufferSize = 256 * 1024; // Max Read buffer size is hard-coded to 256k
 
-        readonly IotHubClientWebSocket webSocket;
-        readonly EndPoint localEndPoint;
-        readonly EndPoint remoteEndPoint;
-        readonly TimeSpan operationTimeout;
-        readonly int asyncReadBufferSize;
-        readonly byte[] asyncReadBuffer;
+        private static readonly AsyncCallback s_onWriteComplete = OnWriteComplete;
 
-        bool disposed;
-        int asyncReadBufferOffset;
-        int remainingBytes;
+        private readonly IotHubClientWebSocket _webSocket;
+        private readonly EndPoint _localEndPoint;
+        private readonly EndPoint _remoteEndPoint;
+        private readonly TimeSpan _operationTimeout;
+        private readonly int _asyncReadBufferSize;
+        private readonly byte[] _asyncReadBuffer;
 
-        public LegacyClientWebSocketTransport(IotHubClientWebSocket webSocket, TimeSpan operationTimeout, EndPoint localEndpoint, EndPoint remoteEndpoint)
+        private bool _isDisposed;
+        private int _asyncReadBufferOffset;
+        private int _remainingBytes;
+
+        public LegacyClientWebSocketTransport(
+            IotHubClientWebSocket webSocket,
+            TimeSpan operationTimeout,
+            EndPoint localEndpoint,
+            EndPoint remoteEndpoint)
             : base("legacyclientwebsocket")
         {
-            this.webSocket = webSocket;
-            this.operationTimeout = operationTimeout;
-            this.localEndPoint = localEndpoint;
-            this.remoteEndPoint = remoteEndpoint;
-            this.asyncReadBufferSize = MaxReadBufferSize; // TODO: read from Config Settings
-            this.asyncReadBuffer = new byte[this.asyncReadBufferSize];
+            _webSocket = webSocket;
+            _operationTimeout = operationTimeout;
+            _localEndPoint = localEndpoint;
+            _remoteEndPoint = remoteEndpoint;
+            _asyncReadBufferSize = MaxReadBufferSize; // TODO: read from Config Settings
+            _asyncReadBuffer = new byte[_asyncReadBufferSize];
         }
 
-        public override string LocalEndPoint
-        {
-            get { return this.localEndPoint.ToString(); }
-        }
+        public override string LocalEndPoint => _localEndPoint.ToString();
 
-        public override string RemoteEndPoint
-        {
-            get { return this.remoteEndPoint.ToString(); }
-        }
+        public override string RemoteEndPoint => _remoteEndPoint.ToString();
 
-        public override bool RequiresCompleteFrames
-        {
-            get { return true; }
-        }
+        public override bool RequiresCompleteFrames => true;
 
-        public override bool IsSecure
-        {
-            get { return true; }
-        }
+        public override bool IsSecure => true;
 
         public override void SetMonitor(ITransportMonitor usageMeter)
         {
@@ -68,51 +61,96 @@ namespace Microsoft.Azure.Devices.Client
         public override bool WriteAsync(TransportAsyncCallbackArgs args)
         {
             if (Logging.IsEnabled)
-            {
                 Logging.Enter(this, args.Transport, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(WriteAsync)}");
-            }
 
-            this.ThrowIfNotOpen();
+            ThrowIfNotOpen();
 
             Fx.AssertAndThrow(args.Buffer != null || args.ByteBufferList != null, "must have a buffer to write");
             Fx.AssertAndThrow(args.CompletedCallback != null, "must have a valid callback");
             args.Exception = null; // null out any exceptions
 
-            Task taskResult = this.WriteAsyncCore(args);
+            Task taskResult = WriteCoreAsync(args);
             if (WriteTaskDone(taskResult, args))
             {
                 return false;
             }
 
-            taskResult.ToAsyncResult(onWriteComplete, args);
+            taskResult.ToAsyncResult(s_onWriteComplete, args);
 
             if (Logging.IsEnabled)
-            {
                 Logging.Exit(this, args.Transport, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(WriteAsync)}");
-            }
 
             return true;
         }
 
-        async Task WriteAsyncCore(TransportAsyncCallbackArgs args)
+        public override bool ReadAsync(TransportAsyncCallbackArgs args)
         {
             if (Logging.IsEnabled)
+                Logging.Enter(this, args.Transport, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(ReadAsync)}");
+
+            ThrowIfNotOpen();
+
+            // Read with buffer list not supported
+            Fx.AssertAndThrow(args.Buffer != null, "must have buffer to read");
+            Fx.AssertAndThrow(args.CompletedCallback != null, "must have a valid callback");
+
+            // TODO: Is this assert valid at all?  It should be ok for caller to ask for more bytes than we can give...
+            Fx.AssertAndThrow(args.Count <= _asyncReadBufferSize, ClientWebSocketTransportReadBufferTooSmall);
+
+            Utils.ValidateBufferBounds(args.Buffer, args.Offset, args.Count);
+            args.Exception = null;
+
+            if (_asyncReadBufferOffset > 0)
             {
-                Logging.Enter(this, args.Transport, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(WriteAsyncCore)}");
+                Fx.AssertAndThrow(_remainingBytes > 0, "Must have data in buffer to transfer");
+
+                // Data left over from previous read
+                TransferData(_remainingBytes, args);
+                return false;
             }
+
+            args.Exception = null; // null out any exceptions
+            Task<int> taskResult = ReadCoreAsync();
+
+            if (ReadTaskDone(taskResult, args))
+            {
+                return false;
+            }
+
+            taskResult.ToAsyncResult(OnReadComplete, args);
+
+            if (Logging.IsEnabled)
+                Logging.Exit(this, args.Transport, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(ReadAsync)}");
+
+            return true;
+        }
+
+        private async Task WriteCoreAsync(TransportAsyncCallbackArgs args)
+        {
+            if (Logging.IsEnabled)
+                Logging.Enter(this, args.Transport, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(WriteCoreAsync)}");
 
             bool succeeded = false;
             try
             {
                 if (args.Buffer != null)
                 {
-                    await this.webSocket.SendAsync(args.Buffer, args.Offset, args.Count, IotHubClientWebSocket.WebSocketMessageType.Binary, this.operationTimeout).ConfigureAwait(false);
+                    await _webSocket
+                        .SendAsync(args.Buffer, args.Offset, args.Count, IotHubClientWebSocket.WebSocketMessageType.Binary, _operationTimeout)
+                        .ConfigureAwait(false);
                 }
                 else
                 {
                     foreach (ByteBuffer byteBuffer in args.ByteBufferList)
                     {
-                        await this.webSocket.SendAsync(byteBuffer.Buffer, byteBuffer.Offset, byteBuffer.Length, IotHubClientWebSocket.WebSocketMessageType.Binary, this.operationTimeout).ConfigureAwait(false);
+                        await _webSocket
+                            .SendAsync(
+                                byteBuffer.Buffer,
+                                byteBuffer.Offset,
+                                byteBuffer.Length,
+                                IotHubClientWebSocket.WebSocketMessageType.Binary,
+                                _operationTimeout)
+                            .ConfigureAwait(false);
                     }
                 }
 
@@ -122,12 +160,10 @@ namespace Microsoft.Azure.Devices.Client
             {
                 throw new IOException(webSocketException.Message, webSocketException);
             }
-#if !NETSTANDARD1_3
             catch (HttpListenerException httpListenerException)
             {
                 throw new IOException(httpListenerException.Message, httpListenerException);
             }
-#endif
             catch (TaskCanceledException taskCanceledException)
             {
                 throw new TimeoutException(taskCanceledException.Message, taskCanceledException);
@@ -136,106 +172,16 @@ namespace Microsoft.Azure.Devices.Client
             {
                 if (!succeeded)
                 {
-                    this.Abort();
+                    Abort();
                 }
                 if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, args.Transport, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(WriteAsyncCore)}");
-                }
+                    Logging.Exit(this, args.Transport, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(WriteCoreAsync)}");
             }
-        }
-
-        async Task<int> ReadAsyncCore()
-        {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(ReadAsyncCore)}");
-            }
-
-            bool succeeded = false;
-            try
-            {
-                int numBytes = await this.webSocket.ReceiveAsync(this.asyncReadBuffer, this.asyncReadBufferOffset, this.operationTimeout).ConfigureAwait(false);
-
-                succeeded = true;
-                return numBytes;
-            }
-            catch (WebSocketException webSocketException)
-            {
-                throw new IOException(webSocketException.Message, webSocketException);
-            }
-#if !NETSTANDARD1_3
-            catch (HttpListenerException httpListenerException)
-            {
-                throw new IOException(httpListenerException.Message, httpListenerException);
-            }
-#endif
-            catch (TaskCanceledException taskCanceledException)
-            {
-                throw new TimeoutException(taskCanceledException.Message, taskCanceledException);
-            }
-            finally
-            {
-                if (!succeeded)
-                {
-                    this.Abort();
-                }
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(ReadAsyncCore)}");
-                }
-            }
-        }
-
-        public override bool ReadAsync(TransportAsyncCallbackArgs args)
-        {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, args.Transport, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(ReadAsync)}");
-            }
-
-            this.ThrowIfNotOpen();
-
-            // Read with buffer list not supported
-            Fx.AssertAndThrow(args.Buffer != null, "must have buffer to read");
-            Fx.AssertAndThrow(args.CompletedCallback != null, "must have a valid callback");
-
-            // TODO: Is this assert valid at all?  It should be ok for caller to ask for more bytes than we can give...
-            Fx.AssertAndThrow(args.Count <= this.asyncReadBufferSize, ClientWebSocketTransportReadBufferTooSmall);
-
-            Utils.ValidateBufferBounds(args.Buffer, args.Offset, args.Count);
-            args.Exception = null;
-
-            if (this.asyncReadBufferOffset > 0)
-            {
-                Fx.AssertAndThrow(this.remainingBytes > 0, "Must have data in buffer to transfer");
-
-                // Data left over from previous read
-                this.TransferData(this.remainingBytes, args);
-                return false;
-            }
-
-            args.Exception = null; // null out any exceptions
-            Task<int> taskResult = this.ReadAsyncCore();
-
-            if (this.ReadTaskDone(taskResult, args))
-            {
-                return false;
-            }
-
-            taskResult.ToAsyncResult(this.OnReadComplete, args);
-
-            if (Logging.IsEnabled)
-            {
-                Logging.Exit(this, args.Transport, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(ReadAsync)}");
-            }
-
-            return true;
         }
 
         protected override bool OpenInternal()
         {
-            this.ThrowIfNotOpen();
+            ThrowIfNotOpen();
 
             return true;
         }
@@ -245,50 +191,20 @@ namespace Microsoft.Azure.Devices.Client
             try
             {
                 if (Logging.IsEnabled)
-                {
                     Logging.Enter(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(CloseInternal)}");
-                }
 
-                var webSocketState = this.webSocket.State;
-                if (webSocketState != IotHubClientWebSocket.WebSocketState.Closed && webSocketState != IotHubClientWebSocket.WebSocketState.Aborted)
+                IotHubClientWebSocket.WebSocketState webSocketState = _webSocket.State;
+                if (webSocketState != IotHubClientWebSocket.WebSocketState.Closed
+                    && webSocketState != IotHubClientWebSocket.WebSocketState.Aborted)
                 {
-                    this.CloseInternalAsync();
+                    CloseInternalAsync().GetAwaiter().GetResult();
                 }
                 return true;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                {
                     Logging.Exit(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(CloseInternal)}");
-                }
-            }            
-        }
-
-        async Task CloseInternalAsync()
-        {
-            try
-            {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Enter(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(CloseInternalAsync)}");
-                }
-
-                await this.webSocket.CloseAsync().ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                if (Fx.IsFatal(e))
-                {
-                    throw;
-                }
-            }
-            finally
-            {
-                if (Logging.IsEnabled)
-                {
-                    Logging.Exit(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(CloseInternalAsync)}");
-                }
             }
         }
 
@@ -297,40 +213,95 @@ namespace Microsoft.Azure.Devices.Client
             try
             {
                 if (Logging.IsEnabled)
-                {
                     Logging.Enter(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(AbortInternal)}");
-                }
 
-                if (!this.disposed && this.webSocket.State != IotHubClientWebSocket.WebSocketState.Aborted)
+                if (!_isDisposed
+                    && _webSocket.State != IotHubClientWebSocket.WebSocketState.Aborted)
                 {
-                    this.disposed = true;
-                    this.webSocket.Abort();
+                    _isDisposed = true;
+                    _webSocket.Abort();
                 }
             }
             finally
             {
                 if (Logging.IsEnabled)
-                {
                     Logging.Exit(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(AbortInternal)}");
+            }
+        }
+
+        private async Task<int> ReadCoreAsync()
+        {
+            if (Logging.IsEnabled)
+                Logging.Enter(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(ReadCoreAsync)}");
+
+            bool succeeded = false;
+            try
+            {
+                int numBytes = await _webSocket.ReceiveAsync(_asyncReadBuffer, _asyncReadBufferOffset, _operationTimeout).ConfigureAwait(false);
+
+                succeeded = true;
+                return numBytes;
+            }
+            catch (WebSocketException webSocketException)
+            {
+                throw new IOException(webSocketException.Message, webSocketException);
+            }
+            catch (HttpListenerException httpListenerException)
+            {
+                throw new IOException(httpListenerException.Message, httpListenerException);
+            }
+            catch (TaskCanceledException taskCanceledException)
+            {
+                throw new TimeoutException(taskCanceledException.Message, taskCanceledException);
+            }
+            finally
+            {
+                if (!succeeded)
+                {
+                    Abort();
+                }
+                if (Logging.IsEnabled)
+                {
+                    Logging.Exit(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(ReadCoreAsync)}");
                 }
             }
         }
 
-        void OnReadComplete(IAsyncResult result)
+        private async Task CloseInternalAsync()
+        {
+            try
+            {
+                if (Logging.IsEnabled)
+                    Logging.Enter(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(CloseInternalAsync)}");
+
+                await _webSocket.CloseAsync().ConfigureAwait(false);
+            }
+            catch (Exception e) when (!Fx.IsFatal(e))
+            {
+                // do nothing
+            }
+            finally
+            {
+                if (Logging.IsEnabled)
+                    Logging.Exit(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(CloseInternalAsync)}");
+            }
+        }
+
+        private void OnReadComplete(IAsyncResult result)
         {
             if (result.CompletedSynchronously)
             {
                 return;
             }
 
-            Task<int> taskResult = (Task<int>)result;
+            var taskResult = (Task<int>)result;
             var args = (TransportAsyncCallbackArgs)taskResult.AsyncState;
 
-            this.ReadTaskDone(taskResult, args);
+            ReadTaskDone(taskResult, args);
             args.CompletedCallback(args);
         }
 
-        bool ReadTaskDone(Task<int> taskResult, TransportAsyncCallbackArgs args)
+        private bool ReadTaskDone(Task<int> taskResult, TransportAsyncCallbackArgs args)
         {
             IAsyncResult result = taskResult;
             args.BytesTransfered = 0;  // reset bytes transferred
@@ -339,54 +310,52 @@ namespace Microsoft.Azure.Devices.Client
                 args.Exception = taskResult.Exception;
                 return true;
             }
-            else if (taskResult.IsCompleted)
+
+            if (taskResult.IsCompleted)
             {
-                this.TransferData(taskResult.Result, args);
+                TransferData(taskResult.Result, args);
                 args.CompletedSynchronously = result.CompletedSynchronously;
                 return true;
             }
-            else if (taskResult.IsCanceled)  // This should not happen since TaskCanceledException is handled in ReadAsyncCore.
-            {
-                return true;
-            }
 
-            return false;
+            // This should not be canceled since TaskCanceledException is handled in ReadCoreAsync.
+            return taskResult.IsCanceled;
         }
 
-        void TransferData(int bytesRead, TransportAsyncCallbackArgs args)
+        private void TransferData(int bytesRead, TransportAsyncCallbackArgs args)
         {
             if (bytesRead <= args.Count)
             {
-                Buffer.BlockCopy(this.asyncReadBuffer, this.asyncReadBufferOffset, args.Buffer, args.Offset, bytesRead);
-                this.asyncReadBufferOffset = 0;
-                this.remainingBytes = 0;
+                Buffer.BlockCopy(_asyncReadBuffer, _asyncReadBufferOffset, args.Buffer, args.Offset, bytesRead);
+                _asyncReadBufferOffset = 0;
+                _remainingBytes = 0;
                 args.BytesTransfered = bytesRead;
             }
             else
             {
-                Buffer.BlockCopy(this.asyncReadBuffer, this.asyncReadBufferOffset, args.Buffer, args.Offset, args.Count);
+                Buffer.BlockCopy(_asyncReadBuffer, _asyncReadBufferOffset, args.Buffer, args.Offset, args.Count);
 
                 // read only part of the data
-                this.asyncReadBufferOffset += args.Count;
-                this.remainingBytes = bytesRead - args.Count;
+                _asyncReadBufferOffset += args.Count;
+                _remainingBytes = bytesRead - args.Count;
                 args.BytesTransfered = args.Count;
             }
         }
 
-        static void OnWriteComplete(IAsyncResult result)
+        private static void OnWriteComplete(IAsyncResult result)
         {
             if (result.CompletedSynchronously)
             {
                 return;
             }
 
-            Task taskResult = (Task)result;
+            var taskResult = (Task)result;
             var args = (TransportAsyncCallbackArgs)taskResult.AsyncState;
             WriteTaskDone(taskResult, args);
             args.CompletedCallback(args);
         }
 
-        static bool WriteTaskDone(Task taskResult, TransportAsyncCallbackArgs args)
+        private static bool WriteTaskDone(Task taskResult, TransportAsyncCallbackArgs args)
         {
             IAsyncResult result = taskResult;
             args.BytesTransfered = 0; // reset bytes transferred
@@ -395,40 +364,35 @@ namespace Microsoft.Azure.Devices.Client
                 args.Exception = taskResult.Exception;
                 return true;
             }
-            else if (taskResult.IsCompleted)
+
+            if (taskResult.IsCompleted)
             {
                 args.BytesTransfered = args.Count;
                 args.CompletedSynchronously = result.CompletedSynchronously;
                 return true;
             }
-            else if (taskResult.IsCanceled)  // This should not happen since TaskCanceledException is handled in WriteAsyncCore.
-            {
-                return true;
-            }
 
-            return false;
+            // This should not be true since TaskCanceledException is handled in WriteCoreAsync.
+            return taskResult.IsCanceled;
         }
 
-        void ThrowIfNotOpen()
+        private void ThrowIfNotOpen()
         {
-           try
+            try
             {
                 if (Logging.IsEnabled)
-                {
                     Logging.Enter(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(ThrowIfNotOpen)}");
-                }
 
-                var webSocketState = this.webSocket.State;
+                IotHubClientWebSocket.WebSocketState webSocketState = _webSocket.State;
                 if (webSocketState == IotHubClientWebSocket.WebSocketState.Open)
                 {
                     return;
                 }
 
-                if (webSocketState == IotHubClientWebSocket.WebSocketState.Aborted ||
-                    webSocketState == IotHubClientWebSocket.WebSocketState.Closed
-                    )
+                if (webSocketState == IotHubClientWebSocket.WebSocketState.Aborted
+                    || webSocketState == IotHubClientWebSocket.WebSocketState.Closed)
                 {
-                    throw new ObjectDisposedException(this.GetType().Name);
+                    throw new ObjectDisposedException(GetType().Name);
                 }
 
                 throw new AmqpException(AmqpErrorCode.IllegalState, null);
@@ -436,9 +400,7 @@ namespace Microsoft.Azure.Devices.Client
             finally
             {
                 if (Logging.IsEnabled)
-                {
                     Logging.Exit(this, $"{nameof(LegacyClientWebSocketTransport)}.{nameof(ThrowIfNotOpen)}");
-                }
             }
         }
     }

--- a/iothub/device/tests/TimeoutHelperTests.cs
+++ b/iothub/device/tests/TimeoutHelperTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -22,7 +23,6 @@ namespace Microsoft.Azure.Devices.Client.Tests
         public async Task TimeoutHelper_Ctor_DoesNotStartTimeout()
         {
             // arrange
-
             var timeout = TimeSpan.FromSeconds(1);
 
             // act
@@ -92,7 +92,10 @@ namespace Microsoft.Azure.Devices.Client.Tests
             TimeSpan remainingTime = toh.GetRemainingTime();
             remainingTime.Should().NotBe(TimeSpan.Zero);
 
-            await Task.Delay(timeout).ConfigureAwait(false);
+            // ensure we're over the time, because the test will sometimes fail with some microseconds remaining
+            var delay = timeout.Add(TimeSpan.FromMilliseconds(50));
+            await Task.Delay(delay).ConfigureAwait(false);
+
             remainingTime = toh.GetRemainingTime();
             remainingTime.Should().Be(TimeSpan.Zero);
         }


### PR DESCRIPTION
<https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs4014>
Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the await operator to the result of the call.
