### PR TITLE
Adding PayloadConvention to ClientOptions

### DIFF
--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerCustomSerializer.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerCustomSerializer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         public async Task PerformOperationsAsync(CancellationToken cancellationToken)
         {
             // Retrieve the device's properties.
-            ClientProperties properties = await _deviceClient.GetPropertiesAsync(s_systemTextJsonPayloadConvention, cancellationToken);
+            ClientProperties properties = await _deviceClient.GetPropertiesAsync(cancellationToken);
 
             // Verify if the device has previously reported a value for property "initialValue" under component "thermostat2".
             // If the expected value has not been previously reported then report it.
@@ -52,10 +52,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 || !((JsonElement)properties[Thermostat2])
                     .TryGetProperty("initialValue", out JsonElement initialValueReported)
                 || !initialValue
-                    .Equals(s_systemTextJsonPayloadConvention.PayloadSerializer
-                        .DeserializeToType<ThermostatInitialValue>(initialValueReported.GetRawText())))
+                    .Equals(_deviceClient.ObjectSerializer.DeserializeToType<ThermostatInitialValue>(initialValueReported.GetRawText())))
             {
-                var propertiesToBeUpdated = new ClientPropertyCollection(s_systemTextJsonPayloadConvention)
+                var propertiesToBeUpdated = new ClientPropertyCollection()
                 {
                     { "initialValue", initialValue, Thermostat2 }
                 };
@@ -72,7 +71,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             using var message = new TelemetryMessage(Thermostat1)
             {
                 MessageId = s_random.Next().ToString(),
-                Telemetry = new TelemetryCollection(s_systemTextJsonPayloadConvention)
+                Telemetry = new TelemetryCollection()
                 {
                     ["deviceHealth"] = deviceHealth
                 },
@@ -92,16 +91,17 @@ namespace Microsoft.Azure.Devices.Client.Samples
                     return;
                 }
 
-                HumidityRange targetHumidityRange = s_systemTextJsonPayloadConvention.PayloadSerializer.DeserializeToType<HumidityRange>(humidityRangeRequested.GetRawText());
+                HumidityRange targetHumidityRange = _deviceClient.ObjectSerializer.DeserializeToType<HumidityRange>(humidityRangeRequested.GetRawText());
+
                 _logger.LogDebug($"Property: Received - component=\"{Thermostat1}\", {{ \"{propertyName}\": {targetHumidityRange} }}.");
 
-                var temperatureUpdateResponse = new SystemTextJsonWritablePropertyResponse(
+                var temperatureUpdateResponse = _deviceClient.CreateWritablePropertyResponse(
                     targetHumidityRange,
                     (int)StatusCode.Completed,
                     writableProperties.Version,
                     "The operation completed successfully.");
 
-                var propertyPatch = new ClientPropertyCollection(s_systemTextJsonPayloadConvention)
+                var propertyPatch = new ClientPropertyCollection()
                 {
                     { propertyName, temperatureUpdateResponse, Thermostat1 }
                 };
@@ -110,7 +110,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 _logger.LogDebug($"Property: Update - \"{propertyPatch.GetSerailizedString()}\" is complete.");
             },
             null,
-            s_systemTextJsonPayloadConvention,
             cancellationToken);
 
             // Subscribe and respond to command "updateTemperatureWithDelay" under component "thermostat2".
@@ -133,7 +132,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                     _logger.LogDebug($"Command: component=\"{commandRequest.ComponentName}\", target temperature {updateTemperatureResponse.TargetTemperature}°C" +
                                 $" has {StatusCode.Completed}.");
 
-                    return new CommandResponse(updateTemperatureResponse, (int)StatusCode.Completed, s_systemTextJsonPayloadConvention);
+                    return new CommandResponse(updateTemperatureResponse, (int)StatusCode.Completed);
                 }
                 catch (JsonException ex)
                 {
@@ -142,7 +141,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 }
             },
             null,
-            s_systemTextJsonPayloadConvention,
             cancellationToken);
 
             Console.ReadKey();

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerCustomSerializer.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerCustomSerializer.cs
@@ -95,15 +95,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
                 _logger.LogDebug($"Property: Received - component=\"{Thermostat1}\", {{ \"{propertyName}\": {targetHumidityRange} }}.");
 
-                var temperatureUpdateResponse = _deviceClient.CreateWritablePropertyResponse(
-                    targetHumidityRange,
-                    (int)StatusCode.Completed,
-                    writableProperties.Version,
-                    "The operation completed successfully.");
-
                 var propertyPatch = new ClientPropertyCollection()
                 {
-                    { propertyName, temperatureUpdateResponse, Thermostat1 }
+                    { propertyName, targetHumidityRange, (int)StatusCode.Completed, writableProperties.Version, "The operation completed successfully.", Thermostat1 }
                 };
 
                 await _deviceClient.UpdatePropertiesAsync(propertyPatch, cancellationToken);

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerSampleNew.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerSampleNew.cs
@@ -97,7 +97,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
                 var propertyPatch = new ClientPropertyCollection
                 {
-                    { propertyName, "1", Thermostat1 },
                     { propertyName, targetHumidityRange, (int)StatusCode.Completed, writableProperties.Version, "The operation completed successfully.", Thermostat1 },
                 };
 

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerSampleNew.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerSampleNew.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         public async Task PerformOperationsAsync(CancellationToken cancellationToken)
         {
             // Retrieve the device's properties.
-            ClientProperties properties = await _deviceClient.GetPropertiesAsync(cancellationToken: cancellationToken);
+            ClientProperties properties = await _deviceClient.GetClientPropertiesAsync(cancellationToken: cancellationToken);
 
             // Verify if the device has previously reported a value for property
             // "initialValue" under component "thermostat2".
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 {
                     { "initialValue", initialValue, Thermostat2 }
                 };
-                await _deviceClient.UpdatePropertiesAsync(propertiesToBeUpdated, cancellationToken);
+                await _deviceClient.UpdateClientPropertiesAsync(propertiesToBeUpdated, cancellationToken);
                 _logger.LogDebug($"Property: Update - {propertiesToBeUpdated.GetSerailizedString()}.");
             }
 
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             _logger.LogDebug($"Telemetry: Sent - {message.Telemetry.GetSerailizedString()}.");
 
             // Subscribe and respond to event for writable property "humidityRange" under component "thermostat1".
