### PR TITLE
[PnP] Separate out root-level and component-level property addition operations

### DIFF
--- a/e2e/test/iothub/command/CommandE2ETests.cs
+++ b/e2e/test/iothub/command/CommandE2ETests.cs
@@ -2,12 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics.Tracing;
-using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client;
-using Microsoft.Azure.Devices.Common.Exceptions;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -77,7 +73,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Commands
             ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
 
             logger.Trace($"{nameof(DigitalTwinsSendCommandAndVerifyResponseAsync)}: Invoke command {commandName}.");
-            
+
             CloudToDeviceMethodResult serviceClientResponse = null;
             if (string.IsNullOrEmpty(componentName))
             {
@@ -130,7 +126,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Commands
             logger.Trace($"{nameof(DigitalTwinsSendCommandAndVerifyResponseAsync)}: Command status: {statusCode}.");
             Assert.AreEqual(200, statusCode, $"The expected response status should be 200 but was {statusCode}");
             Assert.AreEqual(responseExpected, payloadReceived, $"The expected response payload should be {responseExpected} but was {payloadReceived}");
-
         }
 
         public static async Task<Task> SetDeviceReceiveCommandAsync(DeviceClient deviceClient, string componentName, string commandName, MsTestLogger logger)
@@ -152,7 +147,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Commands
                         else
                         {
                             Assert.AreEqual(componentName, request.ComponentName, $"The expected component name should be {componentName} but was {request.ComponentName}");
-
                         }
                         var assertionObject = new ServiceCommandRequestAssertion();
                         string responseExpected = JsonConvert.SerializeObject(assertionObject);

--- a/iothub/device/devdoc/Convention-based operations.md
+++ b/iothub/device/devdoc/Convention-based operations.md
@@ -65,6 +65,7 @@ public abstract class PayloadCollection : IEnumerable, IEnumerable<object> {
     public virtual object this[string key] { get; set; }
     public virtual void Add(string key, object value);
     public virtual void AddOrUpdate(string key, object value);
+    public void ClearCollection();
     public bool Contains(string key);
     public IEnumerator<object> GetEnumerator();
     public virtual byte[] GetPayloadObjectBytes();
@@ -132,17 +133,13 @@ public class ClientPropertyCollection : PayloadCollection {
     public ClientPropertyCollection();
     public long Version { get; protected set; }
     public void Add(IDictionary<string, object> properties);
-    public void Add(string componentName, IDictionary<string, object> properties);
-    public override void Add(string propertyName, object propertyValue);
-    public void Add(string propertyName, object propertyValue, int statusCode, long version, string description = null);
-    public void Add(string componentName, string propertyName, object propertyValue);
-    public void Add(string componentName, string propertyName, object propertyValue, int statusCode, long version, string description = null);
+    public void AddComponentProperties(string componentName, IDictionary<string, object> properties);
+    public void AddComponentProperty(string componentName, string propertyName, object propertyValue);
     public void AddOrUpdate(IDictionary<string, object> properties);
-    public void AddOrUpdate(string componentName, IDictionary<string, object> properties);
-    public override void AddOrUpdate(string propertyName, object propertyValue);
-    public void AddOrUpdate(string propertyName, object propertyValue, int statusCode, long version, string description = null);
-    public void AddOrUpdate(string componentName, string propertyName, object propertyValue);
-    public void AddOrUpdate(string componentName, string propertyName, object propertyValue, int statusCode, long version, string description = null);
+    public void AddOrUpdateComponentProperties(string componentName, IDictionary<string, object> properties);
+    public void AddOrUpdateComponentProperty(string componentName, string propertyName, object propertyValue);
+    public void AddOrUpdateRootProperty(string propertyName, object propertyValue);
+    public void AddRootProperty(string propertyName, object propertyValue);
     public bool Contains(string componentName, string propertyName);
     public virtual bool TryGetValue<T>(string componentName, string propertyName, out T propertyValue);
 }

--- a/iothub/device/samples/convention-based-samples/TemperatureController/TemperatureControllerSample.cs
+++ b/iothub/device/samples/convention-based-samples/TemperatureController/TemperatureControllerSample.cs
@@ -129,8 +129,13 @@ namespace Microsoft.Azure.Devices.Client.Samples
             _logger.LogDebug($"Property: Received - component=\"{componentName}\", [ \"{targetTemperatureProperty}\": {targetTemperature}°C ].");
 
             _temperature[componentName] = targetTemperature;
+            IWritablePropertyResponse writableResponse = _deviceClient
+                .PayloadConvention
+                .PayloadSerializer
+                .CreateWritablePropertyResponse(_temperature[componentName], StatusCodes.OK, version, "Successfully updated target temperature.");
+
             var reportedProperty = new ClientPropertyCollection();
-            reportedProperty.Add(componentName, targetTemperatureProperty, _temperature[componentName], StatusCodes.Accepted, version, "Successfully updated target temperature.");
+            reportedProperty.AddComponentProperty(componentName, targetTemperatureProperty, writableResponse);
 
             ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperty);
 
