### PR TITLE
[PnP] Add common resources for convention-based operations

### DIFF
--- a/iothub/device/devdoc/Convention-based operations.md
+++ b/iothub/device/devdoc/Convention-based operations.md
@@ -161,7 +161,6 @@ public class ClientPropertiesUpdateResponse {
 /// </remarks>
 /// <param name="telemetryMessage">The telemetry message.</param>
 /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-/// <returns></returns>
 public Task SendTelemetryAsync(TelemetryMessage telemetryMessage, CancellationToken cancellationToken = default);
 ```
 #### All related types
@@ -190,7 +189,6 @@ public class TelemetryMessage : Message {
 /// </summary>
 /// <param name="callback">A method implementation that will handle the incoming command.</param>
 /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
-/// <param name="payloadConvention">A convention handler that defines the content encoding and serializer to use for commands.</param>
 /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
 public Task SubscribeToCommandsAsync(Func<CommandRequest, object, Task<CommandResponse>> callback, object userContext, CancellationToken cancellationToken = default);
 ```

--- a/iothub/device/devdoc/Convention-based operations.md
+++ b/iothub/device/devdoc/Convention-based operations.md
@@ -1,0 +1,213 @@
+## Plug and Play convention compatible APIs
+
+#### Common
+
+```csharp
+
+public abstract class PayloadConvention {
+    protected PayloadConvention();
+    public abstract PayloadEncoder PayloadEncoder { get; }
+    public abstract PayloadSerializer PayloadSerializer { get; }
+    public virtual byte[] GetObjectBytes(object objectToSendWithConvention);
+}
+
+public abstract class PayloadEncoder {
+    protected PayloadEncoder();
+    public abstract Encoding ContentEncoding { get; }
+    public abstract byte[] EncodeStringToByteArray(string contentPayload);
+}
+
+public abstract class PayloadSerializer {
+    protected PayloadSerializer();
+    public abstract string ContentType { get; }
+    public abstract T ConvertFromObject<T>(object objectToConvert);
+    public abstract IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = null);
+    public abstract T DeserializeToType<T>(string stringToDeserialize);
+    public abstract string SerializeToString(object objectToSerialize);
+    public abstract bool TryGetNestedObjectValue<T>(object objectToConvert, string propertyName, out T outValue);
+}
+
+public sealed class DefaultPayloadConvention : PayloadConvention {
+    public static readonly DefaultPayloadConvention Instance;
+    public DefaultPayloadConvention();
+    public override PayloadEncoder PayloadEncoder { get; }
+    public override PayloadSerializer PayloadSerializer { get; }
+}
+
+public class Utf8PayloadEncoder : PayloadEncoder {
+    public static readonly Utf8PayloadEncoder Instance;
+    public Utf8PayloadEncoder();
+    public override Encoding ContentEncoding { get; }
+    public override byte[] EncodeStringToByteArray(string contentPayload);
+}
+
+public class NewtonsoftJsonPayloadSerializer : PayloadSerializer {
+    public static readonly NewtonsoftJsonPayloadSerializer Instance;
+    public NewtonsoftJsonPayloadSerializer();
+    public override string ContentType { get; }
+    public override T ConvertFromObject<T>(object objectToConvert);
+    public override IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = null);
+    public override T DeserializeToType<T>(string stringToDeserialize);
+    public override string SerializeToString(object objectToSerialize);
+    public override bool TryGetNestedObjectValue<T>(object objectToConvert, string propertyName, out T outValue);
+}
+
+public abstract class PayloadCollection : IEnumerable, IEnumerable<object> {
+    protected PayloadCollection();
+    public IDictionary<string, object> Collection { get; private set; }
+    public PayloadConvention Convention { get; internal set; }
+    public virtual object this[string key] { get; set; }
+    public virtual void Add(string key, object value);
+    public virtual void AddOrUpdate(string key, object value);
+    public bool Contains(string key);
+    public IEnumerator<object> GetEnumerator();
+    public virtual byte[] GetPayloadObjectBytes();
+    public virtual string GetSerializedString();
+    protected void SetCollection(PayloadCollection payloadCollection);
+    IEnumerator System.Collections.IEnumerable.GetEnumerator();
+    public bool TryGetValue<T>(string key, out T value);
+}
+
+public static class ConventionBasedConstants {
+    public const string AckCodePropertyName = "ac";
+    public const string AckDescriptionPropertyName = "ad";
+    public const string AckVersionPropertyName = "av";
+    public const string ComponentIdentifierKey = "__t";
+    public const string ComponentIdentifierValue = "c";
+    public const string ValuePropertyName = "value";
+}
+```
+
+### Properties
+
+```csharp
+/// <summary>
+/// Retrieve the device properties.
+/// </summary>
+/// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+/// <returns>The device properties.</returns>
+public Task<ClientProperties> GetClientPropertiesAsync(CancellationToken cancellationToken = default);
+
+/// <summary>
+/// Update properties.
+/// </summary>
+/// <param name="propertyCollection">Reported properties to push.</param>
+/// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+/// <returns>The response containing the operation request Id and updated version no.</returns>
+public Task<ClientPropertiesUpdateResponse> UpdateClientPropertiesAsync(ClientPropertyCollection propertyCollection, CancellationToken cancellationToken = default);
+
+/// <summary>
+/// Sets the global listener for Writable properties
+/// </summary>
+/// <param name="callback">The global call back to handle all writable property updates.</param>
+/// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
+/// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+public Task SubscribeToWritablePropertiesEventAsync(Func<ClientPropertyCollection, object, Task> callback, object userContext, CancellationToken cancellationToken = default);
+```
+
+#### All related types
+
+```csharp
+public class ClientProperties : ClientPropertyCollection {
+    public ClientPropertyCollection Writable { get; private set; }
+}
+
+public class ClientPropertyCollection : PayloadCollection {
+    public ClientPropertyCollection();
+    public long Version { get; protected set; }
+    public void Add(IDictionary<string, object> properties, string componentName = null);
+    public override void Add(string propertyName, object propertyValue);
+    public void Add(string propertyName, object propertyValue, int statusCode, long version, string description = null, string componentName = null);
+    public void Add(string propertyName, object propertyValue, string componentName);
+    public void AddOrUpdate(IDictionary<string, object> properties, string componentNam = null);
+    public override void AddOrUpdate(string propertyName, object propertyValue);
+    public void AddOrUpdate(string propertyName, object propertyValue, int statusCode, long version, string description = null, string componentName = null);
+    public void AddOrUpdate(string propertyName, object propertyValue, string componentName);
+    public bool Contains(string componentName, string propertyName);
+    public virtual bool TryGetValue<T>(string componentName, string propertyName, out T propertyValue);
+}
+
+public interface IWritablePropertyResponse {
+    int AckCode { get; set; }
+    string AckDescription { get; set; }
+    long AckVersion { get; set; }
+    object Value { get; set; }
+}
+
+public sealed class NewtonsoftJsonWritablePropertyResponse : IWritablePropertyResponse {
+    public NewtonsoftJsonWritablePropertyResponse(object propertyValue, int ackCode, long ackVersion, string ackDescription = null);
+    public int AckCode { get; set; }
+    public string AckDescription { get; set; }
+    public long AckVersion { get; set; }
+    public object Value { get; set; }
+}
+
+public class ClientPropertiesUpdateResponse {
+    public ClientPropertiesUpdateResponse();
+    public string RequestId { get; internal set; }
+    public long Version { get; internal set; }
+}
+```
+
+### Telemetry
+
+```csharp
+/// <summary>
+/// Send telemetry using the specified message.
+/// </summary>
+/// <remarks>
+/// Use the <see cref="TelemetryMessage(string, TelemetryCollection)"/> constructor to pass in the optional
+/// <see cref="TelemetryCollection"/> that specifies your payload and serialization and encoding rules.
+/// </remarks>
+/// <param name="telemetryMessage">The telemetry message.</param>
+/// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+/// <returns></returns>
+public Task SendTelemetryAsync(TelemetryMessage telemetryMessage, CancellationToken cancellationToken = default);
+```
+#### All related types
+
+```csharp
+public class TelemetryCollection : PayloadCollection {
+    public TelemetryCollection();
+    public override void Add(string telemetryName, object telemetryValue);
+    public override void AddOrUpdate(string telemetryName, object telemetryValue);
+}
+
+public class TelemetryMessage : Message {
+    public TelemetryMessage(string componentName = null);
+    public new string ContentEncoding { get; internal set; }
+    public new string ContentType { get; internal set; }
+    public TelemetryCollection Telemetry { get; set; }
+    public override Stream GetBodyStream();
+}
+```
+
+### Commands
+
+```csharp
+/// <summary>
+/// Set the global command callback handler.
+/// </summary>
+/// <param name="callback">A method implementation that will handle the incoming command.</param>
+/// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
+/// <param name="payloadConvention">A convention handler that defines the content encoding and serializer to use for commands.</param>
+/// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+public Task SubscribeToCommandsAsync(Func<CommandRequest, object, Task<CommandResponse>> callback, object userContext, CancellationToken cancellationToken = default);
+```
+#### All related types
+
+```csharp
+public sealed class CommandRequest {
+    public string CommandName { get; private set; }
+    public string ComponentName { get; private set; }
+    public string DataAsJson { get; }
+    public T GetData<T>();
+}
+
+public sealed class CommandResponse {
+    public CommandResponse(int status);
+    public CommandResponse(object result, int status);
+    public string ResultAsJson { get; }
+    public int Status { get; private set; }
+}
+```

--- a/iothub/device/src/ClientOptions.cs
+++ b/iothub/device/src/ClientOptions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Devices.Client
         /// The payload convention to be used to serialize and encode the messages for convention based methods.
         /// </summary>
         /// <remarks>
-        /// The <see cref="Shared.PayloadConvention"/> defines both the serializer and encoding to be used for convetion based messages.
+        /// The <see cref="Shared.PayloadConvention"/> defines both the serializer and encoding to be used for convention based messages.
         /// You will only need to set this if you have objects that have special serialization rules or require a specific byte encoding.
         /// <para>
         /// The default value is set to <see cref="DefaultPayloadConvention"/> which uses the <see cref="NewtonsoftJsonPayloadSerializer"/> serializer

--- a/iothub/device/src/ClientOptions.cs
+++ b/iothub/device/src/ClientOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <summary>
         /// The transport settings to use for all file upload operations, regardless of what protocol the device
-        /// client is configured with. All file upload operations take place over https. 
+        /// client is configured with. All file upload operations take place over https.
         /// If FileUploadTransportSettings is not provided, then file upload operations will use the client certificates configured
         /// in the transport settings set for the non-file upload operations.
         /// </summary>
@@ -54,5 +54,18 @@ namespace Microsoft.Azure.Devices.Client
         /// or the <see cref="ModuleClient.CreateFromEnvironmentAsync(ClientOptions)"/> flow.
         /// </remarks>
         public int SasTokenRenewalBuffer { get; set; }
+
+        /// <summary>
+        /// The payload convention to be used to serialize and encode the messages for convention based methods.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Shared.PayloadConvention"/> defines both the serializer and encoding to be used for convetion based messages.
+        /// You will only need to set this if you have objects that have special serialization rules or require a specific byte encoding.
+        /// <para>
+        /// The default value is set to <see cref="DefaultPayloadConvention"/> which uses the <see cref="NewtonsoftJsonPayloadSerializer"/> serializer
+        /// and <see cref="Utf8PayloadEncoder"/> encoder.
+        /// </para>
+        /// </remarks>
+        public PayloadConvention PayloadConvention { get; set; } = DefaultPayloadConvention.Instance;
     }
 }

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -4,12 +4,17 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.Azure.Devices.Shared;
 