-            await _deviceClient.SubscribeToWritablePropertyEventAsync(async (writableProperties, userContext) =>
+            await _deviceClient.SubscribeToWritablePropertiesEventAsync(async (writableProperties, userContext) =>
             {
                 string propertyName = "humidityRange";
                 if (!writableProperties.Contains(Thermostat1)
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                     { propertyName, targetHumidityRange, (int)StatusCode.Completed, writableProperties.Version, "The operation completed successfully.", Thermostat1 },
                 };
 
-                await _deviceClient.UpdatePropertiesAsync(propertyPatch, cancellationToken);
+                await _deviceClient.UpdateClientPropertiesAsync(propertyPatch, cancellationToken);
                 _logger.LogDebug($"Property: Update - \"{propertyPatch.GetSerailizedString()}\" is complete.");
             },
             null,

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerSampleNew.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerSampleNew.cs
@@ -95,15 +95,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 HumidityRange targetHumidityRange = humidityRangeRequested.ToObject<HumidityRange>();
                 _logger.LogDebug($"Property: Received - component=\"{Thermostat1}\", {{ \"{propertyName}\": {targetHumidityRange} }}.");
 
-                var temperatureUpdateResponse = _deviceClient.CreateWritablePropertyResponse(
-                    targetHumidityRange,
-                    (int)StatusCode.Completed,
-                    writableProperties.Version,
-                    "The operation completed successfully.");
-
                 var propertyPatch = new ClientPropertyCollection
                 {
-                    { propertyName, temperatureUpdateResponse, Thermostat1 }
+                    { propertyName, "1", Thermostat1 },
+                    { propertyName, targetHumidityRange, (int)StatusCode.Completed, writableProperties.Version, "The operation completed successfully.", Thermostat1 },
                 };
 
                 await _deviceClient.UpdatePropertiesAsync(propertyPatch, cancellationToken);

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerSampleNew.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerSampleNew.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 HumidityRange targetHumidityRange = humidityRangeRequested.ToObject<HumidityRange>();
                 _logger.LogDebug($"Property: Received - component=\"{Thermostat1}\", {{ \"{propertyName}\": {targetHumidityRange} }}.");
 
-                var temperatureUpdateResponse = new NewtonsoftJsonWritablePropertyResponse(
+                var temperatureUpdateResponse = _deviceClient.CreateWritablePropertyResponse(
                     targetHumidityRange,
                     (int)StatusCode.Completed,
                     writableProperties.Version,

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/Program.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/Program.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             var options = new ClientOptions
             {
                 ModelId = ModelId,
+                PayloadConvention = new SystemTextJsonPayloadConvention()
             };
 
             DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(deviceConnectionString, TransportType.Mqtt, options);

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/SimpleTemperatureControllerSampleNew.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/SimpleTemperatureControllerSampleNew.cs
@@ -72,15 +72,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
                 double targetHumidity = writableProperties.GetValue<double>(propertyName);
 
-                var humidityUpdateResponse = _deviceClient.CreateWritablePropertyResponse(
-                    targetHumidity,
-                    (int)StatusCode.Completed,
-                    writableProperties.Version,
-                    "The operation completed successfully.");
-
                 var propertyPatch = new ClientPropertyCollection
                 {
-                    [propertyName] = humidityUpdateResponse,
+                    { propertyName, targetHumidity, (int)StatusCode.Completed, writableProperties.Version, "The operation completed successfully." }
                 };
 
                 await _deviceClient.UpdatePropertiesAsync(propertyPatch, cancellationToken);

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/SimpleTemperatureControllerSampleNew.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/SimpleTemperatureControllerSampleNew.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         public async Task PerformOperationsAsync(CancellationToken cancellationToken)
         {
             // Retrieve the device's properties.
-            ClientProperties properties = await _deviceClient.GetPropertiesAsync(cancellationToken: cancellationToken);
+            ClientProperties properties = await _deviceClient.GetClientPropertiesAsync(cancellationToken: cancellationToken);
 
             // Verify if the device has previously reported a value for property "serialNumber".
             // If the expected value has not been previously reported then report it.
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 {
                     ["serialNumber"] = serialNumber
                 };
-                await _deviceClient.UpdatePropertiesAsync(propertiesToBeUpdated, cancellationToken);
+                await _deviceClient.UpdateClientPropertiesAsync(propertiesToBeUpdated, cancellationToken);
                 _logger.LogDebug($"Property: Update - {propertiesToBeUpdated.GetSerailizedString()} in KB.");
             }
 
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             _logger.LogDebug($"Telemetry: Sent - {message.Telemetry.GetSerailizedString()} in KB.");
 
             // Subscribe and respond to event for writable property "targetHumidity".
-            await _deviceClient.SubscribeToWritablePropertyEventAsync(async (writableProperties, userContext) =>
+            await _deviceClient.SubscribeToWritablePropertiesEventAsync(async (writableProperties, userContext) =>
             {
                 string propertyName = "targetHumidity";
                 if (!writableProperties.Contains(propertyName))
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                     { propertyName, targetHumidity, (int)StatusCode.Completed, writableProperties.Version, "The operation completed successfully." }
                 };
 
-                await _deviceClient.UpdatePropertiesAsync(propertyPatch, cancellationToken);
+                await _deviceClient.UpdateClientPropertiesAsync(propertyPatch, cancellationToken);
                 _logger.LogDebug($"Property: Update - \"{propertyPatch.GetSerailizedString()}\" is complete.");
             },
             null,

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/SimpleTemperatureControllerSampleNew.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/SimpleTemperatureControllerSampleNew.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
                 double targetHumidity = writableProperties.GetValue<double>(propertyName);
 
-                var humidityUpdateResponse = new NewtonsoftJsonWritablePropertyResponse(
+                var humidityUpdateResponse = _deviceClient.CreateWritablePropertyResponse(
                     targetHumidity,
                     (int)StatusCode.Completed,
                     writableProperties.Version,

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/SystemTextJsonPayloadConvention.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/SystemTextJsonPayloadConvention.cs
@@ -15,10 +15,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
             return PayloadEncoder.EncodeStringToByteArray(serializedString);
         }
 
-        /// <inheritdoc/>
-        public override IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = null)
-        {
-            return new SystemTextJsonWritablePropertyResponse(value, statusCode, version, description);
-        }
+       
     }
 }

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/SystemTextJsonPayloadConvention.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/SystemTextJsonPayloadConvention.cs
@@ -14,5 +14,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
             string serializedString = PayloadSerializer.SerializeToString(objectToSendWithConvention);
             return PayloadEncoder.EncodeStringToByteArray(serializedString);
         }
+
+        /// <inheritdoc/>
+        public override IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = null)
+        {
+            return new SystemTextJsonWritablePropertyResponse(value, statusCode, version, description);
+        }
     }
 }

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/SystemTextJsonSerializer.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/SystemTextJsonSerializer.cs
@@ -31,10 +31,5 @@ namespace Microsoft.Azure.Devices.Client.Samples
         {
             return DeserializeToType<T>(((JsonElement)objectToConvert).ToString());
         }
