### PR TITLE
fix(iot-dev): Fix AMQP layer not releasing a semaphore for method links after unsubscribing from methods

### DIFF
--- a/iothub/device/src/Transport/Amqp/AmqpUnit.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnit.cs
@@ -619,6 +619,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIoT
             finally
             {
                 Logging.Exit(this, timeout, nameof(DisableMethodsAsync));
+                _methodLinkSemaphore.Release();
             }
         }
 


### PR DESCRIPTION
This semaphore was just never released in this method

#1822 for additional context