### PR TITLE
feat(iot-service, shared): Add support for configuring http connection lease timeouts

### DIFF
--- a/iothub/service/src/AmqpServiceClient.cs
+++ b/iothub/service/src/AmqpServiceClient.cs
@@ -54,7 +54,8 @@ namespace Microsoft.Azure.Devices
                 iotHubConnectionString,
                 ExceptionHandlingHelper.GetDefaultErrorMapping(),
                 s_defaultOperationTimeout,
-                transportSettings.HttpProxy);
+                transportSettings.HttpProxy,
+                transportSettings.ConnectionLeaseTimeoutMilliseconds);
 
             // Set the trace provider for the AMQP library.
             AmqpTrace.Provider = new AmqpTransportLog();

--- a/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
@@ -37,22 +37,17 @@ namespace Microsoft.Azure.Devices
 
         private DigitalTwinClient(Uri uri, IotServiceClientCredentials credentials, params DelegatingHandler[] handlers)
         {
-#pragma warning disable CA2000 // Dispose objects before losing scope (objects are disposed of when this client is disposed)
-#if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_0 && !NETCOREAPP1_1
-            // SocketsHttpHandler is only available in netcoreapp2.1 and onwards.
-            HttpMessageHandler httpMessageHandler = new SocketsHttpHandler();
-#else
-            HttpMessageHandler httpMessageHandler = new HttpClientHandler();
-#endif
-            // Currently, the connection lease timeout isn't configurable in this client. This may be worth adding later though
-            ServicePointHelpers.SetLimits(httpMessageHandler, uri, ServicePointHelpers.DefaultConnectionLeaseTimeout);
-
+            var httpMessageHandler = HttpClientHelper.CreateDefaultHttpMessageHandler(null, uri, ServicePointHelpers.DefaultConnectionLeaseTimeout);
+#pragma warning disable CA2000 // Dispose objects before losing scope (httpMessageHandlerWithDelegatingHandlers is disposed when the http client owning it is disposed)
             HttpMessageHandler httpMessageHandlerWithDelegatingHandlers = CreateHttpHandlerPipeline(httpMessageHandler, handlers);
+#pragma warning restore CA2000 // Dispose objects before losing scope
 
+#pragma warning disable CA2000 // Dispose objects before losing scope (httpClient is disposed when the protocol layer client owning it is disposed)
             var httpClient = new HttpClient(httpMessageHandlerWithDelegatingHandlers, true)
             {
                 BaseAddress = uri
             };
+#pragma warning restore CA2000 // Dispose objects before losing scope
 
 #pragma warning restore CA2000 // Dispose objects before losing scope
 

--- a/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
@@ -34,10 +34,64 @@ namespace Microsoft.Azure.Devices
             return new DigitalTwinClient(iotHubConnectionString.HttpsEndpoint, sharedAccessKeyCredential, handlers);
         }
 
+
         private DigitalTwinClient(Uri uri, IotServiceClientCredentials credentials, params DelegatingHandler[] handlers)
         {
-            _client = new IotHubGatewayServiceAPIs(uri, credentials, handlers);
+#pragma warning disable CA2000 // Dispose objects before losing scope (objects are disposed of when this client is disposed)
+#if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_0 && !NETCOREAPP1_1
+            // SocketsHttpHandler is only available in netcoreapp2.1 and onwards.
+            HttpMessageHandler httpMessageHandler = new SocketsHttpHandler();
+#else
+            HttpMessageHandler httpMessageHandler = new HttpClientHandler();
+#endif
+            // Currently, the connection lease timeout isn't configurable in this client. This may be worth adding later though
+            ServicePointHelpers.SetLimits(httpMessageHandler, uri, ServicePointHelpers.DefaultConnectionLeaseTimeout);
+
+            HttpMessageHandler httpMessageHandlerWithDelegatingHandlers = CreateHttpHandlerPipeline(httpMessageHandler, handlers);
+
+            var httpClient = new HttpClient(httpMessageHandlerWithDelegatingHandlers, true)
+            {
+                BaseAddress = uri
+            };
+
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+            // When this client is disposed, all the http message handlers and delegating handlers will be disposed automatically
+            _client = new IotHubGatewayServiceAPIs(credentials, httpClient, true);
             _protocolLayer = new DigitalTwin(_client);
+        }
+
+        // Creates a single HttpMessageHandler to construct a HttpClient with from a base httpMessageHandler and some number of custom delegating handlers
+        // This is almost a copy of the Microsoft.Rest.ClientRuntime library's implementation, but with the return and parameter type HttpClientHandler replaced
+        // with the more abstract HttpMessageHandler in order for us to set the base handler as either a SocketsHttpHandler for .net core or an HttpClientHandler otherwise
+        // https://github.com/Azure/azure-sdk-for-net/blob/99f4da88ab0aa01c79aa291c6c101ab94c4ac940/sdk/mgmtcommon/ClientRuntime/ClientRuntime/ServiceClient.cs#L376
+        private static HttpMessageHandler CreateHttpHandlerPipeline(HttpMessageHandler httpMessageHandler, params DelegatingHandler[] handlers)
+        {
+            // The RetryAfterDelegatingHandler should be the absoulte outermost handler
+            // because it's extremely lightweight and non-interfering
+            HttpMessageHandler currentHandler =
+#pragma warning disable CA2000 // Dispose objects before losing scope (delegating handler is disposed when the http client that uses it is disposed)
+                new RetryDelegatingHandler(new RetryAfterDelegatingHandler { InnerHandler = httpMessageHandler });
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+            if (handlers != null)
+            {
+                for (int i = handlers.Length - 1; i >= 0; --i)
+                {
+                    DelegatingHandler handler = handlers[i];
+                    // Non-delegating handlers are ignored since we always
+                    // have RetryDelegatingHandler as the outer-most handler
+                    while (handler.InnerHandler is DelegatingHandler)
+                    {
+                        handler = handler.InnerHandler as DelegatingHandler;
+                    }
+
+                    handler.InnerHandler = currentHandler;
+                    currentHandler = handlers[i];
+                }
+            }
+
+            return currentHandler;
         }
 
         /// <summary>

