### PR TITLE
release: Bump versions for latest release

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.35.0</Version>
+    <Version>1.36.0</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.30.0</Version>
+    <Version>1.31.0</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,6 +1,6 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.35.0
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.30.0
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.36.0
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.31.0
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.27.0
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.3
 provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.4


### PR DESCRIPTION
## Microsoft.Azure.Devices.Client 1.36.0

### Improvements and Features

- Add additional logs to MQTT implementation
- Added extra comments to clarify true and false in dispose (#1805)
- Make the DeviceClient and ModuleClient extensible (#1802)
- Handle Twin failures using Amqp (#1796)

### Bug Fixes

- Fix AMQP layer not releasing a semaphore for method links after unsubscribing from methods (#1831)
- Fix semaphore usage within InternalClient (#1823)
- UnixDomainSocketEndPoint is available in .NET 2.1 and greater (#1816)
- IoTHub Exception for Get and Patch Twin failures (#1815)
- Fix MqttTransportHandler to not await on user supplied C2D callback
- Update dotnetty task calls to use ConfigureAwait(true)
- Update MqttTransportHandler to not use SemaphoreSlim.WaitAsync(TimeSpan, CancellationToken)


## Microsoft.Azure.Devices 1.31.0

### Improvements 

- Update xml comments and backwards compatible changes to the ServiceClient base class that improve the amount of methods to override.

