### PR TITLE
fix(iot-dev): Fix null reference exception case within RetryDelegatingHandler

### DIFF
--- a/iothub/device/src/Transport/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Transport/RetryDelegatingHandler.cs
@@ -968,7 +968,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 _handleDisconnectCts?.Dispose();
 
                 _handlerSemaphore?.Dispose();
-                _handlerSemaphore = null;
             }
         }
     }


### PR DESCRIPTION
If Dispose is called while this semaphore is in use, the other thread using the semaphore will hit a null reference exception when it tries to release the now null semaphore. It would be more appropriate to just hit an ObjectDisposedException instead.

The particular customer issue that motivated me to look into this code involved the user disposing a client without closing it first, which opened the possibility that a connection loss event would trigger while the object is being disposed. In general, though, Dispose should only be called when a client is no longer open.