--- a/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Azure.Devices
 
             // When this client is disposed, all the http message handlers and delegating handlers will be disposed automatically
             _client = new IotHubGatewayServiceAPIs(credentials, httpClient, true);
+            _client.BaseUri = uri;
             _protocolLayer = new DigitalTwin(_client);
         }
 

--- a/iothub/service/src/HttpRegistryManager.cs
+++ b/iothub/service/src/HttpRegistryManager.cs
@@ -62,7 +62,8 @@ namespace Microsoft.Azure.Devices
                 connectionString,
                 ExceptionHandlingHelper.GetDefaultErrorMapping(),
                 s_defaultOperationTimeout,
-                transportSettings.Proxy);
+                transportSettings.Proxy,
+                transportSettings.ConnectionLeaseTimeoutMilliseconds);
         }
 
         // internal test helper

--- a/iothub/service/src/HttpTransportSettings.cs
+++ b/iothub/service/src/HttpTransportSettings.cs
@@ -27,5 +27,19 @@ namespace Microsoft.Azure.Devices
         /// especially when MQTT and AMQP ports are disallowed to the internet.
         /// </remarks>
         public IWebProxy Proxy { get; set; }
+
+        /// <summary>
+        /// How long, in milliseconds, a given cached TCP connection created by this client's HTTP layer will live before being closed. 
+        /// If this value is set to any negative value, the connection lease will be infinite. If this value is set to 0, then the TCP connection will close after
+        /// each HTTP request and a new TCP connection will be opened upon the next request.
+        /// </summary>
+        /// <remarks>
+        /// By closing cached TCP connections and opening a new one upon the next request, the underlying HTTP client has a chance to do a DNS lookup 
+        /// to validate that it will send the requests to the correct IP address. While it is atypical for a given IoT Hub to change its IP address, it does
+        /// happen when a given IoT Hub fails over into a different region. Because of that, users who expect to failover their IoT Hub at any point
+        /// are advised to set this value to a value of 0 or greater. Larger values will make better use of caching to save network resources over time,
+        /// but smaller values will make the client respond more quickly to failed over IoT Hubs.
+        /// </remarks>
+        public int ConnectionLeaseTimeoutMilliseconds { get; set; } = ServicePointHelpers.DefaultConnectionLeaseTimeout;
     }
 }

--- a/iothub/service/src/JobClient/HttpJobClient.cs
+++ b/iothub/service/src/JobClient/HttpJobClient.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Azure.Devices
                 connectionString,
                 ExceptionHandlingHelper.GetDefaultErrorMapping(),
                 s_defaultOperationTimeout,
-                transportSettings.Proxy);
+                transportSettings.Proxy,
+                transportSettings.ConnectionLeaseTimeoutMilliseconds);
         }
 
         // internal test helper

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net472;net451</TargetFrameworks>
+	<!--netcoreapp2.1 target framework here is solely so that this library can use the SocketsHttpHandler class to handle connection lease timeout issues.-->
+	<!--See #1874 for additional details-->
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net472;net451;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <!-- TODO #176: Enable warnings as errors. -->

--- a/iothub/service/src/ServiceClientTransportSettings.cs
+++ b/iothub/service/src/ServiceClientTransportSettings.cs
@@ -29,5 +29,19 @@ namespace Microsoft.Azure.Devices
         /// The proxy settings to be used on the HTTP client.
         /// </summary>
         public IWebProxy HttpProxy { get; set; }
