### PR TITLE
Fix issue where retrieving a twin array from registry manager returned null

### DIFF
--- a/e2e/test/iothub/CombinedClientOperationsPoolAmqpTests.cs
+++ b/e2e/test/iothub/CombinedClientOperationsPoolAmqpTests.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 // Set reported twin properties
                 Logger.Trace($"{nameof(CombinedClientOperationsPoolAmqpTests)}: Operation 4: Set reported property for device={testDevice.Id}");
-                Task setReportedProperties = TwinE2ETests.Twin_DeviceSetsReportedPropertyAndGetsItBackAsync(deviceClient, Guid.NewGuid().ToString(), Logger);
+                Task setReportedProperties = TwinE2ETests.Twin_DeviceSetsReportedPropertyAndGetsItBackAsync(deviceClient, testDevice.Id, Guid.NewGuid().ToString(), Logger);
                 clientOperations.Add(setReportedProperties);
 
                 // Receive set desired twin properties

--- a/e2e/test/iothub/twin/FaultInjectionPoolAmqpTests.TwinFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/twin/FaultInjectionPoolAmqpTests.TwinFaultInjectionPoolAmqpTests.cs
@@ -1436,7 +1436,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
                 Logger.Trace($"{nameof(TwinE2EPoolAmqpTests)}: Setting reported propery and verifying twin for device {testDevice.Id}");
-                await TwinE2ETests.Twin_DeviceSetsReportedPropertyAndGetsItBackAsync(deviceClient, Guid.NewGuid().ToString(), Logger).ConfigureAwait(false);
+                await TwinE2ETests.Twin_DeviceSetsReportedPropertyAndGetsItBackAsync(deviceClient, testDevice.Id, Guid.NewGuid().ToString(), Logger).ConfigureAwait(false);
             }
 
             async Task CleanupOperationAsync(IList<DeviceClient> deviceClients)

--- a/e2e/test/iothub/twin/TwinE2EPoolAmqpTests.cs
+++ b/e2e/test/iothub/twin/TwinE2EPoolAmqpTests.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
                 Logger.Trace($"{nameof(TwinE2EPoolAmqpTests)}: Setting reported propery and verifying twin for device {testDevice.Id}");
-                await TwinE2ETests.Twin_DeviceSetsReportedPropertyAndGetsItBackAsync(deviceClient, Guid.NewGuid().ToString(), Logger).ConfigureAwait(false);
+                await TwinE2ETests.Twin_DeviceSetsReportedPropertyAndGetsItBackAsync(deviceClient, testDevice.Id, Guid.NewGuid().ToString(), Logger).ConfigureAwait(false);
             }
 
             await PoolingOverAmqp

--- a/shared/src/TwinCollection.cs
+++ b/shared/src/TwinCollection.cs
@@ -266,17 +266,15 @@ namespace Microsoft.Azure.Devices.Shared
 
             if (_metadata?[propertyName] is JObject)
             {
-                if (value is JValue)
+                if (value is JValue jsonValue)
                 {
-                    result = new TwinCollectionValue((JValue)value, (JObject)_metadata[propertyName]);
-                }
-                else if (value is JArray)
-                {
-                    result = new TwinCollection(value as JArray, (JObject)_metadata[propertyName]);
+                    result = new TwinCollectionValue(jsonValue, (JObject)_metadata[propertyName]);
                 }
                 else
                 {
-                    result = (object)new TwinCollection(value as JObject, (JObject)_metadata[propertyName]);
+                    result = value is JArray
+                        ? new TwinCollection(value as JArray, (JObject)_metadata[propertyName])
+                        : new TwinCollection(value as JObject, (JObject)_metadata[propertyName]);
                 }
             }
             else

--- a/shared/src/TwinCollection.cs
+++ b/shared/src/TwinCollection.cs
@@ -194,11 +194,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// Gets the LastUpdated time for this property
         /// </summary>
         /// <returns>DateTime instance representing the LastUpdated time for this property</returns>
