### PR TITLE
Update client to not dispose user supplied IDisposable types

### DIFF
--- a/doc/devguide.md
+++ b/doc/devguide.md
@@ -9,6 +9,11 @@ Before starting development on the Azure IoT SDK for C# you will need to install
 ### Design
 We are following the [Azure SDK design specification for C#](https://azuresdkspecs.z5.web.core.windows.net/DotNetSpec.html). To preserve backward compatibility, existing code will not change to follow these rules.
 
+#### Using [`IDisposable`](https://docs.microsoft.com/en-us/dotnet/api/system.idisposable?view=net-5.0#implementing-idisposable) types:
+- The sdk should dispose any `IDisposable` resource that it creates.
+- The sdk should not dispose an `IDisposable` resource that is supplied by the calling application. This is because the caller might want to reuse the resource elsewhere in the application. The responsibility of disposal of caller-supplied `IDisposable` resource is on the caller. An example of such a resource would be an `X509Certificate` instance that is used for authenticating our clients.
+- If the sdk implements `class A` that owns an `IDisposable` resource `X`, then `A` should also be `IDisposable`. In that case, resource `X` can be safely disposed when `class A` is disposed.
+
 ### Code style
 Please read and apply our [coding style](coding-style.md) when proposing PRs against the Azure repository. When changing existing files, please apply changes to the entire file. Otherwise, maintain the same style.
 

--- a/doc/devguide.md
+++ b/doc/devguide.md
@@ -10,9 +10,9 @@ Before starting development on the Azure IoT SDK for C# you will need to install
 We are following the [Azure SDK design specification for C#](https://azuresdkspecs.z5.web.core.windows.net/DotNetSpec.html). To preserve backward compatibility, existing code will not change to follow these rules.
 
 #### Using [`IDisposable`](https://docs.microsoft.com/en-us/dotnet/api/system.idisposable?view=net-5.0#implementing-idisposable) types:
+- If the sdk implements `class A` that owns an `IDisposable` resource `X`, then `A` should also be `IDisposable`. In that case, resource `X` can be safely disposed when `class A` is disposed.
 - The sdk should dispose any `IDisposable` resource that it creates.
 - The sdk should not dispose an `IDisposable` resource that is supplied by the calling application. This is because the caller might want to reuse the resource elsewhere in the application. The responsibility of disposal of caller-supplied `IDisposable` resource is on the caller. An example of such a resource would be an `X509Certificate` instance that is used for authenticating our clients.
-- If the sdk implements `class A` that owns an `IDisposable` resource `X`, then `A` should also be `IDisposable`. In that case, resource `X` can be safely disposed when `class A` is disposed.
 
 ### Code style
 Please read and apply our [coding style](coding-style.md) when proposing PRs against the Azure repository. When changing existing files, please apply changes to the entire file. Otherwise, maintain the same style.

--- a/e2e/test/Helpers/AmqpConnectionStatusChange.cs
+++ b/e2e/test/Helpers/AmqpConnectionStatusChange.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Client;
+
+namespace Microsoft.Azure.Devices.E2ETests.Helpers
+{
+    public class AmqpConnectionStatusChange
+    {
+        private readonly string _deviceId;
+        private readonly MsTestLogger _logger;
+
+        public AmqpConnectionStatusChange(string deviceId, MsTestLogger logger)
+        {
+            LastConnectionStatus = null;
+            LastConnectionStatusChangeReason = null;
+            ConnectionStatusChangeCount = 0;
+            _deviceId = deviceId;
+            _logger = logger;
+        }
+
+        public void ConnectionStatusChangesHandler(ConnectionStatus status, ConnectionStatusChangeReason reason)
+        {
+            ConnectionStatusChangeCount++;
+            LastConnectionStatus = status;
+            LastConnectionStatusChangeReason = reason;
+            _logger.Trace($"{nameof(AmqpConnectionStatusChange)}.{nameof(ConnectionStatusChangesHandler)}: {_deviceId}: status={status} statusChangeReason={reason} count={ConnectionStatusChangeCount}");
+        }
+
+        public int ConnectionStatusChangeCount { get; set; }
+
+        public ConnectionStatus? LastConnectionStatus { get; set; }
+
+        public ConnectionStatusChangeReason? LastConnectionStatusChangeReason { get; set; }
+    }
+}

--- a/e2e/test/Helpers/AmqpConnectionStatusChange.cs
+++ b/e2e/test/Helpers/AmqpConnectionStatusChange.cs
@@ -19,6 +19,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             _logger = logger;
         }
 
+        public int ConnectionStatusChangeCount { get; set; }
+
+        public ConnectionStatus? LastConnectionStatus { get; set; }
+
+        public ConnectionStatusChangeReason? LastConnectionStatusChangeReason { get; set; }
+
         public void ConnectionStatusChangesHandler(ConnectionStatus status, ConnectionStatusChangeReason reason)
         {
             ConnectionStatusChangeCount++;
@@ -26,11 +32,5 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             LastConnectionStatusChangeReason = reason;
             _logger.Trace($"{nameof(AmqpConnectionStatusChange)}.{nameof(ConnectionStatusChangesHandler)}: {_deviceId}: status={status} statusChangeReason={reason} count={ConnectionStatusChangeCount}");
         }
-
-        public int ConnectionStatusChangeCount { get; set; }
-
-        public ConnectionStatus? LastConnectionStatus { get; set; }
-
-        public ConnectionStatusChangeReason? LastConnectionStatusChangeReason { get; set; }
     }
 }

--- a/e2e/test/Helpers/templates/FaultInjectionPoolingOverAmqp.cs
+++ b/e2e/test/Helpers/templates/FaultInjectionPoolingOverAmqp.cs
@@ -217,34 +217,5 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                 }
             }
         }
-
-        public class AmqpConnectionStatusChange
-        {
-            private readonly string _deviceId;
-            private readonly MsTestLogger _logger;
-
-            public AmqpConnectionStatusChange(string deviceId, MsTestLogger logger)
-            {
-                LastConnectionStatus = null;
-                LastConnectionStatusChangeReason = null;
-                ConnectionStatusChangeCount = 0;
-                _deviceId = deviceId;
-                _logger = logger;
-            }
-
-            public void ConnectionStatusChangesHandler(ConnectionStatus status, ConnectionStatusChangeReason reason)
-            {
-                ConnectionStatusChangeCount++;
-                LastConnectionStatus = status;
-                LastConnectionStatusChangeReason = reason;
-                _logger.Trace($"{nameof(FaultInjectionPoolingOverAmqp)}.{nameof(ConnectionStatusChangesHandler)}: {_deviceId}: status={status} statusChangeReason={reason} count={ConnectionStatusChangeCount}");
-            }
-
-            public int ConnectionStatusChangeCount { get; set; }
-
-            public ConnectionStatus? LastConnectionStatus { get; set; }
-
-            public ConnectionStatusChangeReason? LastConnectionStatusChangeReason { get; set; }
-        }
     }
 }

