### PR TITLE
Fix regression on AsyncResult

### DIFF
--- a/iothub/service/src/Common/AsyncResult.cs
+++ b/iothub/service/src/Common/AsyncResult.cs
@@ -272,19 +272,19 @@ namespace Microsoft.Azure.Devices.Common
             }
 
             callback = null;
-            if (result.CompletedSynchronously)
+            if (!result.CompletedSynchronously)
             {
+                return false;
+            }
 #if NET451
+            else
+            {
                 if (ReferenceEquals(result, _deferredTransactionalResult))
                 {
                     _deferredTransactionalResult = null;
                 }
+            }
 #endif
-            }
-            else
-            {
-                return false;
-            }
 
             callback = GetNextCompletion();
             if (callback == null)

--- a/iothub/service/src/Common/AsyncResult.cs
+++ b/iothub/service/src/Common/AsyncResult.cs
@@ -281,6 +281,7 @@ namespace Microsoft.Azure.Devices.Common
             }
             else
 #endif
+            if (!result.CompletedSynchronously)
             {
                 return false;
             }

--- a/iothub/service/src/Common/AsyncResult.cs
+++ b/iothub/service/src/Common/AsyncResult.cs
@@ -272,19 +272,16 @@ namespace Microsoft.Azure.Devices.Common
             }
 
             callback = null;
-
-#if NET451
-            if (!result.CompletedSynchronously && ReferenceEquals(result, _deferredTransactionalResult))
+            if (result.CompletedSynchronously)
             {
-                // Use deferredTransactionalResult to see if we are supposed to execute a post-transaction callback.
-                _deferredTransactionalResult = null;
+#if NET451
+                if (ReferenceEquals(result, _deferredTransactionalResult))
+                {
+                    _deferredTransactionalResult = null;
+                }
+#endif
             }
             else
-            {
-                return false;
-            }
-#endif
-            if (!result.CompletedSynchronously)
             {
                 return false;
             }

--- a/iothub/service/src/Common/AsyncResult.cs
+++ b/iothub/service/src/Common/AsyncResult.cs
@@ -280,6 +280,9 @@ namespace Microsoft.Azure.Devices.Common
                 _deferredTransactionalResult = null;
             }
             else
+            {
+                return false;
+            }
 #endif
             if (!result.CompletedSynchronously)
             {


### PR DESCRIPTION
in a recent change, while removing dead code, we caused an unreachable code warning
https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0162

I have pointed out the state of the code before the regression in the comments.