### PR TITLE
Add a log statement to indicate a NoRetry retry policy was enabled

### DIFF
--- a/e2e/test/iothub/NoRetryE2ETests.cs
+++ b/e2e/test/iothub/NoRetryE2ETests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
 using Microsoft.Azure.Devices.E2ETests.Helpers.Templates;
@@ -16,47 +18,50 @@ namespace Microsoft.Azure.Devices.E2ETests
     [TestCategory("IoTHub")]
     public class NoRetryE2ETests : E2EMsTestBase
     {
-        private readonly string DevicePrefix = $"E2E_{nameof(NoRetryE2ETests)}_";
+        private static readonly string _devicePrefix = $"E2E_{nameof(NoRetryE2ETests)}_";
 
         [LoggedTestMethod]
         [TestCategory("FaultInjection")]
-        public async Task FaultInjection_NoRecovery()
+        public async Task FaultInjection_NoRetry_NoRecovery_OpenAsync()
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix, TestDeviceType.Sasl).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix, TestDeviceType.Sasl).ConfigureAwait(false);
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Amqp_Tcp_Only);
 
-            Logger.Trace($"{nameof(FaultInjection_NoRecovery)}: deviceId={testDevice.Id}");
+            Logger.Trace($"{nameof(FaultInjection_NoRetry_NoRecovery_OpenAsync)}: deviceId={testDevice.Id}");
             deviceClient.SetRetryPolicy(new NoRetry());
 
             ConnectionStatus? lastConnectionStatus = null;
-            Dictionary<ConnectionStatus, int> connectionStatusChanges = new Dictionary<ConnectionStatus, int>();
+            ConnectionStatusChangeReason? lastConnectionStatusChangeReason = null;
+            var connectionStatusChanges = new Dictionary<ConnectionStatus, int>();
             deviceClient.SetConnectionStatusChangesHandler((status, reason) =>
             {
                 connectionStatusChanges.TryGetValue(status, out int count);
                 count++;
                 connectionStatusChanges[status] = count;
                 lastConnectionStatus = status;
+                lastConnectionStatusChangeReason = reason;
             });
 
-            Logger.Trace($"{nameof(FaultInjection_NoRecovery)}: calling OpenAsync...");
+            Logger.Trace($"{nameof(FaultInjection_NoRetry_NoRecovery_OpenAsync)}: calling OpenAsync...");
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
-            Logger.Trace($"{nameof(FaultInjection_NoRecovery)}: injecting fault {FaultInjection.FaultType_Tcp}...");
+            Logger.Trace($"{nameof(FaultInjection_NoRetry_NoRecovery_OpenAsync)}: injecting fault {FaultInjection.FaultType_Tcp}...");
             await FaultInjection
                 .ActivateFaultInjectionAsync(
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
-                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.DefaultFaultDelay,
+                    FaultInjection.DefaultFaultDuration,
                     deviceClient,
                     Logger)
                 .ConfigureAwait(false);
 
-            await Task.Delay(FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+            await Task.Delay(FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
 
-            Logger.Trace($"{nameof(FaultInjection_NoRecovery)}: waiting fault injection occurs...");
-            for (int i = 0; i < FaultInjection.LatencyTimeBufferInSec; i++)
+            Logger.Trace($"{nameof(FaultInjection_NoRetry_NoRecovery_OpenAsync)}: waiting fault injection occurs...");
+            var sw = Stopwatch.StartNew();
+            while (sw.Elapsed < FaultInjection.LatencyTimeBuffer)
             {
                 if (connectionStatusChanges.ContainsKey(ConnectionStatus.Disconnected))
                 {
@@ -64,72 +69,88 @@ namespace Microsoft.Azure.Devices.E2ETests
                 }
                 await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
             }
+            sw.Reset();
 
-            Assert.AreEqual(ConnectionStatus.Disconnected, lastConnectionStatus, $"Excepeted device to be {ConnectionStatus.Disconnected} but was {lastConnectionStatus}.");
-            Assert.IsFalse(connectionStatusChanges.ContainsKey(ConnectionStatus.Disconnected_Retrying), $"Shouldn't get {ConnectionStatus.Disconnected_Retrying} status change.");
+            lastConnectionStatus.Should().Be(ConnectionStatus.Disconnected, $"Expected device to be {ConnectionStatus.Disconnected} but was {lastConnectionStatus}.");
+            lastConnectionStatusChangeReason.Should().Be(ConnectionStatusChangeReason.Retry_Expired, $"Expected device to be {ConnectionStatusChangeReason.Retry_Expired} but was {lastConnectionStatusChangeReason}.");
+            connectionStatusChanges.Should().NotContainKey(ConnectionStatus.Disconnected_Retrying, $"Shouldn't get {ConnectionStatus.Disconnected_Retrying} status change.");
             int connected = connectionStatusChanges[ConnectionStatus.Connected];
-            Assert.AreEqual(1, connected, $"Should get {ConnectionStatus.Connected} once but was {connected}.");
+            connected.Should().Be(1, $"Should get {ConnectionStatus.Connected} once but got it {connected} times.");
             int disconnected = connectionStatusChanges[ConnectionStatus.Disconnected];
-            Assert.AreEqual(1, disconnected, $"Should get {ConnectionStatus.Disconnected} once but was {disconnected}.");
+            disconnected.Should().Be(1, $"Should get {ConnectionStatus.Disconnected} once but got it {disconnected} times.");
         }
 
         [LoggedTestMethod]
-        public async Task Duplicated_NoPingpong()
+        public async Task DuplicateDevice_NoRetry_NoPingpong_OpenAsync()
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix, TestDeviceType.Sasl).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix, TestDeviceType.Sasl).ConfigureAwait(false);
 
