### PR TITLE
Fix for NRE when accessing twin metadata

### DIFF
--- a/shared/src/Metadata.cs
+++ b/shared/src/Metadata.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// </summary>
         /// <param name="lastUpdated"></param>
         /// <param name="lastUpdatedVersion"></param>
-        public Metadata(DateTimeT lastUpdated, long? lastUpdatedVersion)
+        public Metadata(DateTimeT? lastUpdated, long? lastUpdatedVersion)
         {
             LastUpdated = lastUpdated;
             LastUpdatedVersion = lastUpdatedVersion;
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// <summary>
         /// Time when a property was last updated
         /// </summary>
-        public DateTimeT LastUpdated { get; set; }
+        public DateTimeT? LastUpdated { get; set; }
 
         /// <remarks>
         /// This SHOULD be null for Reported properties metadata and MUST not be null for Desired properties metadata.

--- a/shared/src/Metadata.cs
+++ b/shared/src/Metadata.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// </summary>
         /// <param name="lastUpdated"></param>
         /// <param name="lastUpdatedVersion"></param>
-        public Metadata(DateTimeT? lastUpdated, long? lastUpdatedVersion)
+        public Metadata(DateTimeT lastUpdated, long? lastUpdatedVersion)
         {
             LastUpdated = lastUpdated;
             LastUpdatedVersion = lastUpdatedVersion;
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// <summary>
         /// Time when a property was last updated
         /// </summary>
-        public DateTimeT? LastUpdated { get; set; }
+        public DateTimeT LastUpdated { get; set; }
 
         /// <remarks>
         /// This SHOULD be null for Reported properties metadata and MUST not be null for Desired properties metadata.

--- a/shared/src/TwinCollection.cs
+++ b/shared/src/TwinCollection.cs
@@ -176,9 +176,9 @@ namespace Microsoft.Azure.Devices.Shared
         /// Gets the LastUpdated time for this property
         /// </summary>
         /// <returns>DateTime instance representing the LastUpdated time for this property</returns>
-        public DateTime GetLastUpdated()
+        public DateTime? GetLastUpdated()
         {
-            return (DateTime)_metadata[LastUpdatedName];
+            return (DateTime?)_metadata[LastUpdatedName];
         }
 
         /// <summary>

--- a/shared/src/TwinCollection.cs
+++ b/shared/src/TwinCollection.cs
@@ -176,7 +176,8 @@ namespace Microsoft.Azure.Devices.Shared
         /// Gets the LastUpdated time for this property
         /// </summary>
         /// <returns>DateTime instance representing the LastUpdated time for this property</returns>
-        /// <exception cref="System.ArgumentNullException">Thrown when _metadata is null</exception>
+        /// <exception cref="System.ArgumentNullException">Thrown when the TwinCollection metadata is null. 
+        /// An example would be when the TwinCollection class is created with the default constructor</exception>
         public DateTime GetLastUpdated()
         {
             return (DateTime)_metadata?[LastUpdatedName];
@@ -186,7 +187,8 @@ namespace Microsoft.Azure.Devices.Shared
         /// Gets the LastUpdatedVersion for this property
         /// </summary>
         /// <returns>LastUpdatdVersion if present, null otherwise</returns>
-        /// <exception cref="System.ArgumentNullException">Thrown when _metadata is null</exception>
+        /// <exception cref="System.ArgumentNullException">Thrown when the TwinCollection metadata is null. 
+        /// An example would be when the TwinCollection class is created with the default constructor</exception>
         public long? GetLastUpdatedVersion()
         {
             return (long?)_metadata?[LastUpdatedVersionName];

--- a/shared/src/TwinCollection.cs
+++ b/shared/src/TwinCollection.cs
@@ -176,6 +176,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// Gets the LastUpdated time for this property
         /// </summary>
         /// <returns>DateTime instance representing the LastUpdated time for this property</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when _metadata is null</exception>
         public DateTime GetLastUpdated()
         {
             return (DateTime)_metadata?[LastUpdatedName];
@@ -185,6 +186,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// Gets the LastUpdatedVersion for this property
         /// </summary>
         /// <returns>LastUpdatdVersion if present, null otherwise</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when _metadata is null</exception>
         public long? GetLastUpdatedVersion()
         {
             return (long?)_metadata?[LastUpdatedVersionName];

--- a/shared/src/TwinCollection.cs
+++ b/shared/src/TwinCollection.cs
@@ -187,8 +187,6 @@ namespace Microsoft.Azure.Devices.Shared
         /// Gets the LastUpdatedVersion for this property
         /// </summary>
         /// <returns>LastUpdatdVersion if present, null otherwise</returns>
-        /// <exception cref="System.ArgumentNullException">Thrown when the TwinCollection metadata is null. 
-        /// An example would be when the TwinCollection class is created with the default constructor</exception>
         public long? GetLastUpdatedVersion()
         {
             return (long?)_metadata?[LastUpdatedVersionName];

--- a/shared/src/TwinCollection.cs
+++ b/shared/src/TwinCollection.cs
@@ -176,9 +176,9 @@ namespace Microsoft.Azure.Devices.Shared
         /// Gets the LastUpdated time for this property
         /// </summary>
         /// <returns>DateTime instance representing the LastUpdated time for this property</returns>
-        public DateTime? GetLastUpdated()
+        public DateTime GetLastUpdated()
         {
-            return (DateTime?)_metadata[LastUpdatedName];
+            return (DateTime)_metadata?[LastUpdatedName];
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// <returns>LastUpdatdVersion if present, null otherwise</returns>
         public long? GetLastUpdatedVersion()
         {
-            return (long?)_metadata[LastUpdatedVersionName];
+            return (long?)_metadata?[LastUpdatedVersionName];
         }
 
         /// <summary>


### PR DESCRIPTION
This is a fix for github issue [1667](https://github.com/Azure/azure-iot-sdk-csharp/issues/1667#)

This change will change behavior when metadata is null. Prior to this you would see a NRE being thrown, going forward this will throw argument null exception. Added xml comments for the same.