### PR TITLE
Update MqttTransportHandler to not use SemaphoreSlimWaitAsync(TimeSpan, CancellationToken)

### DIFF
--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
     // EventLoop. To limit I/O to the EventLoopGroup and keep Netty semantics, we are going to ensure that the
     // task continuations are executed by this scheduler using ConfigureAwait(true).
     //
-    // All await calls that happen within dotnetty's pipeline should be ConfigureAwait(true).
+    // All awaited calls that happen within dotnetty's pipeline should be ConfigureAwait(true).
     //
     internal sealed class MqttIotHubAdapter : ChannelHandlerAdapter
     {

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
     // EventLoop. To limit I/O to the EventLoopGroup and keep Netty semantics, we are going to ensure that the
     // task continuations are executed by this scheduler using ConfigureAwait(true).
     //
+    // All await calls that happen within dotnetty's pipeline should be ConfigureAwait(true).
+    //
     internal sealed class MqttIotHubAdapter : ChannelHandlerAdapter
     {
         [Flags]
@@ -475,7 +477,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                         Logging.Info(context, $"Idle time was {idleTime}, so ping request was sent.", nameof(PingServerAsync));
 
                     // Wait to capture the ping response semaphore, which is released when a PINGRESP packet is received.
-                    bool receivedPingResponse = await s_pingResponseSemaphore.WaitAsync(s_pingResponseTimeout).ConfigureAwait(false);
+                    bool receivedPingResponse = await s_pingResponseSemaphore.WaitAsync(s_pingResponseTimeout).ConfigureAwait(true);
                     if (!receivedPingResponse)
                     {
                         if (Logging.IsEnabled)
@@ -1162,7 +1164,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             int length = (int)streamLength;
             IByteBuffer buffer = context.Channel.Allocator.Buffer(length, length);
-            await buffer.WriteBytesAsync(payloadStream, length).ConfigureAwait(false);
+            await buffer.WriteBytesAsync(payloadStream, length).ConfigureAwait(true);
             Contract.Assert(buffer.ReadableBytes == length);
 
             packet.Payload = buffer;
@@ -1361,7 +1363,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         {
             try
             {
-                await context.WriteAndFlushAsync(message).ConfigureAwait(false);
+                await context.WriteAndFlushAsync(message).ConfigureAwait(true);
             }
             catch (Exception ex)
             {

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
     // EventLoop. To limit I/O to the EventLoopGroup and keep Netty semantics, we are going to ensure that the
     // task continuations are executed by this scheduler using ConfigureAwait(true).
     //
-    // All await calls that happen within dotnetty's pipeline should be ConfigureAwait(true).
+    // All awaited calls that happen within dotnetty's pipeline should be ConfigureAwait(true).
     //
     internal sealed class MqttTransportHandler : TransportHandler, IMqttIotHubEventHandler
     {
@@ -344,7 +344,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             try
             {
                 if (Logging.IsEnabled)
-                    Logging.Enter(this, message, $"Will begin processing received C2D message", nameof(ProcessMessage));
+                    Logging.Enter(this, message, $"Will begin processing received C2D message, queue size={_messageQueue.Count}", nameof(ProcessMessage));
 
                 lock (_syncRoot)
                 {
@@ -413,7 +413,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     lockToken.Length != actualLockToken.Length + s_generationPrefixLength)
                 {
                     throw new IotHubException(
-                        $"Client must send PUBACK packets in the order in which the corresponding PUBLISH packets were received (QoS 1 messages) per [MQTT-4.6.0-2]. Expected lock token: '{actualLockToken}'; actual lock token: '{lockToken}'.",
+                        $"Client must send PUBACK packets in the order in which the corresponding PUBLISH packets were received (QoS 1 messages) per [MQTT-4.6.0-2]. Expected lock token to end with: '{actualLockToken}'; actual lock token: '{lockToken}'.",
                         isTransient: false);
                 }
 
@@ -556,7 +556,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 Logging.Enter(this, "Process C2D message via callback", nameof(HandleIncomingMessagesAsync));
 
             Message message = ProcessMessage();
-            await (_deviceMessageReceivedListener?.Invoke(message) ?? TaskHelpers.CompletedTask).ConfigureAwait(false);
+
+            // We are intentionally not awaiting _deviceMessageReceivedListener callback.
+            // This is a user-supplied callback that isn't required to be awaited by us. We can simply invoke it and continue.
+            _ = _deviceMessageReceivedListener?.Invoke(message);
+            await TaskHelpers.CompletedTask.ConfigureAwait(false);
 
             if (Logging.IsEnabled)
                 Logging.Exit(this, "Process C2D message via callback", nameof(HandleIncomingMessagesAsync));
@@ -759,6 +763,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         public override async Task EnsurePendingMessagesAreDeliveredAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             // If the device connects with a CleanSession flag set to false, we will need to deliver the messages
             // that were sent before the client had subscribed to the C2D message receive topic.
             if (_retainMessagesAcrossSessions)

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -35,6 +35,13 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 {
+    //
+    // Note on ConfigureAwait: dotNetty is using a custom TaskScheduler that binds Tasks to the corresponding
+    // EventLoop. To limit I/O to the EventLoopGroup and keep Netty semantics, we are going to ensure that the
+    // task continuations are executed by this scheduler using ConfigureAwait(true).
+    //
+    // All await calls that happen within dotnetty's pipeline should be ConfigureAwait(true).
+    //
     internal sealed class MqttTransportHandler : TransportHandler, IMqttIotHubEventHandler
     {
         private const int ProtocolGatewayPort = 8883;
@@ -214,7 +221,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 EnsureValidState(throwIfNotOpen: false);
 
-                await OpenInternalAsync(cancellationToken).ConfigureAwait(true);
+                await OpenInternalAsync(cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -235,7 +242,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 EnsureValidState();
                 Debug.Assert(_channel != null);
 
-                await _channel.WriteAndFlushAsync(message).ConfigureAwait(false);
+                await _channel.WriteAndFlushAsync(message).ConfigureAwait(true);
             }
             finally
             {
@@ -249,7 +256,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             foreach (Message message in messages)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await SendEventAsync(message, cancellationToken).ConfigureAwait(true);
+                await SendEventAsync(message, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -278,7 +285,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                     if (State != TransportState.Receiving)
                     {
-                        await SubscribeCloudToDeviceMessagesAsync().ConfigureAwait(true);
+                        await SubscribeCloudToDeviceMessagesAsync().ConfigureAwait(false);
                     }
 
                     await WaitUntilC2dMessageArrivesAsync(cancellationToken).ConfigureAwait(false);
@@ -314,7 +321,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (State != TransportState.Receiving)
                 {
-                    await SubscribeCloudToDeviceMessagesAsync().ConfigureAwait(true);
+                    await SubscribeCloudToDeviceMessagesAsync().ConfigureAwait(false);
                 }
 
                 TimeSpan timeout = timeoutHelper.GetRemainingTime();
@@ -515,7 +522,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     using var reader = new StreamReader(message.GetBodyStream(), System.Text.Encoding.UTF8);
                     string patch = reader.ReadToEnd();
                     TwinCollection props = JsonConvert.DeserializeObject<TwinCollection>(patch);
-                    await Task.Run(() => _onDesiredStatePatchListener(props)).ConfigureAwait(true);
+                    await Task.Run(() => _onDesiredStatePatchListener(props)).ConfigureAwait(false);
                 }
             }
             finally
@@ -531,7 +538,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 string[] tokens = Regex.Split(message.MqttTopicName, "/", RegexOptions.Compiled, s_regexTimeoutMilliseconds);
 
                 using var mr = new MethodRequestInternal(tokens[3], tokens[4].Substring(6), message.GetBodyStream(), CancellationToken.None);
-                await Task.Run(() => _methodListener(mr)).ConfigureAwait(true);
+                await Task.Run(() => _methodListener(mr)).ConfigureAwait(false);
             }
             finally
             {
@@ -576,15 +583,15 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     }
                     else if (topic.StartsWith(TwinPatchTopicPrefix, StringComparison.OrdinalIgnoreCase))
                     {
-                        await HandleIncomingTwinPatchAsync(message).ConfigureAwait(true);
+                        await HandleIncomingTwinPatchAsync(message).ConfigureAwait(false);
                     }
                     else if (topic.StartsWith(MethodPostTopicPrefix, StringComparison.OrdinalIgnoreCase))
                     {
-                        await HandleIncomingMethodPostAsync(message).ConfigureAwait(true);
+                        await HandleIncomingMethodPostAsync(message).ConfigureAwait(false);
                     }
                     else if (topic.StartsWith(_receiveEventMessagePrefix, StringComparison.OrdinalIgnoreCase))
                     {
-                        await HandleIncomingEventMessageAsync(message).ConfigureAwait(true);
+                        await HandleIncomingEventMessageAsync(message).ConfigureAwait(false);
                     }
                     else if (topic.StartsWith(_deviceboundMessagePrefix, StringComparison.OrdinalIgnoreCase))
                     {
@@ -639,7 +646,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     }
                 }
                 message.LockToken = _generationId + message.LockToken;
-                await (_moduleMessageReceivedListener?.Invoke(inputName, message) ?? TaskHelpers.CompletedTask).ConfigureAwait(true);
+                await (_moduleMessageReceivedListener?.Invoke(inputName, message) ?? TaskHelpers.CompletedTask).ConfigureAwait(false);
             }
             finally
             {
@@ -860,7 +867,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 MqttTopicName = MethodResponseTopic.FormatInvariant(methodResponse.Status, methodResponse.RequestId)
             };
 
-            await SendEventAsync(message, cancellationToken).ConfigureAwait(true);
+            await SendEventAsync(message, cancellationToken).ConfigureAwait(false);
         }
 
         public override async Task EnableTwinPatchAsync(CancellationToken cancellationToken)
@@ -911,7 +918,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_017:  `SendTwinGetAsync` shall wait for a response from the service with a matching $rid value
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_019:  If the response is failed, `SendTwinGetAsync` shall return that failure to the caller.
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_020:  If the response doesn't arrive within `MqttTransportHandler.TwinTimeout`, `SendTwinGetAsync` shall fail with a timeout error
-            using Message response = await SendTwinRequestAsync(request, rid, cancellationToken).ConfigureAwait(true);
+            using Message response = await SendTwinRequestAsync(request, rid, cancellationToken).ConfigureAwait(false);
 
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_021:  If the response contains a success code, `SendTwinGetAsync` shall return success to the caller
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_018:  When a response is received, `SendTwinGetAsync` shall return the Twin object to the caller
@@ -956,7 +963,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_028:  If the response is failed, `SendTwinPatchAsync` shall return that failure to the caller.
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_029:  If the response doesn't arrive within `MqttTransportHandler.TwinTimeout`, `SendTwinPatchAsync` shall fail with a timeout error.
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_030:  If the response contains a success code, `SendTwinPatchAsync` shall return success to the caller.
-            await SendTwinRequestAsync(request, rid, cancellationToken).ConfigureAwait(true);
+            await SendTwinRequestAsync(request, rid, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task OpenInternalAsync(CancellationToken cancellationToken)
@@ -977,7 +984,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 #if NET451
                 _serverAddresses = Dns.GetHostEntry(_hostName).AddressList;
 #else
-                _serverAddresses = await Dns.GetHostAddressesAsync(_hostName).ConfigureAwait(true);
+                _serverAddresses = await Dns.GetHostAddressesAsync(_hostName).ConfigureAwait(false);
 #endif
             }
 
@@ -1022,7 +1029,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 });
             }
 
-            await _connectCompletion.Task.ConfigureAwait(true);
+            await _connectCompletion.Task.ConfigureAwait(false);
 
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_031: `OpenAsync` shall subscribe using the '$iothub/twin/res/#' topic filter
             await SubscribeTwinResponsesAsync().ConfigureAwait(true);
@@ -1072,7 +1079,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     return;
                 }
             }