-            Logger.Trace($"{nameof(Duplicated_NoPingpong)}: 2 device client instances with the same deviceId={testDevice.Id}.");
+            Logger.Trace($"{nameof(DuplicateDevice_NoRetry_NoPingpong_OpenAsync)}: 2 device client instances with the same deviceId={testDevice.Id}.");
 
             using DeviceClient deviceClient1 = testDevice.CreateDeviceClient(Client.TransportType.Amqp_Tcp_Only);
             using DeviceClient deviceClient2 = testDevice.CreateDeviceClient(Client.TransportType.Amqp_Tcp_Only);
 
-            Logger.Trace($"{nameof(Duplicated_NoPingpong)}: set device client instance 1 to no retry.");
+            Logger.Trace($"{nameof(DuplicateDevice_NoRetry_NoPingpong_OpenAsync)}: set device client instance 1 to no retry.");
             deviceClient1.SetRetryPolicy(new NoRetry());
 
-            ConnectionStatus? lastConnectionStatus = null;
-            var connectionStatusChanges = new Dictionary<ConnectionStatus, int>();
+            ConnectionStatus? lastConnectionStatusDevice1 = null;
+            var connectionStatusChangesDevice1 = new Dictionary<ConnectionStatus, int>();
             deviceClient1.SetConnectionStatusChangesHandler((status, reason) =>
             {
-                connectionStatusChanges.TryGetValue(status, out int count);
+                connectionStatusChangesDevice1.TryGetValue(status, out int count);
                 count++;
-                connectionStatusChanges[status] = count;
-                lastConnectionStatus = status;
+                connectionStatusChangesDevice1[status] = count;
+                lastConnectionStatusDevice1 = status;
             });
 
-            Logger.Trace($"{nameof(FaultInjection_NoRecovery)}: device client instance 1 calling OpenAsync...");
+            ConnectionStatus? lastConnectionStatusDevice2 = null;
+            var connectionStatusChangesDevice2 = new Dictionary<ConnectionStatus, int>();
+            deviceClient2.SetConnectionStatusChangesHandler((status, reason) =>
+            {
+                connectionStatusChangesDevice2.TryGetValue(status, out int count);
+                count++;
+                connectionStatusChangesDevice2[status] = count;
+                lastConnectionStatusDevice2 = status;
+            });
+
+            Logger.Trace($"{nameof(DuplicateDevice_NoRetry_NoPingpong_OpenAsync)}: device client instance 1 calling OpenAsync...");
             await deviceClient1.OpenAsync().ConfigureAwait(false);
             await deviceClient1
                 .SetMethodHandlerAsync(
-                    "dummy_method",
+                    "empty_method",
                     (methodRequest, userContext) => Task.FromResult(new MethodResponse(200)),
                     deviceClient1)
                 .ConfigureAwait(false);
 
-            Logger.Trace($"{nameof(FaultInjection_NoRecovery)}: device client instance 2 calling OpenAsync...");
+            Logger.Trace($"{nameof(DuplicateDevice_NoRetry_NoPingpong_OpenAsync)}: device client instance 2 calling OpenAsync...");
             await deviceClient2.OpenAsync().ConfigureAwait(false);
             await deviceClient2
                 .SetMethodHandlerAsync(
-                    "dummy_method",
+                    "empty_method",
                     (methodRequest, userContext) => Task.FromResult(new MethodResponse(200)),
                     deviceClient2)
                 .ConfigureAwait(false);
 
-            Logger.Trace($"{nameof(Duplicated_NoPingpong)}: waiting device client instance 1 to be kicked off...");
-            for (int i = 0; i < FaultInjection.LatencyTimeBufferInSec; i++)
+            Logger.Trace($"{nameof(DuplicateDevice_NoRetry_NoPingpong_OpenAsync)}: waiting device client instance 1 to be kicked off...");
+            var sw = Stopwatch.StartNew();
+            while (sw.Elapsed < FaultInjection.LatencyTimeBuffer)
             {
-                if (connectionStatusChanges.ContainsKey(ConnectionStatus.Disconnected))
+                if (connectionStatusChangesDevice1.ContainsKey(ConnectionStatus.Disconnected))
                 {
                     break;
                 }
                 await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
             }
