### PR TITLE
IoTHub Exception for Get and Patch Twin failures

### DIFF
--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Client.Exceptions;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
 using Microsoft.Azure.Devices.Shared;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -366,10 +367,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                 .ConfigureAwait(false);
         }
 
-        // These tests worked earlier for Amqp and AmqpWs since it was catching a wrong exception
-        // To Do: Fix Update reported properties method behavior (breaking change) to wait for response
-        // and we should be able to enable these tests then.
-        [Ignore]
         [LoggedTestMethod]
         public async Task Twin_ClientHandlesRejectionInvalidPropertyName_Amqp()
         {
@@ -378,7 +375,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                 .ConfigureAwait(false);
         }
 
-        [Ignore]
         [LoggedTestMethod]
         public async Task Twin_ClientHandlesRejectionInvalidPropertyName_AmqpWs()
         {
@@ -713,12 +709,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                         })
                     .ConfigureAwait(false);
             }
-            catch (Exception)
+            catch (IotHubException)
             {
                 exceptionThrown = true;
             }
 
-            Assert.IsTrue(exceptionThrown, "Exception was expected, but not thrown.");
+            Assert.IsTrue(exceptionThrown, "IotHubException was expected for updating reported property with an invalid property name, but was not thrown.");
 
             Twin serviceTwin = await registryManager.GetTwinAsync(testDevice.Id).ConfigureAwait(false);
             Assert.IsFalse(serviceTwin.Properties.Reported.Contains(propName1));

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
         public AmqpUnit CreateAmqpUnit(
             DeviceIdentity deviceIdentity,
             Func<MethodRequestInternal, Task> onMethodCallback,
-            Action<Twin, string, TwinCollection> twinMessageListener,
+            Action<Twin, string, TwinCollection, IotHubException> twinMessageListener,
             Func<string, Message, Task> onModuleMessageReceivedCallback,
             Func<Message, Task> onDeviceMessageReceivedCallback,
             Action onUnitDisconnected)

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Shared;
 using Microsoft.Azure.Devices.Client.Transport.AmqpIoT;
+using Microsoft.Azure.Devices.Client.Exceptions;
 
 namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 {
@@ -18,7 +19,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
         public AmqpUnit CreateAmqpUnit(
             DeviceIdentity deviceIdentity,
             Func<MethodRequestInternal, Task> onMethodCallback,
-            Action<Twin, string, TwinCollection> twinMessageListener,
+            Action<Twin, string, TwinCollection, IotHubException> twinMessageListener,
             Func<string, Message, Task> onModuleMessageReceivedCallback,
             Func<Message, Task> onDeviceMessageReceivedCallback,
             Action onUnitDisconnected)

--- a/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
@@ -378,7 +378,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             {
                 await EnableTwinPatchAsync(cancellationToken).ConfigureAwait(false);
                 await RoundTripTwinMessageAsync(AmqpTwinMessageType.Patch, reportedProperties, cancellationToken).ConfigureAwait(false);
-                Logging.Info("Patch has completed successfully", nameof(SendTwinPatchAsync));
             }
             finally
             {

--- a/iothub/device/src/Transport/Amqp/AmqpUnit.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnit.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
         private readonly DeviceIdentity _deviceIdentity;
 
         private readonly Func<MethodRequestInternal, Task> _onMethodCallback;
-        private readonly Action<Twin, string, TwinCollection> _twinMessageListener;
+        private readonly Action<Twin, string, TwinCollection, IotHubException> _twinMessageListener;
         private readonly Func<string, Message, Task> _onModuleMessageReceivedCallback;
         private readonly Func<Message, Task> _onDeviceMessageReceivedCallback;
         private readonly IAmqpConnectionHolder _amqpConnectionHolder;
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             DeviceIdentity deviceIdentity,
             IAmqpConnectionHolder amqpConnectionHolder,
             Func<MethodRequestInternal, Task> onMethodCallback,
-            Action<Twin, string, TwinCollection> twinMessageListener,
+            Action<Twin, string, TwinCollection, IotHubException> twinMessageListener,
             Func<string, Message, Task> onModuleMessageReceivedCallback,
             Func<Message, Task> onDeviceMessageReceivedCallback,
             Action onUnitDisconnected)
@@ -735,13 +735,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             }
         }
 
