### PR TITLE
Mark ClientWebsocketChannel class as internal

### DIFF
--- a/iothub/device/src/Transport/Mqtt/ClientWebSocketChannel.cs
+++ b/iothub/device/src/Transport/Mqtt/ClientWebSocketChannel.cs
@@ -13,7 +13,7 @@ using Microsoft.Azure.Devices.Client.Extensions;
 
 namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 {
-    public sealed class ClientWebSocketChannel : AbstractChannel, IDisposable
+    internal class ClientWebSocketChannel : AbstractChannel, IDisposable
     {
         private ClientWebSocket _webSocket;
         private CancellationTokenSource _writeCancellationTokenSource;


### PR DESCRIPTION
We have had some back and forth about this class (and honestly, many other classes) that should have never been public to begin with. 
The argument here is that there is no value in terms of our SDK's functionality whether or not the user can instantiate a new ClientWebsocketChannel. 
This type is not exposed in any of our public API signatures and should be hidden from the user.
