### PR TITLE
Update AuthenticationWithTokenRefresh disposal to be non-breaking

### DIFF
--- a/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
+++ b/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
@@ -55,19 +55,72 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task DeviceSak_ReusableAuthenticationMethod_MuxedDevicesPerConnection_Amqp()
         {
-            await ReuseAuthenticationMethod_MuxedDevices(Client.TransportType.Amqp_Tcp_Only, 2);
+            await ReuseAuthenticationMethod_MuxedDevices(Client.TransportType.Amqp_Tcp_Only, 2).ConfigureAwait(false); ;
         }
 
         [LoggedTestMethod]
         public async Task DeviceSak_ReusableAuthenticationMethod_MuxedDevicesPerConnection_AmqpWs()
         {
-            await ReuseAuthenticationMethod_MuxedDevices(Client.TransportType.Amqp_WebSocket_Only, 2);
+            await ReuseAuthenticationMethod_MuxedDevices(Client.TransportType.Amqp_WebSocket_Only, 2).ConfigureAwait(false); ;
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceClient_AuthenticationMethodDisposesTokenRefresher_Http()
+        {
+            await AuthenticationMethodDisposesTokenRefresher(Client.TransportType.Http1).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceClient_AuthenticationMethodDisposesTokenRefresher_Amqp()
+        {
+            await AuthenticationMethodDisposesTokenRefresher(Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceClient_AuthenticationMethodDisposesTokenRefresher_AmqpWs()
+        {
+            await AuthenticationMethodDisposesTokenRefresher(Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceClient_AuthenticationMethodDisposesTokenRefresher_Mqtt()
+        {
+            await AuthenticationMethodDisposesTokenRefresher(Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceClient_AuthenticationMethodDisposesTokenRefresher_MqttWs()
+        {
+            await AuthenticationMethodDisposesTokenRefresher(Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
+        }
+
+        private async Task AuthenticationMethodDisposesTokenRefresher(Client.TransportType transport)
+        {
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
+            var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposalBySdk: true);
+
+            // Create an instance of the device client, send a test message and then close and dispose it.
+            DeviceClient deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, authenticationMethod, transport);
+            using var message1 = new Client.Message();
+            await deviceClient.SendEventAsync(message1).ConfigureAwait(false);
+            await deviceClient.CloseAsync();
+            deviceClient.Dispose();
+            Logger.Trace("Test with instance 1 completed");
+
+            // Perform the same steps again, reusing the previously created authentication method instance.
+            // Since the default behavior is to dispose AuthenticationWithTokenRefresh authentication method on DeviceClient disposal,
+            // this should now throw an ObjectDisposedException.
+            DeviceClient deviceClient2 = DeviceClient.Create(testDevice.IoTHubHostName, authenticationMethod, transport);
+            using var message2 = new Client.Message();
+
+            Func<Task> act = async () => await deviceClient2.SendEventAsync(message2).ConfigureAwait(false);
+            await act.Should().ThrowAsync<ObjectDisposedException>();
         }
 
         private async Task ReuseAuthenticationMethod_SingleDevice(Client.TransportType transport)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString);
+            var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposalBySdk: false);
 
             // Create an instance of the device client, send a test message and then close and dispose it.
             DeviceClient deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, authenticationMethod, transport);
@@ -110,7 +163,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             {
                 TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
 #pragma warning disable CA2000 // Dispose objects before losing scope - the authentication method is disposed at the end of the test.
-                var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString);
+                var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposalBySdk: false);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
                 testDevices.Add(testDevice);
@@ -215,9 +268,13 @@ namespace Microsoft.Azure.Devices.E2ETests
             private const string SasTokenTargetFormat = "{0}/devices/{1}";
             private readonly IotHubConnectionStringBuilder _connectionStringBuilder;
 
+            private static readonly int s_suggestedSasTimeToLiveInSeconds = (int)TimeSpan.FromMinutes(30).TotalSeconds;
+            private static readonly int s_sasRenewalBufferPercentage = 50;
+
             public DeviceAuthenticationSasToken(
-                string connectionString)
-                : base(GetDeviceIdFromConnectionString(connectionString))
+                string connectionString,
+                bool disposalBySdk)
+                : base(GetDeviceIdFromConnectionString(connectionString), s_suggestedSasTimeToLiveInSeconds, s_sasRenewalBufferPercentage, disposalBySdk)
             {
                 if (connectionString == null)
                 {

--- a/iothub/device/src/DeviceAuthenticationWithSakRefresh.cs
+++ b/iothub/device/src/DeviceAuthenticationWithSakRefresh.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Azure.Devices.Client
             string deviceId,
             IotHubConnectionString connectionString,
             TimeSpan sasTokenTimeToLive,
-            int sasTokenRenewalBuffer) : base(deviceId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer)
+            int sasTokenRenewalBuffer,
+            bool disposalBySdk)
+            : base(deviceId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer, disposalBySdk)
         {
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
         }

--- a/iothub/device/src/DeviceAuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/DeviceAuthenticationWithTokenRefresh.cs
@@ -40,7 +40,29 @@ namespace Microsoft.Azure.Devices.Client
             string deviceId,
             int suggestedTimeToLiveSeconds,
             int timeBufferPercentage)
-            : base(SetSasTokenSuggestedTimeToLiveSeconds(suggestedTimeToLiveSeconds), SetSasTokenRenewalBufferPercentage(timeBufferPercentage))
+            : this(deviceId, suggestedTimeToLiveSeconds, timeBufferPercentage, true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeviceAuthenticationWithTokenRefresh"/> class.
+        /// </summary>
+        /// <param name="deviceId">Device Identifier.</param>
+        /// <param name="suggestedTimeToLiveSeconds">
+        /// The suggested time to live value for the generated SAS tokens.
+        /// The default value is 1 hour.
+        /// </param>
+        /// <param name="timeBufferPercentage">
+        /// The time buffer before expiry when the token should be renewed, expressed as a percentage of the time to live.
+        /// The default behavior is that the token will be renewed when it has 15% or less of its lifespan left.
+        /// <param name="disposalBySdk">True if the authentication method should be disposed of by sdk; false if you intend to reuse the authentication method.</param>
+        ///</param>
+        public DeviceAuthenticationWithTokenRefresh(
+            string deviceId,
+            int suggestedTimeToLiveSeconds,
+            int timeBufferPercentage,
+            bool disposalBySdk)
+            : base(SetSasTokenSuggestedTimeToLiveSeconds(suggestedTimeToLiveSeconds), SetSasTokenRenewalBufferPercentage(timeBufferPercentage), disposalBySdk)
         {
             if (deviceId.IsNullOrWhiteSpace())
             {

--- a/iothub/device/src/DeviceAuthenticationWithTpm.cs
+++ b/iothub/device/src/DeviceAuthenticationWithTpm.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="securityProvider">Device Security Provider settings for TPM Hardware Security Modules.</param>
         public DeviceAuthenticationWithTpm(
             string deviceId,
-            SecurityProviderTpm securityProvider) : base(deviceId)
+            SecurityProviderTpm securityProvider)
+            : base(deviceId)
         {
             _securityProvider = securityProvider ?? throw new ArgumentNullException(nameof(securityProvider));
         }
@@ -43,7 +44,27 @@ namespace Microsoft.Azure.Devices.Client
             string deviceId,
             SecurityProviderTpm securityProvider,
             int suggestedTimeToLiveSeconds,
-            int timeBufferPercentage) : base(deviceId, suggestedTimeToLiveSeconds, timeBufferPercentage)
+            int timeBufferPercentage)
+            : this(deviceId, securityProvider, suggestedTimeToLiveSeconds, timeBufferPercentage, true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeviceAuthenticationWithTpm"/> class.
+        /// </summary>
+        /// <param name="deviceId">Device Identifier.</param>
+        /// <param name="securityProvider">Device Security Provider settings for TPM Hardware Security Modules.</param>
+        /// <param name="suggestedTimeToLiveSeconds">Token time to live suggested value.</param>
+        /// <param name="timeBufferPercentage">Time buffer before expiry when the token should be renewed expressed as percentage of
+        /// the time to live. EX: If you want a SAS token to live for 85% of life before proactive renewal, this value should be 15.</param>
+        /// <param name="disposalBySdk">True if the authentication method should be disposed of by sdk; false if you intend to reuse the authentication method.</param>
+        public DeviceAuthenticationWithTpm(
+            string deviceId,
+            SecurityProviderTpm securityProvider,
+            int suggestedTimeToLiveSeconds,
+            int timeBufferPercentage,
+            bool disposalBySdk)
+            : base(deviceId, suggestedTimeToLiveSeconds, timeBufferPercentage, disposalBySdk)
         {
             _securityProvider = securityProvider ?? throw new ArgumentNullException(nameof(securityProvider));
         }

--- a/iothub/device/src/Edge/EdgeModuleClientFactory.cs
+++ b/iothub/device/src/Edge/EdgeModuleClientFactory.cs
@@ -98,11 +98,8 @@ namespace Microsoft.Azure.Devices.Client.Edge
                 int sasTokenRenewalBuffer = _options?.SasTokenRenewalBuffer ?? default;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope - IDisposable ModuleAuthenticationWithHsm is disposed when the client is disposed.
-                var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId, generationId, sasTokenTimeToLive, sasTokenRenewalBuffer)
-                {
-                    // Since the sdk creates the instance of disposable ModuleAuthenticationWithHsm, the sdk needs to dispose it once the client is diposed.
-                    InstanceCreatedBySdk = true,
-                };
+                // Since the sdk creates the instance of disposable ModuleAuthenticationWithHsm, the sdk needs to dispose it once the client is diposed.
+                var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId, generationId, sasTokenTimeToLive, sasTokenRenewalBuffer, disposalBySdk: true);
 #pragma warning restore CA2000 // Dispose objects before losing scope - IDisposable ModuleAuthenticationWithHsm is disposed when the client is disposed.
 
                 Debug.WriteLine("EdgeModuleClientFactory setupTrustBundle from service");

