### PR TITLE
feature(service-client): Adding chaching for aad tokens.

### DIFF
--- a/iothub/service/src/Common/TokenHelper.cs
+++ b/iothub/service/src/Common/TokenHelper.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace Microsoft.Azure.Devices.Common
+{
+    internal static class TokenHelper
+    {
+        /// <summary>
+        /// Determines if the given token expiry date time is close to expiry. The date and time is
+        /// considered close to expiry if it has less than 10 minutes relative to the current time.
+        /// </summary>
+        /// <param name="expiry">The token expiration date and time.</param>
+        /// <returns>True if the token expiry has less than 10 minutes relative to the current time, otherwise false.</returns>
+        public static bool IsCloseToExpiry(DateTimeOffset expiry)
+        {
+            TimeSpan timeToExpiry = expiry - DateTimeOffset.UtcNow;
+            return timeToExpiry.TotalMinutes < 10;
+        }
+    }
+}

--- a/iothub/service/tests/TestTokenCredential.cs
+++ b/iothub/service/tests/TestTokenCredential.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+#if !NET451
+
+using Azure.Core;
+
+namespace Microsoft.Azure.Devices.Tests
+{
+    /// <summary>
+    /// Implementation of TokenCredential class for unit tests.
+    /// </summary>
+    public class TestTokenCredential : TokenCredential
+    {
+        public const string TokenValue = "token";
+        private DateTimeOffset _expiry;
+
+        public TestTokenCredential(DateTimeOffset expiry)
+        {
+            _expiry = expiry;
+        }
+
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            return new AccessToken(TokenValue, _expiry);
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            return new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
+        }
+    }
+}
+
+#endif

--- a/iothub/service/tests/TokenHelperTests.cs
+++ b/iothub/service/tests/TokenHelperTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading;
+using FluentAssertions;
+using Microsoft.Azure.Devices.Common;
+
+#if !NET451
+
+using Microsoft.Azure.Devices.DigitalTwin.Authentication;
+using Azure.Core;
+
+#endif
+
+namespace Microsoft.Azure.Devices.Tests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class TokenHelperTests
+    {
+#if !NET451
+
+        [TestMethod]
+        [DataRow(15, false)] // 15 minutes to expiry
+        [DataRow(2, true)] // 2 minutes to expiry
+        [DataRow(-2, true)] // Expired 2 minutes ago
+        [DataRow(-15, true)] // Expired 15 minutes ago
+        public void TestIsTokenCloseToExpiry_Succeeds(int offsetInMinutes, bool expectedIsExpired)
+        {
+            // arrange
+            var expiry = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(offsetInMinutes);
+            var tokenCredential = new TestTokenCredential(expiry);
+
+            // act
+            AccessToken token = tokenCredential.GetToken(
+                default(TokenRequestContext),
+                new CancellationToken());
+            bool isExpired = TokenHelper.IsCloseToExpiry(token.ExpiresOn);
+
+            // assert
+            isExpired.Should().Be(expectedIsExpired);
+        }
+
+#endif
+    }
+}


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
 The HTTP APIs request for a token on every call. As getting an access token is a expensive operation, we should be cache these tokens. This PR adds caching for the AAD tokens. The AMQP protocol does not need this as we get a new token and update the CBS link only when the token is close to expiry.