-namespace Microsoft.Azure.Devices.Shared
+namespace Microsoft.Azure.Devices.Client
 {
     /// <summary>
     /// The base class for all payloads that accept a <see cref="PayloadConvention"/>.
     /// </summary>
+    /// <remarks>
+    /// This classes uses the <see cref="NewtonsoftJsonPayloadSerializer"/> and
+    /// <see cref="Utf8PayloadEncoder"/> based <see cref="DefaultPayloadConvention"/> by default.
+    /// </remarks>
     public abstract class PayloadCollection : IEnumerable<object>
     {
         /// <summary>

--- a/shared/src/ConventionBasedConstants.cs
+++ b/shared/src/ConventionBasedConstants.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// Container for common convention based constants.
+    /// </summary>
+    public static class ConventionBasedConstants
+    {
+        /// <summary>
+        /// Marker key to indicate a component-level property.
+        /// </summary>
+        public const string ComponentIdentifierKey = "__t";
+
+        /// <summary>
+        /// Marker value to indicate a component-level property.
+        /// </summary>
+        public const string ComponentIdentifierValue = "c";
+
+        /// <summary>
+        /// Represents the JSON document property name for the value of a writable property response.
+        /// </summary>
+        public const string ValuePropertyName = "value";
+
+        /// <summary>
+        /// Represents the JSON document property name for the Ack Code of a writable property response.
+        /// </summary>
+        public const string AckCodePropertyName = "ac";
+
+        /// <summary>
+        /// Represents the JSON document property name for the Ack Version of a writable property response.
+        /// </summary>
+        public const string AckVersionPropertyName = "av";
+
+        /// <summary>
+        /// Represents the JSON document property name for the Ack Description of a writable property response.
+        /// </summary>
+        public const string AckDescriptionPropertyName = "ad";
+    }
+}

--- a/shared/src/ConventionBasedConstants.cs
+++ b/shared/src/ConventionBasedConstants.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.Azure.Devices.Shared
 {

--- a/shared/src/DefaultPayloadConvention.cs
+++ b/shared/src/DefaultPayloadConvention.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// The default implementation of the <see cref="PayloadConvention"/> class.
+    /// </summary>
+    /// <remarks>
+    /// This class is the default <see cref="PayloadConvention"/> that will be used for all <see cref="PayloadCollection"/> implementations.
+    /// This class makes use of the <see cref="NewtonsoftJsonPayloadSerializer"/> serializer and the <see cref="Utf8PayloadEncoder"/>.
+    /// </remarks>
+    public sealed class DefaultPayloadConvention : PayloadConvention
+    {
+        /// <summary>
+        /// A static instance of this class.
+        /// </summary>
+        public static readonly DefaultPayloadConvention Instance = new DefaultPayloadConvention();
+
+        /// <inheritdoc/>
+        public override PayloadSerializer PayloadSerializer { get; } = NewtonsoftJsonPayloadSerializer.Instance;
+
+        /// <inheritdoc/>
+        public override PayloadEncoder PayloadEncoder { get; } = Utf8PayloadEncoder.Instance;
+    }
+}

--- a/shared/src/DefaultPayloadConvention.cs
+++ b/shared/src/DefaultPayloadConvention.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.Devices.Shared
     /// The default implementation of the <see cref="PayloadConvention"/> class.
     /// </summary>
     /// <remarks>
-    /// This class is the default <see cref="PayloadConvention"/> that will be used for all <see cref="PayloadCollection"/> implementations.
     /// This class makes use of the <see cref="NewtonsoftJsonPayloadSerializer"/> serializer and the <see cref="Utf8PayloadEncoder"/>.
     /// </remarks>
     public sealed class DefaultPayloadConvention : PayloadConvention

--- a/shared/src/IWritablePropertyResponse.cs
+++ b/shared/src/IWritablePropertyResponse.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// The interface that defines the structure of a writable property response.
+    /// </summary>
+    /// <remarks>
+    /// This interface is used to allow extension to use a different set of attributes for serialization.
+    /// For example our default implementation found in <see cref="NewtonsoftJsonWritablePropertyResponse"/> is based on <see cref="Newtonsoft.Json"/> seriailizer attributes.
+    /// </remarks>
+    public interface IWritablePropertyResponse
+    {
+        /// <summary>
+        /// The unserialized property value.
+        /// </summary>
+        public object Value { get; set; }
+
+        /// <summary>
+        /// The acknowledgement code, usually an HTTP Status Code e.g. 200, 400.
+        /// </summary>
+        public int AckCode { get; set; }
+
+        /// <summary>
+        /// The acknowledgement version, as supplied in the property update request.
+        /// </summary>
+        public long AckVersion { get; set; }
+
+        /// <summary>
+        /// The acknowledgement description, an optional, human-readable message about the result of the property update.
+        /// </summary>
+        public string AckDescription { get; set; }
+    }
+}

