### PR TITLE
Add deprecated API back to avoid breaking changes.

### DIFF
--- a/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 return _tokenRefreshSemaphore.WaitAsync(cancellationToken);
             }
 
-            protected override Task<string> SafeCreateNewTokenAsync(string iotHub, int suggestedTimeToLive)
+            protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
             {
                 _logger.Trace($"[{DateTime.UtcNow}] Refresher: Creating new token.");
 
@@ -271,12 +271,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 }
 
                 return Task.FromResult(token);
-            }
-
-            [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
-            protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
-            {
-                return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
             }
         }
     }

--- a/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
@@ -272,6 +272,12 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 return Task.FromResult(token);
             }
+
+            [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
+            protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
+            {
+                return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
+            }
         }
     }
 }

--- a/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
@@ -235,6 +235,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 return _tokenRefreshSemaphore.WaitAsync(cancellationToken);
             }
 
+            ///<inheritdoc/>
             protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
             {
                 _logger.Trace($"[{DateTime.UtcNow}] Refresher: Creating new token.");

--- a/iothub/device/src/AuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/AuthenticationWithTokenRefresh.cs
@@ -131,6 +131,16 @@ namespace Microsoft.Azure.Devices.Client
         /// <returns>The token string.</returns>
         protected abstract Task<string> SafeCreateNewTokenAsync(string iotHub, int suggestedTimeToLive);
 
+        /// <summary>
+        /// Creates a new token with a suggested TTL. This method is thread-safe.
+        /// </summary>
+        /// <param name="iotHub">The IoT Hub domain name.</param>
+        /// <param name="suggestedTimeToLive">The suggested TTL.</param>
+        /// <remarks>This is an asynchronous method.</remarks>
+        /// <returns>The token string.</returns>
+        [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
+        protected abstract Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive);
+
         private void UpdateTimeBufferSeconds(int ttl)
         {
             _bufferSeconds = (int)(ttl * ((float)_timeBufferPercentage / 100));

--- a/iothub/device/src/AuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/AuthenticationWithTokenRefresh.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Devices.Client
                     return _token;
                 }
 
-                _token = await SafeCreateNewTokenAsync(iotHub, _suggestedTimeToLiveSeconds).ConfigureAwait(false);
+                _token = await SafeCreateNewToken(iotHub, _suggestedTimeToLiveSeconds).ConfigureAwait(false);
 
                 var sas = SharedAccessSignature.Parse(".", _token);
                 ExpiresOn = sas.ExpiresOn;
@@ -129,16 +129,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="iotHub">The IoT Hub domain name.</param>
         /// <param name="suggestedTimeToLive">The suggested TTL.</param>
         /// <returns>The token string.</returns>
-        protected abstract Task<string> SafeCreateNewTokenAsync(string iotHub, int suggestedTimeToLive);
-
-        /// <summary>
-        /// Creates a new token with a suggested TTL. This method is thread-safe.
-        /// </summary>
-        /// <param name="iotHub">The IoT Hub domain name.</param>
-        /// <param name="suggestedTimeToLive">The suggested TTL.</param>
-        /// <remarks>This is an asynchronous method.</remarks>
-        /// <returns>The token string.</returns>
-        [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
+        /// <remarks>This is an asynchronous method and should be awaited.</remarks>
         protected abstract Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive);
 
         private void UpdateTimeBufferSeconds(int ttl)

--- a/iothub/device/src/DeviceAuthenticationWithSakRefresh.cs
+++ b/iothub/device/src/DeviceAuthenticationWithSakRefresh.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.Client
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
         }
 
-        protected override Task<string> SafeCreateNewTokenAsync(string iotHub, int suggestedTimeToLive)
+        protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
         {
             var builder = new SharedAccessSignatureBuilder
             {
@@ -41,12 +41,6 @@ namespace Microsoft.Azure.Devices.Client
             }
 
             return Task.FromResult(builder.ToSignature());
-        }
-
-        [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
-        protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
-        {
-            return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
         }
     }
 }

--- a/iothub/device/src/DeviceAuthenticationWithSakRefresh.cs
+++ b/iothub/device/src/DeviceAuthenticationWithSakRefresh.cs
@@ -42,5 +42,11 @@ namespace Microsoft.Azure.Devices.Client
 
             return Task.FromResult(builder.ToSignature());
         }