-<<<<<<< Updated upstream
-        /// <exception cref="System.NullReferenceException">Thrown when the TwinCollection metadata is null. 
-=======
-        /// <exception cref="System.ArgumentNullException">Thrown when the TwinCollection metadata is null.
->>>>>>> Stashed changes
+        /// <exception cref="System.NullReferenceException">Thrown when the TwinCollection metadata is null.
         /// An example would be when the TwinCollection class is created with the default constructor</exception>
         public DateTime GetLastUpdated()
         {
@@ -239,14 +235,21 @@ namespace Microsoft.Azure.Devices.Shared
         /// <inheritdoc />
         public IEnumerator GetEnumerator()
         {
-            foreach (KeyValuePair<string, JToken> kvp in JObject)
+            if (JArray != null)
             {
-                if (kvp.Key == MetadataName || kvp.Key == VersionName)
+                yield return JArray.GetEnumerator();
+            }
+            else
+            {
+                foreach (KeyValuePair<string, JToken> kvp in JObject)
                 {
-                    continue;
-                }
+                    if (kvp.Key == MetadataName || kvp.Key == VersionName)
+                    {
+                        continue;
+                    }
 
-                yield return new KeyValuePair<string, dynamic>(kvp.Key, this[kvp.Key]);
+                    yield return new KeyValuePair<string, dynamic>(kvp.Key, this[kvp.Key]);
+                }
             }
         }
 