--- a/shared/src/IWritablePropertyResponse.cs
+++ b/shared/src/IWritablePropertyResponse.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Devices.Shared
     /// </summary>
     /// <remarks>
     /// This interface is used to allow extension to use a different set of attributes for serialization.
-    /// For example our default implementation found in <see cref="NewtonsoftJsonWritablePropertyResponse"/> is based on <see cref="Newtonsoft.Json"/> seriailizer attributes.
+    /// For example our default implementation found in <see cref="NewtonsoftJsonWritablePropertyResponse"/> is based on <see cref="Newtonsoft.Json"/> serializer attributes.
     /// </remarks>
     public interface IWritablePropertyResponse
     {
@@ -18,17 +18,17 @@ namespace Microsoft.Azure.Devices.Shared
         public object Value { get; set; }
 
         /// <summary>
-        /// The acknowledgement code, usually an HTTP Status Code e.g. 200, 400.
+        /// The acknowledgment code, usually an HTTP Status Code e.g. 200, 400.
         /// </summary>
         public int AckCode { get; set; }
 
         /// <summary>
-        /// The acknowledgement version, as supplied in the property update request.
+        /// The acknowledgment version, as supplied in the property update request.
         /// </summary>
         public long AckVersion { get; set; }
 
         /// <summary>
-        /// The acknowledgement description, an optional, human-readable message about the result of the property update.
+        /// The acknowledgment description, an optional, human-readable message about the result of the property update.
         /// </summary>
         public string AckDescription { get; set; }
     }

--- a/shared/src/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/src/Microsoft.Azure.Devices.Shared.csproj
@@ -43,6 +43,11 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
+  <!-- System.Text.Json isn't available on net451 -->
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+  </ItemGroup>
+
   <ItemGroup>
     <!-- FXCop -->
     <PackageReference Condition=" '$(Configuration)' == 'Debug' " Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">