@@ -288,7 +293,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 { "totalMemory", 1024 },
             };
             var deviceInformation = new ClientPropertyCollection();
-            deviceInformation.Add(componentName, deviceInformationProperties);
+            deviceInformation.AddComponentProperties(componentName, deviceInformationProperties);
 
             ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(deviceInformation, cancellationToken);
 
@@ -330,7 +335,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 || serialNumberReported != currentSerialNumber)
             {
                 var reportedProperties = new ClientPropertyCollection();
-                reportedProperties.Add(serialNumber, currentSerialNumber);
+                reportedProperties.AddRootProperty(serialNumber, currentSerialNumber);
 
                 ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperties, cancellationToken);
 
@@ -391,7 +396,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             const string propertyName = "maxTempSinceLastReboot";
             double maxTemp = _maxTemp[componentName];
             var reportedProperties = new ClientPropertyCollection();
-            reportedProperties.Add(componentName, propertyName, maxTemp);
+            reportedProperties.AddComponentProperty(componentName, propertyName, maxTemp);
 
             ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperties, cancellationToken);
 

--- a/iothub/device/samples/convention-based-samples/Thermostat/ThermostatSample.cs
+++ b/iothub/device/samples/convention-based-samples/Thermostat/ThermostatSample.cs
@@ -74,13 +74,18 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 switch (writableProperty.Key)
                 {
                     case "targetTemperature":
-                        const string tagetTemperatureProperty = "targetTemperature";
+                        const string targetTemperatureProperty = "targetTemperature";
                         double targetTemperatureRequested = Convert.ToDouble(writableProperty.Value);
-                        _logger.LogDebug($"Property: Received - [ \"{tagetTemperatureProperty}\": {targetTemperatureRequested}°C ].");
+                        _logger.LogDebug($"Property: Received - [ \"{targetTemperatureProperty}\": {targetTemperatureRequested}°C ].");
 
                         _temperature = targetTemperatureRequested;
+                        IWritablePropertyResponse writableResponse = _deviceClient
+                            .PayloadConvention
+                            .PayloadSerializer
+                            .CreateWritablePropertyResponse(_temperature, StatusCodes.OK, writableProperties.Version, "Successfully updated target temperature");
+
                         var reportedProperty = new ClientPropertyCollection();
-                        reportedProperty.Add(tagetTemperatureProperty, _temperature, StatusCodes.OK, writableProperties.Version, "Successfully updated target temperature");
+                        reportedProperty.AddRootProperty(targetTemperatureProperty, writableResponse);
 
                         ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperty);
 
@@ -184,7 +189,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         {
             const string propertyName = "maxTempSinceLastReboot";
             var reportedProperties = new ClientPropertyCollection();
-            reportedProperties.Add(propertyName, _maxTemp);
+            reportedProperties.AddRootProperty(propertyName, _maxTemp);
 
             ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperties);
 

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Azure.Devices.Shared;
 
 namespace Microsoft.Azure.Devices.Client