-
-        public override bool CheckWritablePropertyResponseType(object typeToCheck)
-        {
-            return typeToCheck is SystemTextJsonWritablePropertyResponse;
-        }
     }
 }

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/SystemTextJsonSerializer.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/SystemTextJsonSerializer.cs
@@ -31,5 +31,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
         {
             return DeserializeToType<T>(((JsonElement)objectToConvert).ToString());
         }
+
+        public override IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = null)
+        {
+            return new SystemTextJsonWritablePropertyResponse(value, statusCode, version, description);
+        }
     }
 }

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -386,15 +386,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
             TemperatureRange temperatureRangeDesired = writableProperties.GetValue<TemperatureRange>(propertyName);
 
-            var temperatureUpdateResponse = _deviceClient.CreateWritablePropertyResponse(
-                temperatureRangeDesired,
-                (int)StatusCode.Completed,
-                writableProperties.Version,
-                "The operation completed successfully.");
-
             var propertyPatch = new ClientPropertyCollection()
             {
-                [propertyName] = temperatureUpdateResponse,
+                { propertyName, temperatureRangeDesired, (int)StatusCode.Completed, writableProperties.Version, "The operation completed successfully."}
             };
 
             await _deviceClient.UpdatePropertiesAsync(propertyPatch, s_cancellationToken);
@@ -416,15 +410,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
             HumidityRange humidityRangeDesired = _deviceClient.ObjectSerializer.DeserializeToType<HumidityRange>(humidityRangeJson.GetRawText());
 
-            var humidityRangeResponse = _deviceClient.CreateWritablePropertyResponse(
-                humidityRangeDesired,
-                (int)StatusCode.Completed,
-                writableProperties.Version,
-                "The operation completed successfully.");
-
             var propertyPatch = new ClientPropertyCollection()
             {
-                [propertyName] = humidityRangeResponse,
+                { propertyName, humidityRangeDesired, (int)StatusCode.Completed, writableProperties.Version, "The operation completed successfully.", Thermostat1 }
             };
 
             await _deviceClient.UpdatePropertiesAsync(propertyPatch, s_cancellationToken);
@@ -450,13 +438,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
             double targetTemperature = targetTemperatureJson.GetDouble();
             _logger.LogDebug($"Property: Received - component=\"{componentName}\", {{ \"{propertyName}\": {targetTemperature}°C }}.");
 
-            var pendingReportedProperty = _deviceClient.CreateWritablePropertyResponse(
-                targetTemperature,
-                (int)StatusCode.InProgress,
-                writableProperties.Version);
-
             var pendingPropertyPatch = new ClientPropertyCollection();
-            pendingPropertyPatch.Add(propertyName, pendingReportedProperty, componentName);
+            pendingPropertyPatch.Add(propertyName, targetTemperature, (int)StatusCode.InProgress, writableProperties.Version, null, componentName);
 
             await _deviceClient.UpdatePropertiesAsync(pendingPropertyPatch, s_cancellationToken);
             _logger.LogDebug($"Property: Update - component=\"{componentName}\", {{\"{propertyName}\": {targetTemperature} }} in °C is {StatusCode.InProgress}.");
@@ -469,14 +452,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 await Task.Delay(6 * 1000);
             }
 
-            var completedReportedProperty = _deviceClient.CreateWritablePropertyResponse(
-                _temperature[componentName],
-                (int)StatusCode.Completed,
-                writableProperties.Version,
-                "Successfully updated target temperature");
-
             var completePropertyPatch = new ClientPropertyCollection();
-            completePropertyPatch.Add(propertyName, completedReportedProperty, componentName);
+            completePropertyPatch.Add(propertyName, _temperature[componentName], (int)StatusCode.Completed, writableProperties.Version, "Successfully updated target temperature", componentName);
 
             await _deviceClient.UpdatePropertiesAsync(completePropertyPatch, s_cancellationToken);
             _logger.LogDebug($"Property: Update - component=\"{componentName}\", {{\"{propertyName}\": {_temperature[componentName]} }} in °C is {StatusCode.Completed}");

--- a/iothub/device/src/ClientOptions.cs
+++ b/iothub/device/src/ClientOptions.cs
@@ -56,10 +56,13 @@ namespace Microsoft.Azure.Devices.Client
         public int SasTokenRenewalBuffer { get; set; }
 
         /// <summary>
-        /// The payload convention to be used to serialize and encode the messages for our convention based methods. The default value is set to <see cref="DefaultPayloadConvention.Instance"/>.
+        /// The payload convention to be used to serialize and encode the messages for our convention based methods. .
         /// </summary>
         /// <remarks>
         /// The <see cref="PayloadConvention"/> defines both the serializer and encoding to be used for our convetion based messages. You will only need to set this if you have objects that have special serialization rules or require a specific byte encoding.
+        /// <para>
+        /// The default value is set to <see cref="DefaultPayloadConvention"/> which uses the <see cref="NewtonsoftJsonObjectSerializer"/> serializer and <see cref="Utf8ContentEncoder"/> encoder.
+        /// </para>
         /// </remarks>
         public PayloadConvention PayloadConvention { get; set; } = DefaultPayloadConvention.Instance;
     }

--- a/iothub/device/src/ClientOptions.cs
+++ b/iothub/device/src/ClientOptions.cs
@@ -54,5 +54,13 @@ namespace Microsoft.Azure.Devices.Client
         /// or the <see cref="ModuleClient.CreateFromEnvironmentAsync(ClientOptions)"/> flow.
         /// </remarks>
         public int SasTokenRenewalBuffer { get; set; }
+
+        /// <summary>
+        /// The payload convention to be used to serialize and encode the messages for our convention based methods. The default value is set to <see cref="DefaultPayloadConvention.Instance"/>.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="PayloadConvention"/> defines both the serializer and encoding to be used for our convetion based messages. You will only need to set this if you have objects that have special serialization rules or require a specific byte encoding.
+        /// </remarks>
+        public PayloadConvention PayloadConvention { get; set; } = DefaultPayloadConvention.Instance;
     }
 }

--- a/iothub/device/src/ClientProperties.cs
+++ b/iothub/device/src/ClientProperties.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Devices.Client
     /// <summary>
     /// A container for properties.
     /// <remarks>
-    /// The Properties class is not meant to be constructed by customer code. It is intended to be returned fully popualated from the <see cref="DeviceClient.GetPropertiesAsync(System.Threading.CancellationToken)"/> method.
+    /// The Properties class is not meant to be constructed by customer code. It is intended to be returned fully popualated from the <see cref="DeviceClient.GetClientPropertiesAsync(System.Threading.CancellationToken)"/> method.
     /// </remarks>
     /// </summary>
     public class ClientProperties : IEnumerable<object>