--- a/shared/src/NewtonsoftJsonPayloadSerializer.cs
+++ b/shared/src/NewtonsoftJsonPayloadSerializer.cs
@@ -7,12 +7,12 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Azure.Devices.Shared
 {
     /// <summary>
-    /// A <see cref="Newtonsoft.Json.JsonConvert"/> <see cref="PayloadSerializer"/> implementation.
+    /// A <see cref="JsonConvert"/> <see cref="PayloadSerializer"/> implementation.
     /// </summary>
     public class NewtonsoftJsonPayloadSerializer : PayloadSerializer
     {
         /// <summary>
-        /// The Content Type string.
+        /// The content type string.
         /// </summary>
         internal const string ApplicationJson = "application/json";
 
@@ -47,14 +47,14 @@ namespace Microsoft.Azure.Devices.Shared
         }
 
         /// <inheritdoc/>
-        public override bool TryGetNestedObjectValue<T>(object objectToConvert, string propertyName, out T outValue)
+        public override bool TryGetNestedObjectValue<T>(object nestedObject, string propertyName, out T outValue)
         {
             outValue = default;
-            if (objectToConvert == null || string.IsNullOrEmpty(propertyName))
+            if (nestedObject == null || string.IsNullOrEmpty(propertyName))
             {
                 return false;
             }
-            if (((JObject)objectToConvert).TryGetValue(propertyName, out var element))
+            if (((JObject)nestedObject).TryGetValue(propertyName, out JToken element))
             {
                 outValue = element.ToObject<T>();
                 return true;

--- a/shared/src/NewtonsoftJsonPayloadSerializer.cs
+++ b/shared/src/NewtonsoftJsonPayloadSerializer.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// A <see cref="Newtonsoft.Json.JsonConvert"/> <see cref="PayloadSerializer"/> implementation.
+    /// </summary>
+    public class NewtonsoftJsonPayloadSerializer : PayloadSerializer
+    {
+        /// <summary>
+        /// The Content Type string.
+        /// </summary>
+        internal const string ApplicationJson = "application/json";
+
+        /// <summary>
+        /// The default instance of this class.
+        /// </summary>
+        public static readonly NewtonsoftJsonPayloadSerializer Instance = new NewtonsoftJsonPayloadSerializer();
+
+        /// <inheritdoc/>
+        public override string ContentType => ApplicationJson;
+
+        /// <inheritdoc/>
+        public override string SerializeToString(object objectToSerialize)
+        {
+            return JsonConvert.SerializeObject(objectToSerialize);
+        }
+
+        /// <inheritdoc/>
+        public override T DeserializeToType<T>(string stringToDeserialize)
+        {
+            return JsonConvert.DeserializeObject<T>(stringToDeserialize);
+        }
+
+        /// <inheritdoc/>
+        public override T ConvertFromObject<T>(object objectToConvert)
+        {
+            if (objectToConvert == null)
+            {
+                return default;
+            }
+            return ((JObject)objectToConvert).ToObject<T>();
+        }
+
+        /// <inheritdoc/>
+        public override bool TryGetNestedObjectValue<T>(object objectToConvert, string propertyName, out T outValue)
+        {
+            outValue = default;
+            if (objectToConvert == null || string.IsNullOrEmpty(propertyName))
+            {
+                return false;
+            }
+            if (((JObject)objectToConvert).TryGetValue(propertyName, out var element))
+            {
+                outValue = element.ToObject<T>();
+                return true;
+            }
+            return false;
+        }
+
+        /// <inheritdoc/>
+        public override IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = null)
+        {
+            return new NewtonsoftJsonWritablePropertyResponse(value, statusCode, version, description);
+        }
+    }
+}

--- a/shared/src/NewtonsoftJsonWritablePropertyResponse.cs
+++ b/shared/src/NewtonsoftJsonWritablePropertyResponse.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Azure.Devices.Shared
         /// Convenience constructor for specifying the properties.
         /// </summary>
         /// <param name="propertyValue">The unserialized property value.</param>
-        /// <param name="ackCode">The acknowledgement code, usually an HTTP Status Code e.g. 200, 400.</param>
-        /// <param name="ackVersion">The acknowledgement version, as supplied in the property update request.</param>
-        /// <param name="ackDescription">The acknowledgement description, an optional, human-readable message about the result of the property update.</param>
+        /// <param name="ackCode">The acknowledgment code, usually an HTTP Status Code e.g. 200, 400.</param>
+        /// <param name="ackVersion">The acknowledgment version, as supplied in the property update request.</param>
+        /// <param name="ackDescription">The acknowledgment description, an optional, human-readable message about the result of the property update.</param>
         public NewtonsoftJsonWritablePropertyResponse(object propertyValue, int ackCode, long ackVersion, string ackDescription = default)
         {
             Value = propertyValue;
@@ -36,19 +36,19 @@ namespace Microsoft.Azure.Devices.Shared
         public object Value { get; set; }
 
         /// <summary>
-        /// The acknowledgement code, usually an HTTP Status Code e.g. 200, 400.
+        /// The acknowledgment code, usually an HTTP Status Code e.g. 200, 400.
         /// </summary>
         [JsonProperty(ConventionBasedConstants.AckCodePropertyName)]
         public int AckCode { get; set; }
 
         /// <summary>
-        /// The acknowledgement version, as supplied in the property update request.
+        /// The acknowledgment version, as supplied in the property update request.
         /// </summary>
         [JsonProperty(ConventionBasedConstants.AckVersionPropertyName)]
         public long AckVersion { get; set; }
 
         /// <summary>
-        /// The acknowledgement description, an optional, human-readable message about the result of the property update.
+        /// The acknowledgment description, an optional, human-readable message about the result of the property update.
         /// </summary>
         [JsonProperty(ConventionBasedConstants.AckDescriptionPropertyName, DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string AckDescription { get; set; }

--- a/shared/src/NewtonsoftJsonWritablePropertyResponse.cs
+++ b/shared/src/NewtonsoftJsonWritablePropertyResponse.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// An optional, helper class for constructing a writable property response.
+    /// </summary>
+    /// <remarks>
+    /// This helper class will only work with <see cref="Newtonsoft.Json"/>.
+    /// It uses <see cref="Newtonsoft.Json"/> based <see cref="JsonPropertyAttribute"/> to define the JSON property names.
+    /// </remarks>
+    public sealed class NewtonsoftJsonWritablePropertyResponse : IWritablePropertyResponse
+    {
+        /// <summary>
+        /// Convenience constructor for specifying the properties.
+        /// </summary>
+        /// <param name="propertyValue">The unserialized property value.</param>
+        /// <param name="ackCode">The acknowledgement code, usually an HTTP Status Code e.g. 200, 400.</param>
+        /// <param name="ackVersion">The acknowledgement version, as supplied in the property update request.</param>
+        /// <param name="ackDescription">The acknowledgement description, an optional, human-readable message about the result of the property update.</param>
+        public NewtonsoftJsonWritablePropertyResponse(object propertyValue, int ackCode, long ackVersion, string ackDescription = default)
+        {
+            Value = propertyValue;
+            AckCode = ackCode;
+            AckVersion = ackVersion;
+            AckDescription = ackDescription;
+        }
+
+        /// <summary>
+        /// The unserialized property value.
+        /// </summary>
+        [JsonProperty(ConventionBasedConstants.ValuePropertyName)]
+        public object Value { get; set; }
+
+        /// <summary>
+        /// The acknowledgement code, usually an HTTP Status Code e.g. 200, 400.
+        /// </summary>
+        [JsonProperty(ConventionBasedConstants.AckCodePropertyName)]
+        public int AckCode { get; set; }
+
+        /// <summary>
+        /// The acknowledgement version, as supplied in the property update request.
+        /// </summary>
+        [JsonProperty(ConventionBasedConstants.AckVersionPropertyName)]
+        public long AckVersion { get; set; }
+
+        /// <summary>
+        /// The acknowledgement description, an optional, human-readable message about the result of the property update.
+        /// </summary>
+        [JsonProperty(ConventionBasedConstants.AckDescriptionPropertyName, DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string AckDescription { get; set; }
+    }
+}

--- a/shared/src/PayloadCollection.cs
+++ b/shared/src/PayloadCollection.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace Microsoft.Azure.Devices.Shared
 {
     /// <summary>
-    /// The base class for all payloads that accept a <see cref="PayloadConvention"/>
+    /// The base class for all payloads that accept a <see cref="PayloadConvention"/>.
     /// </summary>
     public abstract class PayloadCollection : IEnumerable<object>
     {
@@ -23,12 +23,13 @@ namespace Microsoft.Azure.Devices.Shared
         public PayloadConvention Convention { get; internal set; }
 
         /// <summary>
-        /// Get the value at the specified key
+        /// Get the value at the specified key.
         /// </summary>
-        /// <param name="key">Key of value</param>
         /// <remarks>
-        /// This accessor is best used to access simple types. It is recommended to use <see cref="TryGetValue"/> to cast a complex type.
+        /// This accessor is best used to access and cast to simple types.
+        /// It is recommended to use <see cref="TryGetValue"/> to deserialize to a complex type.
         /// </remarks>
+        /// <param name="key">Key of value.</param>
         /// <returns>The specified property.</returns>
         public virtual object this[string key]
         {
@@ -53,17 +54,17 @@ namespace Microsoft.Azure.Devices.Shared
         /// </summary>
         /// <param name="key">The name of the telemetry.</param>
         /// <param name="value">The value of the telemetry.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c> </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c>.</exception>
         public virtual void AddOrUpdate(string key, object value)
         {
             Collection[key] = value;
         }
 
         /// <summary>
-        /// Gets the collection as a byte array
+        /// Gets the collection as a byte array.
         /// </summary>
         /// <remarks>
-        /// This will get the fully encoded serialized string using both <see cref="PayloadSerializer.SerializeToString(object)"/>
+        /// This will get the fully encoded serialized string using both <see cref="PayloadSerializer.SerializeToString(object)"/>.
         /// and <see cref="PayloadEncoder.EncodeStringToByteArray(string)"/> methods implemented in the <see cref="PayloadConvention"/>.
         /// </remarks>
         /// <returns>A fully encoded serialized string.</returns>
@@ -91,7 +92,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// <typeparam name="T">The type to cast the object to.</typeparam>
         /// <param name="key">The key of the property to get.</param>
         /// <param name="value">The value of the object from the collection.</param>
-        /// <returns>true if the collection contains an element with the specified key; otherwise, false.</returns>
+        /// <returns>True if the collection contains an element with the specified key; otherwise, it returns false.</returns>
         public bool TryGetValue<T>(string key, out T value)
         {
             if (Collection.ContainsKey(key))
@@ -113,9 +114,9 @@ namespace Microsoft.Azure.Devices.Shared
         }
 
         /// <summary>
-        /// Returns a serailized string of this collection from the <see cref="PayloadSerializer.SerializeToString(object)"/> method.
+        /// Returns a serialized string of this collection from the <see cref="PayloadSerializer.SerializeToString(object)"/> method.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A serialized string of this collection.</returns>
         public virtual string GetSerializedString()
         {
             return Convention.PayloadSerializer.SerializeToString(Collection);
@@ -139,7 +140,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// <summary>
         /// Will set the underlying <see cref="Collection"/> of the payload collection.
         /// </summary>
-        /// <param name="payloadCollection">The collection to get the underlying dictionary from</param>
+        /// <param name="payloadCollection">The collection to get the underlying dictionary from.</param>
         protected void SetCollection(PayloadCollection payloadCollection)
         {
             if (payloadCollection == null)

--- a/shared/src/PayloadCollection.cs
+++ b/shared/src/PayloadCollection.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// The base class for all payloads that accept a <see cref="PayloadConvention"/>
+    /// </summary>
+    public abstract class PayloadCollection : IEnumerable<object>
+    {
+        /// <summary>
+        /// The underlying collection for the payload.
+        /// </summary>
+        public IDictionary<string, object> Collection { get; private set; } = new Dictionary<string, object>();
+
+        /// <summary>
+        /// The convention to use with this payload.
+        /// </summary>
+        public PayloadConvention Convention { get; internal set; }
+
+        /// <summary>
+        /// Get the value at the specified key
+        /// </summary>
+        /// <param name="key">Key of value</param>
+        /// <remarks>
+        /// This accessor is best used to access simple types. It is recommended to use <see cref="TryGetValue"/> to cast a complex type.
+        /// </remarks>
+        /// <returns>The specified property.</returns>
+        public virtual object this[string key]
+        {
+            get => Collection[key];
+            set => AddOrUpdate(key, value);
+        }
+
+        /// <summary>
+        /// Adds the key-value pair to the collection.
+        /// </summary>
+        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['key']"/>
+        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['value']"/>
+        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/exception"/>
+        /// <exception cref="ArgumentException">An element with the same key already exists in the collection.</exception>
+        public virtual void Add(string key, object value)
+        {
+            Collection.Add(key, value);
+        }
+
+        /// <summary>
+        /// Adds or updates the key-value pair to the collection.
+        /// </summary>
+        /// <param name="key">The name of the telemetry.</param>
+        /// <param name="value">The value of the telemetry.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c> </exception>
+        public virtual void AddOrUpdate(string key, object value)
+        {
+            Collection[key] = value;
+        }
+
+        /// <summary>
+        /// Gets the collection as a byte array
+        /// </summary>
+        /// <remarks>
+        /// This will get the fully encoded serialized string using both <see cref="PayloadSerializer.SerializeToString(object)"/>
+        /// and <see cref="PayloadEncoder.EncodeStringToByteArray(string)"/> methods implemented in the <see cref="PayloadConvention"/>.
+        /// </remarks>
+        /// <returns>A fully encoded serialized string.</returns>
+        public virtual byte[] GetPayloadObjectBytes()
+        {
+            return Convention.GetObjectBytes(Collection);
+        }
+
+        /// <summary>
+        /// Determines whether the specified property is present.
+        /// </summary>
+        /// <param name="key">The key in the collection to locate.</param>
+        /// <returns><c>true</c> if the specified property is present; otherwise, <c>false</c>.</returns>
+        public bool Contains(string key)
+        {
+            return Collection.ContainsKey(key);
+        }
+
+        /// <summary>
+        /// Gets the value of the object from the collection.
+        /// </summary>
+        /// <remarks>
+        /// This class is used for both sending and receiving properties for the device.
+        /// </remarks>
+        /// <typeparam name="T">The type to cast the object to.</typeparam>
+        /// <param name="key">The key of the property to get.</param>
+        /// <param name="value">The value of the object from the collection.</param>
+        /// <returns>true if the collection contains an element with the specified key; otherwise, false.</returns>
+        public bool TryGetValue<T>(string key, out T value)
+        {
+            if (Collection.ContainsKey(key))
+            {
+                // If the object is of type T go ahead and return it.
+                if (Collection[key] is T valueRef)
+                {
+                    value = valueRef;
+                    return true;
+                }
+                // If it's not we need to try to convert it using the serializer.
+                // JObject or JsonElement
+                value = Convention.PayloadSerializer.ConvertFromObject<T>(Collection[key]);
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Returns a serailized string of this collection from the <see cref="PayloadSerializer.SerializeToString(object)"/> method.
+        /// </summary>
+        /// <returns></returns>
+        public virtual string GetSerializedString()
+        {
+            return Convention.PayloadSerializer.SerializeToString(Collection);
+        }
+
+        ///  <inheritdoc />
+        public IEnumerator<object> GetEnumerator()
+        {
+            foreach (object property in Collection)
+            {
+                yield return property;
+            }
+        }
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <summary>
+        /// Will set the underlying <see cref="Collection"/> of the payload collection.
+        /// </summary>
+        /// <param name="payloadCollection">The collection to get the underlying dictionary from</param>
+        protected void SetCollection(PayloadCollection payloadCollection)
+        {
+            if (payloadCollection == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            Collection = payloadCollection.Collection;
+            Convention = payloadCollection.Convention;
+        }
+    }
+}

--- a/shared/src/PayloadConvention.cs
+++ b/shared/src/PayloadConvention.cs
@@ -6,7 +6,9 @@ namespace Microsoft.Azure.Devices.Shared
     /// <summary>
     /// The payload convention class.
     /// </summary>
-    /// <remarks>The payload convention is used to define a specific serializer as well as a specific content encoding. For example, IoT has a <see href="https://docs.microsoft.com/en-us/azure/iot-pnp/concepts-convention">convention</see> that is designed to make it easier to get started with products that use specific conventions by default.</remarks>
+    /// <remarks>The payload convention is used to define a specific serializer as well as a specific content encoding.
+    /// For example, IoT has a <see href="https://docs.microsoft.com/en-us/azure/iot-pnp/concepts-convention">convention</see> that is designed
+    /// to make it easier to get started with products that use specific conventions by default.</remarks>
     public abstract class PayloadConvention
     {
         /// <summary>
@@ -22,10 +24,10 @@ namespace Microsoft.Azure.Devices.Shared
         public abstract PayloadEncoder PayloadEncoder { get; }
 
         /// <summary>
-        /// Returns the byte array for the convention based message.
+        /// Returns the byte array for the convention-based message.
         /// </summary>
         /// <remarks>This base class will use the <see cref="PayloadSerializer"/> and <see cref="PayloadEncoder"/> to create this byte array.</remarks>
-        /// <param name="objectToSendWithConvention"></param>
+        /// <param name="objectToSendWithConvention">The convention-based message that is to be sent.</param>
         /// <returns>The correctly encoded object for this convention.</returns>
         public virtual byte[] GetObjectBytes(object objectToSendWithConvention)
         {

--- a/shared/src/PayloadConvention.cs
+++ b/shared/src/PayloadConvention.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// The payload convention class.
+    /// </summary>
+    /// <remarks>The payload convention is used to define a specific serializer as well as a specific content encoding. For example, IoT has a <see href="https://docs.microsoft.com/en-us/azure/iot-pnp/concepts-convention">convention</see> that is designed to make it easier to get started with products that use specific conventions by default.</remarks>
+    public abstract class PayloadConvention
+    {
+        /// <summary>
+        /// Gets the serializer used for the payload.
+        /// </summary>
+        /// <value>A serializer that will be used to convert the payload object to a string.</value>
+        public abstract PayloadSerializer PayloadSerializer { get; }
+
+        /// <summary>
+        /// Gets the encoder used for the payload to be serialized.
+        /// </summary>
+        /// <value>An encoder that will be used to convert the serialized string to a byte array.</value>
+        public abstract PayloadEncoder PayloadEncoder { get; }
+
+        /// <summary>
+        /// Returns the byte array for the convention based message.
+        /// </summary>
+        /// <remarks>This base class will use the <see cref="PayloadSerializer"/> and <see cref="PayloadEncoder"/> to create this byte array.</remarks>
+        /// <param name="objectToSendWithConvention"></param>
+        /// <returns>The correctly encoded object for this convention.</returns>
+        public virtual byte[] GetObjectBytes(object objectToSendWithConvention)
+        {
+            string serializedString = PayloadSerializer.SerializeToString(objectToSendWithConvention);
+            return PayloadEncoder.EncodeStringToByteArray(serializedString);
+        }
+    }
+}

--- a/shared/src/PayloadEncoder.cs
+++ b/shared/src/PayloadEncoder.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// This class specifies the byte encoding for the the payload.
+    /// </summary>
+    /// <remarks>
+    /// The encoder is responsible for encoding all of your objects into the corrent bytes for the <see cref="PayloadConvention"/> that uses it.
+    /// <para>
+    /// By default we have implemented the <see cref="Utf8PayloadEncoder"/> class that uses <see cref="System.Text.Encoding.UTF8"/>
+    /// to handle the encoding for the <see cref="DefaultPayloadConvention"/> class.
+    /// </para>
+    /// </remarks>
+    public abstract class PayloadEncoder
+    {
+        /// <summary>
+        /// The <see cref="Encoding"/> used for the payload.
+        /// </summary>
+        public abstract Encoding ContentEncoding { get; }
+
+        /// <summary>
+        /// Outputs an encoded byte array for the specified payload string.
+        /// </summary>
+        /// <param name="contentPayload">The contents of the message payload.</param>
+        /// <returns>An encoded byte array.</returns>
+        public abstract byte[] EncodeStringToByteArray(string contentPayload);
+    }
+}

--- a/shared/src/PayloadEncoder.cs
+++ b/shared/src/PayloadEncoder.cs
@@ -6,10 +6,10 @@ using System.Text;
 namespace Microsoft.Azure.Devices.Shared
 {
     /// <summary>
-    /// This class specifies the byte encoding for the the payload.
+    /// This class specifies the byte encoding for the payload.
     /// </summary>
     /// <remarks>
-    /// The encoder is responsible for encoding all of your objects into the corrent bytes for the <see cref="PayloadConvention"/> that uses it.
+    /// The encoder is responsible for encoding all of your objects into the correct bytes for the <see cref="PayloadConvention"/> that uses it.
     /// <para>
     /// By default we have implemented the <see cref="Utf8PayloadEncoder"/> class that uses <see cref="System.Text.Encoding.UTF8"/>
     /// to handle the encoding for the <see cref="DefaultPayloadConvention"/> class.

--- a/shared/src/PayloadSerializer.cs
+++ b/shared/src/PayloadSerializer.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// Provides the serialzation for a specified convention
+    /// </summary>
+    /// <remarks>
+    /// The serializer is responsible for converting all of your objects into the correct format for the <see cref="PayloadConvention"/> that uses it.
+    /// <para>
+    /// By default we have implemented the <see cref="NewtonsoftJsonPayloadSerializer"/> class that uses <see cref="Newtonsoft.Json.JsonConvert"/> to handle the serialization for the <see cref="DefaultPayloadConvention"/> class.
+    /// </para>
+    /// </remarks>
+    public abstract class PayloadSerializer
+    {
+        /// <summary>
+        /// Used to specify what type of content to expect
+        /// </summary>
+        /// <value>A string representing the content type to use when sending a payload</value>
+        /// <remarks>This can be freeform but should adhere to standard MIME types. For example, "application/json" is what we implement by default.</remarks>
+        public abstract string ContentType { get; }
+
+        /// <summary>
+        /// Serialize the specified object to a string
+        /// </summary>
+        /// <param name="objectToSerialize">Object to serialize.</param>
+        /// <returns>A serilaized string of the object.</returns>
+        public abstract string SerializeToString(object objectToSerialize);
+
+        /// <summary>
+        /// Convert the serialized string to an object.
+        /// </summary>
+        /// <typeparam name="T">The type you want to return.</typeparam>
+        /// <param name="stringToDeserialize">String to deserialize.</param>
+        /// <returns>A fully deserialized type.</returns>
+        public abstract T DeserializeToType<T>(string stringToDeserialize);
+
+        /// <summary>
+        /// Converts the object using the serializer.
+        /// </summary>
+        /// <typeparam name="T">The type to convert to.</typeparam>
+        /// <param name="objectToConvert">The object to convert.</param>
+        /// <returns>A converted object</returns>
+        /// <remarks>This class is used by the <see cref="PayloadCollection"/> class to attempt to convert from the native serailizer type (for example, JObject or JsonElement) to the desired type. When you implement this you need to be aware of what type your serializer will use for anonymous types.</remarks>
+        public abstract T ConvertFromObject<T>(object objectToConvert);
+
+        /// <summary>
+        /// Gets a nested property from the serialized data.
+        /// </summary>
+        /// <remarks>
+        /// This is used internally by our <see cref="PayloadCollection"/> to attempt to get a proprty of the underlying object. An example of this would be a property under the component. 
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="objectToConvert"></param>
+        /// <param name="propertyName"></param>
+        /// <returns></returns>
+        /// <param name="outValue"></param>
+        public abstract bool TryGetNestedObjectValue<T>(object objectToConvert, string propertyName, out T outValue);
+
+        /// <summary>
+        /// Creates the correct <see cref="IWritablePropertyResponse"/> to be used with this serializer
+        /// </summary>
+        /// <param name="value">The value of the property.</param>
+        /// <param name="statusCode">The status code of the write operation.</param>
+        /// <param name="version">The version the property is responding to.</param>
+        /// <param name="description">An optional description of the writable property response.</param>
+        /// <returns></returns>
+        public abstract IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = default);
+    }
+}

--- a/shared/src/PayloadSerializer.cs
+++ b/shared/src/PayloadSerializer.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// <summary>
         /// Converts the object using the serializer.
         /// </summary>
-        /// <remarks>This class is used by the <see cref="PayloadCollection"/> class to attempt to convert from the native serializer type
+        /// <remarks>This class is used by the PayloadCollection-based classes to attempt to convert from the native serializer type
         /// (for example, JObject or JsonElement) to the desired type.
         /// When you implement this you need to be aware of what type your serializer will use for anonymous types.</remarks>
         /// <typeparam name="T">The type to convert to.</typeparam>
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// Gets a nested property from the serialized data.
         /// </summary>
         /// <remarks>
-        /// This is used internally by our <see cref="PayloadCollection"/> to attempt to get a property of the underlying object.
+        /// This is used internally by our PayloadCollection-based classes to attempt to get a property of the underlying object.
         /// An example of this would be a property under the component.
         /// </remarks>
         /// <typeparam name="T">The type to convert the retrieved property to.</typeparam>

--- a/shared/src/PayloadSerializer.cs
+++ b/shared/src/PayloadSerializer.cs
@@ -4,28 +4,29 @@
 namespace Microsoft.Azure.Devices.Shared
 {
     /// <summary>
-    /// Provides the serialzation for a specified convention
+    /// Provides the serialization for a specified convention.
     /// </summary>
     /// <remarks>
     /// The serializer is responsible for converting all of your objects into the correct format for the <see cref="PayloadConvention"/> that uses it.
     /// <para>
-    /// By default we have implemented the <see cref="NewtonsoftJsonPayloadSerializer"/> class that uses <see cref="Newtonsoft.Json.JsonConvert"/> to handle the serialization for the <see cref="DefaultPayloadConvention"/> class.
+    /// By default we have implemented the <see cref="NewtonsoftJsonPayloadSerializer"/> class that uses <see cref="Newtonsoft.Json.JsonConvert"/>
+    /// to handle the serialization for the <see cref="DefaultPayloadConvention"/> class.
     /// </para>
     /// </remarks>
     public abstract class PayloadSerializer
     {
         /// <summary>
-        /// Used to specify what type of content to expect
+        /// Used to specify what type of content to expect.
         /// </summary>
-        /// <value>A string representing the content type to use when sending a payload</value>
-        /// <remarks>This can be freeform but should adhere to standard MIME types. For example, "application/json" is what we implement by default.</remarks>
+        /// <remarks>This can be free-form but should adhere to standard MIME types. For example, "application/json" is what we implement by default.</remarks>
+        /// <value>A string representing the content type to use when sending a payload.</value>
         public abstract string ContentType { get; }
 
         /// <summary>
-        /// Serialize the specified object to a string
+        /// Serialize the specified object to a string.
         /// </summary>
         /// <param name="objectToSerialize">Object to serialize.</param>
-        /// <returns>A serilaized string of the object.</returns>
+        /// <returns>A serialized string of the object.</returns>
         public abstract string SerializeToString(object objectToSerialize);
 
         /// <summary>
@@ -39,33 +40,36 @@ namespace Microsoft.Azure.Devices.Shared
         /// <summary>
         /// Converts the object using the serializer.
         /// </summary>
+        /// <remarks>This class is used by the <see cref="PayloadCollection"/> class to attempt to convert from the native serializer type
+        /// (for example, JObject or JsonElement) to the desired type.
+        /// When you implement this you need to be aware of what type your serializer will use for anonymous types.</remarks>
         /// <typeparam name="T">The type to convert to.</typeparam>
         /// <param name="objectToConvert">The object to convert.</param>
         /// <returns>A converted object</returns>
-        /// <remarks>This class is used by the <see cref="PayloadCollection"/> class to attempt to convert from the native serailizer type (for example, JObject or JsonElement) to the desired type. When you implement this you need to be aware of what type your serializer will use for anonymous types.</remarks>
         public abstract T ConvertFromObject<T>(object objectToConvert);
 
         /// <summary>
         /// Gets a nested property from the serialized data.
         /// </summary>
         /// <remarks>
-        /// This is used internally by our <see cref="PayloadCollection"/> to attempt to get a proprty of the underlying object. An example of this would be a property under the component. 
+        /// This is used internally by our <see cref="PayloadCollection"/> to attempt to get a property of the underlying object.
+        /// An example of this would be a property under the component.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="objectToConvert"></param>
-        /// <param name="propertyName"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">The type to convert the retrieved property to.</typeparam>
+        /// <param name="nestedObject">The object that might contain the nested property.</param>
+        /// <param name="propertyName">The name of the property to be retrieved.</param>
+        /// <returns>True if the nested object contains an element with the specified key; otherwise, it returns false.</returns>
         /// <param name="outValue"></param>
-        public abstract bool TryGetNestedObjectValue<T>(object objectToConvert, string propertyName, out T outValue);
+        public abstract bool TryGetNestedObjectValue<T>(object nestedObject, string propertyName, out T outValue);
 
         /// <summary>
-        /// Creates the correct <see cref="IWritablePropertyResponse"/> to be used with this serializer
+        /// Creates the correct <see cref="IWritablePropertyResponse"/> to be used with this serializer.
         /// </summary>
         /// <param name="value">The value of the property.</param>
         /// <param name="statusCode">The status code of the write operation.</param>
         /// <param name="version">The version the property is responding to.</param>
         /// <param name="description">An optional description of the writable property response.</param>
-        /// <returns></returns>
+        /// <returns>The writable property response to be used with this serializer.</returns>
         public abstract IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = default);
     }
 }

--- a/shared/src/SystemTextJsonPayloadSerializer.cs
+++ b/shared/src/SystemTextJsonPayloadSerializer.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !NET451
+
+using System.Text.Json;
+using Microsoft.Azure.Devices.Shared;
+
+namespace Microsoft.Azure.Devices.Client.Samples
+{
+    /// <summary>
+    /// A <see cref="System.Text.Json"/> <see cref="PayloadSerializer"/> implementation.
+    /// </summary>
+    public class SystemTextJsonPayloadSerializer : PayloadSerializer
+    {
+        /// <summary>
+        /// The Content Type string.
+        /// </summary>
+        internal const string ApplicationJson = "application/json";
+
+        /// <summary>
+        /// The default instance of this class.
+        /// </summary>
+        public static readonly SystemTextJsonPayloadSerializer Instance = new SystemTextJsonPayloadSerializer();
+
+        /// <inheritdoc/>
+        public override string ContentType => ApplicationJson;
+
+        /// <inheritdoc/>
+        public override string SerializeToString(object objectToSerialize)
+        {
+            return JsonSerializer.Serialize(objectToSerialize);
+        }
+
+        /// <inheritdoc/>
+        public override T DeserializeToType<T>(string stringToDeserialize)
+        {
+            return JsonSerializer.Deserialize<T>(stringToDeserialize);
+        }
+
+        /// <inheritdoc/>
+        public override T ConvertFromObject<T>(object objectToConvert)
+        {
+            return DeserializeToType<T>(((JsonElement)objectToConvert).ToString());
+        }
+
+        /// <inheritdoc/>
+        public override bool TryGetNestedObjectValue<T>(object objectToConvert, string propertyName, out T outValue)
+        {
+            outValue = default;
+            if (objectToConvert == null || string.IsNullOrEmpty(propertyName))
+            {
+                return false;
+            }
+            if (((JsonElement)objectToConvert).TryGetProperty(propertyName, out JsonElement element))
+            {
+                outValue = DeserializeToType<T>(element.GetRawText());
+                return true;
+            }
+            return false;
+        }
+
+        /// <inheritdoc/>
+        public override IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = null)
+        {
+            return new SystemTextJsonWritablePropertyResponse(value, statusCode, version, description);
+        }
+    }
+}
+
+#endif

--- a/shared/src/SystemTextJsonPayloadSerializer.cs
+++ b/shared/src/SystemTextJsonPayloadSerializer.cs
@@ -45,14 +45,14 @@ namespace Microsoft.Azure.Devices.Client.Samples
         }
 
         /// <inheritdoc/>
-        public override bool TryGetNestedObjectValue<T>(object objectToConvert, string propertyName, out T outValue)
+        public override bool TryGetNestedObjectValue<T>(object nestedObject, string propertyName, out T outValue)
         {
             outValue = default;
-            if (objectToConvert == null || string.IsNullOrEmpty(propertyName))
+            if (nestedObject == null || string.IsNullOrEmpty(propertyName))
             {
                 return false;
             }
-            if (((JsonElement)objectToConvert).TryGetProperty(propertyName, out JsonElement element))
+            if (((JsonElement)nestedObject).TryGetProperty(propertyName, out JsonElement element))
             {
                 outValue = DeserializeToType<T>(element.GetRawText());
                 return true;

--- a/shared/src/SystemTextJsonWritablePropertyResponse.cs
+++ b/shared/src/SystemTextJsonWritablePropertyResponse.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Azure.Devices.Shared
         /// Convenience constructor for specifying the properties.
         /// </summary>
         /// <param name="propertyValue">The unserialized property value.</param>
-        /// <param name="ackCode">The acknowledgement code, usually an HTTP Status Code e.g. 200, 400.</param>
-        /// <param name="ackVersion">The acknowledgement version, as supplied in the property update request.</param>
-        /// <param name="ackDescription">The acknowledgement description, an optional, human-readable message about the result of the property update.</param>
+        /// <param name="ackCode">The acknowledgment code, usually an HTTP Status Code e.g. 200, 400.</param>
+        /// <param name="ackVersion">The acknowledgment version, as supplied in the property update request.</param>
+        /// <param name="ackDescription">The acknowledgment description, an optional, human-readable message about the result of the property update.</param>
         public SystemTextJsonWritablePropertyResponse(object propertyValue, int ackCode, long ackVersion, string ackDescription = default)
         {
             Value = propertyValue;
@@ -38,19 +38,19 @@ namespace Microsoft.Azure.Devices.Shared
         public object Value { get; set; }
 
         /// <summary>
-        /// The acknowledgement code, usually an HTTP Status Code e.g. 200, 400.
+        /// The acknowledgment code, usually an HTTP Status Code e.g. 200, 400.
         /// </summary>
         [JsonPropertyName(ConventionBasedConstants.AckCodePropertyName)]
         public int AckCode { get; set; }
 
         /// <summary>
-        /// The acknowledgement version, as supplied in the property update request.
+        /// The acknowledgment version, as supplied in the property update request.
         /// </summary>
         [JsonPropertyName(ConventionBasedConstants.AckVersionPropertyName)]
         public long AckVersion { get; set; }
 
         /// <summary>
-        /// The acknowledgement description, an optional, human-readable message about the result of the property update.
+        /// The acknowledgment description, an optional, human-readable message about the result of the property update.
         /// </summary>
         [JsonPropertyName(ConventionBasedConstants.AckDescriptionPropertyName)]
         public string AckDescription { get; set; }

--- a/shared/src/SystemTextJsonWritablePropertyResponse.cs
+++ b/shared/src/SystemTextJsonWritablePropertyResponse.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !NET451
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// An optional, helper class for constructing a writable property response.
+    /// </summary>
+    /// <remarks>
+    /// This helper class will only work with <see cref="System.Text.Json"/>.
+    /// It uses <see cref="System.Text.Json"/> based <see cref="JsonPropertyNameAttribute"/> to define the JSON property names.
+    /// </remarks>
+    public sealed class SystemTextJsonWritablePropertyResponse : IWritablePropertyResponse
+    {
+        /// <summary>
+        /// Convenience constructor for specifying the properties.
+        /// </summary>
+        /// <param name="propertyValue">The unserialized property value.</param>
+        /// <param name="ackCode">The acknowledgement code, usually an HTTP Status Code e.g. 200, 400.</param>
+        /// <param name="ackVersion">The acknowledgement version, as supplied in the property update request.</param>
+        /// <param name="ackDescription">The acknowledgement description, an optional, human-readable message about the result of the property update.</param>
+        public SystemTextJsonWritablePropertyResponse(object propertyValue, int ackCode, long ackVersion, string ackDescription = default)
+        {
+            Value = propertyValue;
+            AckCode = ackCode;
+            AckVersion = ackVersion;
+            AckDescription = ackDescription;
+        }
+
+        /// <summary>
+        /// The unserialized property value.
+        /// </summary>
+        [JsonPropertyName(ConventionBasedConstants.ValuePropertyName)]
+        public object Value { get; set; }
+
+        /// <summary>
+        /// The acknowledgement code, usually an HTTP Status Code e.g. 200, 400.
+        /// </summary>
+        [JsonPropertyName(ConventionBasedConstants.AckCodePropertyName)]
+        public int AckCode { get; set; }
+
+        /// <summary>
+        /// The acknowledgement version, as supplied in the property update request.
+        /// </summary>
+        [JsonPropertyName(ConventionBasedConstants.AckVersionPropertyName)]
+        public long AckVersion { get; set; }
+
+        /// <summary>
+        /// The acknowledgement description, an optional, human-readable message about the result of the property update.
+        /// </summary>
+        [JsonPropertyName(ConventionBasedConstants.AckDescriptionPropertyName)]
+        public string AckDescription { get; set; }
+    }
+}
+
+#endif

--- a/shared/src/Utf8PayloadEncoder.cs
+++ b/shared/src/Utf8PayloadEncoder.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// A UTF-8 <see cref="PayloadEncoder"/> implementation.
+    /// </summary>
+    public class Utf8PayloadEncoder : PayloadEncoder
+    {
+        /// <summary>
+        /// A static instance of this class.
+        /// </summary>
+        public static readonly Utf8PayloadEncoder Instance = new Utf8PayloadEncoder();
+
+        /// <inheritdoc/>
+        public override Encoding ContentEncoding => Encoding.UTF8;
+
+        /// <inheritdoc/>
+        public override byte[] EncodeStringToByteArray(string contentPayload)
+        {
+            return ContentEncoding.GetBytes(contentPayload);
+        }
+    }
+}

--- a/shared/src/Utf8PayloadEncoder.cs
+++ b/shared/src/Utf8PayloadEncoder.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices.Shared
     public class Utf8PayloadEncoder : PayloadEncoder
     {
         /// <summary>
-        /// A static instance of this class.
+        /// The default instance of this class.
         /// </summary>
         public static readonly Utf8PayloadEncoder Instance = new Utf8PayloadEncoder();
 


### PR DESCRIPTION
Moving the code from the dev branch to preview branch in small chunks, so that it can be easily reviewed.

Source: https://github.com/Azure/azure-iot-sdk-csharp/tree/previews/pnpImplDev

This PR contains the common resources that will be used for convention-based operations:
- PayloadCollection (this is the base type that telemetry and properties inherit from)
- Convention related abstract classes:
    - PayloadSerializer
    - PayloadEncoder
    - PayloadConvention
    - IWritablePropertyResponse (relevant for properties (twin) operations, but added in this PR since it is a part of PayloadSerializer signature)
- Default implementations provided by the sdk (enabled by default):
    - NewtonsoftJsonPayloadSerializer
    - Utf8PayloadEncoder
    - DefaultPayloadConvention
    - NewtonsoftJsonWritablePropertyResponse
- Sample implementations provided by the sdk:
    - SystemTextJsonPayloadSerializer (not supported on net451)
    - SystemTextJsonWritablePropertyResponse (not supported on net451)
    
The subsequent PRs will deal with telemetry, command and properties APIs specifically.