@@ -14,264 +15,139 @@ namespace Microsoft.Azure.Devices.Client
     {
         private const string VersionName = "$version";
 
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
         /// <summary>
         /// Adds the value to the collection.
         /// </summary>
         /// <remarks>
-        /// If the collection has a key that matches the property name this method will throw an <see cref="ArgumentException"/>.
+        /// If the collection already has a key matching a property name supplied this method will throw an <see cref="ArgumentException"/>.
         /// <para>
         /// When using this as part of the writable property flow to respond to a writable property update you should pass in the value
         /// as an instance of <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>
         /// to ensure the correct formatting is applied when the object is serialized.
         /// </para>
         /// </remarks>
-        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
         /// <param name="propertyName">The name of the property to add.</param>
         /// <param name="propertyValue">The value of the property to add.</param>
-        public override void Add(string propertyName, object propertyValue)
-            => Add(null, propertyName, propertyValue);
+        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c>. </exception>
+        /// <exception cref="ArgumentException"><paramref name="propertyName"/> already exists in the collection.</exception>
+        public void AddRootProperty(string propertyName, object propertyValue)
+            => AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, null, false);
 
-        /// <inheritdoc path="/remarks" cref="Add(string, object)" />
+        /// <inheritdoc path="/remarks" cref="AddRootProperty(string, object)" />
         /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/exception['ArgumentNullException']" cref="AddRootProperty(string, object)" />
+        /// <inheritdoc path="/exception['ArgumentException']" cref="AddRootProperty(string, object)" />
         /// <summary>
         /// Adds the value to the collection.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
         /// <param name="componentName">The component with the property to add.</param>
         /// <param name="propertyName">The name of the property to add.</param>
         /// <param name="propertyValue">The value of the property to add.</param>
-        public void Add(string componentName, string propertyName, object propertyValue)
+        public void AddComponentProperty(string componentName, string propertyName, object propertyValue)
             => AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName, false);
 