--- a/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
+++ b/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 authenticationMethods.Add(authenticationMethod);
             }
 
-            // Initialize the client instances set the connection status change handler and open the connection.
+            // Initialize the client instances, set the connection status change handler and open the connection.
             for (int i = 0; i < devicesCount; i++)
             {
                 DeviceClient deviceClient = DeviceClient.Create(testDevices[i].IoTHubHostName, authenticationMethods[i], new ITransportSettings[] { amqpTransportSettings });

--- a/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
+++ b/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
@@ -1,0 +1,185 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.E2ETests.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Devices.E2ETests.Iothub
+{
+    [TestClass]
+    [TestCategory("E2E")]
+    [TestCategory("IoTHub")]
+    public class AuthenticationWithTokenRefreshDisposalTests : E2EMsTestBase
+    {
+        private readonly string _devicePrefix = $"E2E_{nameof(AuthenticationWithTokenRefreshDisposalTests)}_";
+
+        [LoggedTestMethod]
+        public async Task DeviceSak_ReusableAuthenticationMethod_SingleDevicePerConnection_Amqp()
+        {
+            await ReuseAuthenticationMethod_SingleDevice(Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceSak_ReusableAuthenticationMethod_SingleDevicePerConnection_AmqpWs()
+        {
+            await ReuseAuthenticationMethod_SingleDevice(Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceSak_ReusableAuthenticationMethod_SingleDevicePerConnection_Mqtt()
+        {
+            await ReuseAuthenticationMethod_SingleDevice(Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceSak_ReusableAuthenticationMethod_SingleDevicePerConnection_MqttWs()
+        {
+            await ReuseAuthenticationMethod_SingleDevice(Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceSak_ReusableAuthenticationMethod_SingleDevicePerConnection_Http()
+        {
+            await ReuseAuthenticationMethod_SingleDevice(Client.TransportType.Http1).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceSak_ReusableAuthenticationMethod_MuxedDevicesPerConnection_Amqp()
+        {
+            await ReuseAuthenticationMethod_MuxedDevices(Client.TransportType.Amqp_Tcp_Only, 2);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceSak_ReusableAuthenticationMethod_MuxedDevicesPerConnection_AmqpWs()
+        {
+            await ReuseAuthenticationMethod_MuxedDevices(Client.TransportType.Amqp_WebSocket_Only, 2);
+        }
+
+        private async Task ReuseAuthenticationMethod_SingleDevice(Client.TransportType transport)
+        {
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
+            var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString);
+
+            // Create an instance of the device client, send a test message and then close and dispose it.
+            DeviceClient deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, authenticationMethod, transport);
+            await deviceClient.SendEventAsync(new Client.Message()).ConfigureAwait(false);
+            await deviceClient.CloseAsync();
+            deviceClient.Dispose();
+            Logger.Trace("Test with instance 1 completed");
+
+            // Perform the same steps again, reusing the previously created authentication method instance.
+            DeviceClient deviceClient2 = DeviceClient.Create(testDevice.IoTHubHostName, authenticationMethod, transport);
+            await deviceClient2.SendEventAsync(new Client.Message()).ConfigureAwait(false);
+            await deviceClient2.CloseAsync();
+            deviceClient2.Dispose();
+            Logger.Trace("Test with instance 2 completed");
+        }
+
+        private async Task ReuseAuthenticationMethod_MuxedDevices(Client.TransportType transport, int devicesCount)
+        {
+            IList<TestDevice> testDevices = new List<TestDevice>();
+            IList<AuthenticationWithTokenRefresh> authenticationMethods = new List<AuthenticationWithTokenRefresh>();
+
+            // Set up amqp transport settings to multiplex all device sessions over the same amqp connection.
+            var amqpTransportSettings = new AmqpTransportSettings(transport)
+            {
+                AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings
+                {
+                    Pooling = true,
+                    MaxPoolSize = 1,
+                },
+            };
+
+            for (int i = 0; i < devicesCount; i++)
+            {
+                TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
+                var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString);
+
+                testDevices.Add(testDevice);
+                authenticationMethods.Add(authenticationMethod);
+            }
+
+            // Create an instance of the device client, send a test message and then close and dispose it.
+            for (int i = 0; i < devicesCount; i++)
+            {
+                DeviceClient deviceClient = DeviceClient.Create(testDevices[i].IoTHubHostName, authenticationMethods[i], new ITransportSettings[] { amqpTransportSettings });
+                await deviceClient.SendEventAsync(new Client.Message()).ConfigureAwait(false);
+                await deviceClient.CloseAsync();
+                deviceClient.Dispose();
+                Logger.Trace($"Test with client {i} completed.");
+            }
+            Logger.Trace($"Test run with instance 1 completed.");
+
+            // Perform the same steps again, reusing the previously created authentication method instance.
+            for (int i = 0; i < devicesCount; i++)
+            {
+                DeviceClient deviceClient = DeviceClient.Create(testDevices[i].IoTHubHostName, authenticationMethods[i], new ITransportSettings[] { amqpTransportSettings });
+                await deviceClient.SendEventAsync(new Client.Message()).ConfigureAwait(false);
+                await deviceClient.CloseAsync();
+                deviceClient.Dispose();
+                Logger.Trace($"Test with client {i} completed.");
+            }
+            Logger.Trace($"Test run with instance 2 completed.");
+        }
+
+        private class DeviceAuthenticationSasToken : DeviceAuthenticationWithTokenRefresh
+        {
+            private const string SasTokenTargetFormat = "{0}/devices/{1}";
+            private readonly IotHubConnectionStringBuilder _connectionStringBuilder;
+
+            public DeviceAuthenticationSasToken(
+                string connectionString)
+                : base(GetDeviceIdFromConnectionString(connectionString))
+            {
+                if (connectionString == null)
+                {
+                    throw new ArgumentNullException(nameof(connectionString));
+                }
+
+                _connectionStringBuilder = IotHubConnectionStringBuilder.Create(connectionString);
+            }
+
+            protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
+            {
+                var builder = new SharedAccessSignatureBuilder
+                {
+                    Key = _connectionStringBuilder.SharedAccessKey,
+                    TimeToLive = TimeSpan.FromSeconds(suggestedTimeToLive),
+                };
+
+                if (_connectionStringBuilder.SharedAccessKeyName == null)
+                {
+                    builder.Target = string.Format(
+                        CultureInfo.InvariantCulture,
+                        SasTokenTargetFormat,
+                        iotHub,
+                        WebUtility.UrlEncode(DeviceId));
+                }
+                else
+                {
+                    builder.KeyName = _connectionStringBuilder.SharedAccessKeyName;
+                    builder.Target = _connectionStringBuilder.HostName;
+                }
+
+                return Task.FromResult(builder.ToSignature());
+            }
+
+            private static string GetDeviceIdFromConnectionString(string connectionString)
+            {
+                if (connectionString == null)
+                {
+                    throw new ArgumentNullException(nameof(connectionString));
+                }
+
+                var builder = IotHubConnectionStringBuilder.Create(connectionString);
+                return builder.DeviceId;
+            }
+        }
+    }
+}

--- a/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
+++ b/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
@@ -76,12 +76,13 @@ namespace Microsoft.Azure.Devices.E2ETests
             deviceClient.Dispose();
             Logger.Trace("Test with instance 1 completed");
 
-            // Perform the same steps again, reusing the previously created authentication method instance.
+            // Perform the same steps again, reusing the previously created authentication method instance to ensure
+            // that the sdk did not dispose the user supplied authentication method instance.
             DeviceClient deviceClient2 = DeviceClient.Create(testDevice.IoTHubHostName, authenticationMethod, transport);
             await deviceClient2.SendEventAsync(new Client.Message()).ConfigureAwait(false);
             await deviceClient2.CloseAsync();
             deviceClient2.Dispose();
-            Logger.Trace("Test with instance 2 completed");
+            Logger.Trace("Test with instance 2 completed, reused the previously created authentication method instance for the device client.");
 
             authenticationMethod.Dispose();
         }

--- a/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
+++ b/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
@@ -128,6 +128,8 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // Close and dispose client instance 1.
             // The closed client should report a status of "disabled" while the rest of them should be connected.
+            // This is to ensure that disposal on one multiplexed device doesn't cause cascading failures
+            // in the rest of the devices on the same tcp connection.
 
             await deviceClients[0].CloseAsync().ConfigureAwait(false);
             deviceClients[0].Dispose();

--- a/e2e/test/iothub/SasCredentialAuthenticationTests.cs
+++ b/e2e/test/iothub/SasCredentialAuthenticationTests.cs
@@ -21,7 +21,7 @@ using Azure;
 
 using ClientOptions = Microsoft.Azure.Devices.Client.ClientOptions;
 
-namespace Microsoft.Azure.Devices.E2ETests.iothub
+namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
 {
     /// <summary>
     /// Tests to ensure authentication using SAS credential succeeds in all the clients.

--- a/e2e/test/iothub/TokenCredentialAuthenticationTests.cs
+++ b/e2e/test/iothub/TokenCredentialAuthenticationTests.cs
@@ -21,7 +21,7 @@ using Azure.Identity;
 
 using ClientOptions = Microsoft.Azure.Devices.Client.ClientOptions;
 
-namespace Microsoft.Azure.Devices.E2ETests.iothub
+namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
 {
     /// <summary>
     /// Tests to ensure authentication using Azure active directory succeeds in all the clients.

--- a/iothub/device/src/AuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/AuthenticationWithTokenRefresh.cs
@@ -65,9 +65,9 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         public bool IsExpiring => (ExpiresOn - DateTime.UtcNow).TotalSeconds <= _bufferSeconds;
 
-        internal bool InstanceCreatedBySdk { get; set; }
-
-        internal bool IsIndividualSasAuthenticatedToken { get; set; }
+        // This internal property is used by the sdk to determine if the instance was created by the sdk,
+        // and thus, if it should be disposed by the sdk.
+        internal bool ShouldSdkDisposeInstance { get; set; }
 
         /// <summary>
         /// Gets a snapshot of the security token associated with the device. This call is thread-safe.

--- a/iothub/device/src/AuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/AuthenticationWithTokenRefresh.cs
@@ -67,6 +67,8 @@ namespace Microsoft.Azure.Devices.Client
 
         internal bool InstanceCreatedBySdk { get; set; }
 
+        internal bool IsIndividualSasAuthenticatedToken { get; set; }
+
         /// <summary>
         /// Gets a snapshot of the security token associated with the device. This call is thread-safe.
         /// </summary>

--- a/iothub/device/src/AuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/AuthenticationWithTokenRefresh.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices.Client
 
         // This internal property is used by the sdk to determine if the instance was created by the sdk,
         // and thus, if it should be disposed by the sdk.
-        internal bool ShouldSdkDisposeInstance { get; set; }
+        internal bool InstanceCreatedBySdk { get; set; }
 
         /// <summary>
         /// Gets a snapshot of the security token associated with the device. This call is thread-safe.

--- a/iothub/device/src/AuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/AuthenticationWithTokenRefresh.cs
@@ -65,6 +65,8 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         public bool IsExpiring => (ExpiresOn - DateTime.UtcNow).TotalSeconds <= _bufferSeconds;
 
+        internal bool InstanceCreatedBySdk { get; set; }
+
         /// <summary>
         /// Gets a snapshot of the security token associated with the device. This call is thread-safe.
         /// </summary>

--- a/iothub/device/src/DeviceAuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/DeviceAuthenticationWithTokenRefresh.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     public abstract class DeviceAuthenticationWithTokenRefresh : AuthenticationWithTokenRefresh
     {
-        internal const int DefaultTimeToLiveSeconds = 1 * 60 * 60;
-        internal const int DefaultBufferPercentage = 15;
+        internal const int DefaultTimeToLiveSeconds = 1 * 60;
+        internal const int DefaultBufferPercentage = 50;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DeviceAuthenticationWithTokenRefresh"/> class using default

--- a/iothub/device/src/DeviceAuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/DeviceAuthenticationWithTokenRefresh.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     public abstract class DeviceAuthenticationWithTokenRefresh : AuthenticationWithTokenRefresh
     {
-        internal const int DefaultTimeToLiveSeconds = 1 * 60;
-        internal const int DefaultBufferPercentage = 50;
+        internal const int DefaultTimeToLiveSeconds = 1 * 60 * 60;
+        internal const int DefaultBufferPercentage = 15;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DeviceAuthenticationWithTokenRefresh"/> class using default

--- a/iothub/device/src/Edge/EdgeModuleClientFactory.cs
+++ b/iothub/device/src/Edge/EdgeModuleClientFactory.cs
@@ -100,8 +100,8 @@ namespace Microsoft.Azure.Devices.Client.Edge
 #pragma warning disable CA2000 // Dispose objects before losing scope - IDisposable ModuleAuthenticationWithHsm is disposed when the client is disposed.
                 var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId, generationId, sasTokenTimeToLive, sasTokenRenewalBuffer)
                 {
-                    InstanceCreatedBySdk = true,
-                    IsIndividualSasAuthenticatedToken = true,
+                    // Since the sdk creates the instance of disposable ModuleAuthenticationWithHsm, the sdk needs to dispose it once the client is diposed.
+                    ShouldSdkDisposeInstance = true,
                 };
 #pragma warning restore CA2000 // Dispose objects before losing scope - IDisposable ModuleAuthenticationWithHsm is disposed when the client is disposed.
 

--- a/iothub/device/src/Edge/EdgeModuleClientFactory.cs
+++ b/iothub/device/src/Edge/EdgeModuleClientFactory.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Azure.Devices.Client.Edge
                 var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId, generationId, sasTokenTimeToLive, sasTokenRenewalBuffer)
                 {
                     InstanceCreatedBySdk = true,
+                    IsIndividualSasAuthenticatedToken = true,
                 };
 #pragma warning restore CA2000 // Dispose objects before losing scope - IDisposable ModuleAuthenticationWithHsm is disposed when the client is disposed.
 

--- a/iothub/device/src/Edge/EdgeModuleClientFactory.cs
+++ b/iothub/device/src/Edge/EdgeModuleClientFactory.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.Client.Edge
                 var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId, generationId, sasTokenTimeToLive, sasTokenRenewalBuffer)
                 {
                     // Since the sdk creates the instance of disposable ModuleAuthenticationWithHsm, the sdk needs to dispose it once the client is diposed.
-                    ShouldSdkDisposeInstance = true,
+                    InstanceCreatedBySdk = true,
                 };
 #pragma warning restore CA2000 // Dispose objects before losing scope - IDisposable ModuleAuthenticationWithHsm is disposed when the client is disposed.
 

--- a/iothub/device/src/Edge/EdgeModuleClientFactory.cs
+++ b/iothub/device/src/Edge/EdgeModuleClientFactory.cs
@@ -98,7 +98,10 @@ namespace Microsoft.Azure.Devices.Client.Edge
                 int sasTokenRenewalBuffer = _options?.SasTokenRenewalBuffer ?? default;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope - IDisposable ModuleAuthenticationWithHsm is disposed when the client is disposed.
-                var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId, generationId, sasTokenTimeToLive, sasTokenRenewalBuffer);
+                var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId, generationId, sasTokenTimeToLive, sasTokenRenewalBuffer)
+                {
+                    InstanceCreatedBySdk = true,
+                };
 #pragma warning restore CA2000 // Dispose objects before losing scope - IDisposable ModuleAuthenticationWithHsm is disposed when the client is disposed.
 
                 Debug.WriteLine("EdgeModuleClientFactory setupTrustBundle from service");

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1897,7 +1897,8 @@ namespace Microsoft.Azure.Devices.Client
             _deviceReceiveMessageSemaphore?.Dispose();
             _twinDesiredPropertySemaphore?.Dispose();
 
-            if ((IotHubConnectionString?.TokenRefresher?.InstanceCreatedBySdk).GetValueOrDefault())
+            if ((IotHubConnectionString?.TokenRefresher?.InstanceCreatedBySdk).GetValueOrDefault()
+                && (IotHubConnectionString?.TokenRefresher?.IsIndividualSasAuthenticatedToken).GetValueOrDefault())
             {
                 IotHubConnectionString?.TokenRefresher?.Dispose();
             }

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1896,11 +1896,6 @@ namespace Microsoft.Azure.Devices.Client
             _fileUploadHttpTransportHandler?.Dispose();
             _deviceReceiveMessageSemaphore?.Dispose();
             _twinDesiredPropertySemaphore?.Dispose();
-
-            if ((IotHubConnectionString?.TokenRefresher?.ShouldSdkDisposeInstance).GetValueOrDefault())
-            {
-                IotHubConnectionString?.TokenRefresher?.Dispose();
-            }
         }
 
         internal bool IsE2EDiagnosticSupportedProtocol()

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1897,8 +1897,7 @@ namespace Microsoft.Azure.Devices.Client
             _deviceReceiveMessageSemaphore?.Dispose();
             _twinDesiredPropertySemaphore?.Dispose();
 
-            if ((IotHubConnectionString?.TokenRefresher?.InstanceCreatedBySdk).GetValueOrDefault()
-                && (IotHubConnectionString?.TokenRefresher?.IsIndividualSasAuthenticatedToken).GetValueOrDefault())
+            if ((IotHubConnectionString?.TokenRefresher?.ShouldSdkDisposeInstance).GetValueOrDefault())
             {
                 IotHubConnectionString?.TokenRefresher?.Dispose();
             }

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1896,7 +1896,6 @@ namespace Microsoft.Azure.Devices.Client
             _fileUploadHttpTransportHandler?.Dispose();
             _deviceReceiveMessageSemaphore?.Dispose();
             _twinDesiredPropertySemaphore?.Dispose();
-            IotHubConnectionString?.TokenRefresher?.Dispose();
         }
 
         internal bool IsE2EDiagnosticSupportedProtocol()

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1896,6 +1896,11 @@ namespace Microsoft.Azure.Devices.Client
             _fileUploadHttpTransportHandler?.Dispose();
             _deviceReceiveMessageSemaphore?.Dispose();
             _twinDesiredPropertySemaphore?.Dispose();
+
+            if ((IotHubConnectionString?.TokenRefresher?.InstanceCreatedBySdk).GetValueOrDefault())
+            {
+                IotHubConnectionString?.TokenRefresher?.Dispose();
+            }
         }
 
         internal bool IsE2EDiagnosticSupportedProtocol()

--- a/iothub/device/src/IotHubConnectionString.cs
+++ b/iothub/device/src/IotHubConnectionString.cs
@@ -52,7 +52,11 @@ namespace Microsoft.Azure.Devices.Client
             {
                 if (ModuleId.IsNullOrWhiteSpace())
                 {
-                    TokenRefresher = new DeviceAuthenticationWithSakRefresh(DeviceId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer);
+                    TokenRefresher = new DeviceAuthenticationWithSakRefresh(DeviceId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer)
+                    {
+                        InstanceCreatedBySdk = true,
+                    };
+
                     if (Logging.IsEnabled)
                     {
                         Logging.Info(this, $"{nameof(IAuthenticationMethod)} is {nameof(DeviceAuthenticationWithSakRefresh)}: {Logging.IdOf(TokenRefresher)}");
@@ -60,7 +64,11 @@ namespace Microsoft.Azure.Devices.Client
                 }
                 else
                 {
-                    TokenRefresher = new ModuleAuthenticationWithSakRefresh(DeviceId, ModuleId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer);
+                    TokenRefresher = new ModuleAuthenticationWithSakRefresh(DeviceId, ModuleId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer)
+                    {
+                        InstanceCreatedBySdk = true,
+                    };
+
                     if (Logging.IsEnabled)
                     {
                         Logging.Info(this, $"{nameof(IAuthenticationMethod)} is {nameof(ModuleAuthenticationWithSakRefresh)}: {Logging.IdOf(TokenRefresher)}");

--- a/iothub/device/src/IotHubConnectionString.cs
+++ b/iothub/device/src/IotHubConnectionString.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Azure.Devices.Client
                 : builder.GatewayHostName;
             SharedAccessKeyName = builder.SharedAccessKeyName;
             SharedAccessKey = builder.SharedAccessKey;
-            SharedAccessSignature = builder.SharedAccessSignature;
             IotHubName = builder.IotHubName;
             DeviceId = builder.DeviceId;
             ModuleId = builder.ModuleId;
@@ -74,6 +73,10 @@ namespace Microsoft.Azure.Devices.Client
                 }
 
                 Debug.Assert(TokenRefresher != null);
+            }
+            else if (!string.IsNullOrWhiteSpace(builder.SharedAccessSignature))
+            {
+                SharedAccessSignature = builder.SharedAccessSignature;
             }
         }
 

--- a/iothub/device/src/IotHubConnectionString.cs
+++ b/iothub/device/src/IotHubConnectionString.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Azure.Devices.Client
                     TokenRefresher = new DeviceAuthenticationWithSakRefresh(DeviceId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer)
                     {
                         InstanceCreatedBySdk = true,
+                        IsIndividualSasAuthenticatedToken = builder.SharedAccessKeyName == null,
                     };
 
                     if (Logging.IsEnabled)
@@ -67,6 +68,7 @@ namespace Microsoft.Azure.Devices.Client
                     TokenRefresher = new ModuleAuthenticationWithSakRefresh(DeviceId, ModuleId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer)
                     {
                         InstanceCreatedBySdk = true,
+                        IsIndividualSasAuthenticatedToken = builder.SharedAccessKeyName == null,
                     };
 
                     if (Logging.IsEnabled)

--- a/iothub/device/src/IotHubConnectionString.cs
+++ b/iothub/device/src/IotHubConnectionString.cs
@@ -54,8 +54,10 @@ namespace Microsoft.Azure.Devices.Client
                 {
                     TokenRefresher = new DeviceAuthenticationWithSakRefresh(DeviceId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer)
                     {
-                        InstanceCreatedBySdk = true,
-                        IsIndividualSasAuthenticatedToken = builder.SharedAccessKeyName == null,
+                        // Clients initialized using group sas tokens will have an entry for "SharedAccessKeyName" in the supplied connection string.
+                        // These clients use a connection-wide TokenRefresher for authenticating all clients under the same group.
+                        // In these cases, the disposal of the TokenRefresher is delegated to the transport layer.
+                        ShouldSdkDisposeInstance = builder.SharedAccessKeyName == null,
                     };
 
                     if (Logging.IsEnabled)
@@ -67,8 +69,10 @@ namespace Microsoft.Azure.Devices.Client
                 {
                     TokenRefresher = new ModuleAuthenticationWithSakRefresh(DeviceId, ModuleId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer)
                     {
-                        InstanceCreatedBySdk = true,
-                        IsIndividualSasAuthenticatedToken = builder.SharedAccessKeyName == null,
+                        // Clients initialized using group sas tokens will have an entry for "SharedAccessKeyName" in the supplied connection string.
+                        // These clients use a connection-wide TokenRefresher for authenticating all clients under the same group.
+                        // In these cases, the disposal of the TokenRefresher is delegated to the transport layer.
+                        ShouldSdkDisposeInstance = builder.SharedAccessKeyName == null,
                     };
 
                     if (Logging.IsEnabled)

--- a/iothub/device/src/IotHubConnectionString.cs
+++ b/iothub/device/src/IotHubConnectionString.cs
@@ -54,10 +54,8 @@ namespace Microsoft.Azure.Devices.Client
                 {
                     TokenRefresher = new DeviceAuthenticationWithSakRefresh(DeviceId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer)
                     {
-                        // Clients initialized using group sas tokens will have an entry for "SharedAccessKeyName" in the supplied connection string.
-                        // These clients use a connection-wide TokenRefresher for authenticating all clients under the same group.
-                        // In these cases, the disposal of the TokenRefresher is delegated to the transport layer.
-                        ShouldSdkDisposeInstance = builder.SharedAccessKeyName == null,
+                        // Since the sdk creates the instance of disposable DeviceAuthenticationWithSakRefresh, the sdk needs to dispose it once the client is diposed.
+                        InstanceCreatedBySdk = true,
                     };
 
                     if (Logging.IsEnabled)
@@ -69,10 +67,8 @@ namespace Microsoft.Azure.Devices.Client
                 {
                     TokenRefresher = new ModuleAuthenticationWithSakRefresh(DeviceId, ModuleId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer)
                     {
-                        // Clients initialized using group sas tokens will have an entry for "SharedAccessKeyName" in the supplied connection string.
-                        // These clients use a connection-wide TokenRefresher for authenticating all clients under the same group.
-                        // In these cases, the disposal of the TokenRefresher is delegated to the transport layer.
-                        ShouldSdkDisposeInstance = builder.SharedAccessKeyName == null,
+                        // Since the sdk creates the instance of disposable ModuleAuthenticationWithSakRefresh, the sdk needs to dispose it once the client is diposed.
+                        InstanceCreatedBySdk = true,
                     };
 
                     if (Logging.IsEnabled)

--- a/iothub/device/src/IotHubConnectionString.cs
+++ b/iothub/device/src/IotHubConnectionString.cs
@@ -84,6 +84,13 @@ namespace Microsoft.Azure.Devices.Client
 
                 Debug.Assert(TokenRefresher != null);
             }
+            // SharedAccessSignature should be set only if it is non-null and the authentication method of the device client is
+            // not of type AuthenticationWithTokenRefresh.
+            // Setting the sas value for an AuthenticationWithTokenRefresh authentication type will result in tokens not being renewed.
+            // This flow can be hit if the same authentication method is always used to initialize the client;
+            // as in, on disposal and reinitialization. This is because the value of the sas token computed is stored within the authentication method,
+            // and on reinitialization the client is incorrectly identified as a fixed-sas-token-initialized client,
+            // instead of being identified as a sas-token-refresh-enabled-client.
             else if (!string.IsNullOrWhiteSpace(builder.SharedAccessSignature))
             {
                 SharedAccessSignature = builder.SharedAccessSignature;

--- a/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
@@ -173,7 +173,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             if (disposing)
             {
                 StopLoop();
-                _cancellationTokenSource.Dispose();
+                _cancellationTokenSource?.Dispose();
+                _cancellationTokenSource = null;
+
+                _amqpIotCbsTokenProvider?.Dispose();
             }
 
             _disposed = true;

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
@@ -76,8 +76,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             if (_amqpIotConnection != null && ReferenceEquals(_amqpIotConnection, o))
             {
                 _amqpAuthenticationRefresher?.StopLoop();
-                _amqpAuthenticationRefresher?.Dispose();
-
                 HashSet<AmqpUnit> amqpUnits;
                 lock (_unitsLock)
                 {
@@ -102,8 +100,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
 
             _amqpAuthenticationRefresher?.StopLoop();
-            _amqpAuthenticationRefresher?.Dispose();
-
             _amqpIotConnection?.SafeClose();
             if (Logging.IsEnabled)
             {

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
@@ -66,80 +66,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             return amqpUnit;
         }
 
-        private void OnConnectionClosed(object o, EventArgs args)
-        {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, o, nameof(OnConnectionClosed));
-            }
-
-            if (_amqpIotConnection != null && ReferenceEquals(_amqpIotConnection, o))
-            {
-                _amqpAuthenticationRefresher?.StopLoop();
-                HashSet<AmqpUnit> amqpUnits;
-                lock (_unitsLock)
-                {
-                    amqpUnits = new HashSet<AmqpUnit>(_amqpUnits);
-                }
-                foreach (AmqpUnit unit in amqpUnits)
-                {
-                    unit.OnConnectionDisconnected();
-                }
-            }
-            if (Logging.IsEnabled)
-            {
-                Logging.Exit(this, o, nameof(OnConnectionClosed));
-            }
-        }
-
-        public void Shutdown()
-        {
-            if (Logging.IsEnabled)
-            {
-                Logging.Enter(this, _amqpIotConnection, nameof(Shutdown));
-            }
-
-            _amqpAuthenticationRefresher?.StopLoop();
-            _amqpIotConnection?.SafeClose();
-            if (Logging.IsEnabled)
-            {
-                Logging.Exit(this, _amqpIotConnection, nameof(Shutdown));
-            }
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        private void Dispose(bool disposing)
-        {
-            if (_disposed)
-            {
-                return;
-            }
-
-            if (Logging.IsEnabled)
-            {
-                Logging.Info(this, disposing, nameof(Dispose));
-            }
-
-            if (disposing)
-            {
-                _amqpIotConnection?.SafeClose();
-                _lock?.Dispose();
-                _amqpIotConnector?.Dispose();
-                lock (_unitsLock)
-                {
-                    _amqpUnits.Clear();
-                }
-                _amqpAuthenticationRefresher?.Dispose();
-            }
-
-            _disposed = true;
-        }
-
         public async Task<IAmqpAuthenticationRefresher> CreateRefresherAsync(DeviceIdentity deviceIdentity, TimeSpan timeout)
         {
             if (Logging.IsEnabled)
@@ -206,19 +132,17 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                     // Create AmqpConnection
                     amqpIotConnection = await _amqpIotConnector.OpenConnectionAsync(timeout).ConfigureAwait(false);
 
-                    if (_deviceIdentity.AuthenticationModel != AuthenticationModel.X509)
+                    if (_deviceIdentity.AuthenticationModel == AuthenticationModel.SasGrouped)
                     {
-                        if (_deviceIdentity.AuthenticationModel == AuthenticationModel.SasGrouped)
+                        if (Logging.IsEnabled)
                         {
-                            if (Logging.IsEnabled)
-                            {
-                                Logging.Info(this, "Creating connection width AmqpAuthenticationRefresher", nameof(EnsureConnectionAsync));
-                            }
-
-                            amqpAuthenticationRefresher = new AmqpAuthenticationRefresher(_deviceIdentity, amqpIotConnection.GetCbsLink());
-                            await amqpAuthenticationRefresher.InitLoopAsync(timeout).ConfigureAwait(false);
+                            Logging.Info(this, "Creating connection wide AmqpAuthenticationRefresher", nameof(EnsureConnectionAsync));
                         }
+
+                        amqpAuthenticationRefresher = new AmqpAuthenticationRefresher(_deviceIdentity, amqpIotConnection.GetCbsLink());
+                        await amqpAuthenticationRefresher.InitLoopAsync(timeout).ConfigureAwait(false);
                     }
+
                     _amqpIotConnection = amqpIotConnection;
                     _amqpAuthenticationRefresher = amqpAuthenticationRefresher;
                     _amqpIotConnection.Closed += OnConnectionClosed;
@@ -269,6 +193,85 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             if (Logging.IsEnabled)
             {
                 Logging.Exit(this, amqpUnit, nameof(RemoveAmqpUnit));
+            }
+        }
+
+        public void Shutdown()
+        {
+            if (Logging.IsEnabled)
+            {
+                Logging.Enter(this, _amqpIotConnection, nameof(Shutdown));
+            }
+
+            _amqpAuthenticationRefresher?.StopLoop();
+            _amqpIotConnection?.SafeClose();
+            if (Logging.IsEnabled)
+            {
+                Logging.Exit(this, _amqpIotConnection, nameof(Shutdown));
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (Logging.IsEnabled)
+            {
+                Logging.Info(this, disposing, nameof(Dispose));
+            }
+
+            if (disposing)
+            {
+                _amqpIotConnection?.SafeClose();
+                _lock?.Dispose();
+                _amqpIotConnector?.Dispose();
+                lock (_unitsLock)
+                {
+                    _amqpUnits.Clear();
+                }
+                _amqpAuthenticationRefresher?.Dispose();
+            }
+
+            _disposed = true;
+        }
+
+        internal DeviceIdentity GetDeviceIdentityOfAuthenticationProvider()
+        {
+            return _deviceIdentity;
+        }
+
+        private void OnConnectionClosed(object o, EventArgs args)
+        {
+            if (Logging.IsEnabled)
+            {
+                Logging.Enter(this, o, nameof(OnConnectionClosed));
+            }
+
+            if (_amqpIotConnection != null && ReferenceEquals(_amqpIotConnection, o))
+            {
+                _amqpAuthenticationRefresher?.StopLoop();
+                HashSet<AmqpUnit> amqpUnits;
+                lock (_unitsLock)
+                {
+                    amqpUnits = new HashSet<AmqpUnit>(_amqpUnits);
+                }
+                foreach (AmqpUnit unit in amqpUnits)
+                {
+                    unit.OnConnectionDisconnected();
+                }
+            }
+            if (Logging.IsEnabled)
+            {
+                Logging.Exit(this, o, nameof(OnConnectionClosed));
             }
         }
     }

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
@@ -76,6 +76,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             if (_amqpIotConnection != null && ReferenceEquals(_amqpIotConnection, o))
             {
                 _amqpAuthenticationRefresher?.StopLoop();
+                _amqpAuthenticationRefresher?.Dispose();
+
                 HashSet<AmqpUnit> amqpUnits;
                 lock (_unitsLock)
                 {
@@ -100,6 +102,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
 
             _amqpAuthenticationRefresher?.StopLoop();
+            _amqpAuthenticationRefresher?.Dispose();
+
             _amqpIotConnection?.SafeClose();
             if (Logging.IsEnabled)
             {

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                     {
                         if (Logging.IsEnabled)
                         {
-                            Logging.Info(this, "Creating connection width AmqpAuthenticationRefresher", nameof(EnsureConnectionAsync));
+                            Logging.Info(this, "Creating connection wide AmqpAuthenticationRefresher", nameof(EnsureConnectionAsync));
                         }
 
                         amqpAuthenticationRefresher = new AmqpAuthenticationRefresher(_deviceIdentity, amqpIotConnection.GetCbsLink());

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
@@ -36,6 +36,15 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                 {
                     AmqpConnectionHolder[] amqpConnectionHolders = ResolveConnectionGroup(deviceIdentity);
                     amqpConnectionHolder = ResolveConnectionByHashing(amqpConnectionHolders, deviceIdentity);
+
+                    // For group sas token authenticated devices over a multiplexed connection, the identity
+                    // of the first device connecting will be used for generating the group sas tokens.
+                    // The TokenRefresher of the subsequently connected device identities can be safely disposed.
+                    if (!ReferenceEquals(amqpConnectionHolder.GetDeviceIdentityOfAuthenticationProvider(), deviceIdentity)
+                        && deviceIdentity.IotHubConnectionString?.TokenRefresher != null)
+                    {
+                        deviceIdentity.IotHubConnectionString.TokenRefresher.Dispose();
+                    }
                 }
 
                 if (Logging.IsEnabled)

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                     // For this reason, if the device identity of the client is not the one associated with the
                     // connection, the associated TokenRefresher can be safely disposed.
                     // Note - This does not cause any identity related issues since the group sas tokens are generated
-                    // against "{IoT hub name}.azure-devices.net/" as the intended audience (without the "device Id").
+                    // against the hub host as the intended audience (without the "device Id").
                     if (deviceIdentity.AuthenticationModel == AuthenticationModel.SasGrouped
                         && !ReferenceEquals(amqpConnectionHolder.GetDeviceIdentityOfAuthenticationProvider(), deviceIdentity)
                         && deviceIdentity.IotHubConnectionString?.TokenRefresher != null

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
@@ -37,13 +37,16 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                     AmqpConnectionHolder[] amqpConnectionHolders = ResolveConnectionGroup(deviceIdentity);
                     amqpConnectionHolder = ResolveConnectionByHashing(amqpConnectionHolders, deviceIdentity);
 
-                    // For group sas token authenticated devices over a multiplexed connection, the identity
-                    // of the first device connecting will be used for generating the group sas tokens.
-                    // The TokenRefresher of the subsequently connected device identities can be safely disposed.
-                    if (!ReferenceEquals(amqpConnectionHolder.GetDeviceIdentityOfAuthenticationProvider(), deviceIdentity)
-                        && deviceIdentity.IotHubConnectionString?.TokenRefresher != null)
+                    if (deviceIdentity.AuthenticationModel == AuthenticationModel.SasGrouped)
                     {
-                        deviceIdentity.IotHubConnectionString.TokenRefresher.Dispose();
+                        // For group sas token authenticated devices over a multiplexed connection, the identity
+                        // of the first device connecting will be used for generating the group sas tokens.
+                        // The TokenRefresher of the subsequently connected device identities can be safely disposed.
+                        if (!ReferenceEquals(amqpConnectionHolder.GetDeviceIdentityOfAuthenticationProvider(), deviceIdentity)
+                            && deviceIdentity.IotHubConnectionString?.TokenRefresher != null)
+                        {
+                            deviceIdentity.IotHubConnectionString.TokenRefresher.Dispose();
+                        }
                     }
                 }
 

--- a/iothub/device/src/Transport/Amqp/AmqpUnit.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnit.cs
@@ -852,6 +852,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
 
                 // For device sas authenticated clients the authentication refresher is associated with the AMQP unit itself,
                 // so it needs to be explicitly disposed.
+                _amqpAuthenticationRefresher?.StopLoop();
                 _amqpAuthenticationRefresher?.Dispose();
 
                 _sessionSemaphore?.Dispose();

--- a/iothub/device/src/Transport/Amqp/AmqpUnit.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnit.cs
@@ -850,6 +850,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
                     _amqpConnectionHolder?.Dispose();
                 }
 
+                // For device sas authenticated clients the authentication refresher is associated with the AMQP unit itself,
+                // so it needs to be explicitly disposed.
+                _amqpAuthenticationRefresher?.Dispose();
+
                 _sessionSemaphore?.Dispose();
                 _messageReceivingLinkSemaphore?.Dispose();
                 _messageReceivingCallbackSemaphore?.Dispose();

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotCbsTokenProvider.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotCbsTokenProvider.cs
@@ -9,9 +9,10 @@ using Microsoft.Azure.Devices.Shared;
 
 namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
 {
-    internal class AmqpIotCbsTokenProvider : ICbsTokenProvider
+    internal class AmqpIotCbsTokenProvider : ICbsTokenProvider, IDisposable
     {
         private readonly IotHubConnectionString _connectionString;
+        private bool _disposedValue;
 
         public AmqpIotCbsTokenProvider(IotHubConnectionString connectionString)
         {
@@ -56,6 +57,26 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
                     Logging.Exit(this, namespaceAddress, appliesTo, $"{nameof(IotHubConnectionString)}.{nameof(AmqpIotCbsTokenProvider.GetTokenAsync)}");
                 }
             }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    _connectionString.TokenRefresher.Dispose();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotCbsTokenProvider.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotCbsTokenProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
     internal class AmqpIotCbsTokenProvider : ICbsTokenProvider, IDisposable
     {
         private readonly IotHubConnectionString _connectionString;
-        private bool _disposedValue;
+        private bool _isDisposed;
 
         public AmqpIotCbsTokenProvider(IotHubConnectionString connectionString)
         {
@@ -59,24 +59,28 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
             }
         }
 
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposedValue)
-            {
-                if (disposing)
-                {
-                    _connectionString.TokenRefresher.Dispose();
-                }
-
-                _disposedValue = true;
-            }
-        }
-
         public void Dispose()
         {
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
+            Dispose(true);
             GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                    if (_connectionString?.TokenRefresher != null
+                        && _connectionString.TokenRefresher.InstanceCreatedBySdk)
+                    {
+                        _connectionString.TokenRefresher.Dispose();
+                    }
+                }
+
+                _isDisposed = true;
+            }
         }
     }
 }

--- a/iothub/device/src/Transport/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/HttpClientHelper.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         private HttpClientHandler _httpClientHandler;
         private bool _isDisposed;
         private readonly ProductInfo _productInfo;
+        private readonly bool _isClientPrimaryTransportHandler;
 
         public HttpClientHelper(
             Uri baseAddress,
@@ -51,7 +52,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
             X509Certificate2 clientCert,
             HttpClientHandler httpClientHandler,
             ProductInfo productInfo,
-            IWebProxy proxy
+            IWebProxy proxy,
+            bool isClientPrimaryTransportHandler = false
             )
         {
             _baseAddress = baseAddress;
@@ -115,6 +117,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
             preRequestActionForAllRequests?.Invoke(_httpClientObj);
             _productInfo = productInfo;
+            _isClientPrimaryTransportHandler = isClientPrimaryTransportHandler;
         }
 
         public Task<T> GetAsync<T>(
@@ -536,6 +539,20 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 {
                     _httpClientHandler?.Dispose();
                     _httpClientHandler = null;
+                }
+
+                // The associated TokenRefresher should be disposed by the http client helper only when the http client
+                // is the primary transport handler.
+                // For eg. we create HttpTransportHandler instances for file upload operations even though the client might be
+                // initialized via MQTT/ AMQP. In those scenarios, since the shared TokenRefresher resource would be primarily used by the
+                // corresponding transport layers (MQTT/ AMQP), the diposal should be delegated to them and it should not be disposed here.
+                // The only scenario where the TokenRefresher should be disposed here is when the client has been initialized using HTTP.
+                if (_isClientPrimaryTransportHandler
+                    && _authenticationHeaderProvider is IotHubConnectionString iotHubConnectionString
+                    && iotHubConnectionString.TokenRefresher != null
+                    && iotHubConnectionString.TokenRefresher.InstanceCreatedBySdk)
+                {
+                    iotHubConnectionString.TokenRefresher.Dispose();
                 }
 
                 _isDisposed = true;

--- a/iothub/device/src/Transport/HttpTransportHandler.cs
+++ b/iothub/device/src/Transport/HttpTransportHandler.cs
@@ -60,7 +60,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
         private readonly string _deviceId;
         private readonly string _moduleId;
 
-        internal HttpTransportHandler(IPipelineContext context, IotHubConnectionString iotHubConnectionString, Http1TransportSettings transportSettings, HttpClientHandler httpClientHandler = null)
+        internal HttpTransportHandler(
+            IPipelineContext context,
+            IotHubConnectionString iotHubConnectionString,
+            Http1TransportSettings transportSettings,
+            HttpClientHandler httpClientHandler = null,
+            bool isClientPrimaryTransportHandler = false)
             : base(context, transportSettings)
         {
             ProductInfo productInfo = context.Get<ProductInfo>();
@@ -75,7 +80,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 transportSettings.ClientCertificate,
                 httpClientHandler,
                 productInfo,
-                transportSettings.Proxy);
+                transportSettings.Proxy,
+                isClientPrimaryTransportHandler);
         }
 
         public override Task OpenAsync(TimeoutHelper timeoutHelper)

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -1017,6 +1017,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             finally
             {
+                if (_passwordProvider is IotHubConnectionString iotHubConnectionString
+                    && iotHubConnectionString.TokenRefresher != null
+                    && iotHubConnectionString.TokenRefresher.InstanceCreatedBySdk)
+                {
+                    iotHubConnectionString.TokenRefresher.Dispose();
+                }
+
                 if (Logging.IsEnabled)
                     Logging.Exit(this, context.Name, nameof(ShutdownAsync));
             }

--- a/iothub/device/src/Transport/TransportHandlerFactory.cs
+++ b/iothub/device/src/Transport/TransportHandlerFactory.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         new Func<Message, Task>(onDeviceMessageReceivedCallback));
 
                 case TransportType.Http1:
-                    return new HttpTransportHandler(context, connectionString, transportSetting as Http1TransportSettings);
+                    return new HttpTransportHandler(context, connectionString, transportSetting as Http1TransportSettings, isClientPrimaryTransportHandler: true);
 
                 case TransportType.Mqtt_Tcp_Only:
                 case TransportType.Mqtt_WebSocket_Only:


### PR DESCRIPTION
This PR fixes two issues:
- `IotHubConnectionString.TokenRefresher` is an `IDispoable` `IAuthenticationMethod.AuthenticationWithTokenRefresh`, which can be user-supplied. So, we shouldn't dispose it within our client, since they might want to reuse it.
Reference: https://docs.microsoft.com/en-us/dotnet/api/system.idisposable?view=net-5.0#implementing-idisposable
"You should implement IDisposable only if your type uses unmanaged resources directly. The consumers of your type can call your IDisposable.Dispose implementation to free resources when the instance is no longer needed."

- `IotHubConnectionString.SharedAccessSignature` should be set only if it is non-null and the authentication method of the device client is not of type `AuthenticationWithTokenRefresh`. Setting the sas value for an `AuthenticationWithTokenRefresh` authentication type will result in tokens not being renewed. This flow can be hit if the same authentication method is always used to initialize the client; as in, on disposal and reinitialization. (the value of the sas token computed is stored within the authentication method, and on reinitialization the client is incorrectly identified as a fixed-sas-token-initialized client, instead of being identified as a sas-token-refresh-enabled-client.)

Fix for #1911 

Dependency code map of `IAuthenticationMethod.AuthenticationWithTokenRefresh`:

![image](https://user-images.githubusercontent.com/22563986/118059639-dace4a80-b345-11eb-8688-faf2c4ad6605.png)