-            await _subscribeCompletionSource.Task.ConfigureAwait(true);
+            await _subscribeCompletionSource.Task.ConfigureAwait(false);
         }
 
         private Task SubscribeTwinResponsesAsync()
@@ -1139,9 +1146,9 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             {
                 _twinResponseEvent += onTwinResponse;
 
-                await SendEventAsync(request, cancellationToken).ConfigureAwait(true);
+                await SendEventAsync(request, cancellationToken).ConfigureAwait(false);
 
-                await responseReceived.WaitAsync(TwinTimeout, cancellationToken).ConfigureAwait(true);
+                await responseReceived.WaitAsync(TwinTimeout, cancellationToken).ConfigureAwait(false);
 
                 if (responseException != null)
                 {
@@ -1287,7 +1294,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 #endif
 
                 using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-                await websocket.ConnectAsync(websocketUri, cts.Token).ConfigureAwait(true);
+                await websocket.ConnectAsync(websocketUri, cts.Token).ConfigureAwait(false);
 
                 var clientWebSocketChannel = new ClientWebSocketChannel(null, websocket);
                 clientWebSocketChannel
@@ -1301,7 +1308,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                         new LoggingHandler(LogLevel.DEBUG),
                         _mqttIotHubAdapterFactory.Create(this, iotHubConnectionString, settings, productInfo, options));
 
-                await s_eventLoopGroup.Value.RegisterAsync(clientWebSocketChannel).ConfigureAwait(false);
+                await s_eventLoopGroup.Value.RegisterAsync(clientWebSocketChannel).ConfigureAwait(true);
 
                 return clientWebSocketChannel;
             };