+
+        /// <summary>
+        /// How long, in milliseconds, a given cached TCP connection created by this client's HTTP layer will live before being closed. 
+        /// If this value is set to any negative value, the connection lease will be infinite. If this value is set to 0, then the TCP connection will close after
+        /// each HTTP request and a new TCP connection will be opened upon the next request.
+        /// </summary>
+        /// <remarks>
+        /// By closing cached TCP connections and opening a new one upon the next request, the underlying HTTP client has a chance to do a DNS lookup 
+        /// to validate that it will send the requests to the correct IP address. While it is atypical for a given IoT Hub to change its IP address, it does
+        /// happen when a given IoT Hub fails over into a different region. Because of that, users who expect to failover their IoT Hub at any point
+        /// are advised to set this value to a value of 0 or greater. Larger values will make better use of caching to save network resources over time,
+        /// but smaller values will make the client respond more quickly to failed over IoT Hubs.
+        /// </remarks>
+        public int ConnectionLeaseTimeoutMilliseconds { get; set; } = ServicePointHelpers.DefaultConnectionLeaseTimeout;
     }
 }

--- a/iothub/service/src/ServicePointHelpers.cs
+++ b/iothub/service/src/ServicePointHelpers.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Azure.Devices
                     var servicePoint = ServicePointManager.FindServicePoint(baseUri);
                     servicePoint.ConnectionLeaseTimeout = connectionLeaseTimeoutMilliseconds;
                     break;
-#if NETCOREAPP
+#if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_0 && !NETCOREAPP1_1
+                // SocketsHttpHandler is only available in netcore2.1 and onwards
                 case SocketsHttpHandler socketsHttpHandler:
                     socketsHttpHandler.MaxConnectionsPerServer = DefaultMaxConnectionsPerServer;
                     socketsHttpHandler.PooledConnectionLifetime = TimeSpan.FromMilliseconds(connectionLeaseTimeoutMilliseconds);

--- a/iothub/service/src/ServicePointHelpers.cs
+++ b/iothub/service/src/ServicePointHelpers.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+
+namespace Microsoft.Azure.Devices
+{
+    // This type manages changing HttpClient defaults to more appropriate values
+    // There are two limits we target:
+    // - Per Server Connection Limit
+    // - Keep Alive Connection Timeout
+    // On .NET Core 2.1+ the HttpClient defaults to using the HttpSocketHandler so we adjust both limits on the client handler
+    //
+    // On .NET Standard & NET 4.51+ the HttpClient defaults to using the HttpClientHandler
+    //   and there is no easy way to set Keep Alive Connection Timeout but it's mitigated by setting the service point's connection lease timeout
+    internal static class ServicePointHelpers
+    {
+        // These default values are consistent with Azure.Core default values:
+        // https://github.com/Azure/azure-sdk-for-net/blob/7e3cf643977591e9041f4c628fd4d28237398e0b/sdk/core/Azure.Core/src/Pipeline/ServicePointHelpers.cs#L28
+        internal const int DefaultMaxConnectionsPerServer = 50;
+
+        internal const int DefaultConnectionLeaseTimeout = 300 * 1000; // 5 minutes
+
+        // messageHandler passed in is an HttpClientHandler for .NET Framework and .NET standard, and a SocketsHttpHandler for .NET core
+        public static void SetLimits(HttpMessageHandler messageHandler, Uri baseUri, int connectionLeaseTimeoutMilliseconds)
+        {
+            switch (messageHandler)
+            {
+                case HttpClientHandler httpClientHandler:
+#if !NET451
+                    httpClientHandler.MaxConnectionsPerServer = DefaultMaxConnectionsPerServer;
+#endif
+                    var servicePoint = ServicePointManager.FindServicePoint(baseUri);
+                    servicePoint.ConnectionLeaseTimeout = connectionLeaseTimeoutMilliseconds;
+                    break;
+#if NETCOREAPP
+                case SocketsHttpHandler socketsHttpHandler:
+                    socketsHttpHandler.MaxConnectionsPerServer = DefaultMaxConnectionsPerServer;
+                    socketsHttpHandler.PooledConnectionLifetime = TimeSpan.FromMilliseconds(connectionLeaseTimeoutMilliseconds);
+                    break;
+#endif
+            }
+        }
+    }
+}

--- a/shared/src/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/src/Microsoft.Azure.Devices.Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.1;netstandard2.0;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.1;netstandard2.0;net472;net451;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
(This PR works now) The gist of it is that the servicepointmanager timeout properties work fine for .NET framework applications, but .NET core requires you to construct a SocketsHttpHandler as the basehandler in order to solve this issue. This very closely mimics how Azure.Core solves this same issue.