+            sw.Reset();
 
-            Assert.AreEqual(ConnectionStatus.Disconnected, lastConnectionStatus, $"Excepeted device to be {ConnectionStatus.Disconnected} but was {lastConnectionStatus}.");
-            Assert.IsFalse(connectionStatusChanges.ContainsKey(ConnectionStatus.Disconnected_Retrying), $"Shouldn't get {ConnectionStatus.Disconnected_Retrying} status change.");
-            int connected = connectionStatusChanges[ConnectionStatus.Connected];
-            Assert.AreEqual(1, connected, $"Should get {ConnectionStatus.Connected} once but was {connected}.");
-            int disconnected = connectionStatusChanges[ConnectionStatus.Disconnected];
-            Assert.AreEqual(1, disconnected, $"Should get {ConnectionStatus.Disconnected} once but was {disconnected}.");
+            lastConnectionStatusDevice1.Should().Be(ConnectionStatus.Disconnected, $"Excpected device 1 to be {ConnectionStatus.Disconnected} but was {lastConnectionStatusDevice1}.");
+            connectionStatusChangesDevice1.Should().NotContainKey(ConnectionStatus.Disconnected_Retrying, $"Shouldn't get {ConnectionStatus.Disconnected_Retrying} status change.");
+            int connected = connectionStatusChangesDevice1[ConnectionStatus.Connected];
+            connected.Should().Be(1, $"Should get {ConnectionStatus.Connected} once but got it {connected} times.");
+            int disconnected = connectionStatusChangesDevice1[ConnectionStatus.Disconnected];
+            disconnected.Should().Be(1, $"Should get {ConnectionStatus.Disconnected} once but got it {disconnected} times.");
+
+            lastConnectionStatusDevice2.Should().Be(ConnectionStatus.Connected, $"Expected device 2 to be {ConnectionStatus.Connected} but was {lastConnectionStatusDevice2}.");
         }
     }
 }

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageReceiveFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageReceiveFaultInjectionPoolAmqpTests.cs
@@ -889,8 +889,8 @@ namespace Microsoft.Azure.Devices.E2ETests
             int devicesCount,
             string faultType,
             string reason,
-            int delayInSec = FaultInjection.DefaultDelayInSec,
-            int durationInSec = FaultInjection.DefaultDurationInSec,
+            TimeSpan delayInSec = default,
+            TimeSpan durationInSec = default,
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device,
             string proxyAddress = null)
         {
@@ -932,8 +932,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                     devicesCount,
                     faultType,
                     reason,
-                    delayInSec,
-                    durationInSec,
+                    delayInSec == TimeSpan.Zero ? FaultInjection.DefaultFaultDelay : delayInSec,
+                    durationInSec == TimeSpan.Zero ? FaultInjection.DefaultFaultDuration : durationInSec,
                     (d, t, h) => { return Task.FromResult(false); },
                     TestOperationAsync,
                     CleanupOperationAsync,
@@ -949,8 +949,8 @@ namespace Microsoft.Azure.Devices.E2ETests
             int devicesCount,
             string faultType,
             string reason,
-            int delayInSec = FaultInjection.DefaultDelayInSec,
-            int durationInSec = FaultInjection.DefaultDurationInSec,
+            TimeSpan delayInSec = default,
+            TimeSpan durationInSec = default,
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device,
             string proxyAddress = null)
         {
@@ -997,8 +997,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                     devicesCount,
                     faultType,
                     reason,
-                    delayInSec,
-                    durationInSec,
+                    delayInSec == TimeSpan.Zero ? FaultInjection.DefaultFaultDelay : delayInSec,
+                    durationInSec == TimeSpan.Zero ? FaultInjection.DefaultFaultDuration : durationInSec,
                     InitOperationAsync,
                     TestOperationAsync,
                     CleanupOperationAsync,

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -876,8 +876,8 @@ namespace Microsoft.Azure.Devices.E2ETests
             int devicesCount,
             string faultType,
             string reason,
-            int delayInSec = FaultInjection.DefaultDelayInSec,
-            int durationInSec = FaultInjection.DefaultDurationInSec,
+            TimeSpan delayInSec = default,
+            TimeSpan durationInSec = default,
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device,
             string proxyAddress = null)
         {
@@ -911,8 +911,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                     devicesCount,
                     faultType,
                     reason,
-                    delayInSec,
-                    durationInSec,
+                    delayInSec == TimeSpan.Zero ? FaultInjection.DefaultFaultDelay : delayInSec,
+                    durationInSec == TimeSpan.Zero ? FaultInjection.DefaultFaultDuration : durationInSec,
                     (d, t, h) => { return Task.FromResult(false); },
                     TestOperationAsync,
                     CleanupOperationAsync,

--- a/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             sw.Start();
 
-            while (!received && sw.ElapsedMilliseconds < FaultInjection.RecoveryTimeMilliseconds)
+            while (!received && sw.Elapsed < FaultInjection.RecoveryTime)
             {
                 Client.Message receivedMessage = null;
 
@@ -470,7 +470,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             }
 
             sw.Stop();
-            Assert.IsTrue(received, $"No message received for device {deviceId} with payload={payload} in {FaultInjection.RecoveryTimeMilliseconds}.");
+            Assert.IsTrue(received, $"No message received for device {deviceId} with payload={payload} in {FaultInjection.RecoveryTime}.");
         }
 
         public static async Task VerifyReceivedC2dMessageWithCancellationTokenAsync(Client.TransportType transport, DeviceClient dc, string deviceId, string payload, string p1Value, MsTestLogger logger)
