### PR TITLE
Convert to ClientPropertyCollection

### DIFF
--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerCustomSerializer.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerCustomSerializer.cs
@@ -49,14 +49,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 Temperature = 25
             };
 
-            if (!properties.Contains(Thermostat2)
-                || !((JsonElement)properties[Thermostat2])
-                    .TryGetProperty("initialValue", out JsonElement initialValueReported)
-                || !initialValue
-                    .Equals(_deviceClient
-                        .PayloadConvention
-                        .PayloadSerializer
-                        .DeserializeToType<ThermostatInitialValue>(initialValueReported.GetRawText())))
+            if (!properties.Contains("initialValue", Thermostat2))
             {
                 var propertiesToBeUpdated = new ClientPropertyCollection
                 {
@@ -64,6 +57,12 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 };
                 await _deviceClient.UpdateClientPropertiesAsync(propertiesToBeUpdated, cancellationToken);
                 _logger.LogDebug($"Property: Update - {propertiesToBeUpdated.GetSerializedString()}.");
+            }
+            else
+            {
+                var tValue = properties.Get<ThermostatInitialValue>("initialValue", Thermostat2);
+                _logger.LogDebug($"Property from tValue: {tValue.Humidity}.");
+                _logger.LogDebug($"Property from tValue: {tValue.Temperature}.");
             }
 
             // Send telemetry "deviceHealth" under component "thermostat1".

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerSampleNew.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/ComponentTemperatureControllerSampleNew.cs
@@ -49,17 +49,20 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 Temperature = 25
             };
 
-            if (!properties.Contains(Thermostat2)
-                || !((JObject)properties[Thermostat2])
-                    .TryGetValue("initialValue", out JToken initialValueReported)
-                || !initialValue
-                    .Equals(initialValueReported.ToObject<ThermostatInitialValue>()))
+            if (!properties.Contains("initialValue", Thermostat2))
             {
-                var propertiesToBeUpdated = new ClientPropertyCollection();
-                propertiesToBeUpdated.Add("initialValue", initialValue, Thermostat2);
-
+                var propertiesToBeUpdated = new ClientPropertyCollection
+                {
+                    { "initialValue", initialValue, Thermostat2 }
+                };
                 await _deviceClient.UpdateClientPropertiesAsync(propertiesToBeUpdated, cancellationToken);
                 _logger.LogDebug($"Property: Update - {propertiesToBeUpdated.GetSerializedString()}.");
+            }
+            else
+            {
+                var tValue = properties.Get<ThermostatInitialValue>("initialValue", Thermostat2);
+                _logger.LogDebug($"Property from tValue: {tValue.Humidity}.");
+                _logger.LogDebug($"Property from tValue: {tValue.Temperature}.");
             }
 
             // Send telemetry "deviceHealth" under component "thermostat1".

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/Program.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/Program.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
             s_logger.LogDebug($"Set up the device client.");
             using DeviceClient deviceClient = await SetupDeviceClientAsync(parameters, cts.Token);
-            var sample = new SimpleTemperatureControllerSampleOld(deviceClient, s_logger);
+            var sample = new ComponentTemperatureControllerCustomSerializer(deviceClient, s_logger);
             await sample.PerformOperationsAsync(cts.Token);
         }
 

--- a/iothub/device/samples/PnpDeviceSamples/TemperatureController/SystemTextJsonSerializer.cs
+++ b/iothub/device/samples/PnpDeviceSamples/TemperatureController/SystemTextJsonSerializer.cs
@@ -31,6 +31,20 @@ namespace Microsoft.Azure.Devices.Client.Samples
         {
             return DeserializeToType<T>(((JsonElement)objectToConvert).ToString());
         }
