### PR TITLE
Update versions for 2021-05-11 release.

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.37.1</Version>
+    <Version>1.37.2</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.33.0</Version>
+    <Version>1.34.0</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,6 +1,6 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.37.1
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.33.0
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.37.2
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.34.0
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.28.1
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.17.1
 provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.14.1


### PR DESCRIPTION
Draft release notes:

## Microsoft.Azure.Devices.Client 1.37.2

### Bug fixes

- Allow null payload in method calls (#1940)
- Throw during client initialization for invalid HTTP transport with a model Id (#1939)

## Microsoft.Azure.Devices 1.34.0

- Add user assigned msi support for IoT hub import and export jobs (#1948)