### PR TITLE
fix(edge): UnixDomainSocketEndPoint is available in .NET 2.1 and greater

### DIFF
--- a/iothub/device/src/ModernDotNet/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
+++ b/iothub/device/src/ModernDotNet/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
@@ -57,14 +57,14 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication.Transport
              * around unix sockets in the BCL. For older versions of the framework we will continue to use the existing class since it works
              * fine. For netcore 2.1 and greater as well as .NET 5.0 and greater we'll use the native framework version.
             */
-#if NET451 || NET472 || NETSTANDARD2_0
-            var endpoint = new UnixDomainSocketEndPoint(_providerUri.LocalPath);
-            await socket.ConnectAsync(endpoint).ConfigureAwait(false);
-#else
-            var endpoint = new System.Net.Sockets.UnixDomainSocketEndPoint(_providerUri.LocalPath);
-            await socket.ConnectAsync(endpoint).ConfigureAwait(false);
-#endif
 
+            System.Net.EndPoint endpoint = null;
+#if NET451 || NET472 || NETSTANDARD2_0
+            endpoint = new UnixDomainSocketEndPoint(_providerUri.LocalPath);
+#else
+            endpoint = new System.Net.Sockets.UnixDomainSocketEndPoint(_providerUri.LocalPath);
+#endif
+            await socket.ConnectAsync(endpoint).ConfigureAwait(false);
             return socket;
         }
     }

--- a/iothub/device/src/ModernDotNet/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
+++ b/iothub/device/src/ModernDotNet/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication.Transport
             using var stream = new HttpBufferedStream(new NetworkStream(socket, true));
 
             byte[] requestBytes = HttpRequestResponseSerializer.SerializeRequest(request);
+
 #if NET451 || NET472 || NETSTANDARD2_0
             await stream.WriteAsync(requestBytes, 0, requestBytes.Length, cancellationToken).ConfigureAwait(false);
 #else