-        /// <inheritdoc path="/remarks" cref="Add(string, object)" />
+        /// <inheritdoc path="/remarks" cref="AddRootProperty(string, object)" />
         /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/exception['ArgumentNullException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/exception['ArgumentException']" cref="AddRootProperty(string, object)" />
         /// <summary>
-        /// Adds the values to the collection.
+        /// Adds the value to the collection.
         /// </summary>
-        /// <param name="properties">A collection of properties to add or update.</param>
-        public void Add(IDictionary<string, object> properties)
-            => AddInternal(properties, null, false);
-
-        /// <inheritdoc path="/remarks" cref="Add(string, object)" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <summary>
-        /// Adds the values to the collection.
-        /// </summary>
-        /// <param name="properties">A collection of properties to add or update.</param>
-        /// <param name="componentName">The component with the properties to add or update.</param>
-        public void Add(string componentName, IDictionary<string, object> properties)
-        => AddInternal(properties, componentName, false);
-
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <summary>
-        /// Adds a writable property to the collection.
-        /// </summary>
-        /// <remarks>
-        /// This method will use the <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/> method to create an instance of <see cref="IWritablePropertyResponse"/> that will be properly serialized.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
-        /// <param name="propertyName">The name of the property to add or update.</param>
-        /// <param name="propertyValue">The value of the property to add or update.</param>
-        /// <param name="statusCode"></param>
-        /// <param name="version"></param>
-        /// <param name="description"></param>
-        public void Add(string propertyName, object propertyValue, int statusCode, long version, string description = default)
-            => Add(null, propertyName, propertyValue, statusCode, version, description);
-
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <summary>
-        /// Adds a writable property to the collection.
-        /// </summary>
-        /// <remarks>
-        /// This method will use the <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/> method to create an instance of <see cref="IWritablePropertyResponse"/> that will be properly serialized.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
-        /// <param name="propertyName">The name of the property to add or update.</param>
-        /// <param name="propertyValue">The value of the property to add or update.</param>
-        /// <param name="statusCode"></param>
-        /// <param name="version"></param>
-        /// <param name="description"></param>
-        /// <param name="componentName"></param>
-        public void Add(string componentName, string propertyName, object propertyValue, int statusCode, long version, string description = default)
-        {
-            if (Convention?.PayloadSerializer == null)
-            {
-                Add(componentName, propertyName, new { value = propertyValue, ac = statusCode, av = version, ad = description });
-            }
-            else
-            {
-                Add(componentName, propertyName, Convention.PayloadSerializer.CreateWritablePropertyResponse(propertyValue, statusCode, version, description));
-            }
-        }
-
-        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/remarks" cref="AddOrUpdate(string, IDictionary{string, object})" />
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
-        /// <param name="propertyName">The name of the property to add or update.</param>
-        /// <param name="propertyValue">The value of the property to add or update.</param>
-        public override void AddOrUpdate(string propertyName, object propertyValue)
-            => AddOrUpdate(null, propertyName, propertyValue);
-
-        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/remarks" cref="AddOrUpdate(string, IDictionary{string, object})" />
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
-        /// <param name="componentName">The component with the property to add or update.</param>
-        /// <param name="propertyName">The name of the property to add or update.</param>
-        /// <param name="propertyValue">The value of the property to add or update.</param>
-        public void AddOrUpdate(string componentName, string propertyName, object propertyValue)
-            => AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName, true);
-
-        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <remarks>
-        /// If the collection has a key that matches this will overwrite the current value. Otherwise it will attempt to add this to the collection.
-        /// <para>
-        /// When using this as part of the writable property flow to respond to a writable property update
-        /// you should pass in the value as an instance of <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>
-        /// to ensure the correct formatting is applied when the object is serialized.
-        /// </para>
-        /// </remarks>
-        /// <param name="properties">A collection of properties to add or update.</param>
-        public void AddOrUpdate(IDictionary<string, object> properties)
-            => AddInternal(properties, null, true);
-
-        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <remarks>
-        /// If the collection has a key that matches this will overwrite the current value. Otherwise it will attempt to add this to the collection.
-        /// <para>
-        /// When using this as part of the writable property flow to respond to a writable property update
-        /// you should pass in the value as an instance of <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>
-        /// to ensure the correct formatting is applied when the object is serialized.
-        /// </para>
-        /// </remarks>
-        /// <param name="componentName">The component with the properties to add or update.</param>
-        /// <param name="properties">A collection of properties to add or update.</param>
-        public void AddOrUpdate(string componentName, IDictionary<string, object> properties)
+        /// <param name="componentName">The component with the properties to add.</param>
+        /// <param name="properties">A collection of properties to add.</param>
+        public void AddComponentProperties(string componentName, IDictionary<string, object> properties)
             => AddInternal(properties, componentName, true);
 
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/exception['ArgumentNullException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/exception['ArgumentException']" cref="AddRootProperty(string, object)" />
         /// <summary>
-        /// Adds or updates a type of <see cref="IWritablePropertyResponse"/> to the collection.
+        /// Adds the values to the collection.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
-        /// <param name="propertyName">The name of the writable property to add or update.</param>
-        /// <param name="propertyValue">The value of the writable property to add or update.</param>
-        /// <param name="statusCode"></param>
-        /// <param name="version"></param>
-        /// <param name="description"></param>
-        public void AddOrUpdate(string propertyName, object propertyValue, int statusCode, long version, string description = default)
-            => AddOrUpdate(null, propertyName, propertyValue, statusCode, version, description);
-
-        /// <inheritdoc path="/remarks" cref="Add(string, object, int, long, string)"/>
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <summary>
-        /// Adds or updates a type of <see cref="IWritablePropertyResponse"/> to the collection.
-        /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c> </exception>
-        /// <param name="propertyName">The name of the writable property to add or update.</param>
-        /// <param name="propertyValue">The value of the writable property to add or update.</param>
-        /// <param name="statusCode"></param>
-        /// <param name="version"></param>
-        /// <param name="description"></param>
-        /// <param name="componentName"></param>
-        public void AddOrUpdate(string componentName, string propertyName, object propertyValue, int statusCode, long version, string description = default)
-        {
-            if (Convention?.PayloadSerializer == null)
-            {
-                AddOrUpdate(componentName, propertyName, new { value = propertyValue, ac = statusCode, av = version, ad = description });
-            }
-            else
-            {
-                AddOrUpdate(componentName, propertyName, Convention.PayloadSerializer.CreateWritablePropertyResponse(propertyValue, statusCode, version, description));
-            }
-        }
-
-        /// <summary>
-        /// Adds or updates the value for the collection.
-        /// </summary>
-        /// <seealso cref="PayloadConvention"/>
-        /// <seealso cref="PayloadSerializer"/>
-        /// <seealso cref="PayloadEncoder"/>
-        /// <param name="properties">A collection of properties to add or update.</param>
-        /// <param name="componentName">The component with the properties to add or update.</param>
-        /// <param name="forceUpdate">Forces the collection to use the Add or Update behavior.
-        /// Setting to true will simply overwrite the value. Setting to false will use <see cref="IDictionary{TKey, TValue}.Add(TKey, TValue)"/></param>
-        private void AddInternal(IDictionary<string, object> properties, string componentName = default, bool forceUpdate = false)
+        /// <remarks>
+        /// If the collection already has a key matching a property name supplied this method will throw an <see cref="ArgumentException"/>.
+        /// <para>
+        /// When using this as part of the writable property flow to respond to a writable property update you should pass in the value
+        /// as an instance of <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>
+        /// to ensure the correct formatting is applied when the object is serialized.
+        /// </para>
+        /// <para>
+        /// This method directly adds the supplied <paramref name="properties"/> to the collection.
+        /// For component-level properties, either ensure that you include the component identifier markers {"__t": "c"} as a part of the supplied <paramref name="properties"/>,
+        /// or use the <see cref="AddComponentProperties(string, IDictionary{string, object})"/> convenience method instead.
+        /// For more information see <see href="https://docs.microsoft.com/en-us/azure/iot-pnp/concepts-convention#sample-multiple-components-read-only-property"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="properties">A collection of properties to add.</param>
+        public void Add(IDictionary<string, object> properties)
         {
             if (properties == null)
             {
                 throw new ArgumentNullException(nameof(properties));
             }
 
-            // If the componentName is null then simply add the key-value pair to Collection dictionary.
-            // this will either insert a property or overwrite it if it already exists.
-            if (componentName == null)
-            {
-                foreach (KeyValuePair<string, object> entry in properties)
-                {
-                    if (forceUpdate)
-                    {
-                        Collection[entry.Key] = entry.Value;
-                    }
-                    else
-                    {
-                        Collection.Add(entry.Key, entry.Value);
-                    }
-                }
-            }
-            else
-            {
-                // If the component name already exists within the dictionary, then the value is a dictionary containing the component level property key and values.
-                // Append this property dictionary to the existing property value dictionary (overwrite entries if they already exist).
-                // Otherwise, add this as a new entry.
-                var componentProperties = new Dictionary<string, object>();
-                if (Collection.ContainsKey(componentName))
-                {
-                    componentProperties = (Dictionary<string, object>)Collection[componentName];
-                }
-                foreach (KeyValuePair<string, object> entry in properties)
-                {
-                    if (forceUpdate)
-                    {
-                        componentProperties[entry.Key] = entry.Value;
-                    }
-                    else
-                    {
-                        componentProperties.Add(entry.Key, entry.Value);
-                    }
-                }
-
-                // For a component level property, the property patch needs to contain the {"__t": "c"} component identifier.
-                if (!componentProperties.ContainsKey(ConventionBasedConstants.ComponentIdentifierKey))
-                {
-                    componentProperties[ConventionBasedConstants.ComponentIdentifierKey] = ConventionBasedConstants.ComponentIdentifierValue;
-                }
-
-                if (forceUpdate)
-                {
-                    Collection[componentName] = componentProperties;
-                }
-                else
-                {
-                    Collection.Add(componentName, componentProperties);
-                }
-            }
+            properties
+                .ToList()
+                .ForEach(entry => Collection.Add(entry.Key, entry.Value));
         }
+
+        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/remarks" cref="AddOrUpdateComponentProperties(string, IDictionary{string, object})" />
+        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/exception['ArgumentNullException']" cref="AddRootProperty(string, object)" />
+        /// <param name="propertyName">The name of the property to add or update.</param>
+        /// <param name="propertyValue">The value of the property to add or update.</param>
+        public void AddOrUpdateRootProperty(string propertyName, object propertyValue)
+            => AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, null, true);
+
+        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/remarks" cref="AddOrUpdateComponentProperties(string, IDictionary{string, object})" />
+        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/exception['ArgumentNullException']" cref="AddRootProperty(string, object)" />
+        /// <param name="componentName">The component with the property to add or update.</param>
+        /// <param name="propertyName">The name of the property to add or update.</param>
+        /// <param name="propertyValue">The value of the property to add or update.</param>
+        public void AddOrUpdateComponentProperty(string componentName, string propertyName, object propertyValue)
+            => AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName, true);
+
+        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/exception['ArgumentNullException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <remarks>
+        /// If the collection has a key that matches this will overwrite the current value. Otherwise it will attempt to add this to the collection.
+        /// <para>
+        /// When using this as part of the writable property flow to respond to a writable property update
+        /// you should pass in the value as an instance of <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>
+        /// to ensure the correct formatting is applied when the object is serialized.
+        /// </para>
+        /// </remarks>
+        /// <param name="componentName">The component with the properties to add or update.</param>
+        /// <param name="properties">A collection of properties to add or update.</param>
+        public void AddOrUpdateComponentProperties(string componentName, IDictionary<string, object> properties)
+            => AddInternal(properties, componentName, true);
+
+        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
+        /// <remarks>
+        /// If the collection has a key that matches this will overwrite the current value. Otherwise it will attempt to add this to the collection.
+        /// <para>
+        /// When using this as part of the writable property flow to respond to a writable property update you should pass in the value
+        /// as an instance of <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>
+        /// to ensure the correct formatting is applied when the object is serialized.
+        /// </para>
+        /// <para>
+        /// This method directly adds or updates the supplied <paramref name="properties"/> to the collection.
+        /// For component-level properties, either ensure that you include the component identifier markers {"__t": "c"} as a part of the supplied <paramref name="properties"/>,
+        /// or use the <see cref="AddOrUpdateComponentProperties(string, IDictionary{string, object})"/> convenience method instead.
+        /// For more information see <see href="https://docs.microsoft.com/en-us/azure/iot-pnp/concepts-convention#sample-multiple-components-read-only-property"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="properties">A collection of properties to add or update.</param>
+        public void AddOrUpdate(IDictionary<string, object> properties)
+            => properties
+                .ToList()
+                .ForEach(entry => Collection[entry.Key] = entry.Value);
 
         /// <summary>
         /// Determines whether the specified property is present.
@@ -323,14 +199,27 @@ namespace Microsoft.Azure.Devices.Client
 
                 if (componentProperties is IDictionary<string, object> nestedDictionary)
                 {
-                    if (nestedDictionary.TryGetValue(propertyName, out object dictionaryElement) && dictionaryElement is T valueRef)
+                    if (nestedDictionary.TryGetValue(propertyName, out object dictionaryElement))
                     {
-                        propertyValue = valueRef;
-                        return true;
+                        // If the value is null, go ahead and return it.
+                        if (dictionaryElement == null)
+                        {
+                            propertyValue = default;
+                            return true;
+                        }
+
+                        // If the object is of type T or can be cast to type T, go ahead and return it.
+                        if (dictionaryElement is T valueRef
+                            || NumericHelpers.TryCastNumericTo(dictionaryElement, out valueRef))
+                        {
+                            propertyValue = valueRef;
+                            return true;
+                        }
                     }
                 }
                 else
                 {
+                    // If it's not, we need to try to convert it using the serializer.
                     Convention.PayloadSerializer.TryGetNestedObjectValue<T>(componentProperties, propertyName, out propertyValue);
                     return true;
                 }
@@ -396,6 +285,72 @@ namespace Microsoft.Azure.Devices.Client
             }
 
             return propertyCollectionToReturn;
