### PR TITLE
fix(service): avoid possible NRE when accessing Twin.ParentScopes

### DIFF
--- a/iothub/service/tests/RegistryManagerTests.cs
+++ b/iothub/service/tests/RegistryManagerTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Devices.Api.Test
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
+    using FluentAssertions;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -888,6 +889,14 @@ namespace Microsoft.Azure.Devices.Api.Test
             var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);
             await registryManager.CloseAsync().ConfigureAwait(false);
             restOpMock.Verify(restOp => restOp.Dispose(), Times.Never());
+        }
+
+        [TestMethod]
+        public void Twin_ParentScopes_NotNull()
+        {
+            var twin = new Twin();
+            twin.ParentScopes.Should().NotBeNull("To prevent NREs because a property was unexecptedly null, it should have a default list instance assigned.");
+            twin.ParentScopes.Should().BeEmpty("The default list instance should be empty.");
         }
     }
 }

--- a/shared/src/Twin.cs
+++ b/shared/src/Twin.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// The scopes of the upper level edge devices if applicable. Only available for edge devices.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public virtual IReadOnlyList<string> ParentScopes { get; internal set; }
+        public virtual IReadOnlyList<string> ParentScopes { get; internal set; } = new List<string>();
 
         /// <summary>
         /// Gets the Twin as a JSON string


### PR DESCRIPTION
I found, when updating a sample for the ParentScopes feature, that it doesn't have a default instance, which can cause an NRE if someone doesn't check for null.