@@ -43,6 +44,19 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication.Transport
         private async Task<Socket> GetConnectedSocketAsync()
         {
             Socket socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+
+            /*
+             * The Edge Agent uses unix sockets for communication with the modules deployed in docker for HSM.
+             * For netstandard 2.0 there was no implementation for a Unix Domain Socket (UDS) so we used a version
+             * that was part of a test that was reused in a number of libraries on the internet.
+             *
+             * https://github.com/dotnet/corefx/blob/12b51c6bf153cc237b251a4e264d5e7c0ee84a33/src/System.IO.Pipes/src/System/Net/Sockets/UnixDomainSocketEndPoint.cs
+             * https://github.com/dotnet/corefx/blob/12b51c6bf153cc237b251a4e264d5e7c0ee84a33/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs#L248
+             *
+             * Since then the UnixDomainSocketEndpoint has been added to the dotnet framework and there has been considerable work
+             * around unix sockets in the BCL. For older versions of the framework we will continue to use the existing class since it works
+             * fine. For netcore 2.1 and greater as well as .NET 5.0 and greater we'll use the native framework version.
+            */
 #if NET451 || NET472 || NETSTANDARD2_0
             var endpoint = new UnixDomainSocketEndPoint(_providerUri.LocalPath);
             await socket.ConnectAsync(endpoint).ConfigureAwait(false);

--- a/iothub/device/src/ModernDotNet/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
+++ b/iothub/device/src/ModernDotNet/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
@@ -58,11 +58,10 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication.Transport
              * fine. For netcore 2.1 and greater as well as .NET 5.0 and greater we'll use the native framework version.
             */
 
-            System.Net.EndPoint endpoint = null;
 #if NET451 || NET472 || NETSTANDARD2_0
-            endpoint = new UnixDomainSocketEndPoint(_providerUri.LocalPath);
+            var endpoint = new UnixDomainSocketEndPoint(_providerUri.LocalPath);
 #else
-            endpoint = new System.Net.Sockets.UnixDomainSocketEndPoint(_providerUri.LocalPath);
+            var endpoint = new System.Net.Sockets.UnixDomainSocketEndPoint(_providerUri.LocalPath);
 #endif
             await socket.ConnectAsync(endpoint).ConfigureAwait(false);
             return socket;

--- a/iothub/device/src/ModernDotNet/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
+++ b/iothub/device/src/ModernDotNet/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
@@ -45,21 +45,19 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication.Transport
         {
             Socket socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
 
-            /*
-             * The Edge Agent uses unix sockets for communication with the modules deployed in docker for HSM.
-             * For netstandard 2.0 there was no implementation for a Unix Domain Socket (UDS) so we used a version
-             * that was part of a test that was reused in a number of libraries on the internet.
-             *
-             * https://github.com/dotnet/corefx/blob/12b51c6bf153cc237b251a4e264d5e7c0ee84a33/src/System.IO.Pipes/src/System/Net/Sockets/UnixDomainSocketEndPoint.cs
-             * https://github.com/dotnet/corefx/blob/12b51c6bf153cc237b251a4e264d5e7c0ee84a33/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs#L248
-             *
-             * Since then the UnixDomainSocketEndpoint has been added to the dotnet framework and there has been considerable work
-             * around unix sockets in the BCL. For older versions of the framework we will continue to use the existing class since it works
-             * fine. For netcore 2.1 and greater as well as .NET 5.0 and greater we'll use the native framework version.
-            */
+            // The Edge Agent uses unix sockets for communication with the modules deployed in docker for HSM.
+            // For netstandard 2.0 there was no implementation for a Unix Domain Socket (UDS) so we used a version
+            // that was part of a test that was reused in a number of libraries on the internet.
+            //
+            // https://github.com/dotnet/corefx/blob/12b51c6bf153cc237b251a4e264d5e7c0ee84a33/src/System.IO.Pipes/src/System/Net/Sockets/UnixDomainSocketEndPoint.cs
+            // https://github.com/dotnet/corefx/blob/12b51c6bf153cc237b251a4e264d5e7c0ee84a33/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs#L248
+            //
+            // Since then the UnixDomainSocketEndpoint has been added to the dotnet framework and there has been considerable work
+            // around unix sockets in the BCL. For older versions of the framework we will continue to use the existing class since it works
+            // fine. For netcore 2.1 and greater as well as .NET 5.0 and greater we'll use the native framework version.
 
 #if NET451 || NET472 || NETSTANDARD2_0
-            var endpoint = new UnixDomainSocketEndPoint(_providerUri.LocalPath);
+            var endpoint = new Microsoft.Azure.Devices.Client.HsmAuthentication.Transport.UnixDomainSocketEndPoint(_providerUri.LocalPath);
 #else
             var endpoint = new System.Net.Sockets.UnixDomainSocketEndPoint(_providerUri.LocalPath);
 #endif

--- a/iothub/device/src/ModernDotNet/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
+++ b/iothub/device/src/ModernDotNet/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
@@ -42,9 +42,14 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication.Transport
 
         private async Task<Socket> GetConnectedSocketAsync()
         {
-            var endpoint = new UnixDomainSocketEndPoint(_providerUri.LocalPath);
             Socket socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+#if NET451 || NET472 || NETSTANDARD2_0
+            var endpoint = new UnixDomainSocketEndPoint(_providerUri.LocalPath);
             await socket.ConnectAsync(endpoint).ConfigureAwait(false);
+#else
+            var endpoint = new System.Net.Sockets.UnixDomainSocketEndPoint(_providerUri.LocalPath);
+            await socket.ConnectAsync(endpoint).ConfigureAwait(false);
+#endif
 
             return socket;
         }


### PR DESCRIPTION
Fixes #1804 

The edge client HSM provider uses UnixDomainSockets (UDS) for communication. Before .NET 2.1 to implement a Unix Socket you had to create your own class to do so. Since 2.1 there has been a native UnixDomainSocketEndPoint class in the runtime.

In 2.1 and 3.1 there is no issue. However in 5.0 there are some changes to the way the Socket class handles the native UnixDomainSocketEndPoint class. I didn't dig down extremely deep, but I suspect it's due to the way the endpoint handles the SocketAddress and the string manipulation there seeing as how there is a specific implementation for Windows and for Unix.

## Tested On Windows Containers
dotnetcore 2.1
dotnetcore 3.1
.NET 5.0