--- a/iothub/device/src/ClientProperties.cs
+++ b/iothub/device/src/ClientProperties.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Devices.Client
     /// <summary>
     /// A container for properties.
     /// <remarks>
-    /// The Properties class is not meant to be constructed by customer code. It is intended to be returned fully popualated from the <see cref="DeviceClient.GetPropertiesAsync(PayloadConvention, System.Threading.CancellationToken)"/> method.
+    /// The Properties class is not meant to be constructed by customer code. It is intended to be returned fully popualated from the <see cref="DeviceClient.GetPropertiesAsync(System.Threading.CancellationToken)"/> method.
     /// </remarks>
     /// </summary>
     public class ClientProperties : IEnumerable<object>

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// If the collection has a key that matches the property name this method will throw an <see cref="ArgumentException"/>.
         /// <para>
-        /// When using this as part of the <see cref="DeviceClient.UpdatePropertiesAsync(ClientPropertyCollection, System.Threading.CancellationToken)"/> flow you to respond to a writable property update you should use <see cref="Add(string, object, int, long, string, string)"/> to ensure the correct formatting is applied when the object is serialized.
+        /// When using this as part of the <see cref="DeviceClient.UpdateClientPropertiesAsync(ClientPropertyCollection, System.Threading.CancellationToken)"/> flow you to respond to a writable property update you should use <see cref="Add(string, object, int, long, string, string)"/> to ensure the correct formatting is applied when the object is serialized.
         /// </para>
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// If the collection has a key that matches this will overwrite the current value. Otherwise it will attempt to add this to the collection.
         /// <para>
-        /// When using this as part of the <see cref="DeviceClient.UpdatePropertiesAsync(ClientPropertyCollection, System.Threading.CancellationToken)"/> flow you to respond to a writable property update you should use <see cref="AddOrUpdate(string, object, int, long, string, string)"/> to ensure the correct formatting is applied when the object is serialized.
+        /// When using this as part of the <see cref="DeviceClient.UpdateClientPropertiesAsync(ClientPropertyCollection, System.Threading.CancellationToken)"/> flow you to respond to a writable property update you should use <see cref="AddOrUpdate(string, object, int, long, string, string)"/> to ensure the correct formatting is applied when the object is serialized.
         /// </para>
         /// </remarks>
         /// <param name="properties">A collection of properties to add or update.</param>

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -27,11 +27,16 @@ namespace Microsoft.Azure.Devices.Client
         {
         }
 
+        /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <summary>
         /// Adds the value for the collection.
         /// </summary>
-        /// <inheritdoc path="/remarks" cref="Add(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
+        /// <remarks>
+        /// If the collection has a key that matches the property name this method will throw an <see cref="ArgumentException"/>.
+        /// <para>
+        /// When using this as part of the <see cref="DeviceClient.UpdatePropertiesAsync(ClientPropertyCollection, System.Threading.CancellationToken)"/> flow you to respond to a writable property update you should use <see cref="Add(string, object, int, long, string, string)"/> to ensure the correct formatting is applied when the object is serialized.
+        /// </para>
+        /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
         /// <param name="propertyName">The name of the property to add.</param>
         /// <param name="propertyValue">The value of the property to add.</param>
@@ -40,20 +45,20 @@ namespace Microsoft.Azure.Devices.Client
             Add(propertyName, propertyValue, null);
         }
 
+        /// <inheritdoc path="/remarks" cref="Add(string, object)" />
+        /// <inheritdoc path="/seealso" cref="Add(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <summary>
         /// Adds the value for the collection.
         /// </summary>
-        /// <inheritdoc path="/remarks" cref="Add(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/seealso" cref="Add(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
         /// <param name="propertyName">The name of the property to add.</param>
         /// <param name="propertyValue">The value of the property to add.</param>
         /// <param name="componentName">The component with the property to add.</param>
-        public void Add(string propertyName, object propertyValue, string componentName)
+        public void Add(string propertyName, object propertyValue, string componentName = default)
             => Add(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName, false);
 
-        /// <inheritdoc path="/remarks" cref="Add(IDictionary{string, object}, string, bool)"/>
+        /// <inheritdoc path="/remarks" cref="Add(string, object)" />
         /// <inheritdoc path="/seealso" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <summary>
@@ -64,8 +69,28 @@ namespace Microsoft.Azure.Devices.Client
         public void Add(IDictionary<string, object> properties, string componentName = default)
         => Add(properties, componentName, false);
 
+        /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/seealso" cref="Add(IDictionary{string, object}, string, bool)" />
+        /// <summary>
+        /// Adds a type of <see cref="IWritablePropertyResponse"/> to the collection.
+        /// </summary>
+        /// <remarks>
+        /// This method will use the <see cref="ObjectSerializer.CreateWritablePropertyResponse(object, int, long, string)"/> method to create an instance of <see cref="IWritablePropertyResponse"/> that will be properly serialized.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
+        /// <param name="propertyName">The name of the property to add or update.</param>
+        /// <param name="propertyValue">The value of the property to add or update.</param>
+        /// <param name="statusCode"></param>
+        /// <param name="version"></param>
+        /// <param name="description"></param>
+        /// <param name="componentName"></param>
+        public void Add(string propertyName, object propertyValue, int statusCode, long version, string description = default, string componentName = default)
+        {
+            Add(propertyName, Convention.PayloadSerializer.CreateWritablePropertyResponse(propertyValue, statusCode, version, description), componentName);
+        }
+
         /// <inheritdoc path="/summary" cref="Add(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/remarks" cref="Add(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/remarks" cref="AddOrUpdate(IDictionary{string, object}, string)" />
         /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/seealso" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
@@ -77,7 +102,7 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <inheritdoc path="/summary" cref="Add(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/remarks" cref="Add(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/remarks" cref="AddOrUpdate(IDictionary{string, object}, string)" />
         /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/seealso" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
@@ -88,20 +113,40 @@ namespace Microsoft.Azure.Devices.Client
             => Add(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName, true);
 
         /// <inheritdoc path="/summary" cref="Add(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/remarks" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/seealso" cref="Add(IDictionary{string, object}, string, bool)" />
