### PR TITLE
feat(registry-manager): Add support to use user defined msi for import export jobs.

### DIFF
--- a/e2e/test/config/Configuration.IoTHub.cs
+++ b/e2e/test/config/Configuration.IoTHub.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Azure.Devices.E2ETests
             public static string ConnectionString => GetValue("IOTHUB_CONNECTION_STRING");
             public static string X509ChainDeviceName => GetValue("IOTHUB_X509_CHAIN_DEVICE_NAME");
 
+            public static string UserAssignedMsiResourceId => GetValue("IOTHUB_USER_ASSIGNED_MSI_RESOURCE_ID");
+
             public static X509Certificate2 GetCertificateWithPrivateKey()
             {
                 const string hubPfxCert = "IOTHUB_X509_PFX_CERTIFICATE";

--- a/e2e/test/iothub/service/RegistryManagerExportDevicesTests.cs
+++ b/e2e/test/iothub/service/RegistryManagerExportDevicesTests.cs
@@ -46,9 +46,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         [TestCategory("LongRunning")]
         [Timeout(120000)]
         [DoNotParallelize]
-        [DataRow(StorageAuthenticationType.KeyBased)]
-        [DataRow(StorageAuthenticationType.IdentityBased)]
-        public async Task RegistryManager_ExportDevices(StorageAuthenticationType storageAuthenticationType)
+        [DataRow(StorageAuthenticationType.KeyBased, false)]
+        [DataRow(StorageAuthenticationType.IdentityBased, false)]
+        [DataRow(StorageAuthenticationType.IdentityBased, true)]
+        public async Task RegistryManager_ExportDevices(StorageAuthenticationType storageAuthenticationType, bool isUserAssignedMsi)
         {
             // arrange
 
@@ -86,13 +87,24 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                 {
                     try
                     {
+                        ManagedIdentity identity = null;
+                        if (isUserAssignedMsi)
+                        {
+                            string userAssignedMsiResourceId = Configuration.IoTHub.UserAssignedMsiResourceId;
+                            identity = new ManagedIdentity
+                            {
+                                userAssignedIdentity = userAssignedMsiResourceId
+                            };
+                        }
+
                         exportJobResponse = await registryManager
                            .ExportDevicesAsync(
                                 JobProperties.CreateForExportJob(
                                     containerUri.ToString(),
                                     true,
                                     null,
-                                    storageAuthenticationType))
+                                    storageAuthenticationType,
+                                    identity))
                            .ConfigureAwait(false);
                         break;
                     }

--- a/iothub/service/src/JobProperties.cs
+++ b/iothub/service/src/JobProperties.cs
@@ -118,6 +118,13 @@ namespace Microsoft.Azure.Devices
         [JsonProperty(PropertyName = "storageAuthenticationType", NullValueHandling = NullValueHandling.Ignore)]
         public StorageAuthenticationType? StorageAuthenticationType { get; set; }
 
+        /// <summary>
+        /// The managed identity used to access the storage account for import and export jobs.
+        /// TODO link from service team: For more information, see <see href=""/>
+        /// </summary>
+        [JsonProperty(PropertyName = "identity", NullValueHandling = NullValueHandling.Ignore)]
+        public ManagedIdentity Identity { get; set; }
+
 #pragma warning disable CA1054 // Uri parameters should not be strings
 
         /// <summary>
@@ -151,12 +158,14 @@ namespace Microsoft.Azure.Devices
         /// <param name="excludeKeysInExport">Indicates if authorization keys are included in export output</param>
         /// <param name="outputBlobName">The name of the blob that will be created in the provided output blob container</param>
         /// <param name="storageAuthenticationType">Specifies authentication type being used for connecting to storage account</param>
+        /// <param name="identity">User assigned managed identity used to access storage account for import and export jobs.</param>
         /// <returns>An instance of JobProperties</returns>
         public static JobProperties CreateForExportJob(
             string outputBlobContainerUri,
             bool excludeKeysInExport,
             string outputBlobName = null,
-            StorageAuthenticationType? storageAuthenticationType = null)
+            StorageAuthenticationType? storageAuthenticationType = null,
+            ManagedIdentity identity = null)
         {
             return new JobProperties
             {
@@ -165,6 +174,7 @@ namespace Microsoft.Azure.Devices
                 ExcludeKeysInExport = excludeKeysInExport,
                 OutputBlobName = outputBlobName,
                 StorageAuthenticationType = storageAuthenticationType,
+                Identity = identity
             };
         }
 

--- a/iothub/service/src/ManagedIdentity.cs
+++ b/iothub/service/src/ManagedIdentity.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.Devices
+{
+    /// <summary>
+    /// The managed identity used to access the storage account for IoT hub import and export jobs.
+    /// TODO link from service team: For more information, see <see href=""/>
+    /// </summary>
+    public class ManagedIdentity
+    {
+        /// <summary>
+        /// The user identity resource Id used to access the storage account for import and export jobs.
+        /// </summary>
+        [JsonProperty(PropertyName = "userAssignedIdentity", NullValueHandling = NullValueHandling.Ignore)]
+        public string userAssignedIdentity { get; set; }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
This contains the implementation to support using configured user defined managed identity to perform import and export jobs. What this means is the hub itself will use the passed in managed identity (in JobProperties) to perform operations on the storage account used during import and export.

This feature is still under a ff and only works on a specific subscription. I've tested these changes against that and pushing the code to a feature branch. I have not turned on any gates for this branch as the feature is not yet available in canary. Once it is available, I will create the required assets and add the gating.

Details about where the feature is enabled and how to use it:
https://review.docs.microsoft.com/en-us/azure/iot-hub/iot-hub-managed-identity?branch=pr-en-us-154985

Use following subscriptions for creating the hub. 
	1.	DEVICEHUB_DEV1 [91d12660-3dec-467a-be2a-213b5544ddc0] 
	2.	IOT_PLATFORM_UPX_TEST --> portal team test sub

Use this link for your portal access https://ms.portal.azure.com/?feature.canmodifystamps=true&Microsoft_Azure_Iothub=tip1