### PR TITLE
Use CultureInvariant for validating device connection string values

### DIFF
--- a/iothub/device/src/IotHubConnectionStringBuilder.cs
+++ b/iothub/device/src/IotHubConnectionStringBuilder.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.Client
         private const string GatewayHostNamePropertyName = "GatewayHostName";
         private const string X509CertPropertyName = "X509Cert";
 
-        private const RegexOptions CommonRegexOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+        private const RegexOptions CommonRegexOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant;
         private static readonly TimeSpan s_regexTimeoutMilliseconds = TimeSpan.FromMilliseconds(500);
         private static readonly Regex s_hostNameRegex = new Regex(@"[a-zA-Z0-9_\-\.]+$", CommonRegexOptions, s_regexTimeoutMilliseconds);
         private static readonly Regex s_idNameRegex = new Regex(@"^[A-Za-z0-9\-:.+%_#*?!(),=@;$']{1,128}$", CommonRegexOptions, s_regexTimeoutMilliseconds);

--- a/iothub/device/tests/ConnectionString/IotHubConnectionStringBuilderTests.cs
+++ b/iothub/device/tests/ConnectionString/IotHubConnectionStringBuilderTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Globalization;
+using System.Threading;
 using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.Client.ApiTest;
@@ -39,6 +41,32 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             var connectionString = $"HostName={HostName};SharedAccessKeyName={SharedAccessKeyName};DeviceId={DeviceId};SharedAccessKey={SharedAccessKey}";
             var csBuilder = IotHubConnectionStringBuilder.Create(connectionString);
             csBuilder.DeviceId.Should().Be(DeviceId);
+        }
+
+        [TestMethod]
+        [DoNotParallelize]
+        public void IotHubConnectionStringBuilder_ParamConnectionString_ParsesCultureDeviceId()
+        {
+            const string deviceId = "IoTDeviceCheck";
+
+            CultureInfo savedCultureInfo = Thread.CurrentThread.CurrentCulture;
+            CultureInfo[] allCultures = CultureInfo.GetCultures(CultureTypes.AllCultures);
+
+            try
+            {
+                foreach (CultureInfo culture in allCultures)
+                {
+                    Console.WriteLine($"Testing culture {culture}");
+                    Thread.CurrentThread.CurrentCulture = culture;
+                    var connectionString = $"HostName={HostName};DeviceId={deviceId};SharedAccessKey={SharedAccessKey}";
+                    var csBuilder = IotHubConnectionStringBuilder.Create(connectionString);
+                    csBuilder.DeviceId.Should().Be(deviceId, $"failed to match in {culture}");
+                }
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = savedCultureInfo;
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
The test I added fails without the additional regex option, and passes with it.