### PR TITLE
Update versions for 2021-05-20 preview release.

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.37.2</Version>
+    <Version>1.38.0-preview-001</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.34.0</Version>
+    <Version>1.35.0-preview-001</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.17.1</Version>
+    <Version>1.18.0-preview-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.17.1</Version>
+    <Version>1.18.0-preview-001</Version>
     <Title>Microsoft Azure IoT Provisioning Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.14.1</Version>
+    <Version>1.15.0-preview-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client AMQP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
+++ b/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.13.1</Version>
+    <Version>1.14.0-preview-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client HTTP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
+++ b/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.15.1</Version>
+    <Version>1.16.0-preview-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client MQTT Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
+++ b/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>1.13.1</Version>
+    <Version>1.14.0-preview-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Security TPM Client</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/shared/src/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/src/Microsoft.Azure.Devices.Shared.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.28.1</Version>
+    <Version>1.29.0-preview-001</Version>
     <Title>Microsoft Azure IoT Devices Shared</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,10 +1,10 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.37.2
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.34.0
-shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.28.1
-provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.17.1
-provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.14.1
-provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.13.1
-provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.15.1
-security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.13.1
-provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.17.1
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj,1.38.0-preview-001
+iothub\service\src\Microsoft.Azure.Devices.csproj,1.35.0-preview-001
+shared\src\Microsoft.Azure.Devices.Shared.csproj,1.29.0-preview-001
+provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj,1.18.0-preview-001
+provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj,1.15.0-preview-001
+provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj,1.14.0-preview-001
+provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj,1.16.0-preview-001
+security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj,1.14.0-preview-001
+provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj,1.18.0-preview-001


### PR DESCRIPTION
# SDK updates from `master` branch.

This release is bringing changes from the master release [2021-05-13](https://github.com/Azure/azure-iot-sdk-csharp/tree/2021-05-13).
The previous preview release was based on the master release  [2020-10-8](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2020-10-8).

> Note: This preview release does not contain the device streaming feature.

## Microsoft.Azure.Devices.Shared 1.29.0-preview-001

- Updates from `GA release` [2021-05-13](https://github.com/Azure/azure-iot-sdk-csharp/tree/2021-05-13).
- Add support for .NET 5.0 (#1900)

## Microsoft.Azure.Devices.Provisioning.Transport.Mqtt 1.16.0-preview-001

- Updated reference to `Microsoft.Azure.Devices.Shared` nuget.
- Updates from `GA release` [2021-05-13](https://github.com/Azure/azure-iot-sdk-csharp/tree/2021-05-13).
- Add support for .NET 5.0 (#1900)

## Microsoft.Azure.Devices.Client 1.38.0-preview-001

- Updated reference to `Microsoft.Azure.Devices.Shared` nuget.
- Updates from `GA release` [2021-05-13](https://github.com/Azure/azure-iot-sdk-csharp/tree/2021-05-13).
- Add support for .NET 5.0 (#1900)

## Microsoft.Azure.Devices 1.35.0-preview-001

- Updated reference to `Microsoft.Azure.Devices.Shared` nuget.
- Updates from `GA release` [2021-05-13](https://github.com/Azure/azure-iot-sdk-csharp/tree/2021-05-13).
- Make all clients mockable (#1875), (#1878), (#1881), (#1892)
- Add support for .NET 5.0 (#1900)

## Microsoft.Azure.Devices.Provisioning.Client 1.18.0-preview-001

- Updated reference to `Microsoft.Azure.Devices.Shared` nuget.
- Updates from `GA release` [2021-05-13](https://github.com/Azure/azure-iot-sdk-csharp/tree/2021-05-13).
- Add support for .NET 5.0 (#1900)

## Microsoft.Azure.Devices.Provisioning.Transport.Amqp 1.15.0-preview-001

- Updated reference to `Microsoft.Azure.Devices.Shared` nuget.
- Updates from `GA release` [2021-05-13](https://github.com/Azure/azure-iot-sdk-csharp/tree/2021-05-13).
- Add support for .NET 5.0 (#1900)

## Microsoft.Azure.Devices.Provisioning.Client.Transport.Http 1.14.0-preview-001

- Updated reference to `Microsoft.Azure.Devices.Shared` nuget.
- Updates from `GA release` [2021-05-13](https://github.com/Azure/azure-iot-sdk-csharp/tree/2021-05-13).
- Add support for .NET 5.0 (#1900)

## Microsoft.Azure.Devices.Provisioning.Security.Tpm 1.14.0-preview-001

- Updated reference to `Microsoft.Azure.Devices.Shared` nuget.
- Updates from `GA release` [2021-05-13](https://github.com/Azure/azure-iot-sdk-csharp/tree/2021-05-13).
- Add support for .NET 5.0 (#1900)

## Microsoft.Azure.Devices.Provisioning.Service 1.18.0-preview-001

- Updated reference to `Microsoft.Azure.Devices.Shared` nuget.
- Updates from `GA release` [2021-05-13](https://github.com/Azure/azure-iot-sdk-csharp/tree/2021-05-13).
- Add support for .NET 5.0 (#1900)