### PR TITLE
Code clean up of ClientWebSocketChannel files

### DIFF
--- a/iothub/device/src/Transport/Mqtt/ClientWebSocketChannel.cs
+++ b/iothub/device/src/Transport/Mqtt/ClientWebSocketChannel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Net;
 using System.Net.WebSockets;
@@ -13,21 +14,20 @@ using Microsoft.Azure.Devices.Client.Extensions;
 
 namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 {
+    [SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "WS is owned by the caller.")]
     public class ClientWebSocketChannel : AbstractChannel
     {
-        private readonly ClientWebSocket _webSocket;
-        private readonly CancellationTokenSource _writeCancellationTokenSource;
-        private bool _active;
-
-        internal bool ReadPending { get; set; }
-
-        internal bool WriteInProgress { get; set; }
+        private ClientWebSocket _webSocket;
+        private CancellationTokenSource _writeCancellationTokenSource;
+        private bool _isActive;
+        private bool _isReadPending;
+        private bool _isWriteInProgress;
 
         public ClientWebSocketChannel(IChannel parent, ClientWebSocket webSocket)
             : base(parent)
         {
             _webSocket = webSocket;
-            _active = true;
+            _isActive = true;
             Metadata = new ChannelMetadata(false, 16);
             Configuration = new ClientWebSocketChannelConfig();
             _writeCancellationTokenSource = new CancellationTokenSource();
@@ -35,11 +35,19 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         public override IChannelConfiguration Configuration { get; }
 
-        public override bool Open => (_webSocket.State == WebSocketState.Open && Active);
+        public override bool Open => _isActive && _webSocket?.State == WebSocketState.Open;
 
-        public override bool Active => _active;
+        public override bool Active => _isActive;
 
         public override ChannelMetadata Metadata { get; }
+
+        protected override EndPoint LocalAddressInternal { get; }
+
+        protected override EndPoint RemoteAddressInternal { get; }
+
+        protected override IChannelUnsafe NewUnsafe() => new WebSocketChannelUnsafe(this);
+
+        protected override bool IsCompatible(IEventLoop eventLoop) => true;
 
         public ClientWebSocketChannel Option<T>(ChannelOption<T> option, T value)
         {
@@ -48,12 +56,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             Configuration.SetOption(option, value);
             return this;
         }
-
-        protected override EndPoint LocalAddressInternal { get; }
-
-        protected override EndPoint RemoteAddressInternal { get; }
-
-        protected override IChannelUnsafe NewUnsafe() => new WebSocketChannelUnsafe(this);
 
         protected class WebSocketChannelUnsafe : AbstractUnsafe
         {
@@ -72,7 +74,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 // Flush immediately only when there's no pending flush.
                 // If there's a pending flush operation, event loop will call FinishWrite() later,
                 // and thus there's no need to call it now.
-                if (((ClientWebSocketChannel)channel).WriteInProgress)
+                if (((ClientWebSocketChannel)channel)._isWriteInProgress)
                 {
                     return;
                 }
@@ -80,8 +82,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 base.Flush0();
             }
         }
-
-        protected override bool IsCompatible(IEventLoop eventLoop) => true;
 
         protected override void DoBind(EndPoint localAddress)
         {
@@ -102,12 +102,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 {
                     // Cancel any pending write
                     CancelPendingWrite();
-                    _active = false;
+                    _isActive = false;
 
-                    using (var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
-                    {
-                        await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationTokenSource.Token).ConfigureAwait(false);
-                    }
+                    using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                    await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationTokenSource.Token).ConfigureAwait(false);
                 }
             }
             catch (Exception e) when (!e.IsFatal())
@@ -123,19 +121,19 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             bool close = false;
             try
             {
-                if (!Open || ReadPending)
+                if (!Open || _isReadPending)
                 {
                     return;
                 }
 
-                ReadPending = true;
+                _isReadPending = true;
                 IByteBufferAllocator allocator = Configuration.Allocator;
                 allocHandle = Configuration.RecvByteBufAllocator.NewHandle();
                 allocHandle.Reset(Configuration);
                 do
                 {
                     byteBuffer = allocHandle.Allocate(allocator);
-                    allocHandle.LastBytesRead = await DoReadBytes(byteBuffer).ConfigureAwait(false);
+                    allocHandle.LastBytesRead = await DoReadBytesAsync(byteBuffer).ConfigureAwait(false);
                     if (allocHandle.LastBytesRead <= 0)
                     {
                         // nothing was read -> release the buffer.
@@ -147,11 +145,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                     Pipeline.FireChannelRead(byteBuffer);
                     allocHandle.IncMessagesRead(1);
-                }
-                while (allocHandle.ContinueReading());
+                } while (allocHandle.ContinueReading());
 
                 allocHandle.ReadComplete();
-                ReadPending = false;
+                _isReadPending = false;
                 Pipeline.FireChannelReadComplete();
             }
             catch (Exception e) when (!e.IsFatal())
@@ -159,7 +156,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 // Since this method returns void, all exceptions must be handled here.
                 byteBuffer?.Release();
                 allocHandle?.ReadComplete();
-                ReadPending = false;
+                _isReadPending = false;
                 Pipeline.FireChannelReadComplete();
                 Pipeline.FireExceptionCaught(e);
                 close = true;
@@ -183,7 +180,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             try
             {
-                WriteInProgress = true;
+                _isWriteInProgress = true;
                 while (true)
                 {
                     object currentMessage = channelOutboundBuffer.Current;
@@ -206,19 +203,19 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     channelOutboundBuffer.Remove();
                 }
 
-                WriteInProgress = false;
+                _isWriteInProgress = false;
             }
             catch (Exception e) when (!e.IsFatal())
             {
                 // Since this method returns void, all exceptions must be handled here.
 
-                WriteInProgress = false;
+                _isWriteInProgress = false;
                 Pipeline.FireExceptionCaught(e);
                 await HandleCloseAsync().ConfigureAwait(false);
             }
         }
 
-        private async Task<int> DoReadBytes(IByteBuffer byteBuffer)
+        private async Task<int> DoReadBytesAsync(IByteBuffer byteBuffer)
         {
             WebSocketReceiveResult receiveResult = await _webSocket.ReceiveAsync(new ArraySegment<byte>(byteBuffer.Array, byteBuffer.ArrayOffset + byteBuffer.WriterIndex, byteBuffer.WritableBytes), CancellationToken.None).ConfigureAwait(false);
             if (receiveResult.MessageType == WebSocketMessageType.Text)
@@ -262,9 +259,12 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         private void Abort()
         {
-            _webSocket.Abort();
-            _webSocket.Dispose();
-            _writeCancellationTokenSource.Dispose();
+            _webSocket?.Abort();
+            _webSocket?.Dispose();
+            _webSocket = null;
+
+            _writeCancellationTokenSource?.Dispose();
+            _writeCancellationTokenSource = null;
         }
     }
 }


### PR DESCRIPTION
More incremental changes leading up the the CA1001 fix, to track down what is causing test run failures in the pipeline.

These classes look awfully similar but are used in 2 different projects, and one is public (why? I don't know).