### PR TITLE
(fix): Build error due to missing dispose

### DIFF
--- a/iothub/device/src/ClientFactory.cs
+++ b/iothub/device/src/ClientFactory.cs
@@ -100,7 +100,9 @@ namespace Microsoft.Azure.Devices.Client
                     throw new ArgumentException("No certificate was found. To use certificate authentication certificate must be present.");
                 }
 
+#pragma warning disable CA2000 // This is returned to client so cannot be disposed here.
                 InternalClient dc = CreateFromConnectionString(connectionStringBuilder.ToString(), PopulateCertificateInTransportSettings(connectionStringBuilder, transportType), options);
+#pragma warning restore CA2000
                 dc.Certificate = connectionStringBuilder.Certificate;
 
                 // Install all the intermediate certificates in the chain if specified.

--- a/iothub/device/src/DeviceAuthenticationWithRegistrySymmetricKey.cs
+++ b/iothub/device/src/DeviceAuthenticationWithRegistrySymmetricKey.cs
@@ -69,8 +69,8 @@ namespace Microsoft.Azure.Devices.Client
                 throw new ArgumentNullException(nameof(iotHubConnectionStringBuilder));
             }
 
-            iotHubConnectionStringBuilder.DeviceId = this.DeviceId;
-            iotHubConnectionStringBuilder.SharedAccessKey = this.KeyAsBase64String;
+            iotHubConnectionStringBuilder.DeviceId = DeviceId;
+            iotHubConnectionStringBuilder.SharedAccessKey = KeyAsBase64String;
             iotHubConnectionStringBuilder.SharedAccessKeyName = null;
             iotHubConnectionStringBuilder.SharedAccessSignature = null;
 

--- a/iothub/device/src/Edge/EdgeModuleClientFactory.cs
+++ b/iothub/device/src/Edge/EdgeModuleClientFactory.cs
@@ -93,7 +93,9 @@ namespace Microsoft.Azure.Devices.Client.Edge
                 }
 
                 ISignatureProvider signatureProvider = new HttpHsmSignatureProvider(edgedUri, DefaultApiVersion);
+#pragma warning disable CA2000 // This is disposed when the client is disposed.
                 var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId, generationId);
+#pragma warning restore CA2000
 
                 Debug.WriteLine("EdgeModuleClientFactory setupTrustBundle from service");
 

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1974,11 +1974,17 @@ namespace Microsoft.Azure.Devices.Client
         public void Dispose()
         {
             InnerHandler?.Dispose();
+            InnerHandler = null;
             _methodsDictionarySemaphore?.Dispose();
             _moduleReceiveMessageSemaphore?.Dispose();
             _fileUploadHttpTransportHandler?.Dispose();
             _deviceReceiveMessageSemaphore?.Dispose();
             _twinDesiredPropertySemaphore?.Dispose();
+#if !NET451
+            Certificate?.Dispose();
+            Certificate = null;
+#endif
+            IotHubConnectionString?.TokenRefresher?.Dispose();
         }
 
         internal bool IsE2EDiagnosticSupportedProtocol()


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
Some implementations of IAuthenticationMethod  have objects that need to be disposed. And we were not disposing because the interface did not have IDisposable and the implementations did not dispose anything. 
This change makes the interface disposable and hence any implementation that has disposable objects, dispose them. It is a no-op for the rest.

This also means, the public IotHubConnectionStringBuilder is now IDisposable. This could be a breaking change but something necessary.