+        /// <remarks>
+        /// If the collection has a key that matches this will overwrite the current value. Otherwise it will attempt to add this to the collection.
+        /// <para>
+        /// When using this as part of the <see cref="DeviceClient.UpdatePropertiesAsync(ClientPropertyCollection, System.Threading.CancellationToken)"/> flow you to respond to a writable property update you should use <see cref="AddOrUpdate(string, object, int, long, string, string)"/> to ensure the correct formatting is applied when the object is serialized.
+        /// </para>
+        /// </remarks>
         /// <param name="properties">A collection of properties to add or update.</param>
         /// <param name="componentName">The component with the properties to add or update.</param>
         public void AddOrUpdate(IDictionary<string, object> properties, string componentName = default)
             => Add(properties, componentName, true);
 
+        /// <inheritdoc path="/remarks" cref="Add(string, object, int, long, string, string)"/>
+        /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/seealso" cref="Add(IDictionary{string, object}, string, bool)" />
+        /// <summary>
+        /// Adds or updates a type of <see cref="IWritablePropertyResponse"/> to the collection.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
+        /// <param name="propertyName">The name of the writable property to add or update.</param>
+        /// <param name="propertyValue">The value of the writable property to add or update.</param>
+        /// <param name="statusCode"></param>
+        /// <param name="version"></param>
+        /// <param name="description"></param>
+        /// <param name="componentName"></param>
+        public void AddOrUpdate(string propertyName, object propertyValue, int statusCode, long version, string description = default, string componentName = default)
+        {
+            AddOrUpdate(propertyName, Convention.PayloadSerializer.CreateWritablePropertyResponse(propertyValue, statusCode, version, description), componentName);
+        }
+
         /// <summary>
         /// Adds or updates the value for the collection.
         /// </summary>
-        /// <remarks>
-        /// When using this as part of the <see cref="DeviceClient.SubscribeToWritablePropertyEventAsync(Func{ClientPropertyCollection, object, System.Threading.Tasks.Task}, object, System.Threading.CancellationToken)"/> flow. You should use the <see cref="PayloadConvention.CreateWritablePropertyResponse(object, int, long, string)"/> method to add the correct <see cref="IWritablePropertyResponse"/> to ensure the correct formatting is applied when the object is serialized.
-        /// </remarks>
         /// <seealso cref="PayloadConvention"/>
         /// <seealso cref="ObjectSerializer"/>
         /// <seealso cref="ContentEncoder"/>

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -16,8 +16,13 @@ namespace Microsoft.Azure.Devices.Client
     {
         private const string VersionName = "$version";
 
+        /// <summary>
+        /// Default constructor for this class.
+        /// </summary>
+        public ClientPropertyCollection() { }
+
         /// <inheritdoc/>
-        public ClientPropertyCollection(PayloadConvention payloadConvention = default)
+        internal ClientPropertyCollection(PayloadConvention payloadConvention)
             : base(payloadConvention)
         {
         }
@@ -39,6 +44,7 @@ namespace Microsoft.Azure.Devices.Client
         /// Adds the value for the collection.
         /// </summary>
         /// <inheritdoc path="/remarks" cref="Add(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/seealso" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
         /// <param name="propertyName">The name of the property to add.</param>
@@ -48,6 +54,7 @@ namespace Microsoft.Azure.Devices.Client
             => Add(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName, false);
 
         /// <inheritdoc path="/remarks" cref="Add(IDictionary{string, object}, string, bool)"/>
+        /// <inheritdoc path="/seealso" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <summary>
         /// Adds the value for the collection.
@@ -60,6 +67,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <inheritdoc path="/summary" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/remarks" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/seealso" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
         /// <param name="propertyName">The name of the property to add or update.</param>
         /// <param name="propertyValue">The value of the property to add or update.</param>
@@ -71,6 +79,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <inheritdoc path="/summary" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/remarks" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/seealso" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
         /// <param name="propertyName">The name of the property to add or update.</param>
         /// <param name="propertyValue">The value of the property to add or update.</param>
@@ -81,6 +90,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <inheritdoc path="/summary" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/remarks" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/exception['ArgumentException']" cref="Add(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/seealso" cref="Add(IDictionary{string, object}, string, bool)" />
         /// <param name="properties">A collection of properties to add or update.</param>
         /// <param name="componentName">The component with the properties to add or update.</param>
         public void AddOrUpdate(IDictionary<string, object> properties, string componentName = default)
@@ -90,12 +100,11 @@ namespace Microsoft.Azure.Devices.Client
         /// Adds or updates the value for the collection.
         /// </summary>
         /// <remarks>
-        /// When adding a type of <see cref="IWritablePropertyResponse"/> the <see cref="ObjectSerializer.CheckWritablePropertyResponseType(object)"/>
-        /// checks to make sure it can serialize this type correctly.
-        /// This will only be evaluated at runtime so it will throw an exception if the type does not pass the check.
+        /// When using this as part of the <see cref="DeviceClient.SubscribeToWritablePropertyEventAsync(Func{ClientPropertyCollection, object, System.Threading.Tasks.Task}, object, System.Threading.CancellationToken)"/> flow. You should use the <see cref="PayloadConvention.CreateWritablePropertyResponse(object, int, long, string)"/> method to add the correct <see cref="IWritablePropertyResponse"/> to ensure the correct formatting is applied when the object is serialized.
         /// </remarks>
-        /// <exception cref="ArgumentException">This is thrown when the object is of <see cref="IWritablePropertyResponse"/>
-        /// and does not pass the check from <see cref="ObjectSerializer.CheckWritablePropertyResponseType(object)"/> method.</exception>
+        /// <seealso cref="PayloadConvention"/>
+        /// <seealso cref="ObjectSerializer"/>
+        /// <seealso cref="ContentEncoder"/>
         /// <param name="properties">A collection of properties to add or update.</param>
         /// <param name="componentName">The component with the properties to add or update.</param>
         /// <param name="forceUpdate">Forces the collection to use the Add or Update behavior. Setting to true will simply overwrite the value; setting to false will use <see cref="IDictionary{TKey, TValue}.Add(TKey, TValue)"/></param>
@@ -112,11 +121,6 @@ namespace Microsoft.Azure.Devices.Client
             {
                 foreach (KeyValuePair<string, object> entry in properties)
                 {
-                    if (entry.Value is IWritablePropertyResponse && !Convention.PayloadSerializer.CheckWritablePropertyResponseType(entry.Value))
-                    {
-                        throw new ArgumentException("Please use the proper class implemented from IWritablePropertyResponse to match your payload convention.");
-                    }
-
                     if (forceUpdate)
                     {
                         Collection[entry.Key] = entry.Value;
@@ -139,11 +143,6 @@ namespace Microsoft.Azure.Devices.Client
                 }
                 foreach (KeyValuePair<string, object> entry in properties)
                 {
-                    if (entry.Value is IWritablePropertyResponse && !Convention.PayloadSerializer.CheckWritablePropertyResponseType(entry.Value))
-                    {
-                        throw new ArgumentException("Please use the proper class implemented from IWritablePropertyResponse to match your payload convention.");
-                    }
-
                     if (forceUpdate)
                     {
                         componentProperties[entry.Key] = entry.Value;

--- a/iothub/device/src/CommandRequest.cs
+++ b/iothub/device/src/CommandRequest.cs
@@ -13,12 +13,12 @@ namespace Microsoft.Azure.Devices.Client
         private readonly byte[] _data;
         private readonly PayloadConvention _payloadConvention;
 
-        internal CommandRequest(string commandName, string componentName = default, byte[] data = default, PayloadConvention payloadConvention = default)
+        internal CommandRequest(string commandName, PayloadConvention payloadConvention, string componentName = default, byte[] data = default)
         {
             Name = commandName;
             ComponentName = componentName;
             _data = data;
-            _payloadConvention = payloadConvention ?? DefaultPayloadConvention.Instance;
+            _payloadConvention = payloadConvention;
         }
 
         /// <summary>

--- a/iothub/device/src/CommandRequest.cs
+++ b/iothub/device/src/CommandRequest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices.Client
         private readonly byte[] _data;
         private readonly PayloadConvention _payloadConvention;
 
-        internal CommandRequest(string commandName, PayloadConvention payloadConvention, string componentName = default, byte[] data = default)
+        internal CommandRequest(PayloadConvention payloadConvention, string commandName, string componentName = default, byte[] data = default)
         {
             Name = commandName;
             ComponentName = componentName;

--- a/iothub/device/src/CommandResponse.cs
+++ b/iothub/device/src/CommandResponse.cs
@@ -11,20 +11,18 @@ namespace Microsoft.Azure.Devices.Client
     public sealed class CommandResponse
     {
         private readonly object _result;
-        private readonly PayloadConvention _payloadConvention;
+        internal PayloadConvention PayloadConvention { get; set; }
 
         /// <summary>
         /// Make a new instance of the return class and validates that the payload is correct JSON.
         /// </summary>
         /// <param name="result">data returned by the method call.</param>
         /// <param name="status">status indicating success or failure.</param>
-        /// <param name="payloadConvention"></param>
         /// <returns></returns>
-        public CommandResponse(object result, int status, PayloadConvention payloadConvention = default)
+        public CommandResponse(object result, int status)
         {
             _result = result;
             Status = status;
-            _payloadConvention = payloadConvention ?? DefaultPayloadConvention.Instance;
         }
 
         /// <summary>
@@ -47,7 +45,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Property containing the entire result data, in Json format.
         /// </summary>
-        public string ResultAsJson => _result == null ? null : _payloadConvention.PayloadSerializer.SerializeToString(_result);
+        public string ResultAsJson => _result == null ? null : PayloadConvention.PayloadSerializer.SerializeToString(_result);
 
         internal byte[] ResultAsBytes => _result == null ? null : Encoding.UTF8.GetBytes(ResultAsJson);
     }

--- a/iothub/device/src/DefaultPayloadConvention.cs
+++ b/iothub/device/src/DefaultPayloadConvention.cs
@@ -22,10 +22,6 @@ namespace Microsoft.Azure.Devices.Client
         /// <inheritdoc/>
         public override ContentEncoder PayloadEncoder { get; } = Utf8ContentEncoder.Instance;
 
-        /// <inheritdoc/>
-        public override IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = null)
-        {
-            return new NewtonsoftJsonWritablePropertyResponse(value, statusCode, version, description);
-        }
+       
     }
 }

--- a/iothub/device/src/DefaultPayloadConvention.cs
+++ b/iothub/device/src/DefaultPayloadConvention.cs
@@ -21,5 +21,11 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <inheritdoc/>
         public override ContentEncoder PayloadEncoder { get; } = Utf8ContentEncoder.Instance;
+
+        /// <inheritdoc/>
+        public override IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = null)
+        {
+            return new NewtonsoftJsonWritablePropertyResponse(value, statusCode, version, description);
+        }
     }
 }

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Azure.Devices.Client
         public const uint DefaultOperationTimeoutInMilliseconds = 4 * 60 * 1000;
 
         /// <summary>