--- a/iothub/device/src/HsmAuthentication/ModuleAuthenticationWithHsm.cs
+++ b/iothub/device/src/HsmAuthentication/ModuleAuthenticationWithHsm.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication
             string moduleId,
             string generationId,
             TimeSpan sasTokenTimeToLive,
-            int sasTokenRenewalBuffer) : base(deviceId, moduleId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer)
+            int sasTokenRenewalBuffer,
+            bool disposalBySdk)
+            : base(deviceId, moduleId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer, disposalBySdk)
         {
             _signatureProvider = signatureProvider ?? throw new ArgumentNullException(nameof(signatureProvider));
             _generationId = generationId ?? throw new ArgumentNullException(nameof(generationId));

--- a/iothub/device/src/IotHubConnectionString.cs
+++ b/iothub/device/src/IotHubConnectionString.cs
@@ -52,11 +52,8 @@ namespace Microsoft.Azure.Devices.Client
             {
                 if (ModuleId.IsNullOrWhiteSpace())
                 {
-                    TokenRefresher = new DeviceAuthenticationWithSakRefresh(DeviceId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer)
-                    {
-                        // Since the sdk creates the instance of disposable DeviceAuthenticationWithSakRefresh, the sdk needs to dispose it once the client is diposed.
-                        InstanceCreatedBySdk = true,
-                    };
+                    // Since the sdk creates the instance of disposable DeviceAuthenticationWithSakRefresh, the sdk needs to dispose it once the client is disposed.
+                    TokenRefresher = new DeviceAuthenticationWithSakRefresh(DeviceId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer, disposalBySdk: true);
 
                     if (Logging.IsEnabled)
                     {
@@ -65,11 +62,8 @@ namespace Microsoft.Azure.Devices.Client
                 }
                 else
                 {
-                    TokenRefresher = new ModuleAuthenticationWithSakRefresh(DeviceId, ModuleId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer)
-                    {
-                        // Since the sdk creates the instance of disposable ModuleAuthenticationWithSakRefresh, the sdk needs to dispose it once the client is diposed.
-                        InstanceCreatedBySdk = true,
-                    };
+                    // Since the sdk creates the instance of disposable ModuleAuthenticationWithSakRefresh, the sdk needs to dispose it once the client is disposed.
+                    TokenRefresher = new ModuleAuthenticationWithSakRefresh(DeviceId, ModuleId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer, disposalBySdk: true);
 
                     if (Logging.IsEnabled)
                     {

--- a/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
+++ b/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Azure.Devices.Client
         public ModuleAuthenticationWithSakRefresh(
             string deviceId,
             string moduleId,
-            IotHubConnectionString connectionString) : base(deviceId, moduleId)
+            IotHubConnectionString connectionString)
+            : base(deviceId, moduleId)
         {
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
         }
@@ -26,7 +27,9 @@ namespace Microsoft.Azure.Devices.Client
             string moduleId,
             IotHubConnectionString connectionString,
             TimeSpan sasTokenTimeToLive,
-            int sasTokenRenewalBuffer) : base(deviceId, moduleId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer)
+            int sasTokenRenewalBuffer,
+            bool disposalBySdk = true)
+            : base(deviceId, moduleId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer, disposalBySdk)
         {
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
         }

--- a/iothub/device/src/ModuleAuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/ModuleAuthenticationWithTokenRefresh.cs
@@ -53,7 +53,31 @@ namespace Microsoft.Azure.Devices.Client
             string moduleId,
             int suggestedTimeToLiveSeconds,
             int timeBufferPercentage)
-            : base(SetSasTokenSuggestedTimeToLiveSeconds(suggestedTimeToLiveSeconds), SetSasTokenRenewalBufferPercentage(timeBufferPercentage))
+            : this(deviceId, moduleId, suggestedTimeToLiveSeconds, timeBufferPercentage, true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModuleAuthenticationWithTokenRefresh"/> class.
+        /// </summary>
+        /// <param name="deviceId">The device Id.</param>
+        /// <param name="moduleId">The module Id.</param>
+        /// <param name="suggestedTimeToLiveSeconds">
+        /// The suggested time to live value for the generated SAS tokens.
+        /// The default value is 1 hour.
+        /// </param>
+        /// <param name="timeBufferPercentage">
+        /// The time buffer before expiry when the token should be renewed, expressed as a percentage of the time to live.
+        /// The default behavior is that the token will be renewed when it has 15% or less of its lifespan left.
+        /// <param name="disposalBySdk">True if the authentication method should be disposed of by sdk; false if you intend to reuse the authentication method.</param>
+        ///</param>
+        public ModuleAuthenticationWithTokenRefresh(
+            string deviceId,
+            string moduleId,
+            int suggestedTimeToLiveSeconds,
+            int timeBufferPercentage,
+            bool disposalBySdk)
+            : base(SetSasTokenSuggestedTimeToLiveSeconds(suggestedTimeToLiveSeconds), SetSasTokenRenewalBufferPercentage(timeBufferPercentage), disposalBySdk)
         {
             if (moduleId.IsNullOrWhiteSpace())
             {

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                     if (deviceIdentity.AuthenticationModel == AuthenticationModel.SasGrouped
                         && !ReferenceEquals(amqpConnectionHolder.GetDeviceIdentityOfAuthenticationProvider(), deviceIdentity)
                         && deviceIdentity.IotHubConnectionString?.TokenRefresher != null
-                        && deviceIdentity.IotHubConnectionString.TokenRefresher.InstanceCreatedBySdk)
+                        && deviceIdentity.IotHubConnectionString.TokenRefresher.DisposalBySdk)
                     {
                         deviceIdentity.IotHubConnectionString.TokenRefresher.Dispose();
                     }

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotCbsTokenProvider.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotCbsTokenProvider.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
                 if (disposing)
                 {
                     if (_connectionString?.TokenRefresher != null
-                        && _connectionString.TokenRefresher.InstanceCreatedBySdk)
+                        && _connectionString.TokenRefresher.DisposalBySdk)
                     {
                         _connectionString.TokenRefresher.Dispose();
                     }

--- a/iothub/device/src/Transport/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/HttpClientHelper.cs
@@ -550,7 +550,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (_isClientPrimaryTransportHandler
                     && _authenticationHeaderProvider is IotHubConnectionString iotHubConnectionString
                     && iotHubConnectionString.TokenRefresher != null
-                    && iotHubConnectionString.TokenRefresher.InstanceCreatedBySdk)
+                    && iotHubConnectionString.TokenRefresher.DisposalBySdk)
                 {
                     iotHubConnectionString.TokenRefresher.Dispose();
                 }

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -1019,7 +1019,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             {
                 if (_passwordProvider is IotHubConnectionString iotHubConnectionString
                     && iotHubConnectionString.TokenRefresher != null
-                    && iotHubConnectionString.TokenRefresher.InstanceCreatedBySdk)
+                    && iotHubConnectionString.TokenRefresher.DisposalBySdk)
                 {
                     iotHubConnectionString.TokenRefresher.Dispose();
                 }


### PR DESCRIPTION
Update `AuthenticationWithTokenRefresh` to be disposed by the sdk, by default, but make the setting configurable.

Linked: #1954, #1911 