@@ -480,7 +480,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             sw.Start();
 
-            while (!received && sw.ElapsedMilliseconds < FaultInjection.RecoveryTimeMilliseconds)
+            while (!received && sw.Elapsed < FaultInjection.RecoveryTime)
             {
                 logger.Trace($"Receiving messages for device {deviceId}.");
 
@@ -515,7 +515,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             }
 
             sw.Stop();
-            Assert.IsTrue(received, $"No message received for device {deviceId} with payload={payload} in {FaultInjection.RecoveryTimeMilliseconds}.");
+            Assert.IsTrue(received, $"No message received for device {deviceId} with payload={payload} in {FaultInjection.RecoveryTime}.");
         }
 
         private async Task ReceiveMessageInOperationTimeoutAsync(TestDeviceType type, Client.TransportType transport)

--- a/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Amqp_Tcp_Only,
                 FaultInjection.FaultType_Tcp,
                 FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+                FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Amqp_WebSocket_Only,
                 FaultInjection.FaultType_Tcp,
                 FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+                FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Mqtt_Tcp_Only,
                 FaultInjection.FaultType_Tcp,
                 FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec
+                FaultInjection.DefaultFaultDelay
                 ).ConfigureAwait(false);
         }
 
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Mqtt_WebSocket_Only,
                 FaultInjection.FaultType_Tcp,
                 FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+                FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Amqp_Tcp_Only,
                 FaultInjection.FaultType_AmqpConn,
                 "",
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+                FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 TestDeviceType.Sasl,
                 Client.TransportType.Amqp_WebSocket_Only,
                 FaultInjection.FaultType_AmqpConn, "",
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+                FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Amqp_Tcp_Only,
                 FaultInjection.FaultType_AmqpSess,
                 "",
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+                FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Amqp_WebSocket_Only,
                 FaultInjection.FaultType_AmqpSess,
                 "",
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+                FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Amqp_Tcp_Only,
                 FaultInjection.FaultType_AmqpC2D,
                 FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+                FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Amqp_WebSocket_Only,
                 FaultInjection.FaultType_AmqpD2C,
                 FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+                FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Amqp_Tcp_Only,
                 FaultInjection.FaultType_GracefulShutdownAmqp,
                 FaultInjection.FaultCloseReason_Bye,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+                FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Amqp_WebSocket_Only,
                 FaultInjection.FaultType_GracefulShutdownAmqp,
                 FaultInjection.FaultCloseReason_Bye,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+                FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Mqtt_Tcp_Only,
                 FaultInjection.FaultType_GracefulShutdownMqtt,
                 FaultInjection.FaultCloseReason_Bye,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+                FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Mqtt_WebSocket_Only,
                 FaultInjection.FaultType_GracefulShutdownMqtt,
                 FaultInjection.FaultCloseReason_Bye,
-                FaultInjection.DefaultDelayInSec).ConfigureAwait(false);
+                FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Mqtt_Tcp_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Mqtt_WebSocket_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Mqtt_Tcp_Only,
                     FaultInjection.FaultType_GracefulShutdownMqtt,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Mqtt_WebSocket_Only,
                     FaultInjection.FaultType_GracefulShutdownMqtt,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -248,7 +248,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -261,7 +261,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_AmqpConn,
                     "",
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -273,7 +273,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     TestDeviceType.Sasl,
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_AmqpConn, "",
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -286,7 +286,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_AmqpSess,
                     "",
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -299,7 +299,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_AmqpSess,
                     "",
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -312,7 +312,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_AmqpC2D,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -325,7 +325,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_AmqpD2C,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -338,7 +338,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_GracefulShutdownAmqp,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -351,7 +351,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_GracefulShutdownAmqp,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -360,7 +360,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             Client.TransportType transport,
             string faultType,
             string reason,