-        /// The object serializer used by the <see cref="PayloadConvention"/> set in <see cref="ClientOptions.PayloadConvention"/>. If no <see cref="PayloadConvention"/> is set this will default to <see cref="NewtonsoftJsonObjectSerializer"/>.
+        /// The object serializer used by the <see cref="Client.PayloadConvention"/> set in <see cref="ClientOptions.PayloadConvention"/>. If no <see cref="Client.PayloadConvention"/> is set this will default to <see cref="NewtonsoftJsonObjectSerializer"/>.
         /// </summary>
-        public ObjectSerializer ObjectSerializer => InternalClient.ObjectSerializer;
+        public PayloadConvention PayloadConvention => InternalClient.PayloadConvention;
 
         private DeviceClient(InternalClient internalClient)
         {
@@ -714,16 +714,16 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <returns>The device properties.</returns>
-        public Task<ClientProperties> GetPropertiesAsync(CancellationToken cancellationToken = default)
-            => InternalClient.GetPropertiesAsync(cancellationToken);
+        public Task<ClientProperties> GetClientPropertiesAsync(CancellationToken cancellationToken = default)
+            => InternalClient.GetClientPropertiesAsync(cancellationToken);
 
         /// <summary>
         /// Update properties.
         /// </summary>
         /// <param name="propertyCollection">Reported properties to push.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        public Task UpdatePropertiesAsync(ClientPropertyCollection propertyCollection, CancellationToken cancellationToken = default)
-            => InternalClient.UpdatePropertiesAsync(propertyCollection, cancellationToken);
+        public Task UpdateClientPropertiesAsync(ClientPropertyCollection propertyCollection, CancellationToken cancellationToken = default)
+            => InternalClient.UpdateClientPropertiesAsync(propertyCollection, cancellationToken);
 
         /// <summary>
         /// Sets the global listener for Writable properties
@@ -731,8 +731,8 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="callback">The global call back to handle all writable property updates.</param>
         /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        public Task SubscribeToWritablePropertyEventAsync(Func<ClientPropertyCollection, object, Task> callback, object userContext, CancellationToken cancellationToken = default)
-            => InternalClient.SubscribeToWritablePropertyEventAsync(callback, userContext, cancellationToken);
+        public Task SubscribeToWritablePropertiesEventAsync(Func<ClientPropertyCollection, object, Task> callback, object userContext, CancellationToken cancellationToken = default)
+            => InternalClient.SubscribeToWritablePropertiesEventAsync(callback, userContext, cancellationToken);
 
         #endregion Properties
 

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -710,17 +710,6 @@ namespace Microsoft.Azure.Devices.Client
         #region Properties
 
         /// <summary>
-        /// Creates the correct <see cref="IWritablePropertyResponse"/> to be used with the <see cref="ClientPropertyCollection"/>
-        /// </summary>
-        /// <param name="value">The value of the property.</param>
-        /// <param name="statusCode">The status code of the write operation.</param>
-        /// <param name="version">The version the property is responding to.</param>
-        /// <param name="description">An optional description of the writable property response.</param>
-        /// <returns></returns>
-        public IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = default)
-            => InternalClient.CreateWritablePropertyResponse(value, statusCode, version, description);
-
-        /// <summary>
         /// Retrieve the device properties.
         /// </summary>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         public const uint DefaultOperationTimeoutInMilliseconds = 4 * 60 * 1000;
 
