### PR TITLE
fix(e2e) - Change event logging to opt in to specific events only.

### DIFF
--- a/e2e/test/E2EMsTestBase.cs
+++ b/e2e/test/E2EMsTestBase.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Azure.Devices.E2ETests
     /// </summary>
     public class E2EMsTestBase : IDisposable
     {
-        private static readonly string[] s_eventProviders = new string[] { "DotNetty-Default", "Microsoft-Azure-", };
         private ConsoleEventListener _listener;
 
         // Test specific logger instance
@@ -41,7 +40,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             // Note: Events take long and increase run time of the test suite, so only using trace.
             Logger.Trace($"Starting test - {TestContext.TestName}", SeverityLevel.Information);
 
-            _listener = new ConsoleEventListener(s_eventProviders);
+            _listener = new ConsoleEventListener();
         }
 
         [TestCleanup]

--- a/e2e/test/Helpers/ConsoleEventListener.cs
+++ b/e2e/test/Helpers/ConsoleEventListener.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
@@ -8,82 +9,47 @@ namespace System.Diagnostics.Tracing
 {
     public sealed class ConsoleEventListener : EventListener
     {
-        private readonly string[] _eventFilters;
+        // Configure this value to filter all the necessary events when OnEventSourceCreated is called.
+        // OnEventSourceCreated is triggered as soon as the EventListener is registered and an event source is created.
+        // So trying to configure this value in the ConsoleEventListener constructor does not work.
+        // The OnEventSourceCreated can be triggered sooner than the filter is initialized in the ConsoleEventListener constructor.
+        private static string[] _eventFilters = new string[] { "DotNetty-Default", "Microsoft-Azure-Devices" };
+
         private readonly object _lock = new object();
-
-        public ConsoleEventListener(string filter)
-        {
-            _eventFilters = new string[1];
-            _eventFilters[0] = filter ?? throw new ArgumentNullException(nameof(filter));
-
-            InitializeEventSources();
-        }
-
-        public ConsoleEventListener(string[] filters)
-        {
-            _eventFilters = filters ?? throw new ArgumentNullException(nameof(filters));
-            if (_eventFilters.Length == 0)
-            {
-                throw new ArgumentException("Filters cannot be empty", nameof(filters));
-            }
-
-            foreach (string filter in _eventFilters)
-            {
-                if (string.IsNullOrWhiteSpace(filter))
-                {
-                    throw new ArgumentNullException(nameof(filters));
-                }
-            }
-
-            InitializeEventSources();
-        }
-
-        private void InitializeEventSources()
-        {
-            foreach (EventSource source in EventSource.GetSources())
-            {
-                EnableEvents(source, EventLevel.LogAlways);
-            }
-        }
 
         protected override void OnEventSourceCreated(EventSource eventSource)
         {
-            base.OnEventSourceCreated(eventSource);
-            EnableEvents(
-                eventSource,
-                EventLevel.LogAlways
+            if (_eventFilters.Any(filter => eventSource.Name.StartsWith(filter, StringComparison.OrdinalIgnoreCase)))
+            {
+                base.OnEventSourceCreated(eventSource);
+                EnableEvents(
+                    eventSource,
+                    EventLevel.LogAlways
 #if !NET451
                 , EventKeywords.All
 #endif
                 );
+            }
         }
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            if (_eventFilters == null)
-            {
-                return;
-            }
-
             lock (_lock)
             {
-                if (_eventFilters.Any(ef => eventData.EventSource.Name.StartsWith(ef, StringComparison.Ordinal)))
-                {
-                    string eventIdent;
+                string eventIdent;
 #if NET451
                     // net451 doesn't have EventName, so we'll settle for EventId
                     eventIdent = eventData.EventId.ToString(CultureInfo.InvariantCulture);
 #else
-                    eventIdent = eventData.EventName;
+                eventIdent = eventData.EventName;
 #endif
-                    string text = $"{DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fffffff", CultureInfo.InvariantCulture)} [{eventData.EventSource.Name}-{eventIdent}]{(eventData.Payload != null ? $" ({string.Join(", ", eventData.Payload)})." : "")}";
+                string text = $"{DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fffffff", CultureInfo.InvariantCulture)} [{eventData.EventSource.Name}-{eventIdent}]{(eventData.Payload != null ? $" ({string.Join(", ", eventData.Payload)})." : "")}";
 
-                    ConsoleColor origForeground = Console.ForegroundColor;
-                    Console.ForegroundColor = ConsoleColor.DarkYellow;
-                    Console.WriteLine(text);
-                    Debug.WriteLine(text);
-                    Console.ForegroundColor = origForeground;
-                }
+                ConsoleColor origForeground = Console.ForegroundColor;
+                Console.ForegroundColor = ConsoleColor.DarkYellow;
+                Console.WriteLine(text);
+                Debug.WriteLine(text);
+                Console.ForegroundColor = origForeground;
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
This change ensures that our E2E tests only subscribe to a specific set of event sources. After this change is checked in, I will take the changes into the aad branch as well. Having this change in master directly is beneficial and can help us upgrade the storage sdk.
