### PR TITLE
fix(iot-device): Fix NullReferenceException in MqttTransportHandler

### DIFF
--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -1011,7 +1011,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 ScheduleCleanup(async () =>
                 {
-                    _disconnectAwaitersCancellationSource.Cancel();
+                    _disconnectAwaitersCancellationSource?.Cancel();
                     if (_channel == null)
                     {
                         return;


### PR DESCRIPTION
_disconnectAwaitersCancellationSource CancellationTokenSource is disposed (and set to null) when the transport handler is disposed. Since this cts ;lifecycle is also managed through a scheduled cleanup task, which can run on a different thread in the event of an exception, we need to perform a null check before attempting cancellation.
Failure to do so ends in the code throwing a NullReferenceException.