-        private void OnDesiredPropertyReceived(Twin twin, string correlationId, TwinCollection twinCollection)
+        private void OnDesiredPropertyReceived(Twin twin, string correlationId, TwinCollection twinCollection, IotHubException ex = default)
         {
             Logging.Enter(this, twin, nameof(OnDesiredPropertyReceived));
 
             try
             {
-                _twinMessageListener?.Invoke(twin, correlationId, twinCollection);
+                _twinMessageListener?.Invoke(twin, correlationId, twinCollection, ex);
             }
             finally
             {

--- a/iothub/device/src/Transport/Amqp/AmqpUnitManager.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnitManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Shared;
 using Microsoft.Azure.Devices.Client.Transport.AmqpIoT;
+using Microsoft.Azure.Devices.Client.Exceptions;
 
 namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 {
@@ -29,7 +30,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
         public AmqpUnit CreateAmqpUnit(
             DeviceIdentity deviceIdentity,
             Func<MethodRequestInternal, Task> onMethodCallback,
-            Action<Twin, string, TwinCollection> twinMessageListener,
+            Action<Twin, string, TwinCollection, IotHubException> twinMessageListener,
             Func<string, Message, Task> onModuleMessageReceivedCallback,
             Func<Message, Task> onDeviceMessageReceivedCallback,
             Action onUnitDisconnected)

--- a/iothub/device/src/Transport/Amqp/IAmqpUnitManager.cs
+++ b/iothub/device/src/Transport/Amqp/IAmqpUnitManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Azure.Devices.Client.Exceptions;
 using Microsoft.Azure.Devices.Client.Transport.AmqpIoT;
 using Microsoft.Azure.Devices.Shared;
 
@@ -13,7 +14,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
         AmqpUnit CreateAmqpUnit(
             DeviceIdentity deviceIdentity,
             Func<MethodRequestInternal, Task> onMethodCallback,
-            Action<Twin, string, TwinCollection> twinMessageListener,
+            Action<Twin, string, TwinCollection, IotHubException> twinMessageListener,
             Func<string, Message, Task> onModuleMessageReceivedCallback,
             Func<Message, Task> onDeviceMessageReceivedCallback,
             Action onUnitDisconnected);

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTReceivingLink.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTReceivingLink.cs
@@ -280,8 +280,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 if (status >= 400)
                 {
                     // Handle failures
-                    if (correlationId.StartsWith(AmqpTwinMessageType.Get.ToString(), StringComparison.OrdinalIgnoreCase) ||
-                        correlationId.StartsWith(AmqpTwinMessageType.Patch.ToString(), StringComparison.OrdinalIgnoreCase))
+                    if (correlationId.StartsWith(AmqpTwinMessageType.Get.ToString(), StringComparison.OrdinalIgnoreCase) 
+                    || correlationId.StartsWith(AmqpTwinMessageType.Patch.ToString(), StringComparison.OrdinalIgnoreCase))
                     {
                         string error = null;
                         using (var reader = new StreamReader(amqpMessage.BodyStream, System.Text.Encoding.UTF8))

--- a/iothub/device/src/Transport/AmqpIoT/AmqpIoTReceivingLink.cs
+++ b/iothub/device/src/Transport/AmqpIoT/AmqpIoTReceivingLink.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
         private Action<Message> _onEventsReceived;
         private Action<Message> _onDeviceMessageReceived;
         private Action<MethodRequestInternal> _onMethodReceived;
-        private Action<Twin, string, TwinCollection> _onTwinMessageReceived;
+        private Action<Twin, string, TwinCollection, IotHubException> _onTwinMessageReceived;
 
         public AmqpIoTReceivingLink(ReceivingAmqpLink receivingAmqpLink)
         {
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
 
         #region Twin handling
 
-        internal void RegisterTwinListener(Action<Twin, string, TwinCollection> onDesiredPropertyReceived)
+        internal void RegisterTwinListener(Action<Twin, string, TwinCollection, IotHubException> onDesiredPropertyReceived)
         {
             _onTwinMessageReceived = onDesiredPropertyReceived;
             _receivingAmqpLink.RegisterMessageListener(OnTwinChangesReceived);
@@ -280,16 +280,18 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                 if (status >= 400)
                 {
                     // Handle failures
-                    _onTwinMessageReceived.Invoke(null, correlationId, null);
-                    if (correlationId.StartsWith(AmqpTwinMessageType.Get.ToString(), StringComparison.OrdinalIgnoreCase))
+                    if (correlationId.StartsWith(AmqpTwinMessageType.Get.ToString(), StringComparison.OrdinalIgnoreCase) ||
+                        correlationId.StartsWith(AmqpTwinMessageType.Patch.ToString(), StringComparison.OrdinalIgnoreCase))
                     {
                         string error = null;
                         using (var reader = new StreamReader(amqpMessage.BodyStream, System.Text.Encoding.UTF8))
                         {
                             error = reader.ReadToEnd();
                         };
+
                         // Retry for Http status code request timeout, Too many requests and server errors
-                        throw new IotHubException(error, status >= 500 || status == 429 || status == 408);
+                        var exception = new IotHubException(error, status >= 500 || status == 429 || status == 408);
+                        _onTwinMessageReceived.Invoke(null, correlationId, null, exception);
                     }
                 }
                 else
@@ -325,7 +327,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
                         // This shouldn't happen
                         Logging.Info("Received a correlation Id for Twin operation that does not match Get, Patch or Put request", nameof(OnTwinChangesReceived));
                     }
-                    _onTwinMessageReceived.Invoke(twin, correlationId, twinProperties);
+                    _onTwinMessageReceived.Invoke(twin, correlationId, twinProperties, null);
                 }
             }
             finally


### PR DESCRIPTION
This PR includes changes in follow up to handing Twin failures feature.

Old behavior:
On a failure, a wrong exception (InvalidOperationException) was thrown no matter what the error was.

New behavior:
On a failure, a correct IoTHub exception with status code and message will be thrown in context of Get Twin or Update Reported Properties call.