+        }
+
+        /// <summary>
+        /// Adds or updates the value for the collection.
+        /// </summary>
+        /// <seealso cref="PayloadConvention"/>
+        /// <seealso cref="PayloadSerializer"/>
+        /// <seealso cref="PayloadEncoder"/>
+        /// <param name="properties">A collection of properties to add or update.</param>
+        /// <param name="componentName">The component with the properties to add or update.</param>
+        /// <param name="forceUpdate">Forces the collection to use the Add or Update behavior.
+        /// Setting to true will simply overwrite the value. Setting to false will use <see cref="IDictionary{TKey, TValue}.Add(TKey, TValue)"/></param>
+        /// <exception cref="ArgumentNullException"><paramref name="properties"/> is <c>null</c>. </exception>
+        private void AddInternal(IDictionary<string, object> properties, string componentName = default, bool forceUpdate = false)
+        {
+            if (properties == null)
+            {
+                throw new ArgumentNullException(nameof(properties));
+            }
+
+            // If the componentName is null then simply add the key-value pair to Collection dictionary.
+            // This will either insert a property or overwrite it if it already exists.
+            if (componentName == null)
+            {
+                foreach (KeyValuePair<string, object> entry in properties)
+                {
+                    if (forceUpdate)
+                    {
+                        Collection[entry.Key] = entry.Value;
+                    }
+                    else
+                    {
+                        Collection.Add(entry.Key, entry.Value);
+                    }
+                }
+            }
+            else
+            {
+                // If the component name already exists within the dictionary, then the value is a dictionary containing the component level property key and values.
+                // Append this property dictionary to the existing property value dictionary (overwrite entries if they already exist, if forceUpdate is true).
+                // Otherwise, if the component name does not exist in the dictionary, then add this as a new entry.
+                var componentProperties = new Dictionary<string, object>();
+                if (Collection.ContainsKey(componentName))
+                {
+                    componentProperties = (Dictionary<string, object>)Collection[componentName];
+                }
+                foreach (KeyValuePair<string, object> entry in properties)
+                {
+                    if (forceUpdate)
+                    {
+                        componentProperties[entry.Key] = entry.Value;
+                    }
+                    else
+                    {
+                        componentProperties.Add(entry.Key, entry.Value);
+                    }
+                }
+
+                // For a component level property, the property patch needs to contain the {"__t": "c"} component identifier.
+                if (!componentProperties.ContainsKey(ConventionBasedConstants.ComponentIdentifierKey))
+                {
+                    componentProperties[ConventionBasedConstants.ComponentIdentifierKey] = ConventionBasedConstants.ComponentIdentifierValue;
+                }
+
+                Collection[componentName] = componentProperties;
+            }
         }
     }
 }

