### PR TITLE
fix(iot-service): Fix bug where registry manager never invalidated DNS cache to force DNS lookup

### DIFF
--- a/iothub/service/src/AmqpServiceClient.cs
+++ b/iothub/service/src/AmqpServiceClient.cs
@@ -54,7 +54,8 @@ namespace Microsoft.Azure.Devices
                 iotHubConnectionString,
                 ExceptionHandlingHelper.GetDefaultErrorMapping(),
                 s_defaultOperationTimeout,
-                transportSettings.HttpProxy);
+                transportSettings.HttpProxy,
+                transportSettings.ConnectionLeaseTimeoutMilliseconds);
 
             // Set the trace provider for the AMQP library.
             AmqpTrace.Provider = new AmqpTransportLog();

--- a/iothub/service/src/ConnectionLeaseTimeoutHandler.cs
+++ b/iothub/service/src/ConnectionLeaseTimeoutHandler.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices
+{
+    /// <summary>
+    /// HttpClient delegating handler for periodically revoking the connection lease after a specified amount of time. This allows cached HttpClients to periodically do DNS lookups
+    /// which keeps the client communicating with the correct service endpoint in failover scenarios.
+    /// </summary>
+    internal class ConnectionLeaseTimeoutHandler : DelegatingHandler
+    {
+        private readonly Stopwatch _stopwatch;
+        private readonly int _leaseTimeoutMilliseconds;
+        private SemaphoreSlim _timeoutCheckSemaphore;
+
+        internal ConnectionLeaseTimeoutHandler(int leaseTimeoutMilliseconds) : base()
+        {
+            _stopwatch = Stopwatch.StartNew();
+            _timeoutCheckSemaphore = new SemaphoreSlim(1, 1);
+            _leaseTimeoutMilliseconds = leaseTimeoutMilliseconds;
+        }
+
+        protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // By default, singleton/static HttpClient instances will never do a DNS lookup after the first request, which leads to some
+            // bugs such as https://github.com/Azure/azure-iot-sdk-csharp/issues/1865
+
+            // Special case for lease timeout is when the value is set to a negative value. In those instances, the lease timeout is infinite,
+            // so there is no reason to ever set the ConnectionClose header. As such, there is no need to wait for the semaphore to be available.
+            if (_leaseTimeoutMilliseconds >= 0 && _stopwatch.Elapsed.TotalMilliseconds >= _leaseTimeoutMilliseconds)
+            {
+                // This handler is designed to force the connection to close periodically in order to ensure that httpclients are eventually made aware
+                // of any DNS changes from an IoT Hub failing over.
+                await _timeoutCheckSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                try
+                {
+                    // re-check the stopwatch. This thread may have waited for the semaphore thinking it would need to close the connection and reset
+                    // the timer, but another thread may have already done that since this thread started waiting.
+                    if (_stopwatch.Elapsed.TotalMilliseconds >= _leaseTimeoutMilliseconds)
+                    {
+                        request.Headers.ConnectionClose = true;
+                        _stopwatch.Restart();
+                    }
+                }
+                finally
+                {
+                    _timeoutCheckSemaphore.Release();
+                }
+            }
+
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _stopwatch.Reset();
+            _timeoutCheckSemaphore.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Devices
             _connectionLeaseTimeoutHandler = new ConnectionLeaseTimeoutHandler(HttpTransportSettings.DefaultConnectionLeaseTimeoutMilliseconds);
 
             DelegatingHandler[] handlersWithConnectionLeaseTimeoutHandler = new DelegatingHandler[handlers.Length + 1];
-            handlersWithConnectionLeaseTimeoutHandler[handlers.Length + 1] = _connectionLeaseTimeoutHandler;
+            handlersWithConnectionLeaseTimeoutHandler[handlers.Length] = _connectionLeaseTimeoutHandler;
 
             _client = new IotHubGatewayServiceAPIs(uri, credentials, handlersWithConnectionLeaseTimeoutHandler);
             _protocolLayer = new DigitalTwin(_client);

--- a/iothub/service/src/HttpRegistryManager.cs
+++ b/iothub/service/src/HttpRegistryManager.cs
@@ -62,7 +62,8 @@ namespace Microsoft.Azure.Devices
                 connectionString,
                 ExceptionHandlingHelper.GetDefaultErrorMapping(),
                 s_defaultOperationTimeout,
-                transportSettings.Proxy);
+                transportSettings.Proxy,
+                transportSettings.ConnectionLeaseTimeoutMilliseconds);
         }
 
         // internal test helper

