### PR TITLE
fix(iot-device, iot-service): Fix warnings for CA2227, CA2237, CA5350

### DIFF
--- a/iothub/device/src/HsmAuthentication/HttpHsmComunicationException.cs
+++ b/iothub/device/src/HsmAuthentication/HttpHsmComunicationException.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Azure.Devices.Client.HsmAuthentication
 {
     /// <summary>
     /// The exception that is thrown when communication fails with HSM HTTP server.
     /// </summary>
+    [Serializable]
     public class HttpHsmComunicationException : Exception
     {
         /// <summary>
@@ -18,6 +20,16 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication
         public HttpHsmComunicationException(string message, int statusCode) : base($"{message}, StatusCode: {statusCode}")
         {
             StatusCode = statusCode;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpHsmComunicationException"/> class with the specified serialization and context information.
+        /// </summary>
+        /// <param name="info">An object that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">An object that contains contextual information about the source or destination.</param>
+        protected HttpHsmComunicationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
 
         internal HttpHsmComunicationException()

--- a/iothub/device/src/Transport/Mqtt/ChannelMessageProcessingException.cs
+++ b/iothub/device/src/Transport/Mqtt/ChannelMessageProcessingException.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.Serialization;
 using DotNetty.Transport.Channels;
 
 namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
@@ -9,6 +10,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
     /// <summary>
     /// The exception that is thrown when an error occurs while processing messages over an MQTT channel.
     /// </summary>
+    [Serializable]
     public class ChannelMessageProcessingException : Exception
     {
         /// <summary>
@@ -21,6 +23,16 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             : base(string.Empty, innerException)
         {
             Context = context;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChannelMessageProcessingException"/> class with the specified serialization and context information.
+        /// </summary>
+        /// <param name="info">An object that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">An object that contains contextual information about the source or destination.</param>
+        protected ChannelMessageProcessingException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
 
         internal ChannelMessageProcessingException()

--- a/iothub/device/src/net451/IotHubClientWebSocket.cs
+++ b/iothub/device/src/net451/IotHubClientWebSocket.cs
@@ -498,7 +498,7 @@ namespace Microsoft.Azure.Devices.Client
             }
         }
 
-        [SuppressMessage("Microsoft.Cryptographic.Standard", "CA5354:SHA1CannotBeUsed", Justification = "SHA-1 Hash mandated by RFC 6455")]
+        [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "SHA-1 Hash mandated by RFC 6455")]
         private static SHA1 InitCryptoServiceProvider()
         {
             return SHA1.Create();

--- a/iothub/service/src/Configurations/ConfigurationMetrics.cs
+++ b/iothub/service/src/Configurations/ConfigurationMetrics.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
 namespace Microsoft.Azure.Devices
 {
-    using System.Collections.Generic;
-    using Newtonsoft.Json;
-
     /// <summary>
     /// Azure IOT Configuration Metrics
     /// </summary>
@@ -16,20 +16,22 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         public ConfigurationMetrics()
         {
-            this.Results = new Dictionary<string, long>();
-            this.Queries = new Dictionary<string, string>();
+            Results = new Dictionary<string, long>();
+            Queries = new Dictionary<string, string>();
         }
 
         /// <summary>
         /// Results of the metrics collection queries
         /// </summary>
         [JsonProperty("results")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Public facing property cannot be modified since it will be a breaking change.")]
         public IDictionary<string, long> Results { get; set; }
 
         /// <summary>
         /// Queries used for metrics collection
         /// </summary>
         [JsonProperty("queries")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Public facing property cannot be modified since it will be a breaking change.")]
         public IDictionary<string, string> Queries { get; set; }
     }
 }

--- a/iothub/service/src/Configurations/ConfigurationMetrics.cs
+++ b/iothub/service/src/Configurations/ConfigurationMetrics.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices
@@ -24,14 +25,14 @@ namespace Microsoft.Azure.Devices
         /// Results of the metrics collection queries
         /// </summary>
         [JsonProperty("results")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Public facing property cannot be modified since it will be a breaking change.")]
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Public facing property cannot be modified since it will be a breaking change.")]
         public IDictionary<string, long> Results { get; set; }
 
         /// <summary>
         /// Queries used for metrics collection
         /// </summary>
         [JsonProperty("queries")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Public facing property cannot be modified since it will be a breaking change.")]
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Public facing property cannot be modified since it will be a breaking change.")]
         public IDictionary<string, string> Queries { get; set; }
     }
 }

--- a/iothub/service/src/DigitalTwin/Serialization/BasicDigitalTwin.cs
+++ b/iothub/service/src/DigitalTwin/Serialization/BasicDigitalTwin.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.Devices.Serialization
         /// Additional properties of the digital twin. This field will contain any properties of the digital twin that are not already defined by the other strong types of this class.
         /// </summary>
         [JsonExtensionData]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Public facing property cannot be modified since it will be a breaking change.")]
         public IDictionary<string, object> CustomProperties { get; set; } = new Dictionary<string, object>();
     }
 }

--- a/iothub/service/src/DigitalTwin/Serialization/BasicDigitalTwin.cs
+++ b/iothub/service/src/DigitalTwin/Serialization/BasicDigitalTwin.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Serialization
@@ -27,7 +28,7 @@ namespace Microsoft.Azure.Devices.Serialization
         /// Additional properties of the digital twin. This field will contain any properties of the digital twin that are not already defined by the other strong types of this class.
         /// </summary>
         [JsonExtensionData]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Public facing property cannot be modified since it will be a breaking change.")]
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Public facing property cannot be modified since it will be a breaking change.")]
         public IDictionary<string, object> CustomProperties { get; set; } = new Dictionary<string, object>();
     }
 }

--- a/iothub/service/src/IotHubClientWebSocket.cs
+++ b/iothub/service/src/IotHubClientWebSocket.cs
@@ -454,7 +454,7 @@ namespace Microsoft.Azure.Devices
             }
         }
 
-        [SuppressMessage("Microsoft.Cryptographic.Standard", "CA5354:SHA1CannotBeUsed", Justification = "SHA-1 Hash mandated by RFC 6455")]
+        [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "SHA-1 Hash mandated by RFC 6455")]
         private static SHA1 InitCryptoServiceProvider()
         {
             return SHA1.Create();


### PR DESCRIPTION
[CA2227](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/CA2227): Collection properties should be read only
   - suppressed: cannot modify public properties.

[CA2237](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/CA2237): Mark ISerializable types with SerializableAttribute
    - updated.

[CA5350](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/CA5350): Do Not Use Weak Cryptographic Algorithms
    - suppressed: SHA-1 mandated by [RFC6455](https://tools.ietf.org/html/rfc6455).