### PR TITLE
E2E tests for auth using TokenCredential

### DIFF
--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -45,6 +45,7 @@
   <!-- NetCore and .NET 4.7.2 -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.3" />
+    <PackageReference Include="Azure.Identity" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(AZURE_IOT_LOCALPACKAGES)' == '' ">

--- a/e2e/test/config/Configuration.IoTHub.cs
+++ b/e2e/test/config/Configuration.IoTHub.cs
@@ -3,6 +3,13 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
+
+#if !NET451
+
+using Azure.Identity;
+
+#endif
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.Devices.E2ETests
@@ -13,6 +20,24 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             public static string ConnectionString => GetValue("IOTHUB_CONN_STRING_CSHARP");
             public static string X509ChainDeviceName => GetValue("IOTHUB_X509_CHAIN_DEVICE_NAME");
+
+            public static string GetIotHubHostName()
+            {
+                ConnectionStringParser connectionString = new ConnectionStringParser(ConnectionString);
+                return connectionString.IotHubHostName;
+            }
+
+#if !NET451
+
+            public static ClientSecretCredential GetClientSecretCredential()
+            {
+                return new ClientSecretCredential(
+                    GetValue("IOTHUB_TENANT_ID"),
+                    GetValue("IOTHUB_CLIENT_ID"),
+                    GetValue("IOTHUB_CLIENT_SECRET"));
+            }
+
+#endif
 
             public static X509Certificate2 GetCertificateWithPrivateKey()
             {
@@ -65,9 +90,9 @@ namespace Microsoft.Azure.Devices.E2ETests
             /// </summary>
             public const string InvalidProxyServerAddress = "127.0.0.1:1234";
 
-            public class DeviceConnectionStringParser
+            public class ConnectionStringParser
             {
-                public DeviceConnectionStringParser(string connectionString)
+                public ConnectionStringParser(string connectionString)
                 {
                     string[] parts = connectionString.Split(';');
                     foreach (string part in parts)
@@ -77,7 +102,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                         switch (tv[0].ToUpperInvariant())
                         {
                             case "HOSTNAME":
-                                IoTHub = part.Substring("HOSTNAME=".Length);
+                                IotHubHostName = part.Substring("HOSTNAME=".Length);
                                 break;
 
                             case "SHAREDACCESSKEY":
@@ -94,7 +119,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     }
                 }
 
-                public string IoTHub
+                public string IotHubHostName
                 {
                     get;
                     private set;

--- a/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix + $"_{Guid.NewGuid()}").ConfigureAwait(false);
             string deviceConnectionString = testDevice.ConnectionString;
 
-            var config = new Configuration.IoTHub.DeviceConnectionStringParser(deviceConnectionString);
+            var config = new Configuration.IoTHub.ConnectionStringParser(deviceConnectionString);
             string deviceId = config.DeviceID;
 
             ConnectionStatus? status = null;

--- a/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
 
-            var config = new Configuration.IoTHub.DeviceConnectionStringParser(testDevice.ConnectionString);
-            using (DeviceClient deviceClient = DeviceClient.CreateFromConnectionString($"HostName={config.IoTHub};DeviceId=device_id_not_exist;SharedAccessKey={config.SharedAccessKey}", Client.TransportType.Amqp_Tcp_Only))
+            var config = new Configuration.IoTHub.ConnectionStringParser(testDevice.ConnectionString);
+            using (DeviceClient deviceClient = DeviceClient.CreateFromConnectionString($"HostName={config.IotHubHostName};DeviceId=device_id_not_exist;SharedAccessKey={config.SharedAccessKey}", Client.TransportType.Amqp_Tcp_Only))
             {
                 await deviceClient.OpenAsync().ConfigureAwait(false);
             }
@@ -43,9 +43,9 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
 
-            var config = new Configuration.IoTHub.DeviceConnectionStringParser(testDevice.ConnectionString);
+            var config = new Configuration.IoTHub.ConnectionStringParser(testDevice.ConnectionString);
             string invalidKey = Convert.ToBase64String(Encoding.UTF8.GetBytes("invalid_key"));
-            using (DeviceClient deviceClient = DeviceClient.CreateFromConnectionString($"HostName={config.IoTHub};DeviceId={config.DeviceID};SharedAccessKey={invalidKey}", Client.TransportType.Amqp_Tcp_Only))
+            using (DeviceClient deviceClient = DeviceClient.CreateFromConnectionString($"HostName={config.IotHubHostName};DeviceId={config.DeviceID};SharedAccessKey={invalidKey}", Client.TransportType.Amqp_Tcp_Only))
             {
                 await deviceClient.OpenAsync().ConfigureAwait(false);
             }
@@ -82,8 +82,8 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             string deviceConnectionString = testDevice.ConnectionString;
 
-            var config = new Configuration.IoTHub.DeviceConnectionStringParser(deviceConnectionString);
-            string iotHub = config.IoTHub;
+            var config = new Configuration.IoTHub.ConnectionStringParser(deviceConnectionString);
+            string iotHub = config.IotHubHostName;
             string deviceId = config.DeviceID;
             string key = config.SharedAccessKey;
 

--- a/e2e/test/iothub/TokenCredentialAuthenticationTests.cs
+++ b/e2e/test/iothub/TokenCredentialAuthenticationTests.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Common.Exceptions;
+using Microsoft.Azure.Devices.E2ETests.Helpers;
+using Microsoft.Azure.Devices.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+#if !NET451
+
+using Microsoft.Rest;
+using Azure.Core;
+using Azure.Identity;
+
+#endif
+
+using ClientOptions = Microsoft.Azure.Devices.Client.ClientOptions;
+
+namespace Microsoft.Azure.Devices.E2ETests.iothub
+{
+    /// <summary>
+    /// Tests to ensure authentication using Azure active directory succeeds in all the clients.
+    /// </summary>
+    [TestClass]
+    [TestCategory("E2E")]
+    [TestCategory("IoTHub")]
+    public class TokenCredentialAuthenticationTests : E2EMsTestBase
+    {
+        private readonly string _devicePrefix = $"E2E_{nameof(TokenCredentialAuthenticationTests)}_";
+
+#if !NET451
+
+        [Ignore]
+        [LoggedTestMethod]
+        public async Task RegistryManager_Http_TokenCredentialAuth_Success()
+        {
+            // arrange
+            using var registryManager = RegistryManager.Create(
+                Configuration.IoTHub.GetIotHubHostName(),
+                Configuration.IoTHub.GetClientSecretCredential());
+
+            var device = new Device(Guid.NewGuid().ToString());
+
+            // act
+            Device createdDevice = await registryManager.AddDeviceAsync(device).ConfigureAwait(false);
+
+            // assert
+            Assert.IsNotNull(createdDevice);
+
+            // cleanup
+            await registryManager.RemoveDeviceAsync(device.Id).ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [LoggedTestMethod]
+        public async Task JobClient_Http_TokenCredentialAuth_Success()
+        {
+            // arrange
+            using var jobClient = JobClient.Create(
+                Configuration.IoTHub.GetIotHubHostName(),
+                Configuration.IoTHub.GetClientSecretCredential());
+
+            string jobId = "JOBSAMPLE" + Guid.NewGuid().ToString();
+            string jobDeviceId = "JobsSample_Device";
+            string query = $"DeviceId IN ['{jobDeviceId}']";
+            Twin twin = new Twin(jobDeviceId);
+
+            try
+            {
+                // act
+                JobResponse createJobResponse = await jobClient
+                    .ScheduleTwinUpdateAsync(
+                        jobId,
+                        query,
+                        twin,
+                        DateTime.UtcNow,
+                        (long)TimeSpan.FromMinutes(2).TotalSeconds)
+                    .ConfigureAwait(false);
+            }
+            catch (ThrottlingException)
+            {
+                // Concurrent jobs can be rejected, but it still means authentication was successful. Ignore the exception.
+            }
+        }
+
+        [Ignore]
+        [LoggedTestMethod]
+        public async Task DigitalTwinClient_Http_TokenCredentialAuth_Success()
+        {
+            // arrange
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
+            string thermostatModelId = "dtmi:com:example:TemperatureController;1";
+
+            // Create a device client instance initializing it with the "Thermostat" model.
+            var options = new ClientOptions
+            {
+                ModelId = thermostatModelId,
+            };
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt, options);
+
+            // Call openAsync() to open the device's connection, so that the ModelId is sent over Mqtt CONNECT packet.
+            await deviceClient.OpenAsync().ConfigureAwait(false);
+
+            using var digitalTwinClient = DigitalTwinClient.Create(
+                Configuration.IoTHub.GetIotHubHostName(),
+                Configuration.IoTHub.GetClientSecretCredential());
+
+            // act
+            HttpOperationResponse<ThermostatTwin, DigitalTwinGetHeaders> response = await digitalTwinClient
+                .GetDigitalTwinAsync<ThermostatTwin>(testDevice.Id)
+                .ConfigureAwait(false);
+            ThermostatTwin twin = response.Body;
+
+            // assert
+            twin.Metadata.ModelId.Should().Be(thermostatModelId);
+
+            // cleanup
+            await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
+        }
+
+        [Ignore]
+        [LoggedTestMethod]
+        public async Task Service_Amqp_TokenCredentialAuth_Success()
+        {
+            // arrange
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt);
+            await deviceClient.OpenAsync().ConfigureAwait(false);
+
+            using var serviceClient = ServiceClient.Create(
+                Configuration.IoTHub.GetIotHubHostName(),
+                Configuration.IoTHub.GetClientSecretCredential(),
+                TransportType.Amqp);
+
+            // act
+            await serviceClient.OpenAsync().ConfigureAwait(false);
+            using var message = new Message(Encoding.ASCII.GetBytes("Hello, Cloud!"));
+            await serviceClient.SendAsync(testDevice.Id, message);
+
+            // cleanup
+            await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
+        }
+
+#endif
+    }
+}


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
These tests don't work yet. Once we have a test hub instance, it will be tested and updated if necessary.
AAD tokens are valid for a time period based on azure policy on a subscription. Hence the renewal aspect cannot be tested in E2E and we'll have to do a manual or long-haul test.