### PR DESCRIPTION
It is generally not a good idea to combine Timeouts and cancellation tokens when used with Semaphores. This is because either the semaphore is gained/ not gained but timed out (returns false)/ not gained but cancelled (throws OperationCencelledException). All three scenarios will need to be handled.

For our code, since the only behavior we needs is:
- cancellation token valid -> wait to acquire the semaphore
- cancellation token expired -> exit

it makes more sense to use the SemaphoreSlim.WaitAsync(CancellationToken) API.
This PR doesn't solve a bug but rather encourages usage of a "better suited" API.

Note, since our code intends for the semaphore to wait indefinitely (-1):
- we don't need to handle the "false" returning scenario
- the above issue won't cause "race" conditions for us. Else, using both timeouts and cancellation tokens for awaiting for a semaphore will always give rise to "race" conditions => if the timeout and cancellation token both end (or expire) at the same time, we result could either be "false" or an exception, depending on the internal state of the thread pool.

Another fix is in this PR is:
Dotnetty uses a custom task scheduler to bind tasks to the corresponding EventLoop. To limit I/O to the EventLoop, it requires that tasks scheduled are resumed by the same thread => using ConfigureAwait(true). 
For this reason, calls to dotnetty library are made with ConfigureAwait(true)*. Other tasks are configured with ConfigureAwait(false), thus allowing completed tasks to be resumed on any available thread.
* = getting clarification on this from Max.