### PR TITLE
Logic with writable property request flow

### DIFF
--- a/iothub/device/samples/convention-based-samples/Thermostat/ThermostatSample.cs
+++ b/iothub/device/samples/convention-based-samples/Thermostat/ThermostatSample.cs
@@ -98,10 +98,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
                                 && targetTemperatureWritableResponse.AckVersion >= writableProperties.Version)
                             {
                                 _logger.LogDebug($"Property: Update - {targetTemperatureProperty} is already at {targetTemperatureRequested} " +
-                                $"with a version of {targetTemperatureWritableResponse.AckVersion}. The update request with a version of {writableProperties.Version} " +
-                                $"has been discarded.");
+                                    $"with a version of {targetTemperatureWritableResponse.AckVersion}. The update request with a version of {writableProperties.Version} " +
+                                    $"has been ignored.");
+
+                                break;
                             }
-                            break;
                         }
 
                         _temperature = targetTemperatureRequested;


### PR DESCRIPTION
Is this something we feel is useful for the sample?

Pro:
Demonstrate how to retrieve a previously reported writable property update value, and use that to determine if the device should respond to the update request received.

Con:
Complicated, and might mislead people into thinking that they always have to implement this kind of guard code (user scenario will usually differ case-by-case basis).