@@ -301,7 +304,7 @@ namespace Microsoft.Azure.Devices.Shared
 
         private void TryClearMetadata(string propertyName)
         {
-            if (JObject.TryGetValue(propertyName, out _))
+            if (JObject != null && JObject.TryGetValue(propertyName, out _))
             {
                 JObject.Remove(propertyName);
             }

--- a/shared/src/TwinCollection.cs
+++ b/shared/src/TwinCollection.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Azure.Devices.Shared
     [JsonConverter(typeof(TwinCollectionJsonConverter))]
     public class TwinCollection : IEnumerable
     {
-        private const string MetadataName = "$metadata";
-        private const string LastUpdatedName = "$lastUpdated";
-        private const string LastUpdatedVersionName = "$lastUpdatedVersion";
-        private const string VersionName = "$version";
+        internal const string MetadataName = "$metadata";
+        internal const string LastUpdatedName = "$lastUpdated";
+        internal const string LastUpdatedVersionName = "$lastUpdatedVersion";
+        internal const string VersionName = "$version";
         private readonly JObject _metadata;
 
         /// <summary>

--- a/shared/src/TwinCollection.cs
+++ b/shared/src/TwinCollection.cs
@@ -237,7 +237,10 @@ namespace Microsoft.Azure.Devices.Shared
         {
             if (JArray != null)
             {
-                yield return JArray.GetEnumerator();
+                foreach (JToken item in JArray)
+                {
+                    yield return item;
+                }
             }
             else
             {

--- a/shared/src/TwinCollectionArray.cs
+++ b/shared/src/TwinCollectionArray.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.Shared
         internal TwinCollectionArray(JArray jArray, JObject metadata)
             : base(jArray)
         {
-            _metadata = metadata;
+            _metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
         }
 
         /// <summary>

--- a/shared/src/TwinCollectionArray.cs
+++ b/shared/src/TwinCollectionArray.cs
@@ -11,10 +11,6 @@ namespace Microsoft.Azure.Devices.Shared
     /// </summary>
     public class TwinCollectionArray : JArray
     {
-        private const string MetadataName = "$metadata";
-        private const string LastUpdatedName = "$lastUpdated";
-        private const string LastUpdatedVersionName = "$lastUpdatedVersion";
-
         private readonly JObject _metadata;
 
         internal TwinCollectionArray(JArray jArray, JObject metadata)
@@ -27,27 +23,27 @@ namespace Microsoft.Azure.Devices.Shared
         /// Gets the value for the given property name
         /// </summary>
         /// <param name="propertyName">Property Name to lookup</param>
-        /// <returns>Value if present</returns>
+        /// <returns>Property value, if present</returns>
         public dynamic this[string propertyName]
         {
             get
             {
-                if (propertyName == MetadataName)
+                if (propertyName == TwinCollection.MetadataName)
                 {
                     return GetMetadata();
                 }
 
-                if (propertyName == LastUpdatedName)
+                if (propertyName == TwinCollection.LastUpdatedName)
                 {
                     return GetLastUpdated();
                 }
 
-                if (propertyName == LastUpdatedVersionName)
+                if (propertyName == TwinCollection.LastUpdatedVersionName)
                 {
                     return GetLastUpdatedVersion();
                 }
 
-                throw new ArgumentException($"'Newtonsoft.Json.Linq.JArray' does not contain a definition for '{propertyName}'.");
+                throw new ArgumentException($"{nameof(TwinCollectionArray)} does not contain a definition for '{propertyName}'.");
             }
         }
 
@@ -66,7 +62,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// <returns>DateTime instance representing the LastUpdated time for this property</returns>
         public DateTime GetLastUpdated()
         {
-            return (DateTime)_metadata[LastUpdatedName];
+            return (DateTime)_metadata[TwinCollection.LastUpdatedName];
         }
 
         /// <summary>
@@ -75,7 +71,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// <returns>LastUpdatdVersion if present, null otherwise</returns>
         public long? GetLastUpdatedVersion()
         {
-            return (long?)_metadata[LastUpdatedVersionName];
+            return (long?)_metadata[TwinCollection.LastUpdatedVersionName];
         }
     }
 }

--- a/shared/src/TwinCollectionArray.cs
+++ b/shared/src/TwinCollectionArray.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Azure.Devices.Shared
 {
     /// <summary>
-    /// Represents a property array in <see cref="TwinCollection"/>
+    /// Represents a property array in a <see cref="TwinCollection"/>
     /// </summary>
     public class TwinCollectionArray : JArray
     {

--- a/shared/src/TwinCollectionArray.cs
+++ b/shared/src/TwinCollectionArray.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// Represents a property array in <see cref="TwinCollection"/>
+    /// </summary>
+    public class TwinCollectionArray : JArray
+    {
+        private const string MetadataName = "$metadata";
+        private const string LastUpdatedName = "$lastUpdated";
+        private const string LastUpdatedVersionName = "$lastUpdatedVersion";
+
+        private readonly JObject _metadata;
+
+        internal TwinCollectionArray(JArray jArray, JObject metadata)
+            : base(jArray)
+        {
+            _metadata = metadata;
+        }
+
+        /// <summary>
+        /// Gets the value for the given property name
+        /// </summary>
+        /// <param name="propertyName">Property Name to lookup</param>
+        /// <returns>Value if present</returns>
+        public dynamic this[string propertyName]
+        {
+            get
+            {
+                if (propertyName == MetadataName)
+                {
+                    return GetMetadata();
+                }
+
+                if (propertyName == LastUpdatedName)
+                {
+                    return GetLastUpdated();
+                }
+
+                if (propertyName == LastUpdatedVersionName)
+                {
+                    return GetLastUpdatedVersion();
+                }
+
+                throw new ArgumentException($"'Newtonsoft.Json.Linq.JArray' does not contain a definition for '{propertyName}'.");
+            }
+        }
+
+        /// <summary>
+        /// Gets the Metadata for this property
+        /// </summary>
+        /// <returns>Metadata instance representing the metadata for this property</returns>
+        public Metadata GetMetadata()
+        {
+            return new Metadata(GetLastUpdated(), GetLastUpdatedVersion());
+        }
+
+        /// <summary>
+        /// Gets the LastUpdated time for this property
+        /// </summary>
+        /// <returns>DateTime instance representing the LastUpdated time for this property</returns>
+        public DateTime GetLastUpdated()
+        {
+            return (DateTime)_metadata[LastUpdatedName];
+        }
+
+        /// <summary>
+        /// Gets the LastUpdatedVersion for this property
+        /// </summary>
+        /// <returns>LastUpdatdVersion if present, null otherwise</returns>
+        public long? GetLastUpdatedVersion()
+        {
+            return (long?)_metadata[LastUpdatedVersionName];
+        }
+    }
+}

--- a/shared/src/TwinCollectionValue.cs
+++ b/shared/src/TwinCollectionValue.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CSharp.RuntimeBinder;
+using Newtonsoft.Json.Linq;
+
 namespace Microsoft.Azure.Devices.Shared
 {
-    using System;
-    using System.Diagnostics.CodeAnalysis;
-    using Microsoft.CSharp.RuntimeBinder;
-    using Newtonsoft.Json.Linq;
-
     /// <summary>
     /// Represents a property value in <see cref="TwinCollection"/>
     /// </summary>
@@ -17,9 +17,9 @@ namespace Microsoft.Azure.Devices.Shared
         Justification = "Uses default JValue comparison, equality and hashing implementations.")]
     public class TwinCollectionValue : JValue
     {
-        const string metadataName = "$metadata";
-        const string lastUpdatedName = "$lastUpdated";
-        const string lastUpdatedVersionName = "$lastUpdatedVersion";
+        private const string metadataName = "$metadata";
+        private const string lastUpdatedName = "$lastUpdated";
+        private const string lastUpdatedVersionName = "$lastUpdatedVersion";
 
         private readonly JObject _metadata;
 

--- a/shared/src/TwinCollectionValue.cs
+++ b/shared/src/TwinCollectionValue.cs
@@ -17,10 +17,6 @@ namespace Microsoft.Azure.Devices.Shared
         Justification = "Uses default JValue comparison, equality and hashing implementations.")]
     public class TwinCollectionValue : JValue
     {
-        private const string metadataName = "$metadata";
-        private const string lastUpdatedName = "$lastUpdated";
-        private const string lastUpdatedVersionName = "$lastUpdatedVersion";
-
         private readonly JObject _metadata;
 
         internal TwinCollectionValue(JValue jValue, JObject metadata)
@@ -33,29 +29,29 @@ namespace Microsoft.Azure.Devices.Shared
         /// Gets the value for the given property name
         /// </summary>
         /// <param name="propertyName">Property Name to lookup</param>
-        /// <returns>Value if present</returns>
+        /// <returns>Property value, if present</returns>
         [SuppressMessage("Microsoft.Design", "CA1065:DoNotRaiseExceptionsInUnexpectedLocations",
             Justification = "AppCompat. Changing the exception to ArgumentException might break existing applications.")]
         public dynamic this[string propertyName]
         {
             get
             {
-                if (propertyName == metadataName)
+                if (propertyName == TwinCollection.MetadataName)
                 {
                     return GetMetadata();
                 }
 
-                if (propertyName == lastUpdatedName)
+                if (propertyName == TwinCollection.LastUpdatedName)
                 {
                     return GetLastUpdated();
                 }
 
-                if (propertyName == lastUpdatedVersionName)
+                if (propertyName == TwinCollection.LastUpdatedVersionName)
                 {
                     return GetLastUpdatedVersion();
                 }
 
-                throw new RuntimeBinderException($"'Newtonsoft.Linq.JValue' does not contain a definition for '{propertyName}'.");
+                throw new RuntimeBinderException($"{nameof(TwinCollectionValue)} does not contain a definition for '{propertyName}'.");
             }
         }
 
@@ -74,7 +70,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// <returns>DateTime instance representing the LastUpdated time for this property</returns>
         public DateTime GetLastUpdated()
         {
-            return (DateTime)_metadata[lastUpdatedName];
+            return (DateTime)_metadata[TwinCollection.LastUpdatedName];
         }
 
         /// <summary>
@@ -83,7 +79,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// <returns>LastUpdatdVersion if present, null otherwise</returns>
         public long? GetLastUpdatedVersion()
         {
-            return (long?)_metadata[lastUpdatedVersionName];
+            return (long?)_metadata[TwinCollection.LastUpdatedVersionName];
         }
     }
 }

--- a/shared/src/TwinCollectionValue.cs
+++ b/shared/src/TwinCollectionValue.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Azure.Devices.Shared
 {
     /// <summary>
-    /// Represents a property value in <see cref="TwinCollection"/>
+    /// Represents a property value in a <see cref="TwinCollection"/>
     /// </summary>
     [SuppressMessage("Microsoft.Design", "CA1710:IdentifiersShouldHaveCorrectSuffix",
         Justification = "Public API cannot change name.")]


### PR DESCRIPTION
On retrieving a twin property by index/ key, our sdk will try to return it as a `JObject` within a `TwinCollection`. For twin arrays, since they are represented as `JArray`, they cannot be converted to a `JObject` (`JArray` is not inherited from `JObject`), and are thus returned as `null`. 
This PR adds a new `TwinCollectionArray` type, one that is inherited from a `JArray`, and returns that instead`.

Note: this only affects the registry manager retuned twin. The device-client returned twin is always returned as the base `JToken` type: https://github.com/Azure/azure-iot-sdk-csharp/blob/abmisr/twinArrayNull/shared/src/TwinCollection.cs#L255