### PR TITLE
Code cleanup in OrderedTwoPhaseWorkQueue

### DIFF
--- a/iothub/device/src/Transport/Mqtt/ClientWebSocketChannel.cs
+++ b/iothub/device/src/Transport/Mqtt/ClientWebSocketChannel.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             _writeCancellationTokenSource = null;
         }
 
-        protected class WebSocketChannelUnsafe : AbstractUnsafe
+        private class WebSocketChannelUnsafe : AbstractUnsafe
         {
             public WebSocketChannelUnsafe(AbstractChannel channel)
                 : base(channel)


### PR DESCRIPTION
Initial look at code referenced in (#1737). Cleaning up code, and providing one possible NRE protection.

Also added parameter checking to provide more info in the even of an NRE. This is an internal class, and when it does throw an NRE the customer is helpless so better to provide more info even if it is a slight behavior change - I don't believe it is a meaningful behavior change that would affect a device app that could continue to run (it can't).