+
+        [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
+        protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
+        {
+            return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
+        }
     }
 }

--- a/iothub/device/src/DeviceAuthenticationWithSakRefresh.cs
+++ b/iothub/device/src/DeviceAuthenticationWithSakRefresh.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.Devices.Client
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
         }
 
+        ///<inheritdoc/>
         protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
         {
             var builder = new SharedAccessSignatureBuilder

--- a/iothub/device/src/DeviceAuthenticationWithTpm.cs
+++ b/iothub/device/src/DeviceAuthenticationWithTpm.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.Devices.Client
             _securityProvider = securityProvider ?? throw new ArgumentNullException(nameof(securityProvider));
         }
 
+        ///<inheritdoc/>
         protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLiveSeconds)
         {
             var builder = new TpmSharedAccessSignatureBuilder(_securityProvider)

--- a/iothub/device/src/DeviceAuthenticationWithTpm.cs
+++ b/iothub/device/src/DeviceAuthenticationWithTpm.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Client
             _securityProvider = securityProvider ?? throw new ArgumentNullException(nameof(securityProvider));
         }
 
-        protected override Task<string> SafeCreateNewTokenAsync(string iotHub, int suggestedTimeToLiveSeconds)
+        protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLiveSeconds)
         {
             var builder = new TpmSharedAccessSignatureBuilder(_securityProvider)
             {
@@ -45,12 +45,6 @@ namespace Microsoft.Azure.Devices.Client
             };
 
             return Task.FromResult(builder.ToSignature());
-        }
-
-        [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
-        protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLiveSeconds)
-        {
-            return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLiveSeconds);
         }
 
         private class TpmSharedAccessSignatureBuilder : SharedAccessSignatureBuilder

--- a/iothub/device/src/DeviceAuthenticationWithTpm.cs
+++ b/iothub/device/src/DeviceAuthenticationWithTpm.cs
@@ -47,6 +47,12 @@ namespace Microsoft.Azure.Devices.Client
             return Task.FromResult(builder.ToSignature());
         }
 
+        [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
+        protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLiveSeconds)
+        {
+            return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLiveSeconds);
+        }
+
         private class TpmSharedAccessSignatureBuilder : SharedAccessSignatureBuilder
         {
             private SecurityProviderTpm _securityProvider;

--- a/iothub/device/src/HsmAuthentication/ModuleAuthenticationWithHsm.cs
+++ b/iothub/device/src/HsmAuthentication/ModuleAuthenticationWithHsm.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication
         /// <param name="iotHub">IotHub hostname</param>
         /// <param name="suggestedTimeToLive">Suggested time to live seconds</param>
         /// <returns></returns>
-        protected override async Task<string> SafeCreateNewTokenAsync(string iotHub, int suggestedTimeToLive)
+        protected override async Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
         {
             DateTime startTime = DateTime.UtcNow;
             string audience = SasTokenBuilder.BuildAudience(iotHub, DeviceId, ModuleId);
@@ -44,17 +44,6 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication
             string signature = await _signatureProvider.SignAsync(ModuleId, _generationId, data).ConfigureAwait(false);
 
             return SasTokenBuilder.BuildSasToken(audience, signature, expiresOn);
-        }
-
-        /// <summary>
-        /// Creates a new token with the specified TTL.
-        /// </summary>
-        /// <param name="iotHub">IotHub hostname</param>
-        /// <param name="suggestedTimeToLive">Suggested time to live seconds</param>
-        [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
-        protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
-        {
-            return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
         }
     }
 }

--- a/iothub/device/src/HsmAuthentication/ModuleAuthenticationWithHsm.cs
+++ b/iothub/device/src/HsmAuthentication/ModuleAuthenticationWithHsm.cs
@@ -45,5 +45,16 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication
 
             return SasTokenBuilder.BuildSasToken(audience, signature, expiresOn);
         }
+
+        /// <summary>
+        /// Creates a new token with the specified TTL.
+        /// </summary>
+        /// <param name="iotHub">IotHub hostname</param>
+        /// <param name="suggestedTimeToLive">Suggested time to live seconds</param>
+        [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
+        protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
+        {
+            return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
+        }
     }
 }

