### PR TITLE
Bump API Version for release 2020-02-05

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.1;netstandard2.0;net472;net451</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.34.0</Version>
+    <Version>1.35.0</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net472;net451</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.29.0</Version>
+    <Version>1.30.0</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,6 +1,6 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.34.0
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.29.0
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.35.0
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.30.0
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.27.0
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.3
 provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.4


### PR DESCRIPTION
## Microsoft.Azure.Devices.Client 1.35.0
 
- Add a log statement indicating a no-retry retry policy has been enabled (#1763)
- Unused memeber removal
  - `NotAllowedCharacter` from `UrlEncodedDictionarySerializer`

### Bug fixes
 
- Amqp connections are not getting disposed leaving the socket open (#1770, #1771) 
 
## Microsoft.Azure.Devices 1.30.0

- Unused memeber removal
  - `DeliveryFailureReason` enum
  - `EventHubPartitionKeyResolver` class
  - `SharedAccessSignatureAuthorizationRule` class
  - `SharedAccessSignature` class
  - `ISharedAccessSignatureCredential` interface