--- a/iothub/device/src/DeviceClient.ConventionBasedOperations.cs
+++ b/iothub/device/src/DeviceClient.ConventionBasedOperations.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Devices.Shared;
 
 namespace Microsoft.Azure.Devices.Client
 {
@@ -14,6 +15,11 @@ namespace Microsoft.Azure.Devices.Client
     /// <threadsafety static="true" instance="true" />
     public partial class DeviceClient : IDisposable
     {
+        /// <summary>
+        /// The <see cref="PayloadConvention"/> that the client uses for convention-based operations.
+        /// </summary>
+        public PayloadConvention PayloadConvention => InternalClient.PayloadConvention;
+
         /// <summary>
         /// Send telemetry using the specified message.
         /// </summary>

--- a/iothub/device/src/ModuleClient.ConventionBasedOperations.cs
+++ b/iothub/device/src/ModuleClient.ConventionBasedOperations.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Devices.Shared;
 
 namespace Microsoft.Azure.Devices.Client
 {
@@ -14,6 +15,11 @@ namespace Microsoft.Azure.Devices.Client
     /// <threadsafety static="true" instance="true" />
     public partial class ModuleClient : IDisposable
     {
+        /// <summary>
+        /// The <see cref="PayloadConvention"/> that the client uses for convention-based operations.
+        /// </summary>
+        public PayloadConvention PayloadConvention => InternalClient.PayloadConvention;
+
         /// <summary>
         /// Send telemetry using the specified message.
         /// </summary>

--- a/iothub/device/src/NumericHelpers.cs
+++ b/iothub/device/src/NumericHelpers.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.Azure.Devices.Client
+{
+    internal class NumericHelpers
+    {
+        internal static bool TryCastNumericTo<T>(object input, out T result)
+        {
+            if (TryGetNumeric(input))
+            {
+                try
+                {
+                    result = (T)Convert.ChangeType(input, typeof(T), CultureInfo.InvariantCulture);
+                    return true;
+                }
+                catch
+                {
+                }
+            }
+
+            result = default;
+            return false;
+        }
+
+        private static bool TryGetNumeric(object expression)
+        {
+            if (expression == null)
+                return false;
+
+            return double.TryParse(
+                Convert.ToString(
+                    expression,
+                    CultureInfo.InvariantCulture),
+                NumberStyles.Any,
+                NumberFormatInfo.InvariantInfo,
+                out _);
+        }
+    }
+}

--- a/iothub/device/src/NumericHelpers.cs
+++ b/iothub/device/src/NumericHelpers.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Azure.Devices.Client
         private static bool TryGetNumeric(object expression)
         {
             if (expression == null)
+            {
                 return false;
+            }
 
             return double.TryParse(
                 Convert.ToString(

--- a/iothub/device/src/TelemetryCollection.cs
+++ b/iothub/device/src/TelemetryCollection.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Microsoft.Azure.Devices.Shared;
 
 namespace Microsoft.Azure.Devices.Client
 {
     /// <summary>
-    /// The telmetry collection used to populate a <see cref="TelemetryMessage"/>.
+    /// The telemetry collection used to populate a <see cref="TelemetryMessage"/>.
     /// </summary>
     public class TelemetryCollection : PayloadCollection
     {


### PR DESCRIPTION
This PR separates out the root-level and component-level property operations.
This is to resolve the ambiguity between adding a root-level property that is of map schema vs adding a collection of component-level properties.

Eg:

Model:
```json
{
	"@id": "dtmi:com:example:NestedInterface;1",
	"@type": "Interface",
	"displayName": "Sample Model",
	"contents": [
		{
			"@type": "Component",
			"displayName": {
				"en": "myComponent"
			},
			"name": "myComponent",
			"schema": "dtmi:com:example:RootInterface;1"
		}
	],
	"@context": "dtmi:dtdl:context;2"
}
```

```json
{
	"@id": "dtmi:com:example:RootInterface;1",
	"@type": "Interface",
	"displayName": "Sample Model",
	"contents": [
		{
			"@type": "Property",
			"name": "modules",
			"writable": true,
			"schema": {
				"@type": "Map",
				"mapKey": {
					"name": "moduleName",
					"schema": "string"
				},
				"mapValue": {
					"name": "moduleState",
					"schema": "string"
				}
			}
		},
		{
			"@type": "Property",
			"name": "manufacturer",
			"displayName": "Manufacturer",
			"schema": "string",
			"description": "Company name of the device manufacturer. This could be the same as the name of the original equipment manufacturer (OEM). Ex. Contoso."
		},
		{
			"@type": "Property",
			"name": "model",
			"displayName": "Device model",
			"schema": "string",
			"description": "Device model name or ID. Ex. Surface Book 2."
		}
	],
	"@context": "dtmi:dtdl:context;2"
}
```

(1) Device registers with no-component model `"dtmi:com:example:RootInterface;1"` and creates a `ClientPropertyCollection` to update a root-level property `modules` that is of map schema:
```csharp
var modulesMap = new Dictionary<string, string>
{
    { "myModuleA", "running" },
    { "myModuleB", "stopped" }
};

var rootProperty = new ClientPropertyCollection();
rootProperty.Add("modules", modulesMap);
```

(2) Device registers with nested component model `"dtmi:com:example:NestedInterface;1"` and creates a `ClientPropertyCollection` to update a collection of component-level properties:
```csharp
var allProperties = new Dictionary<string, object>
{
    { "manufacturer", "Intel" },
    { "model", "DFC5646" },
    { "modules", modulesMap }
};

var componentProperties = new ClientPropertyCollection();
componentProperties.Add("myComponent", allProperties);
```

At this point, the sdk cannot differentiate between (1) and (2), since both have the same method signature; and as a result, cannot correctly identify the component-level property addition in order to add the component identifiers: `{ "__t" : "c" }`.

For this reason, we are splitting the `Add` APIs into separate APIs for root-level operations and component-level operations.