--- a/iothub/device/src/HsmAuthentication/ModuleAuthenticationWithHsm.cs
+++ b/iothub/device/src/HsmAuthentication/ModuleAuthenticationWithHsm.cs
@@ -29,12 +29,7 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication
             _generationId = generationId ?? throw new ArgumentNullException(nameof(generationId));
         }
 
-        /// <summary>
-        /// Creates a new token with the specified TTL.
-        /// </summary>
-        /// <param name="iotHub">IotHub hostname</param>
-        /// <param name="suggestedTimeToLive">Suggested time to live seconds</param>
-        /// <returns></returns>
+        ///<inheritdoc/>
         protected override async Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
         {
             DateTime startTime = DateTime.UtcNow;

--- a/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
+++ b/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.Client
             _connectionString = connectionString;
         }
 
-        protected override Task<string> SafeCreateNewTokenAsync(string iotHub, int suggestedTimeToLive)
+        protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
         {
             var builder = new SharedAccessSignatureBuilder()
             {
@@ -43,12 +43,6 @@ namespace Microsoft.Azure.Devices.Client
             }
 
             return Task.FromResult(builder.ToSignature());
-        }
-
-        [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
-        protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
-        {
-            return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
         }
     }
 }

--- a/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
+++ b/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
@@ -44,5 +44,11 @@ namespace Microsoft.Azure.Devices.Client
 
             return Task.FromResult(builder.ToSignature());
         }
+
+        [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
+        protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
+        {
+            return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
+        }
     }
 }

--- a/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
+++ b/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.Devices.Client
             _connectionString = connectionString;
         }
 
+        ///<inheritdoc/>
         protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
         {
             var builder = new SharedAccessSignatureBuilder()

--- a/iothub/device/tests/AuthenticationMethod/AuthenticationWithTokenRefreshTests.cs
+++ b/iothub/device/tests/AuthenticationMethod/AuthenticationWithTokenRefreshTests.cs
@@ -182,6 +182,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             {
             }
 
+            ///<inheritdoc/>
             protected override async Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
             {
                 _callCount++;

--- a/iothub/device/tests/AuthenticationMethod/AuthenticationWithTokenRefreshTests.cs
+++ b/iothub/device/tests/AuthenticationMethod/AuthenticationWithTokenRefreshTests.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             {
             }
 
-            protected override async Task<string> SafeCreateNewTokenAsync(string iotHub, int suggestedTimeToLive)
+            protected override async Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
             {
                 _callCount++;
 
@@ -195,12 +195,6 @@ namespace Microsoft.Azure.Devices.Client.Test
                 }
 
                 return CreateToken(ttl);
-            }
-
-            [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
-            protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
-            {
-                return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
             }
         }
     }

--- a/iothub/device/tests/AuthenticationMethod/AuthenticationWithTokenRefreshTests.cs
+++ b/iothub/device/tests/AuthenticationMethod/AuthenticationWithTokenRefreshTests.cs
@@ -196,6 +196,12 @@ namespace Microsoft.Azure.Devices.Client.Test
 
                 return CreateToken(ttl);
             }
+
+            [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
+            protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
+            {
+                return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
+            }
         }
     }
 }

--- a/iothub/device/tests/AuthenticationMethod/DeviceAuthenticationWithTokenRefreshTests.cs
+++ b/iothub/device/tests/AuthenticationMethod/DeviceAuthenticationWithTokenRefreshTests.cs
@@ -249,6 +249,12 @@ namespace Microsoft.Azure.Devices.Client.Test
 
                 return CreateToken(ttl);
             }
+
+            [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
+            protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
+            {
+                return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
+            }
         }
     }
 }

--- a/iothub/device/tests/AuthenticationMethod/DeviceAuthenticationWithTokenRefreshTests.cs
+++ b/iothub/device/tests/AuthenticationMethod/DeviceAuthenticationWithTokenRefreshTests.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             {
             }
 