+        /// <summary>
+        /// The object serializer used by the <see cref="PayloadConvention"/> set in <see cref="ClientOptions.PayloadConvention"/>. If no <see cref="PayloadConvention"/> is set this will default to <see cref="NewtonsoftJsonObjectSerializer"/>.
+        /// </summary>
+        public ObjectSerializer ObjectSerializer => InternalClient.ObjectSerializer;
+
         private DeviceClient(InternalClient internalClient)
         {
             InternalClient = internalClient ?? throw new ArgumentNullException(nameof(internalClient));
@@ -705,13 +710,23 @@ namespace Microsoft.Azure.Devices.Client
         #region Properties
 
         /// <summary>
+        /// Creates the correct <see cref="IWritablePropertyResponse"/> to be used with the <see cref="ClientPropertyCollection"/>
+        /// </summary>
+        /// <param name="value">The value of the property.</param>
+        /// <param name="statusCode">The status code of the write operation.</param>
+        /// <param name="version">The version the property is responding to.</param>
+        /// <param name="description">An optional description of the writable property response.</param>
+        /// <returns></returns>
+        public IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = default)
+            => InternalClient.CreateWritablePropertyResponse(value, statusCode, version, description);
+
+        /// <summary>
         /// Retrieve the device properties.
         /// </summary>
-        /// <param name="payloadConvention">A convention handler that defines the content encoding and serializer to use for commands.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <returns>The device properties.</returns>
-        public Task<ClientProperties> GetPropertiesAsync(PayloadConvention payloadConvention = default, CancellationToken cancellationToken = default)
-            => InternalClient.GetPropertiesAsync(payloadConvention, cancellationToken);
+        public Task<ClientProperties> GetPropertiesAsync(CancellationToken cancellationToken = default)
+            => InternalClient.GetPropertiesAsync(cancellationToken);
 
         /// <summary>
         /// Update properties.
@@ -726,10 +741,9 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="callback">The global call back to handle all writable property updates.</param>
         /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
-        /// <param name="payloadConvention">A convention handler that defines the content encoding and serializer to use for commands.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        public Task SubscribeToWritablePropertyEventAsync(Func<ClientPropertyCollection, object, Task> callback, object userContext, PayloadConvention payloadConvention = default, CancellationToken cancellationToken = default)
-            => InternalClient.SubscribeToWritablePropertyEventAsync(callback, userContext, payloadConvention, cancellationToken);
+        public Task SubscribeToWritablePropertyEventAsync(Func<ClientPropertyCollection, object, Task> callback, object userContext, CancellationToken cancellationToken = default)
+            => InternalClient.SubscribeToWritablePropertyEventAsync(callback, userContext, cancellationToken);
 
         #endregion Properties
 
@@ -757,13 +771,11 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="callback">A method implementation that will handle the incoming command.</param>
         /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
-        /// <param name="payloadConvention">A convention handler that defines the content encoding and serializer to use for commands.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         public Task SubscribeToCommandsAsync(
             Func<CommandRequest, object, Task<CommandResponse>> callback, object userContext,
-            PayloadConvention payloadConvention = default,
             CancellationToken cancellationToken = default)
-            => InternalClient.SubscribeToCommandsAsync(callback, userContext, payloadConvention, cancellationToken);
+            => InternalClient.SubscribeToCommandsAsync(callback, userContext, cancellationToken);
 
         #endregion Commands
 

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -149,8 +149,7 @@ namespace Microsoft.Azure.Devices.Client
 
         internal delegate Task OnModuleEventMessageReceivedDelegate(string input, Message message);
 
-        internal ObjectSerializer ObjectSerializer => _clientOptions.PayloadConvention.PayloadSerializer;
-
+        internal PayloadConvention PayloadConvention => _clientOptions.PayloadConvention;
 
         public InternalClient(IotHubConnectionString iotHubConnectionString, ITransportSettings[] transportSettings, IDeviceClientPipelineBuilder pipelineBuilder, ClientOptions options)
         {
@@ -1890,7 +1889,7 @@ namespace Microsoft.Azure.Devices.Client
 
         #region Convention driven operations
 
-        internal Task<ClientProperties> GetPropertiesAsync(CancellationToken cancellationToken)
+        internal Task<ClientProperties> GetClientPropertiesAsync(CancellationToken cancellationToken)
         {
             var payloadConvention = _clientOptions.PayloadConvention;
 
@@ -1905,7 +1904,7 @@ namespace Microsoft.Azure.Devices.Client
             }
         }
 
-        internal Task UpdatePropertiesAsync(ClientPropertyCollection clientProperties, CancellationToken cancellationToken)
+        internal Task UpdateClientPropertiesAsync(ClientPropertyCollection clientProperties, CancellationToken cancellationToken)
         {
             try
             {
@@ -1918,7 +1917,7 @@ namespace Microsoft.Azure.Devices.Client
             }
         }
 
