### PR TITLE
Fix potential security issue

### DIFF
--- a/iothub/device/src/Common/Security/SharedAccessSignature.cs
+++ b/iothub/device/src/Common/Security/SharedAccessSignature.cs
@@ -117,7 +117,11 @@ namespace Microsoft.Azure.Devices.Client
             if (sasAuthorizationRule.PrimaryKey != null)
             {
                 string primareyKeyComputedSignature = ComputeSignature(Convert.FromBase64String(sasAuthorizationRule.PrimaryKey));
+#if NETSTANDARD2_1
+                if (CryptographicOperations.FixedTimeEquals(Encoding.ASCII.GetBytes(Signature), Encoding.ASCII.GetBytes(primareyKeyComputedSignature)))
+#else
                 if (FixedTimeEquals(Signature, primareyKeyComputedSignature))
+#endif
                 {
                     return;
                 }
@@ -126,7 +130,11 @@ namespace Microsoft.Azure.Devices.Client
             if (sasAuthorizationRule.SecondaryKey != null)
             {
                 string secondaryKeyComputedSignature = ComputeSignature(Convert.FromBase64String(sasAuthorizationRule.SecondaryKey));
+#if NETSTANDARD2_1
+                if (CryptographicOperations.FixedTimeEquals(Encoding.ASCII.GetBytes(Signature), Encoding.ASCII.GetBytes(secondaryKeyComputedSignature)))
+#else
                 if (FixedTimeEquals(Signature, secondaryKeyComputedSignature))
+#endif
                 {
                     return;
                 }

--- a/iothub/device/src/Common/Security/SharedAccessSignature.cs
+++ b/iothub/device/src/Common/Security/SharedAccessSignature.cs
@@ -213,6 +213,9 @@ namespace Microsoft.Azure.Devices.Client
         //
         // This is also a function that can be removed later once the C# version being used
         // supports https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.cryptographicoperations.fixedtimeequals?view=net-5.0
+        //
+        // This implementation is taken directly from 
+        // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptographicOperations.cs#L31
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
         private static bool FixedTimeEquals(string left, string right)
         {
@@ -220,12 +223,16 @@ namespace Microsoft.Azure.Devices.Client
             {
                 return false;
             }
-            var result = 0;
-            for (var i = 0; i < left.Length; i++)
+
+            int length = left.Length;
+            int accum = 0;
+
+            for (int i = 0; i < length; i++)
             {
-                result |= left[i] ^ right[i];
+                accum |= left[i] - right[i];
             }
-            return result == 0;
+
+            return accum == 0;
         }
     }
 }

--- a/iothub/service/src/Common/Security/SharedAccessSignature.cs
+++ b/iothub/service/src/Common/Security/SharedAccessSignature.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Azure.Devices.Common.Data;
@@ -180,7 +181,7 @@ namespace Microsoft.Azure.Devices.Common.Security
             if (sasAuthorizationRule.PrimaryKey != null)
             {
                 string primareyKeyComputedSignature = ComputeSignature(Convert.FromBase64String(sasAuthorizationRule.PrimaryKey));
-                if (StringComparer.Ordinal.Equals(Signature, primareyKeyComputedSignature))
+                if (FixedTimeEquals(Signature, primareyKeyComputedSignature))
                 {
                     return;
                 }
@@ -189,7 +190,7 @@ namespace Microsoft.Azure.Devices.Common.Security
             if (sasAuthorizationRule.SecondaryKey != null)
             {
                 string secondaryKeyComputedSignature = ComputeSignature(Convert.FromBase64String(sasAuthorizationRule.SecondaryKey));
-                if (StringComparer.Ordinal.Equals(Signature, secondaryKeyComputedSignature))
+                if (FixedTimeEquals(Signature, secondaryKeyComputedSignature))
                 {
                     return;
                 }
@@ -278,6 +279,26 @@ namespace Microsoft.Azure.Devices.Common.Security
             }
 
             return parsedFields;
+        }
+
+        // N.B. This allows for string comparisons without a potential security vulnerability.
+        // Without this it could be possible to attempt different values and determine length
+        // and maybe even entire string through brute force atttempts.
+        //
+        // This is also a function that can be removed later once the C# version being used
+        // supports https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.cryptographicoperations.fixedtimeequals?view=net-5.0
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+        private static bool FixedTimeEquals(string left, string right) {
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+            var result = 0;
+            for (var i = 0; i < left.Length; i++)
+            {
+                result |= left[i] ^ right[i];
+            }
+            return result == 0;
         }
     }
 }

--- a/iothub/service/src/Common/Security/SharedAccessSignature.cs
+++ b/iothub/service/src/Common/Security/SharedAccessSignature.cs
@@ -287,18 +287,26 @@ namespace Microsoft.Azure.Devices.Common.Security
         //
         // This is also a function that can be removed later once the C# version being used
         // supports https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.cryptographicoperations.fixedtimeequals?view=net-5.0
+        //
+        // This implementation is taken directly from 
+        // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptographicOperations.cs#L31
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        private static bool FixedTimeEquals(string left, string right) {
+        private static bool FixedTimeEquals(string left, string right) 
+        {
             if (left.Length != right.Length)
             {
                 return false;
             }
-            var result = 0;
-            for (var i = 0; i < left.Length; i++)
+
+            int length = left.Length;
+            int accum = 0;
+
+            for (int i = 0; i < length; i++)
             {
-                result |= left[i] ^ right[i];
+                accum |= left[i] - right[i];
             }
-            return result == 0;
+
+            return accum == 0;
         }
     }
 }

--- a/iothub/service/src/Common/Security/SharedAccessSignature.cs
+++ b/iothub/service/src/Common/Security/SharedAccessSignature.cs
@@ -181,7 +181,11 @@ namespace Microsoft.Azure.Devices.Common.Security
             if (sasAuthorizationRule.PrimaryKey != null)
             {
                 string primareyKeyComputedSignature = ComputeSignature(Convert.FromBase64String(sasAuthorizationRule.PrimaryKey));
+#if NETSTANDARD2_1
+                if (CryptographicOperations.FixedTimeEquals(Encoding.ASCII.GetBytes(Signature), Encoding.ASCII.GetBytes(primareyKeyComputedSignature)))
+#else
                 if (FixedTimeEquals(Signature, primareyKeyComputedSignature))
+#endif
                 {
                     return;
                 }
@@ -190,7 +194,11 @@ namespace Microsoft.Azure.Devices.Common.Security
             if (sasAuthorizationRule.SecondaryKey != null)
             {
                 string secondaryKeyComputedSignature = ComputeSignature(Convert.FromBase64String(sasAuthorizationRule.SecondaryKey));
+#if NETSTANDARD2_1
+                if (CryptographicOperations.FixedTimeEquals(Encoding.ASCII.GetBytes(Signature), Encoding.ASCII.GetBytes(secondaryKeyComputedSignature)))
+#else
                 if (FixedTimeEquals(Signature, secondaryKeyComputedSignature))
+#endif
                 {
                     return;
                 }


### PR DESCRIPTION
String equals can be a potentially timed security vulnerability, and could be problematic for authenticating SAS. This was noticed by the iotedge team and this PR is a way to bring notice or fix the issue. 

Please let me know if an issue should be filed instead. :)

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `master` branch.

## Description of the changes
This handles a potential security issue that could arise where an attacker could try to get information based on the time it takes to compare strings. This is just a quick fix; perhaps a shared location for comparing sensitive strings could be worthwhile?

## Reference/Link to the issue solved with this PR (if any)
N/A
