### PR TITLE
Add ParentScope property to Device

### DIFF
--- a/iothub/service/src/Device.cs
+++ b/iothub/service/src/Device.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Azure.Devices.Shared;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -109,9 +110,26 @@ namespace Microsoft.Azure.Devices
         public virtual DeviceCapabilities Capabilities { get; set; }
 
         /// <summary>
-        /// Scope to which this device instance belongs to
+        /// The scope of the device. For edge devices, this is auto-generated and immutable. For leaf devices, set this to create child/parent
+        /// relationship.
         /// </summary>
+        /// <remarks>
+        /// For leaf devices, the value to set a parent edge device can be retrieved from the parent edge device's <see cref="Scope"/> property.
+        /// </remarks>
         [JsonProperty(PropertyName = "deviceScope", NullValueHandling = NullValueHandling.Ignore)]
         public virtual string Scope { get; set; }
+
+        /// <summary>
+        /// The scopes of the upper level edge devices if applicable.
+        /// </summary>
+        /// <remarks>
+        /// For edge devices, the value to set a parent edge device can be retrieved from the parent edge device's <see cref="Scope"/> property.
+        ///
+        /// For leaf devices, this could be set to the same value as <see cref="Scope"/> or left for the service to copy over.
+        ///
+        /// For now, this list can only have 1 element in the collection.
+        /// </remarks>
+        [JsonProperty(PropertyName = "parentScopes", NullValueHandling = NullValueHandling.Ignore)]
+        public virtual IList<string> ParentScopes { get; internal set; } = new List<string>();
     }
 }

--- a/shared/src/Twin.cs
+++ b/shared/src/Twin.cs
@@ -152,6 +152,19 @@ namespace Microsoft.Azure.Devices.Shared
         public X509Thumbprint X509Thumbprint { get; internal set; }
 
         /// <summary>
+        /// The scope of the device. Auto-generated and immutable for edge devices and modifiable in leaf devices to create child/parent relationship.
+        /// </summary>
+        [DefaultValue(null)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public string DeviceScope { get; internal set; }
+
+        /// <summary>
+        /// The scopes of the upper level edge devices if applicable. Only available for edge devices.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public virtual IReadOnlyList<string> ParentScopes { get; internal set; }
+
+        /// <summary>
         /// Gets the Twin as a JSON string
         /// </summary>
         /// <param name="formatting">Optional. Formatting for the output JSON string.</param>

--- a/shared/src/TwinJsonConverter.cs
+++ b/shared/src/TwinJsonConverter.cs
@@ -1,20 +1,17 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+
 namespace Microsoft.Azure.Devices.Shared
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Globalization;
-    using System.Reflection;
-    using System.Runtime.Serialization;
-    using Microsoft.Azure.Devices.Common;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
-    using Newtonsoft.Json.Linq;
-    using Newtonsoft.Json.Serialization;
-
     /// <summary>
     /// Converts <see cref="Twin"/> to Json
     /// </summary>
@@ -40,6 +37,8 @@ namespace Microsoft.Azure.Devices.Shared
         private const string AuthenticationTypeTag = "authenticationType";
         private const string X509ThumbprintTag = "x509Thumbprint";
         private const string ModelId = "modelId";
+        private const string DeviceScope = "deviceScope";
+        private const string ParentScopes = "parentScopes";
 
         /// <summary>
         /// Converts <see cref="Twin"/> to its equivalent Json representation.
@@ -173,6 +172,18 @@ namespace Microsoft.Azure.Devices.Shared
                 writer.WriteEndObject();
             }
 
+            if (twin.DeviceScope != null)
+            {
+                writer.WritePropertyName(DeviceScope);
+                serializer.Serialize(writer, twin.DeviceScope, typeof(string));
+            }
+
+            if (twin.ParentScopes != null && twin.ParentScopes.Any())
+            {
+                writer.WritePropertyName(ParentScopes);
+                serializer.Serialize(writer, twin.ParentScopes, typeof(IList<string>));
+            }
+
             writer.WriteEndObject();
         }
 
@@ -301,6 +312,14 @@ namespace Microsoft.Azure.Devices.Shared
 
                     case X509ThumbprintTag:
                         twin.X509Thumbprint = serializer.Deserialize<X509Thumbprint>(reader);
+                        break;
+
+                    case DeviceScope:
+                        twin.DeviceScope = serializer.Deserialize<string>(reader);
+                        break;
+
+                    case ParentScopes:
+                        twin.ParentScopes = serializer.Deserialize<IReadOnlyList<string>>(reader);
                         break;
 
                     default:


### PR DESCRIPTION
Also added to Twin, along with ParentScope property. Updated a test to validate edge devices can be put into a parent/child relationship.