-        internal Task SubscribeToWritablePropertyEventAsync(Func<ClientPropertyCollection, object, Task> callback, object userContext, CancellationToken cancellationToken)
+        internal Task SubscribeToWritablePropertiesEventAsync(Func<ClientPropertyCollection, object, Task> callback, object userContext, CancellationToken cancellationToken)
         {
             var payloadConvention = _clientOptions.PayloadConvention;
 

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1890,19 +1890,6 @@ namespace Microsoft.Azure.Devices.Client
 
         #region Convention driven operations
 
-        /// <summary>
-        /// Creates the correct <see cref="IWritablePropertyResponse"/> to be used with this serializer
-        /// </summary>
-        /// <param name="value">The value of the property.</param>
-        /// <param name="statusCode">The status code of the write operation.</param>
-        /// <param name="version">The version the property is responding to.</param>
-        /// <param name="description">An optional description of the writable property response.</param>
-        /// <returns></returns>
-        internal IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = default)
-        {
-            return _clientOptions.PayloadConvention.CreateWritablePropertyResponse(value, statusCode, version, description);
-        }
-
         internal Task<ClientProperties> GetPropertiesAsync(CancellationToken cancellationToken)
         {
             var payloadConvention = _clientOptions.PayloadConvention;
@@ -1963,11 +1950,11 @@ namespace Microsoft.Azure.Devices.Client
                     string[] split = methodRequest.Name.Split(ComponentLevelCommandIdentifier);
                     string componentName = split[0];
                     string commandName = split[1];
-                    commandRequest = new CommandRequest(commandName, payloadConvention, componentName, methodRequest.Data);
+                    commandRequest = new CommandRequest(payloadConvention, commandName, componentName, methodRequest.Data);
                 }
                 else
                 {
-                    commandRequest = new CommandRequest(methodRequest.Name, payloadConvention: payloadConvention, data: methodRequest.Data);
+                    commandRequest = new CommandRequest(payloadConvention: payloadConvention, commandName: methodRequest.Name, data: methodRequest.Data);
                 }
 
                 CommandResponse commandResponse = await callback.Invoke(commandRequest, userContext).ConfigureAwait(false);

--- a/iothub/device/src/NewtonsoftJsonObjectSerializer.cs
+++ b/iothub/device/src/NewtonsoftJsonObjectSerializer.cs
@@ -45,5 +45,11 @@ namespace Microsoft.Azure.Devices.Client
             }
             return ((JObject)objectToConvert).ToObject<T>();
         }
+
+        /// <inheritdoc/>
+        public override IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = null)
+        {
+            return new NewtonsoftJsonWritablePropertyResponse(value, statusCode, version, description);
+        }
     }
 }

--- a/iothub/device/src/NewtonsoftJsonObjectSerializer.cs
+++ b/iothub/device/src/NewtonsoftJsonObjectSerializer.cs
@@ -45,11 +45,5 @@ namespace Microsoft.Azure.Devices.Client
             }
             return ((JObject)objectToConvert).ToObject<T>();
         }
-
-        /// <inheritdoc/>
-        public override bool CheckWritablePropertyResponseType(object typeToCheck)
-        {
-            return typeToCheck is NewtonsoftJsonWritablePropertyResponse;
-        }
     }
 }

--- a/iothub/device/src/ObjectSerializer.cs
+++ b/iothub/device/src/ObjectSerializer.cs
@@ -44,5 +44,15 @@ namespace Microsoft.Azure.Devices.Client
         /// <returns>A converted object</returns>
         /// <remarks>This class is used by the <see cref="ClientPropertyCollection"/> to attempt to convert from the native serailizer type (for example, JObject or JsonElement) to the desired type. When you implement this you need to be aware of what type your serializer will use for anonymous types.</remarks>
         public abstract T ConvertFromObject<T>(object objectToConvert);
+
+        /// <summary>
+        /// Creates the correct <see cref="IWritablePropertyResponse"/> to be used with this serializer
+        /// </summary>
+        /// <param name="value">The value of the property.</param>
+        /// <param name="statusCode">The status code of the write operation.</param>
+        /// <param name="version">The version the property is responding to.</param>
+        /// <param name="description">An optional description of the writable property response.</param>
+        /// <returns></returns>
+        public abstract IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = default);
     }
 }

--- a/iothub/device/src/ObjectSerializer.cs
+++ b/iothub/device/src/ObjectSerializer.cs
@@ -44,12 +44,5 @@ namespace Microsoft.Azure.Devices.Client
         /// <returns>A converted object</returns>
         /// <remarks>This class is used by the <see cref="ClientPropertyCollection"/> to attempt to convert from the native serailizer type (for example, JObject or JsonElement) to the desired type. When you implement this you need to be aware of what type your serializer will use for anonymous types.</remarks>
         public abstract T ConvertFromObject<T>(object objectToConvert);
-
-        /// <summary>
-        /// Checks to make sure the type of <see cref="IWritablePropertyResponse"/> can be properly serialized by this class.
-        /// </summary>
-        /// <param name="typeToCheck"></param>
-        /// <returns><c>true</c> if the type is supported; <c>false</c> if it is not</returns>
-        public abstract bool CheckWritablePropertyResponseType(object typeToCheck);
     }
 }

--- a/iothub/device/src/PayloadConvention.cs
+++ b/iothub/device/src/PayloadConvention.cs
@@ -32,15 +32,5 @@ namespace Microsoft.Azure.Devices.Client
             string serializedString = PayloadSerializer.SerializeToString(objectToSendWithConvention);
             return PayloadEncoder.EncodeStringToByteArray(serializedString);
         }
-
-        /// <summary>
-        /// Creates the correct <see cref="IWritablePropertyResponse"/> to be used with this serializer
-        /// </summary>
-        /// <param name="value">The value of the property.</param>
-        /// <param name="statusCode">The status code of the write operation.</param>
-        /// <param name="version">The version the property is responding to.</param>
-        /// <param name="description">An optional description of the writable property response.</param>
-        /// <returns></returns>
-        public abstract IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = default);
     }
 }

--- a/iothub/device/src/PayloadConvention.cs
+++ b/iothub/device/src/PayloadConvention.cs
@@ -32,5 +32,15 @@ namespace Microsoft.Azure.Devices.Client
             string serializedString = PayloadSerializer.SerializeToString(objectToSendWithConvention);
             return PayloadEncoder.EncodeStringToByteArray(serializedString);
         }
+
+        /// <summary>
+        /// Creates the correct <see cref="IWritablePropertyResponse"/> to be used with this serializer
+        /// </summary>
+        /// <param name="value">The value of the property.</param>
+        /// <param name="statusCode">The status code of the write operation.</param>
+        /// <param name="version">The version the property is responding to.</param>
+        /// <param name="description">An optional description of the writable property response.</param>
+        /// <returns></returns>
+        public abstract IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = default);
     }
 }

--- a/iothub/device/src/TelemetryCollection.cs
+++ b/iothub/device/src/TelemetryCollection.cs
@@ -10,8 +10,12 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     public class TelemetryCollection : PayloadCollection
     {
+        /// <summary>
+        /// Default constructor for this class.
+        /// </summary>
+        public TelemetryCollection() { }
         /// <inheritdoc/>
-        public TelemetryCollection(PayloadConvention payloadConvention = default)
+        internal TelemetryCollection(PayloadConvention payloadConvention = default)
             : base(payloadConvention)
         {
         }


### PR DESCRIPTION
Adds the PayloadConvention to ClientOptions to simplify the command usage around the samples.