+        
+        public override bool TryGetNestedObjectValue<T>(object objectToConvert, string propertyName, out T outValue)
+        {
+            outValue = default;
+            if (objectToConvert == null || string.IsNullOrEmpty(propertyName))
+            {
+                return false;
+            }
+            if (((JsonElement)objectToConvert).TryGetProperty(propertyName, out var element)) {
+                outValue = DeserializeToType<T>(element.GetRawText());
+                return true;
+            }
+            return false;
+        }
 
         public override IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = null)
         {

--- a/iothub/device/src/ClientProperties.cs
+++ b/iothub/device/src/ClientProperties.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.Client
     /// The Properties class is not meant to be constructed by customer code. It is intended to be returned fully popualated from the <see cref="DeviceClient.GetClientPropertiesAsync(System.Threading.CancellationToken)"/> method.
     /// </remarks>
     /// </summary>
-    public class ClientProperties : IEnumerable<object>
+    public class ClientProperties : ClientPropertyCollection
     {
         private readonly ClientPropertyCollection _reportedPropertyCollection = new ClientPropertyCollection();
 
@@ -47,56 +47,10 @@ namespace Microsoft.Azure.Devices.Client
         public ClientPropertyCollection Writable { get; private set; }
 
         /// <summary>
-        /// Get the property from the propeties collection.
-        /// </summary>
-        /// <param name="key">The key of the property to get.</param>
-        /// <remarks>
-        /// This accessor is best used to access simple types. It is recommended to use <see cref="Get{T}(string)"/> to cast a complex type.
-        /// </remarks>
-        /// <returns>The specified property.</returns>
-        public object this[string key]
-        {
-            get
-            {
-                return _reportedPropertyCollection[key];
-            }
-        }
-
-        /// <summary>
-        /// Determines whether the specified property is present.
-        /// </summary>
-        /// <param name="propertyName">The property to locate.</param>
-        /// <returns>true if the specified property is present; otherwise, false</returns>
-        public bool Contains(string propertyName)
-        {
-            return _reportedPropertyCollection.Collection.TryGetValue(propertyName, out _);
-        }
-
-        /// <summary>
-        /// Gets the version of the properties.
-        /// </summary>
-        public long Version => _reportedPropertyCollection.Version;
-
-        /// <inheritdoc/>
-        public IEnumerator<object> GetEnumerator()
-        {
-            foreach (object property in _reportedPropertyCollection)
-            {
-                yield return property;
-            }
-        }
-
-        /// <inheritdoc/>
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
-        /// <summary>
         /// Gets the property from the collection.
         /// </summary>
         /// <remarks>
-        /// This calls <see cref="PayloadCollection.GetValue{T}(string)"/> and will use the serializer if needed. It is recommended to use this method over the <see cref="this[string]"/> accessor.
+        /// This calls <see cref="PayloadCollection.GetValue{T}(string)"/> and will use the serializer if needed. It is recommended to use this method over the <see cref="PayloadCollection.this[string]"/> accessor.
         /// </remarks>
         /// <typeparam name="T">The type to be returned.</typeparam>
         /// <param name="propertyKey">The key of the property to be returned.</param>

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -219,9 +219,14 @@ namespace Microsoft.Azure.Devices.Client
         /// Determines whether the specified property is present.
         /// </summary>
         /// <param name="propertyName">The property to locate.</param>
+        /// <param name="componentName"></param>
         /// <returns><c>true</c> if the specified property is present; otherwise, <c>false</c>.</returns>
-        public bool Contains(string propertyName)
+        public bool Contains(string propertyName, string componentName = default)
         {
+            if (!string.IsNullOrEmpty(componentName) && Collection.TryGetValue(componentName, out var component))
+            {
+                return Convention.PayloadSerializer.TryGetNestedObjectValue<object>(component, propertyName, out _);
+            }
             return Collection.TryGetValue(propertyName, out _);
         }
 
@@ -229,7 +234,7 @@ namespace Microsoft.Azure.Devices.Client
         /// Gets the version of the property collection.
         /// </summary>
         /// <value>A <see cref="long"/> that is used to identify the version of the property collection.</value>
-        public long Version { get; private set; }
+        public long Version { get; protected set; }
 
         /// <summary>
         /// Converts a <see cref="TwinCollection"/> collection to a properties collection.

--- a/iothub/device/src/NewtonsoftJsonPayloadSerializer.cs
+++ b/iothub/device/src/NewtonsoftJsonPayloadSerializer.cs
@@ -47,6 +47,22 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <inheritdoc/>
+        public override bool TryGetNestedObjectValue<T>(object objectToConvert, string propertyName, out T outValue)
+        {
+            outValue = default;
+            if (objectToConvert == null || string.IsNullOrEmpty(propertyName))
+            {
+                return false;
+            }
+            if (((JObject)objectToConvert).TryGetValue(propertyName, out var element))
+            {
+                outValue = element.ToObject<T>();
+                return true;
+            }
+            return false;
+        }
+
+        /// <inheritdoc/>
         public override IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = null)
         {
             return new NewtonsoftJsonWritablePropertyResponse(value, statusCode, version, description);

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -88,9 +88,17 @@ namespace Microsoft.Azure.Devices.Client
         /// </remarks>
         /// <typeparam name="T">The type to cast the object to.</typeparam>
         /// <param name="key">The key of the property to get.</param>
+        /// <param name="componentName">The optional component name.</param>
         /// <returns></returns>
-        public virtual T GetValue<T>(string key)
+        public virtual T GetValue<T>(string key, string componentName = default)
         {
+            if (!string.IsNullOrEmpty(componentName) && !string.IsNullOrEmpty(key))
+            {
+                if (Convention.PayloadSerializer.TryGetNestedObjectValue(Collection[componentName], key, out T outValue))
+                {
+                    return outValue;
+                }
+            }
             // If the object is of type T go ahead and return it.
             if (Collection[key] is T)
             {
@@ -123,6 +131,20 @@ namespace Microsoft.Azure.Devices.Client
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
+        }
+
+        /// <summary>
+        /// Will set the underlying <see cref="Collection"/> of the payload collection.
+        /// </summary>
+        /// <param name="payloadCollection">The collection to get the underlying dictionary from</param>
+        protected void SetCollection(PayloadCollection payloadCollection)
+        {
+            if (payloadCollection == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            Collection = payloadCollection.Collection;
         }
     }
 }

--- a/iothub/device/src/PayloadSerializer.cs
+++ b/iothub/device/src/PayloadSerializer.cs
@@ -46,6 +46,19 @@ namespace Microsoft.Azure.Devices.Client
         public abstract T ConvertFromObject<T>(object objectToConvert);
 
         /// <summary>
+        /// Gets a nested property from the serialized data.
+        /// </summary>
+        /// <remarks>
+        /// This is used internally by our <see cref="PayloadCollection"/> to attempt to get a proprty of the underlying object. An example of this would be a property under the component. 
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="objectToConvert"></param>
+        /// <param name="propertyName"></param>
+        /// <returns></returns>
+        /// <param name="outValue"></param>
+        public abstract bool TryGetNestedObjectValue<T>(object objectToConvert, string propertyName, out T outValue);
+
+        /// <summary>
         /// Creates the correct <see cref="IWritablePropertyResponse"/> to be used with this serializer
         /// </summary>
         /// <param name="value">The value of the property.</param>


### PR DESCRIPTION
The primary purpose if this PR is to convert the ClientProperties to inherit from ClientPropertyCollection. But there was an opportunity to improve the flow when using this object.

Notes about the `TryGetNestedObjectValue` method highlighted below.

This method will be used by the PayloadCollections to help simplify handling properties under components. The most common use case is to get a single component property value to compare.

Here is an example of it simplifying using Contains on ClientProperties. So instead of using the proper serialization methods in the customer code it's offloaded to the Serializer.

### Questions
* If you were tasked with implementing a serializer would  the new method added be too much to do this? 
* Is there a better place to add this? 
* Is it intuitive to call Contains from the collection?

### Before Update
```c#
if (!properties.Contains(Thermostat2)
                || !((JsonElement)properties[Thermostat2])
                    .TryGetProperty("initialValue", out JsonElement initialValueReported)
                || !initialValue
                    .Equals(_deviceClient
                        .PayloadConvention
                        .PayloadSerializer
                        .DeserializeToType<ThermostatInitialValue>(initialValueReported.GetRawText())))
{

    // work
}
else
{
    (JsonElement)properties[Thermostat2]).TryGetProperty("initialValue", out JsonElement initialValueReported);
    var tValue = _deviceClient
                        .PayloadConvention
                        .PayloadSerializer
                        .DeserializeToType<ThermostatInitialValue>(initialValueReported.GetRawText()))
    // other work
}
```
### After Update
```c#
if (!properties.Contains("initialValue", Thermostat2))
{
    // work
}
else
{
    var tValue = properties.Get<ThermostatInitialValue>("initialValue", Thermostat2);
    // other work
}
```  