-            int delayInSec,
+            TimeSpan delayInSec,
             string proxyAddress = null)
         {
             using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
@@ -401,7 +401,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     faultType,
                     reason,
                     delayInSec,
-                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.DefaultFaultDuration,
                     InitOperationAsync,
                     TestOperationAsync,
                     CleanupOperationAsync,
@@ -414,7 +414,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             Client.TransportType transport,
             string faultType,
             string reason,
-            int delayInSec,
+            TimeSpan delayInSec,
             string proxyAddress = null)
         {
             TestDeviceCallbackHandler testDeviceCallbackHandler = null;
@@ -457,7 +457,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     faultType,
                     reason,
                     delayInSec,
-                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.DefaultFaultDuration,
                     InitOperationAsync,
                     TestOperationAsync,
                     CleanupOperationAsync,

--- a/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultFaultDelay,
                     proxyAddress: s_proxyServerAddress)
                 .ConfigureAwait(false);
         }
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Mqtt_Tcp_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Mqtt_WebSocket_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Mqtt_WebSocket_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultFaultDelay,
                     proxyAddress: s_proxyServerAddress)
                 .ConfigureAwait(false);
         }
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_AmqpConn,
                     "",
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_AmqpConn,
                     "",
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_AmqpSess,
                     "",
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_AmqpSess,
                     "",
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_AmqpD2C,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_AmqpD2C,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -178,8 +178,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_Throttle,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
-                    FaultInjection.DefaultDurationInSec)
+                    FaultInjection.DefaultFaultDelay,
+                    FaultInjection.DefaultFaultDuration)
                 .ConfigureAwait(false);
         }
 
@@ -192,8 +192,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_Throttle,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
-                    FaultInjection.DefaultDurationInSec)
+                    FaultInjection.DefaultFaultDelay,
+                    FaultInjection.DefaultFaultDuration)
                 .ConfigureAwait(false);
         }
 
@@ -207,9 +207,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                         Client.TransportType.Amqp_Tcp_Only,
                         FaultInjection.FaultType_Throttle,
                         FaultInjection.FaultCloseReason_Boom,
-                        FaultInjection.DefaultDelayInSec,
-                        FaultInjection.DefaultDurationInSec,
-                        FaultInjection.ShortRetryInMilliSec)
+                        FaultInjection.DefaultFaultDelay,
+                        FaultInjection.DefaultFaultDuration,
+                        FaultInjection.ShortRetryDuration)
                     .ConfigureAwait(false);
 
                 Assert.Fail("None of the expected exceptions were thrown.");
@@ -232,9 +232,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                         Client.TransportType.Amqp_WebSocket_Only,
                         FaultInjection.FaultType_Throttle,
                         FaultInjection.FaultCloseReason_Boom,
-                        FaultInjection.DefaultDelayInSec,
-                        FaultInjection.DefaultDurationInSec,
-                        FaultInjection.ShortRetryInMilliSec)
+                        FaultInjection.DefaultFaultDelay,
+                        FaultInjection.DefaultFaultDuration,
+                        FaultInjection.ShortRetryDuration)
                     .ConfigureAwait(false);
                 Assert.Fail("None of the expected exceptions were thrown.");
             }
@@ -256,9 +256,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                         Client.TransportType.Http1,
                         FaultInjection.FaultType_Throttle,
                         FaultInjection.FaultCloseReason_Boom,
-                        FaultInjection.DefaultDelayInSec,
-                        FaultInjection.DefaultDurationInSec,
-                        FaultInjection.ShortRetryInMilliSec)
+                        FaultInjection.DefaultFaultDelay,
+                        FaultInjection.DefaultFaultDuration,
+                        FaultInjection.ShortRetryDuration)
                     .ConfigureAwait(false);
 
                 Assert.Fail("None of the expected exceptions were thrown.");
@@ -281,8 +281,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Client.TransportType.Amqp_Tcp_Only,
                 FaultInjection.FaultType_QuotaExceeded,
                 FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec,
-                FaultInjection.DefaultDurationInSec)
+                FaultInjection.DefaultFaultDelay,
+                FaultInjection.DefaultFaultDuration)
                 .ConfigureAwait(false);
         }
 
@@ -297,8 +297,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_QuotaExceeded,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
-                    FaultInjection.DefaultDurationInSec)
+                    FaultInjection.DefaultFaultDelay,
+                    FaultInjection.DefaultFaultDuration)
                 .ConfigureAwait(false);
         }
 
@@ -313,9 +313,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                         Client.TransportType.Http1,
                         FaultInjection.FaultType_QuotaExceeded,
                         FaultInjection.FaultCloseReason_Boom,
-                        FaultInjection.DefaultDelayInSec,
-                        FaultInjection.DefaultDurationInSec,
-                        FaultInjection.ShortRetryInMilliSec)
+                        FaultInjection.DefaultFaultDelay,
+                        FaultInjection.DefaultFaultDuration,
+                        FaultInjection.ShortRetryDuration)
                     .ConfigureAwait(false);
 
                 Assert.Fail("None of the expected exceptions were thrown.");
@@ -337,8 +337,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_Auth,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
-                    FaultInjection.DefaultDurationInSec)
+                    FaultInjection.DefaultFaultDelay,
+                    FaultInjection.DefaultFaultDuration)
                 .ConfigureAwait(false);
         }
 
@@ -351,8 +351,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_Auth,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
-                    FaultInjection.DefaultDurationInSec)
+                    FaultInjection.DefaultFaultDelay,
+                    FaultInjection.DefaultFaultDuration)
                 .ConfigureAwait(false);
         }
 