--- a/iothub/service/src/HttpTransportSettings.cs
+++ b/iothub/service/src/HttpTransportSettings.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Azure.Devices
     /// </summary>
     public sealed class HttpTransportSettings
     {
+        // 5 minute timeout consistent with track 2 guidance
+        // https://github.com/Azure/azure-sdk-for-net/blob/2c338d26571f4ee84c3c280984af49bcb771fe2a/sdk/core/Azure.Core/src/Pipeline/ServicePointHelpers.cs#L27
+        internal const int DefaultConnectionLeaseTimeoutMilliseconds = 5 * 60 * 1000;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpTransportSettings"/> class.
         /// </summary>
@@ -27,5 +31,19 @@ namespace Microsoft.Azure.Devices
         /// especially when MQTT and AMQP ports are disallowed to the internet.
         /// </remarks>
         public IWebProxy Proxy { get; set; }
+
+        /// <summary>
+        /// How long, in milliseconds, a given cached TCP connection created by this client's HTTP layer will live before being closed. 
+        /// If this value is set to any negative value, the connection lease will be infinite. If this value is set to 0, then the TCP connection will close after
+        /// each HTTP request and a new TCP connection will be opened upon the next request.
+        /// </summary>
+        /// <remarks>
+        /// By closing cached TCP connections and opening a new one upon the next request, the underlying HTTP client has a chance to do a DNS lookup 
+        /// to validate that it will send the requests to the correct IP address. While it is atypical for a given IoT Hub to change its IP address, it does
+        /// happen when a given IoT Hub fails over into a different region. Because of that, users who expect to failover their IoT Hub at any point
+        /// are advised to set this value to a value of 0 or greater. Larger values will make better use of caching to save network resources over time,
+        /// but smaller values will make the client respond more quickly to failed over IoT Hubs.
+        /// </remarks>
+        public int ConnectionLeaseTimeoutMilliseconds { get; set; } = DefaultConnectionLeaseTimeoutMilliseconds;
     }
 }

--- a/iothub/service/src/JobClient/HttpJobClient.cs
+++ b/iothub/service/src/JobClient/HttpJobClient.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Azure.Devices
                 connectionString,
                 ExceptionHandlingHelper.GetDefaultErrorMapping(),
                 s_defaultOperationTimeout,
-                transportSettings.Proxy);
+                transportSettings.Proxy,
+                transportSettings.ConnectionLeaseTimeoutMilliseconds);
         }
 
         // internal test helper

--- a/iothub/service/src/ServiceClientTransportSettings.cs
+++ b/iothub/service/src/ServiceClientTransportSettings.cs
@@ -29,5 +29,19 @@ namespace Microsoft.Azure.Devices
         /// The proxy settings to be used on the HTTP client.
         /// </summary>
         public IWebProxy HttpProxy { get; set; }
+
+        /// <summary>
+        /// How long, in milliseconds, a given cached TCP connection created by this client's HTTP layer will live before being closed. 
+        /// If this value is set to any negative value, the connection lease will be infinite. If this value is set to 0, then the TCP connection will close after
+        /// each HTTP request and a new TCP connection will be opened upon the next request.
+        /// </summary>
+        /// <remarks>
+        /// By closing cached TCP connections and opening a new one upon the next request, the underlying HTTP client has a chance to do a DNS lookup 
+        /// to validate that it will send the requests to the correct IP address. While it is atypical for a given IoT Hub to change its IP address, it does
+        /// happen when a given IoT Hub fails over into a different region. Because of that, users who expect to failover their IoT Hub at any point
+        /// are advised to set this value to a value of 0 or greater. Larger values will make better use of caching to save network resources over time,
+        /// but smaller values will make the client respond more quickly to failed over IoT Hubs.
+        /// </remarks>
+        public int ConnectionLeaseTimeoutMilliseconds { get; set; } = HttpTransportSettings.DefaultConnectionLeaseTimeoutMilliseconds;
     }
 }


### PR DESCRIPTION
The singleton http clients in the service client never update to reflect any DNS changes.

#1865

This new approach simply closes the underlying TCP socket once every 5 minutes and reopens it on the next request. The 5 minutes value here follows track 2 SDK guidance and is a nice balance between not needlessly closing TCP sockets while still being responsive when a failover occurs

Manual testing of this feature looks good. A single registry manager instance stuck in an infinite loop of adding new devices eventually catches on to the failover, and starts successfully registering devices again in a reasonable amount of time.

We don't have any sort of failover tests in our gates, so manual testing is all that I'm relying on here for now.

Edit: After talking a bit with the Azure.Core folks about how they solved this issue, it turns out that they haven't solved this issue for HTTPClients, so they just use a different HTTP primitive (HttpWebRequest) for handling it. With that in mind, this approach is better than trying to migrate our existing code over to the same HTTP primitive just so that we can use the same approach as Azure.Core does.