-            protected override async Task<string> SafeCreateNewTokenAsync(string iotHub, int suggestedTimeToLive)
+            protected override async Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
             {
                 _callCount++;
 
@@ -248,12 +248,6 @@ namespace Microsoft.Azure.Devices.Client.Test
                 }
 
                 return CreateToken(ttl);
-            }
-
-            [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
-            protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
-            {
-                return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
             }
         }
     }

--- a/iothub/device/tests/AuthenticationMethod/DeviceAuthenticationWithTokenRefreshTests.cs
+++ b/iothub/device/tests/AuthenticationMethod/DeviceAuthenticationWithTokenRefreshTests.cs
@@ -235,6 +235,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             {
             }
 
+            ///<inheritdoc/>
             protected override async Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
             {
                 _callCount++;

--- a/iothub/device/tests/AuthenticationMethod/ModuleAuthenticationWithTokenRefreshTests.cs
+++ b/iothub/device/tests/AuthenticationMethod/ModuleAuthenticationWithTokenRefreshTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public async Task ModuleAuthenticationWithSakRefresh_SharedAccessKeyConnectionString_HasRefresher()
         {
-            var csBuilder = IotHubConnectionStringBuilder.Create(TestIoTHubName, 
+            var csBuilder = IotHubConnectionStringBuilder.Create(TestIoTHubName,
                 new ModuleAuthenticationWithRegistrySymmetricKey(TestDeviceId, TestModuleId, TestSharedAccessKey));
 
             IotHubConnectionString cs = csBuilder.ToIotHubConnectionString();
@@ -156,6 +156,12 @@ namespace Microsoft.Azure.Devices.Client.Test
                 }
 
                 return CreateToken(ttl);
+            }
+
+            [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
+            protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
+            {
+                return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
             }
         }
     }

--- a/iothub/device/tests/AuthenticationMethod/ModuleAuthenticationWithTokenRefreshTests.cs
+++ b/iothub/device/tests/AuthenticationMethod/ModuleAuthenticationWithTokenRefreshTests.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             {
             }
 
+            ///<inheritdoc/>
             protected override async Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
             {
                 _callCount++;

--- a/iothub/device/tests/AuthenticationMethod/ModuleAuthenticationWithTokenRefreshTests.cs
+++ b/iothub/device/tests/AuthenticationMethod/ModuleAuthenticationWithTokenRefreshTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             {
             }
 
-            protected override async Task<string> SafeCreateNewTokenAsync(string iotHub, int suggestedTimeToLive)
+            protected override async Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
             {
                 _callCount++;
 
@@ -156,12 +156,6 @@ namespace Microsoft.Azure.Devices.Client.Test
                 }
 
                 return CreateToken(ttl);
-            }
-
-            [Obsolete("This method has been deprecated due to lack of the asynchronous suffix in the method name. Please use SafeCreateNewTokenAsync instead.")]
-            protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
-            {
-                return SafeCreateNewTokenAsync(iotHub, suggestedTimeToLive);
             }
         }
     }

--- a/iothub/service/src/Configurations/Configuration.cs
+++ b/iothub/service/src/Configurations/Configuration.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Azure.Devices
     /// <summary>
     /// Azure IoT Edge Configurations.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Naming",