@@ -365,9 +365,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Http1,
                     FaultInjection.FaultType_Auth,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec,
-                    FaultInjection.DefaultDurationInSec,
-                    FaultInjection.RecoveryTimeMilliseconds)
+                    FaultInjection.DefaultFaultDelay,
+                    FaultInjection.DefaultFaultDuration,
+                    FaultInjection.RecoveryTime)
                 .ConfigureAwait(false);
         }
 
@@ -379,7 +379,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_GracefulShutdownAmqp,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -391,7 +391,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_GracefulShutdownAmqp,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -403,7 +403,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Mqtt_Tcp_Only,
                     FaultInjection.FaultType_GracefulShutdownMqtt,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -415,7 +415,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     Client.TransportType.Mqtt_WebSocket_Only,
                     FaultInjection.FaultType_GracefulShutdownMqtt,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -424,14 +424,15 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             Client.TransportType transport,
             string faultType,
             string reason,
-            int delayInSec,
-            int durationInSec = FaultInjection.DefaultDurationInSec,
-            int retryDurationInMilliSec = FaultInjection.RecoveryTimeMilliseconds,
+            TimeSpan delayInSec,
+            TimeSpan durationInSec = default,
+            TimeSpan retryDurationInMilliSec = default,
             string proxyAddress = null)
         {
-            Func<DeviceClient, TestDevice, Task> init = (deviceClient, testDevice) =>
+            TimeSpan operationTimeoutInMilliSecs = retryDurationInMilliSec == TimeSpan.Zero ? FaultInjection.RecoveryTime : retryDurationInMilliSec;
+            Func <DeviceClient, TestDevice, Task> init = (deviceClient, testDevice) =>
             {
-                deviceClient.OperationTimeoutInMilliseconds = (uint)retryDurationInMilliSec;
+                deviceClient.OperationTimeoutInMilliseconds = (uint)retryDurationInMilliSec.TotalMilliseconds;
                 return Task.FromResult(0);
             };
 
@@ -450,7 +451,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     faultType,
                     reason,
                     delayInSec,
-                    durationInSec,
+                    durationInSec == TimeSpan.Zero ? FaultInjection.DefaultFaultDuration : durationInSec,
                     init,
                     testOperation,
                     () => { return Task.FromResult(false); },

--- a/e2e/test/iothub/method/FaultInjectionPoolAmqpTests.MethodFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/method/FaultInjectionPoolAmqpTests.MethodFaultInjectionPoolAmqpTests.cs
@@ -730,8 +730,8 @@ namespace Microsoft.Azure.Devices.E2ETests
             Func<DeviceClient, string, MsTestLogger, Task<Task>> setDeviceReceiveMethod,
             string faultType,
             string reason,
-            int delayInSec = FaultInjection.DefaultDelayInSec,
-            int durationInSec = FaultInjection.DefaultDurationInSec,
+            TimeSpan delayInSec = default,
+            TimeSpan durationInSec = default,
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device,
             string proxyAddress = null)
         {
@@ -751,7 +751,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
                 TestDeviceCallbackHandler testDeviceCallbackHandler = testDevicesWithCallbackHandler[testDevice.Id];
-                using var cts = new CancellationTokenSource(FaultInjection.RecoveryTimeMilliseconds);
+                using var cts = new CancellationTokenSource(FaultInjection.RecoveryTime);
 
                 Logger.Trace($"{nameof(MethodE2EPoolAmqpTests)}: Preparing to receive method for device {testDevice.Id}");
                 Task serviceSendTask = MethodE2ETests
@@ -792,8 +792,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                     devicesCount,
                     faultType,
                     reason,
-                    delayInSec,
-                    durationInSec,
+                    delayInSec == TimeSpan.Zero ? FaultInjection.DefaultFaultDelay : delayInSec,
+                    durationInSec == TimeSpan.Zero ? FaultInjection.DefaultFaultDuration : durationInSec,
                     InitOperationAsync,
                     TestOperationAsync,
                     CleanupOperationAsync,

--- a/e2e/test/iothub/method/MethodFaultInjectionTests.cs
+++ b/e2e/test/iothub/method/MethodFaultInjectionTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Mqtt_WebSocket_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Mqtt_Tcp_Only,
                     FaultInjection.FaultType_GracefulShutdownMqtt,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await SendMethodAndRespondRecoveryAsync(Client.TransportType.Mqtt_Tcp_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Mqtt_WebSocket_Only,
                     FaultInjection.FaultType_GracefulShutdownMqtt,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await SendMethodAndRespondRecoveryAsync(Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_AmqpConn,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_AmqpConn,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_AmqpSess,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_AmqpSess,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_AmqpMethodReq,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_AmqpMethodReq,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_AmqpMethodResp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_AmqpMethodResp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_GracefulShutdownAmqp,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_GracefulShutdownAmqp,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             ExceptionDispatchInfo exceptionDispatchInfo = null;
             int attempt = 0;
 
-            while (!done && sw.ElapsedMilliseconds < FaultInjection.RecoveryTimeMilliseconds)
+            while (!done && sw.Elapsed < FaultInjection.RecoveryTime)
             {
                 attempt++;
                 try
@@ -247,10 +247,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             }
         }
 
-        private async Task SendMethodAndRespondRecoveryAsync(Client.TransportType transport, string faultType, string reason, int delayInSec, string proxyAddress = null)
+        private async Task SendMethodAndRespondRecoveryAsync(Client.TransportType transport, string faultType, string reason, TimeSpan delayInSec, string proxyAddress = null)
         {
             TestDeviceCallbackHandler testDeviceCallbackHandler = null;
-            using var cts = new CancellationTokenSource(FaultInjection.RecoveryTimeMilliseconds);
+            using var cts = new CancellationTokenSource(FaultInjection.RecoveryTime);
 
             // Configure the callback and start accepting method calls.
             async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice)
@@ -292,7 +292,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     faultType,
                     reason,
                     delayInSec,
-                    FaultInjection.DefaultDelayInSec,
+                    FaultInjection.DefaultFaultDelay,
                     InitOperationAsync,
                     TestOperationAsync,
                     CleanupOperationAsync,

--- a/e2e/test/iothub/twin/FaultInjectionPoolAmqpTests.TwinFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/twin/FaultInjectionPoolAmqpTests.TwinFaultInjectionPoolAmqpTests.cs
@@ -1428,8 +1428,8 @@ namespace Microsoft.Azure.Devices.E2ETests
             int devicesCount,
             string faultType,
             string reason,
-            int delayInSec = FaultInjection.DefaultDelayInSec,
-            int durationInSec = FaultInjection.DefaultDurationInSec,
+            TimeSpan delayInSec = default,
+            TimeSpan durationInSec = default,
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device,
             string proxyAddress = null)
         {
@@ -1457,8 +1457,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                     devicesCount,
                     faultType,
                     reason,
-                    delayInSec,
-                    durationInSec,
+                    delayInSec == TimeSpan.Zero ? FaultInjection.DefaultFaultDelay : delayInSec,
+                    durationInSec == TimeSpan.Zero ? FaultInjection.DefaultFaultDuration : durationInSec,
                     (d, t, h) => { return Task.FromResult(false); },
                     TestOperationAsync,
                     CleanupOperationAsync,
@@ -1475,8 +1475,8 @@ namespace Microsoft.Azure.Devices.E2ETests
             string faultType,
             string reason,
             Func<DeviceClient, string, string, MsTestLogger, Task<Task>> setTwinPropertyUpdateCallbackAsync,
-            int delayInSec = FaultInjection.DefaultDelayInSec,
-            int durationInSec = FaultInjection.DefaultDurationInSec,
+            TimeSpan delayInSec = default,
+            TimeSpan durationInSec = default,
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device,
             string proxyAddress = null)
         {
@@ -1500,7 +1500,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
                 TestDeviceCallbackHandler testDeviceCallbackHandler = testDevicesWithCallbackHandler[testDevice.Id];
-                using var cts = new CancellationTokenSource(FaultInjection.RecoveryTimeMilliseconds);
+                using var cts = new CancellationTokenSource(FaultInjection.RecoveryTime);
 
                 List<string> twinProperties = twinPropertyMap[testDevice.Id];
                 var propName = twinProperties[0];
@@ -1542,8 +1542,8 @@ namespace Microsoft.Azure.Devices.E2ETests
                     devicesCount,
                     faultType,
                     reason,
-                    delayInSec,
-                    durationInSec,
+                    delayInSec == TimeSpan.Zero ? FaultInjection.DefaultFaultDelay : delayInSec,
+                    durationInSec == TimeSpan.Zero ? FaultInjection.DefaultFaultDuration : durationInSec,
                     InitOperationAsync,
                     TestOperationAsync,
                     CleanupOperationAsync,

--- a/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
+++ b/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Mqtt_Tcp_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Mqtt_WebSocket_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Mqtt_Tcp_Only,
                     FaultInjection.FaultType_GracefulShutdownMqtt,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Mqtt_WebSocket_Only,
                     FaultInjection.FaultType_GracefulShutdownMqtt,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_GracefulShutdownAmqp,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_GracefulShutdownAmqp,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Mqtt_Tcp_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Mqtt_WebSocket_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                 Client.TransportType.Amqp_Tcp_Only,
                 FaultInjection.FaultType_Tcp,
                 FaultInjection.FaultCloseReason_Boom,
-                FaultInjection.DefaultDelayInSec)
+                FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_Tcp,
                     FaultInjection.FaultCloseReason_Boom,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Mqtt_Tcp_Only,
                     FaultInjection.FaultType_GracefulShutdownMqtt,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Mqtt_WebSocket_Only,
                     FaultInjection.FaultType_GracefulShutdownMqtt,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Amqp_Tcp_Only,
                     FaultInjection.FaultType_GracefulShutdownAmqp,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     Client.TransportType.Amqp_WebSocket_Only,
                     FaultInjection.FaultType_GracefulShutdownAmqp,
                     FaultInjection.FaultCloseReason_Bye,
-                    FaultInjection.DefaultDelayInSec)
+                    FaultInjection.DefaultFaultDelay)
                 .ConfigureAwait(false);
         }
 
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             Client.TransportType transport,
             string faultType,
             string reason,
