### PR TITLE
Fix issue where we accidentally disposed the user supplied certificates

### DIFF
--- a/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
@@ -383,8 +383,50 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [LoggedTestMethod]
         public async Task DeviceDoesNotReceivePendingMessageUsingCallback_MqttWs()
         {
-            var settings = new ITransportSettings[] { new MqttTransportSettings(Client.TransportType.Mqtt_Tcp_Only) { CleanSession = true } };
+            var settings = new ITransportSettings[] { new MqttTransportSettings(Client.TransportType.Mqtt_WebSocket_Only) { CleanSession = true } };
             await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceDoesNotReceivePendingMessageUsingCallback_Amqp()
+        {
+            var settings = new ITransportSettings[] { new AmqpTransportSettings(Client.TransportType.Amqp_Tcp_Only) };
+            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceDoesNotReceivePendingMessageUsingCallback_AmqpWs()
+        {
+            var settings = new ITransportSettings[] { new AmqpTransportSettings(Client.TransportType.Amqp_WebSocket_Only) };
+            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task X509_DeviceDoesNotReceivePendingMessageUsingCallback_Mqtt()
+        {
+            var settings = new ITransportSettings[] { new MqttTransportSettings(Client.TransportType.Mqtt_Tcp_Only) { CleanSession = true } };
+            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.X509, settings).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task X509_DeviceDoesNotReceivePendingMessageUsingCallback_MqttWs()
+        {
+            var settings = new ITransportSettings[] { new MqttTransportSettings(Client.TransportType.Mqtt_WebSocket_Only) { CleanSession = true } };
+            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.X509, settings).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task X509_DeviceDoesNotReceivePendingMessageUsingCallback_Amqp()
+        {
+            var settings = new ITransportSettings[] { new AmqpTransportSettings(Client.TransportType.Amqp_Tcp_Only) };
+            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.X509, settings).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task X509_DeviceDoesNotReceivePendingMessageUsingCallback_AmqpWs()
+        {
+            var settings = new ITransportSettings[] { new AmqpTransportSettings(Client.TransportType.Amqp_WebSocket_Only) };
+            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.X509, settings).ConfigureAwait(false);
         }
 
         public static (Message message, string payload, string p1Value) ComposeC2dTestMessage(MsTestLogger logger)
@@ -875,11 +917,11 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             testDeviceCallbackHandler.Dispose();
             testDeviceCallbackHandler = null;
 
-            // Create a device client instance over MQTT, with CleanSession flag set to true.
-            // This will ensure that messages sent before the device had subscribed to c2d topic are not delivered.
             deviceClient = testDevice.CreateDeviceClient(settings);
             testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
 
+            // Open the device client - for MQTT, this will connect the device with CleanSession flag set to true.
+            // This will ensure that messages sent before the device had subscribed to c2d topic are not delivered.
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
             // Send the message from service.

--- a/iothub/device/src/DeviceAuthenticationWithX509Certificate.cs
+++ b/iothub/device/src/DeviceAuthenticationWithX509Certificate.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Devices.Client
     /// <summary>
     /// Authentication method that uses a X.509 certificate
     /// </summary>
-    public sealed class DeviceAuthenticationWithX509Certificate : IAuthenticationMethod
+    public sealed class DeviceAuthenticationWithX509Certificate : IAuthenticationMethod, IDisposable
     {
         private string _deviceId;
 
@@ -79,6 +79,17 @@ namespace Microsoft.Azure.Devices.Client
             }
 
             _deviceId = deviceId;
+        }
+
+        /// <summary>
+        /// Dispose the X509 certificate associated with this authentication method.
+        /// </summary>
+        public void Dispose()
+        {
+#if !NET451
+            Certificate?.Dispose();
+            Certificate = null;
+#endif
         }
     }
 }

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1980,10 +1980,6 @@ namespace Microsoft.Azure.Devices.Client
             _fileUploadHttpTransportHandler?.Dispose();
             _deviceReceiveMessageSemaphore?.Dispose();
             _twinDesiredPropertySemaphore?.Dispose();
-#if !NET451
-            Certificate?.Dispose();
-            Certificate = null;
-#endif
             IotHubConnectionString?.TokenRefresher?.Dispose();
         }
 


### PR DESCRIPTION
The X509 certificate being passed during client initialization should be disposed by the user. If we dispose it when the client is disposed, they won't be able to reuse the previously created IAuthenticationMethod (which in turn has a reference to these certificates).
Note: IAuthenticationMethod should probably have been IDisposable, but isn't, and updating it _might_ require a bunch of refactoring. Certificates being the only IDisposable field in there, it feels like a reasonable solution to ask users to manage its lifecycle.

Edit: Spoke with @vinagesh offline, making the X509 specific implementation of IAuthenticationMethod requires much less of a refactor while still indicating to the user that it has IDisposable types within it.