+    "CA1724:Type names should not match namespaces",
+    Justification = "Cannot change type names as it is considered a breaking change.")]
     public class Configuration : IETagHolder
     {
         /// <summary>

--- a/iothub/service/src/RegistryManager.cs
+++ b/iothub/service/src/RegistryManager.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Azure.Devices
     /// <summary>
     /// Contains methods that services can use to perform create, remove, update and delete operations on devices.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Naming",
+        "CA1716:Identifiers should not match keywords",
+        Justification = "Cannot change parameter names as it is considered a breaking change.")]
     public abstract class RegistryManager : IDisposable
     {
         /// <summary>
@@ -79,6 +83,7 @@ namespace Microsoft.Azure.Devices
         /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
         /// <returns>The Device object with the generated keys and ETags.</returns>
         public abstract Task<Device> AddDeviceAsync(Device device, CancellationToken cancellationToken);
+
 
         /// <summary>
         /// Register a new module with device in the system

--- a/iothub/service/src/RegistryManager.cs
+++ b/iothub/service/src/RegistryManager.cs
@@ -83,17 +83,17 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Register a new module with device in the system
         /// </summary>
-        /// <param name="iotHubModule">The Module object being registered.</param>
+        /// <param name="module">The Module object being registered.</param>
         /// <returns>The Module object with the generated keys and ETags.</returns>
-        public abstract Task<Module> AddModuleAsync(Module iotHubModule);
+        public abstract Task<Module> AddModuleAsync(Module module);
 
         /// <summary>
         /// Register a new module with device in the system
         /// </summary>
-        /// <param name="iotHubModule">The Module object being registered.</param>
+        /// <param name="module">The Module object being registered.</param>
         /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
         /// <returns>The Module object with the generated keys and ETags.</returns>
-        public abstract Task<Module> AddModuleAsync(Module iotHubModule, CancellationToken cancellationToken);
+        public abstract Task<Module> AddModuleAsync(Module module, CancellationToken cancellationToken);
 
         /// <summary>
         /// Adds a Device with Twin information
@@ -179,34 +179,34 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Update the mutable fields of the module registration
         /// </summary>
-        /// <param name="iotHubModule">The Module object with updated fields.</param>
+        /// <param name="module">The Module object with updated fields.</param>
         /// <returns>The Module object with updated ETags.</returns>
-        public abstract Task<Module> UpdateModuleAsync(Module iotHubModule);
+        public abstract Task<Module> UpdateModuleAsync(Module module);
 
         /// <summary>
         /// Update the mutable fields of the module registration
         /// </summary>
-        /// <param name="iotHubModule">The Module object with updated fields.</param>
+        /// <param name="module">The Module object with updated fields.</param>
         /// <param name="forceUpdate">Forces the device object to be replaced without regard for an ETag match.</param>
         /// <returns>The Module object with updated ETags.</returns>
-        public abstract Task<Module> UpdateModuleAsync(Module iotHubModule, bool forceUpdate);
+        public abstract Task<Module> UpdateModuleAsync(Module module, bool forceUpdate);
 
         /// <summary>
         /// Update the mutable fields of the module registration
         /// </summary>
-        /// <param name="iotHubModule">The Module object with updated fields.</param>
+        /// <param name="module">The Module object with updated fields.</param>
         /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
         /// <returns>The Module object with updated ETags.</returns>
-        public abstract Task<Module> UpdateModuleAsync(Module iotHubModule, CancellationToken cancellationToken);
+        public abstract Task<Module> UpdateModuleAsync(Module module, CancellationToken cancellationToken);
 
         /// <summary>
         /// Update the mutable fields of the module registration
         /// </summary>
-        /// <param name="iotHubModule">The Module object with updated fields.</param>
+        /// <param name="module">The Module object with updated fields.</param>
         /// <param name="forceUpdate">Forces the module object to be replaced even if it was updated since it was retrieved last time.</param>
         /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
         /// <returns>The Module object with updated ETags.</returns>
-        public abstract Task<Module> UpdateModuleAsync(Module iotHubModule, bool forceUpdate, CancellationToken cancellationToken);
+        public abstract Task<Module> UpdateModuleAsync(Module module, bool forceUpdate, CancellationToken cancellationToken);
 
         /// <summary>
         /// Update a list of devices with the system
@@ -286,15 +286,15 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Deletes a previously registered module from device in the system.
         /// </summary>
-        /// <param name="iotHubModule">The module being deleted.</param>
-        public abstract Task RemoveModuleAsync(Module iotHubModule);
+        /// <param name="module">The module being deleted.</param>
+        public abstract Task RemoveModuleAsync(Module module);
 
         /// <summary>
         /// Deletes a previously registered module from device in the system.
         /// </summary>
-        /// <param name="iotHubModule">The module being deleted.</param>
+        /// <param name="module">The module being deleted.</param>
         /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
-        public abstract Task RemoveModuleAsync(Module iotHubModule, CancellationToken cancellationToken);
+        public abstract Task RemoveModuleAsync(Module module, CancellationToken cancellationToken);
 
         /// <summary>
         /// Deletes a list of previously registered devices from the system.


### PR DESCRIPTION
Based on a conversation in the release PR here: 
https://github.com/Azure/iot-sdks-internals/pull/220

Bringing back the old API and mark it as deprecated.