-            int delayInSec,
+            TimeSpan delayInSec,
             string proxyAddress = null)
         {
             var propName = Guid.NewGuid().ToString();
@@ -246,7 +246,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     faultType,
                     reason,
                     delayInSec,
-                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.DefaultFaultDuration,
                     (d, t) => { return Task.FromResult<bool>(false); },
                     testOperation,
                     () => { return Task.FromResult<bool>(false); },
@@ -269,12 +269,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             Client.TransportType transport,
             string faultType,
             string reason,
-            int delayInSec,
+            TimeSpan delayInSec,
             string proxyAddress = null)
         {
             TestDeviceCallbackHandler testDeviceCallbackHandler = null;
             var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
-            using var cts = new CancellationTokenSource(FaultInjection.RecoveryTimeMilliseconds);
+            using var cts = new CancellationTokenSource(FaultInjection.RecoveryTime);
 
             var propName = Guid.NewGuid().ToString();
             var props = new TwinCollection();
@@ -322,7 +322,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                     faultType,
                     reason,
                     delayInSec,
-                    FaultInjection.DefaultDurationInSec,
+                    FaultInjection.DefaultFaultDuration,
                     InitOperationAsync,
                     TestOperationAsync,
                     CleanupOperationAsync,

--- a/iothub/device/src/HsmAuthentication/HttpClientHelper.cs
+++ b/iothub/device/src/HsmAuthentication/HttpClientHelper.cs
@@ -17,7 +17,10 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication
     {
         private const string HttpScheme = "http";
         private const string HttpsScheme = "https";
+
+#if !NET451
         private const string UnixScheme = "unix";
+#endif
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Reliability", "CA2000:Dispose objects before losing scope",

--- a/iothub/device/src/RetryPolicies/NoRetry.cs
+++ b/iothub/device/src/RetryPolicies/NoRetry.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using Microsoft.Azure.Devices.Shared;
 
 namespace Microsoft.Azure.Devices.Client
 {
@@ -10,6 +11,16 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     public class NoRetry : IRetryPolicy
     {
+        /// <summary>
+        /// Create an instance of a retry policy that perfrms no retries.
+        /// </summary>
+        public NoRetry()
+        {
+            if (Logging.IsEnabled)
+                Logging.Info(this, $"NOTE: A no-retry retry policy has been enabled," +
+                    $" the device client will not perform any retries on disconnection.", nameof(NoRetry));
+        }
+
         /// <summary>
         /// A policy to never retry
         /// </summary>

--- a/iothub/device/src/RetryPolicies/NoRetry.cs
+++ b/iothub/device/src/RetryPolicies/NoRetry.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.Client
         {
             if (Logging.IsEnabled)
                 Logging.Info(this, $"NOTE: A no-retry retry policy has been enabled," +
-                    $" the device client will not perform any retries on disconnection.", nameof(NoRetry));
+                    $" the client will not perform any retries on disconnection.", nameof(NoRetry));
         }
 
         /// <summary>


### PR DESCRIPTION
The ask from the CSS team is as below:
In certain situations customers raise support issues stating that the client does not recover on disconnection, only to discover on inspection of customer code that they have explicitly disabled the inbuilt retry policy in the client.
In order to avoid long delays in identifying the issue, the CSS team wants us to log a statement in case the retry policy is disabled.

This PR adds the following statement if a customer chooses a `NoRetry` retry policy:
`NOTE: A no-retry retry policy has been enabled, the device client will not perform any retries on disconnection.`

In addition, since the sdk has a default retry policy of retrying indefinitely(!), the CSS team can be advised to look for the following information:
1. Advise customers to always set a `ConnectionStatusChangeHandler`. 
   If the customer has disabled retries, or has enabled a custom retry policy with a limited no of retry attempts; they will seea connection status change event returned with a reason `Retry_Expired`: 
   i. `NoRetry` policy:
      Connection status changed: status=Connected, reason=Connection_Ok
      Disconnection
      Connection status changed: status=Disconnected, reason=Retry_Expired
      
   ii. Custom retry policy: (eg.: single retry attempt)
      Connection status changed: status=Connected, reason=Connection_Ok
      Disconnection
      Retry policy's ShouldRetry is = True
      Connection status changed: status=Disconnected_Retrying, reason=Communication_Error
      Retry policy's ShouldRetry is = False
      Connection status changed: status=Disconnected, reason=Retry_Expired
      
2. If, for some reason the customer cannot monitor this status change callback, look for the newly added log statement.
