### PR TITLE
use sha256 thumbprint in e2e setup

### DIFF
--- a/e2e/test/Helpers/TestDevice.cs
+++ b/e2e/test/Helpers/TestDevice.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client;
@@ -83,7 +84,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                 {
                     X509Thumbprint = new X509Thumbprint
                     {
-                        PrimaryThumbprint = Configuration.IoTHub.GetCertificateWithPrivateKey().Thumbprint
+                        PrimaryThumbprint = Configuration.IoTHub.GetCertificateWithPrivateKey().GetCertHashString(HashAlgorithmName.SHA256)
                     }
                 };
 

--- a/e2e/test/Helpers/TestDevice.cs
+++ b/e2e/test/Helpers/TestDevice.cs
@@ -80,14 +80,18 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             var requestDevice = new Device(deviceName);
             if (type == TestDeviceType.X509)
             {
-                requestDevice.Authentication = new AuthenticationMechanism
-                {
-                    X509Thumbprint = new X509Thumbprint
+                using (var hasher = SHA256.Create())
+                {  
+                    var hash = hasher.ComputeHash(Configuration.IoTHub.GetCertificateWithPrivateKey().RawData);
+                    requestDevice.Authentication = new AuthenticationMechanism
                     {
-                        PrimaryThumbprint = Configuration.IoTHub.GetCertificateWithPrivateKey().GetCertHashString(HashAlgorithmName.SHA256)
-                    }
-                };
-
+                        X509Thumbprint = new X509Thumbprint
+                        {
+                            PrimaryThumbprint = BitConverter.ToString(hash).Replace("-", "")
+                        }
+                    }; 
+                }
+                
                 auth = new DeviceAuthenticationWithX509Certificate(deviceName, Configuration.IoTHub.GetCertificateWithPrivateKey());
             }
 


### PR DESCRIPTION
IoT Hub Gateway V2 requires sha256 thumbprint with API versions
2017-06-30 and later. this fixes X509 tests with Gateway V2.

<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes

Use a SHA256 thumbprint when creating test devices.

## Reference/Link to the issue solved with this PR (if any)

OneBranch Bug #9790227