### PR TITLE
Update AuthenticationWithTokenRefresh disposal fix to be non-breaking

### DIFF
--- a/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
+++ b/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         private async Task AuthenticationMethodDisposesTokenRefresher(Client.TransportType transport)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposalBySdk: true);
+            var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposeWithClient: true);
 
             // Create an instance of the device client, send a test message and then close and dispose it.
             DeviceClient deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, authenticationMethod, transport);
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         private async Task ReuseAuthenticationMethod_SingleDevice(Client.TransportType transport)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposalBySdk: false);
+            var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposeWithClient: false);
 
             // Create an instance of the device client, send a test message and then close and dispose it.
             DeviceClient deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, authenticationMethod, transport);
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             {
                 TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
 #pragma warning disable CA2000 // Dispose objects before losing scope - the authentication method is disposed at the end of the test.
-                var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposalBySdk: false);
+                var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposeWithClient: false);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
                 testDevices.Add(testDevice);
@@ -278,8 +278,8 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             public DeviceAuthenticationSasToken(
                 string connectionString,
-                bool disposalBySdk)
-                : base(GetDeviceIdFromConnectionString(connectionString), s_suggestedSasTimeToLiveInSeconds, s_sasRenewalBufferPercentage, disposalBySdk)
+                bool disposeWithClient)
+                : base(GetDeviceIdFromConnectionString(connectionString), s_suggestedSasTimeToLiveInSeconds, s_sasRenewalBufferPercentage, disposeWithClient)
             {
                 if (connectionString == null)
                 {

--- a/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
+++ b/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
@@ -82,6 +82,11 @@ namespace Microsoft.Azure.Devices.E2ETests
             await AuthenticationMethodDisposesTokenRefresher(Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
         }
 
+        // Even on encountering an exception, the MQTT layer keeps on reattempting CONNECT when communicating via DotNetty's TCP..
+        // As a result, instead of throwing the actual exception encountered an IotHubCommunicationException is thrown (on operation timeout).
+        // This is not an issue when the communication is over websockets (where we use the sdk's websocket implementation).
+        // This test has been ignored until we root-cause the issue on DotNetty's TCP stack.
+        [Ignore]
         [LoggedTestMethod]
         public async Task DeviceClient_AuthenticationMethodDisposesTokenRefresher_Mqtt()
         {

--- a/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
+++ b/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             await AuthenticationMethodDisposesTokenRefresher(Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
         }
 
-        // Even on encountering an exception, the MQTT layer keeps on reattempting CONNECT when communicating via DotNetty's TCP..
+        // Even on encountering an exception, the MQTT layer keeps on reattempting CONNECT when communicating via DotNetty's TCP stack.
         // As a result, instead of throwing the actual exception encountered an IotHubCommunicationException is thrown (on operation timeout).
         // This is not an issue when the communication is over websockets (where we use the sdk's websocket implementation).
         // This test has been ignored until we root-cause the issue on DotNetty's TCP stack.

--- a/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
+++ b/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
@@ -55,19 +55,72 @@ namespace Microsoft.Azure.Devices.E2ETests
         [LoggedTestMethod]
         public async Task DeviceSak_ReusableAuthenticationMethod_MuxedDevicesPerConnection_Amqp()
         {
-            await ReuseAuthenticationMethod_MuxedDevices(Client.TransportType.Amqp_Tcp_Only, 2);
+            await ReuseAuthenticationMethod_MuxedDevices(Client.TransportType.Amqp_Tcp_Only, 2).ConfigureAwait(false); ;
         }
 
         [LoggedTestMethod]
         public async Task DeviceSak_ReusableAuthenticationMethod_MuxedDevicesPerConnection_AmqpWs()
         {
-            await ReuseAuthenticationMethod_MuxedDevices(Client.TransportType.Amqp_WebSocket_Only, 2);
+            await ReuseAuthenticationMethod_MuxedDevices(Client.TransportType.Amqp_WebSocket_Only, 2).ConfigureAwait(false); ;
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceClient_AuthenticationMethodDisposesTokenRefresher_Http()
+        {
+            await AuthenticationMethodDisposesTokenRefresher(Client.TransportType.Http1).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceClient_AuthenticationMethodDisposesTokenRefresher_Amqp()
+        {
+            await AuthenticationMethodDisposesTokenRefresher(Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceClient_AuthenticationMethodDisposesTokenRefresher_AmqpWs()
+        {
+            await AuthenticationMethodDisposesTokenRefresher(Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceClient_AuthenticationMethodDisposesTokenRefresher_Mqtt()
+        {
+            await AuthenticationMethodDisposesTokenRefresher(Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task DeviceClient_AuthenticationMethodDisposesTokenRefresher_MqttWs()
+        {
+            await AuthenticationMethodDisposesTokenRefresher(Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
+        }
+
+        private async Task AuthenticationMethodDisposesTokenRefresher(Client.TransportType transport)
+        {
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
+            var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposalBySdk: true);
+
+            // Create an instance of the device client, send a test message and then close and dispose it.
+            DeviceClient deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, authenticationMethod, transport);
+            using var message1 = new Client.Message();
+            await deviceClient.SendEventAsync(message1).ConfigureAwait(false);
+            await deviceClient.CloseAsync();
+            deviceClient.Dispose();
+            Logger.Trace("Test with instance 1 completed");
+
+            // Perform the same steps again, reusing the previously created authentication method instance.
+            // Since the default behavior is to dispose AuthenticationWithTokenRefresh authentication method on DeviceClient disposal,
+            // this should now throw an ObjectDisposedException.
+            DeviceClient deviceClient2 = DeviceClient.Create(testDevice.IoTHubHostName, authenticationMethod, transport);
+            using var message2 = new Client.Message();
+
+            Func<Task> act = async () => await deviceClient2.SendEventAsync(message2).ConfigureAwait(false);
+            await act.Should().ThrowAsync<ObjectDisposedException>();
         }
 
         private async Task ReuseAuthenticationMethod_SingleDevice(Client.TransportType transport)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString);
+            var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposalBySdk: false);
 
             // Create an instance of the device client, send a test message and then close and dispose it.
             DeviceClient deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, authenticationMethod, transport);
@@ -110,7 +163,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             {
                 TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
 #pragma warning disable CA2000 // Dispose objects before losing scope - the authentication method is disposed at the end of the test.
-                var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString);
+                var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposalBySdk: false);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
                 testDevices.Add(testDevice);
@@ -215,9 +268,13 @@ namespace Microsoft.Azure.Devices.E2ETests
             private const string SasTokenTargetFormat = "{0}/devices/{1}";
             private readonly IotHubConnectionStringBuilder _connectionStringBuilder;
 
+            private static readonly int s_suggestedSasTimeToLiveInSeconds = (int)TimeSpan.FromMinutes(30).TotalSeconds;
+            private static readonly int s_sasRenewalBufferPercentage = 50;
+
             public DeviceAuthenticationSasToken(
-                string connectionString)
-                : base(GetDeviceIdFromConnectionString(connectionString))
+                string connectionString,
+                bool disposalBySdk)
+                : base(GetDeviceIdFromConnectionString(connectionString), s_suggestedSasTimeToLiveInSeconds, s_sasRenewalBufferPercentage, disposalBySdk)
             {
                 if (connectionString == null)
                 {

--- a/iothub/device/src/AuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/AuthenticationWithTokenRefresh.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// This constructor will create an authentication method instance that will be disposed when its
         /// associated device/ module client instance is disposed. To reuse the authentication method instance across multiple client instance lifetimes,
-        /// use <see cref="AuthenticationWithTokenRefresh(int, int, bool)"/> constructor and set <c>disposalBySdk</c> to <c>false</c>.
+        /// use <see cref="AuthenticationWithTokenRefresh(int, int, bool)"/> constructor and set <c>disposeWithClient</c> to <c>false</c>.
         /// </remarks>
         /// <param name="suggestedTimeToLiveSeconds">Token time to live suggested value. The implementations of this abstract
         /// may choose to ignore this value.</param>
@@ -48,11 +48,12 @@ namespace Microsoft.Azure.Devices.Client
         /// may choose to ignore this value.</param>
         /// <param name="timeBufferPercentage">Time buffer before expiry when the token should be renewed expressed as
         /// a percentage of the time to live.</param>
-        /// <param name="disposalBySdk">True if the authentication method should be disposed of by sdk; false if you intend to reuse the authentication method.</param>
+        /// <param name="disposeWithClient "><c>true</c> if the authentication method should be disposed of by the client
+        /// when the client using this instance is itself disposed; <c>false</c> if you intend to reuse the authentication method.</param>
         public AuthenticationWithTokenRefresh(
             int suggestedTimeToLiveSeconds,
             int timeBufferPercentage,
-            bool disposalBySdk)
+            bool disposeWithClient)
         {
             if (suggestedTimeToLiveSeconds < 0)
             {
@@ -70,7 +71,7 @@ namespace Microsoft.Azure.Devices.Client
             Debug.Assert(IsExpiring);
             UpdateTimeBufferSeconds(_suggestedTimeToLiveSeconds);
 
-            DisposalBySdk = disposalBySdk;
+            DisposalWithClient = disposeWithClient;
         }
 
         /// <summary>
@@ -88,8 +89,9 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         public bool IsExpiring => (ExpiresOn - DateTime.UtcNow).TotalSeconds <= _bufferSeconds;
 
-        // This internal property is used by the sdk to determine if the disposal should be handled by the sdk.
-        internal bool DisposalBySdk { get; }
+        // This internal property is used by the sdk to determine if the authentication method
+        // should be disposed when the client that it is initialized with is disposed.
+        internal bool DisposalWithClient { get; }
 
         /// <summary>
         /// Gets a snapshot of the security token associated with the device. This call is thread-safe.

--- a/iothub/device/src/AuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/AuthenticationWithTokenRefresh.cs
@@ -93,8 +93,9 @@ namespace Microsoft.Azure.Devices.Client
         {
             if (_isDisposed)
             {
-                throw new ObjectDisposedException("This authentication method instance has already been disposed. " +
-                    "Please create a new instance and pass it to the DeviceClient/ ModuleClient during initialization.");
+                throw new ObjectDisposedException("The authentication method instance has already been disposed, so this client is no longer usable. " +
+                    "Please close and dispose your current client instance. To continue carrying out operations from your device/ module, " +
+                    "create a new authentication method instance and use it for reinitializing your client.");
             }
 
             if (!IsExpiring)

--- a/iothub/device/src/AuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/AuthenticationWithTokenRefresh.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthenticationWithTokenRefresh"/> class.
         /// </summary>
+        /// <remarks>
+        /// This constructor will create an authentication method instance that will be disposed when its
+        /// associated device/ module client instance is disposed. To reuse the authentication method instance across multiple client instance lifetimes,
+        /// use <see cref="AuthenticationWithTokenRefresh(int, int, bool)"/> constructor and set <c>disposalBySdk</c> to <c>false</c>.
+        /// </remarks>
         /// <param name="suggestedTimeToLiveSeconds">Token time to live suggested value. The implementations of this abstract
         /// may choose to ignore this value.</param>
         /// <param name="timeBufferPercentage">Time buffer before expiry when the token should be renewed expressed as

--- a/iothub/device/src/DeviceAuthenticationWithSakRefresh.cs
+++ b/iothub/device/src/DeviceAuthenticationWithSakRefresh.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Azure.Devices.Client
             string deviceId,
             IotHubConnectionString connectionString,
             TimeSpan sasTokenTimeToLive,
-            int sasTokenRenewalBuffer) : base(deviceId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer)
+            int sasTokenRenewalBuffer,
+            bool disposalBySdk)
+            : base(deviceId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer, disposalBySdk)
         {
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
         }

--- a/iothub/device/src/DeviceAuthenticationWithSakRefresh.cs
+++ b/iothub/device/src/DeviceAuthenticationWithSakRefresh.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Azure.Devices.Client
             IotHubConnectionString connectionString,
             TimeSpan sasTokenTimeToLive,
             int sasTokenRenewalBuffer,
-            bool disposalBySdk)
-            : base(deviceId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer, disposalBySdk)
+            bool disposeWithClient)
+            : base(deviceId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer, disposeWithClient)
         {
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
         }

--- a/iothub/device/src/DeviceAuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/DeviceAuthenticationWithTokenRefresh.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Azure.Devices.Client
         /// Initializes a new instance of the <see cref="DeviceAuthenticationWithTokenRefresh"/> class using default
         /// TTL and TTL buffer time settings.
         /// </summary>
+        /// <remarks>
+        /// This constructor will create an authentication method instance that will be disposed when its
+        /// associated device client instance is disposed. To reuse the authentication method instance across multiple client instance lifetimes,
+        /// use <see cref="DeviceAuthenticationWithTokenRefresh(string, int, int, bool)"/> constructor and set <c>disposalBySdk</c> to <c>false</c>.
+        /// </remarks>
         /// <param name="deviceId">Device Identifier.</param>
         public DeviceAuthenticationWithTokenRefresh(string deviceId)
             : this(deviceId, DefaultTimeToLiveSeconds, DefaultBufferPercentage)
@@ -27,6 +32,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="DeviceAuthenticationWithTokenRefresh"/> class.
         /// </summary>
+        /// <remarks>
+        /// This constructor will create an authentication method instance that will be disposed when its
+        /// associated device client instance is disposed. To reuse the authentication method instance across multiple client instance lifetimes,
+        /// use <see cref="DeviceAuthenticationWithTokenRefresh(string, int, int, bool)"/> constructor and set <c>disposalBySdk</c> to <c>false</c>.
+        /// </remarks>
         /// <param name="deviceId">Device Identifier.</param>
         /// <param name="suggestedTimeToLiveSeconds">
         /// The suggested time to live value for the generated SAS tokens.

--- a/iothub/device/src/DeviceAuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/DeviceAuthenticationWithTokenRefresh.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// This constructor will create an authentication method instance that will be disposed when its
         /// associated device client instance is disposed. To reuse the authentication method instance across multiple client instance lifetimes,
-        /// use <see cref="DeviceAuthenticationWithTokenRefresh(string, int, int, bool)"/> constructor and set <c>disposalBySdk</c> to <c>false</c>.
+        /// use <see cref="DeviceAuthenticationWithTokenRefresh(string, int, int, bool)"/> constructor and set <c>disposeWithClient</c> to <c>false</c>.
         /// </remarks>
         /// <param name="deviceId">Device Identifier.</param>
         public DeviceAuthenticationWithTokenRefresh(string deviceId)
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// This constructor will create an authentication method instance that will be disposed when its
         /// associated device client instance is disposed. To reuse the authentication method instance across multiple client instance lifetimes,
-        /// use <see cref="DeviceAuthenticationWithTokenRefresh(string, int, int, bool)"/> constructor and set <c>disposalBySdk</c> to <c>false</c>.
+        /// use <see cref="DeviceAuthenticationWithTokenRefresh(string, int, int, bool)"/> constructor and set <c>disposeWithClient</c> to <c>false</c>.
         /// </remarks>
         /// <param name="deviceId">Device Identifier.</param>
         /// <param name="suggestedTimeToLiveSeconds">
@@ -65,14 +65,17 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="timeBufferPercentage">
         /// The time buffer before expiry when the token should be renewed, expressed as a percentage of the time to live.
         /// The default behavior is that the token will be renewed when it has 15% or less of its lifespan left.
-        /// <param name="disposalBySdk">True if the authentication method should be disposed of by sdk; false if you intend to reuse the authentication method.</param>
         ///</param>
+        ///<param name="disposeWithClient ">
+        ///<c>true</c> if the authentication method should be disposed of by the client
+        /// when the client using this instance is itself disposed; <c>false</c> if you intend to reuse the authentication method.
+        /// </param>
         public DeviceAuthenticationWithTokenRefresh(
             string deviceId,
             int suggestedTimeToLiveSeconds,
             int timeBufferPercentage,
-            bool disposalBySdk)
-            : base(SetSasTokenSuggestedTimeToLiveSeconds(suggestedTimeToLiveSeconds), SetSasTokenRenewalBufferPercentage(timeBufferPercentage), disposalBySdk)
+            bool disposeWithClient)
+            : base(SetSasTokenSuggestedTimeToLiveSeconds(suggestedTimeToLiveSeconds), SetSasTokenRenewalBufferPercentage(timeBufferPercentage), disposeWithClient)
         {
             if (deviceId.IsNullOrWhiteSpace())
             {

--- a/iothub/device/src/DeviceAuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/DeviceAuthenticationWithTokenRefresh.cs
@@ -40,7 +40,29 @@ namespace Microsoft.Azure.Devices.Client
             string deviceId,
             int suggestedTimeToLiveSeconds,
             int timeBufferPercentage)
-            : base(SetSasTokenSuggestedTimeToLiveSeconds(suggestedTimeToLiveSeconds), SetSasTokenRenewalBufferPercentage(timeBufferPercentage))
+            : this(deviceId, suggestedTimeToLiveSeconds, timeBufferPercentage, true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeviceAuthenticationWithTokenRefresh"/> class.
+        /// </summary>
+        /// <param name="deviceId">Device Identifier.</param>
+        /// <param name="suggestedTimeToLiveSeconds">
+        /// The suggested time to live value for the generated SAS tokens.
+        /// The default value is 1 hour.
+        /// </param>
+        /// <param name="timeBufferPercentage">
+        /// The time buffer before expiry when the token should be renewed, expressed as a percentage of the time to live.
+        /// The default behavior is that the token will be renewed when it has 15% or less of its lifespan left.
+        /// <param name="disposalBySdk">True if the authentication method should be disposed of by sdk; false if you intend to reuse the authentication method.</param>
+        ///</param>
+        public DeviceAuthenticationWithTokenRefresh(
+            string deviceId,
+            int suggestedTimeToLiveSeconds,
+            int timeBufferPercentage,
+            bool disposalBySdk)
+            : base(SetSasTokenSuggestedTimeToLiveSeconds(suggestedTimeToLiveSeconds), SetSasTokenRenewalBufferPercentage(timeBufferPercentage), disposalBySdk)
         {
             if (deviceId.IsNullOrWhiteSpace())
             {

--- a/iothub/device/src/DeviceAuthenticationWithTpm.cs
+++ b/iothub/device/src/DeviceAuthenticationWithTpm.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="securityProvider">Device Security Provider settings for TPM Hardware Security Modules.</param>
         public DeviceAuthenticationWithTpm(
             string deviceId,
-            SecurityProviderTpm securityProvider) : base(deviceId)
+            SecurityProviderTpm securityProvider)
+            : base(deviceId)
         {
             _securityProvider = securityProvider ?? throw new ArgumentNullException(nameof(securityProvider));
         }
@@ -43,7 +44,27 @@ namespace Microsoft.Azure.Devices.Client
             string deviceId,
             SecurityProviderTpm securityProvider,
             int suggestedTimeToLiveSeconds,
-            int timeBufferPercentage) : base(deviceId, suggestedTimeToLiveSeconds, timeBufferPercentage)
+            int timeBufferPercentage)
+            : this(deviceId, securityProvider, suggestedTimeToLiveSeconds, timeBufferPercentage, true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeviceAuthenticationWithTpm"/> class.
+        /// </summary>
+        /// <param name="deviceId">Device Identifier.</param>
+        /// <param name="securityProvider">Device Security Provider settings for TPM Hardware Security Modules.</param>
+        /// <param name="suggestedTimeToLiveSeconds">Token time to live suggested value.</param>
+        /// <param name="timeBufferPercentage">Time buffer before expiry when the token should be renewed expressed as percentage of
+        /// the time to live. EX: If you want a SAS token to live for 85% of life before proactive renewal, this value should be 15.</param>
+        /// <param name="disposalBySdk">True if the authentication method should be disposed of by sdk; false if you intend to reuse the authentication method.</param>
+        public DeviceAuthenticationWithTpm(
+            string deviceId,
+            SecurityProviderTpm securityProvider,
+            int suggestedTimeToLiveSeconds,
+            int timeBufferPercentage,
+            bool disposalBySdk)
+            : base(deviceId, suggestedTimeToLiveSeconds, timeBufferPercentage, disposalBySdk)
         {
             _securityProvider = securityProvider ?? throw new ArgumentNullException(nameof(securityProvider));
         }

--- a/iothub/device/src/DeviceAuthenticationWithTpm.cs
+++ b/iothub/device/src/DeviceAuthenticationWithTpm.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// This constructor will create an authentication method instance that will be disposed when its
         /// associated device client instance is disposed. To reuse the authentication method instance across multiple client instance lifetimes,
-        /// use <see cref="DeviceAuthenticationWithTpm(string, SecurityProviderTpm, int, int, bool)"/> constructor and set <c>disposalBySdk</c> to <c>false</c>.
+        /// use <see cref="DeviceAuthenticationWithTpm(string, SecurityProviderTpm, int, int, bool)"/> constructor and set <c>disposeWithClient</c> to <c>false</c>.
         /// </remarks>
         /// <param name="deviceId">Device Identifier.</param>
         /// <param name="securityProvider">Device Security Provider settings for TPM Hardware Security Modules.</param>
@@ -62,14 +62,15 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="suggestedTimeToLiveSeconds">Token time to live suggested value.</param>
         /// <param name="timeBufferPercentage">Time buffer before expiry when the token should be renewed expressed as percentage of
         /// the time to live. EX: If you want a SAS token to live for 85% of life before proactive renewal, this value should be 15.</param>
-        /// <param name="disposalBySdk">True if the authentication method should be disposed of by sdk; false if you intend to reuse the authentication method.</param>
+        /// <param name="disposeWithClient "><c>true</c> if the authentication method should be disposed of by the client
+        /// when the client using this instance is itself disposed; <c>false</c> if you intend to reuse the authentication method.</param>
         public DeviceAuthenticationWithTpm(
             string deviceId,
             SecurityProviderTpm securityProvider,
             int suggestedTimeToLiveSeconds,
             int timeBufferPercentage,
-            bool disposalBySdk)
-            : base(deviceId, suggestedTimeToLiveSeconds, timeBufferPercentage, disposalBySdk)
+            bool disposeWithClient)
+            : base(deviceId, suggestedTimeToLiveSeconds, timeBufferPercentage, disposeWithClient)
         {
             _securityProvider = securityProvider ?? throw new ArgumentNullException(nameof(securityProvider));
         }

--- a/iothub/device/src/DeviceAuthenticationWithTpm.cs
+++ b/iothub/device/src/DeviceAuthenticationWithTpm.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Azure.Devices.Client
         /// Initializes a new instance of the <see cref="DeviceAuthenticationWithTpm"/> class with default
         /// time to live of 1 hour and default buffer percentage value of 15.
         /// </summary>
+        /// <remarks>
+        /// This constructor will create an authentication method instance that will be disposed when its
+        /// associated device client instance is disposed. To reuse the authentication method instance across multiple client instance lifetimes,
+        /// use <see cref="DeviceAuthenticationWithTpm(string, SecurityProviderTpm, int, int, bool)"/> constructor and set <c>disposalBySdk</c> to <c>false</c>.
+        /// </remarks>
         /// <param name="deviceId">Device Identifier.</param>
         /// <param name="securityProvider">Device Security Provider settings for TPM Hardware Security Modules.</param>
         public DeviceAuthenticationWithTpm(

--- a/iothub/device/src/Edge/EdgeModuleClientFactory.cs
+++ b/iothub/device/src/Edge/EdgeModuleClientFactory.cs
@@ -98,8 +98,8 @@ namespace Microsoft.Azure.Devices.Client.Edge
                 int sasTokenRenewalBuffer = _options?.SasTokenRenewalBuffer ?? default;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope - IDisposable ModuleAuthenticationWithHsm is disposed when the client is disposed.
-                // Since the sdk creates the instance of disposable ModuleAuthenticationWithHsm, the sdk needs to dispose it once the client is diposed.
-                var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId, generationId, sasTokenTimeToLive, sasTokenRenewalBuffer, disposalBySdk: true);
+                // Since the sdk creates the instance of disposable ModuleAuthenticationWithHsm, the sdk needs to dispose it once the client is disposed.
+                var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId, generationId, sasTokenTimeToLive, sasTokenRenewalBuffer, disposeWithClient: true);
 #pragma warning restore CA2000 // Dispose objects before losing scope - IDisposable ModuleAuthenticationWithHsm is disposed when the client is disposed.
 
                 Debug.WriteLine("EdgeModuleClientFactory setupTrustBundle from service");

--- a/iothub/device/src/Edge/EdgeModuleClientFactory.cs
+++ b/iothub/device/src/Edge/EdgeModuleClientFactory.cs
@@ -98,11 +98,8 @@ namespace Microsoft.Azure.Devices.Client.Edge
                 int sasTokenRenewalBuffer = _options?.SasTokenRenewalBuffer ?? default;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope - IDisposable ModuleAuthenticationWithHsm is disposed when the client is disposed.
-                var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId, generationId, sasTokenTimeToLive, sasTokenRenewalBuffer)
-                {
-                    // Since the sdk creates the instance of disposable ModuleAuthenticationWithHsm, the sdk needs to dispose it once the client is diposed.
-                    InstanceCreatedBySdk = true,
-                };
+                // Since the sdk creates the instance of disposable ModuleAuthenticationWithHsm, the sdk needs to dispose it once the client is diposed.
+                var authMethod = new ModuleAuthenticationWithHsm(signatureProvider, deviceId, moduleId, generationId, sasTokenTimeToLive, sasTokenRenewalBuffer, disposalBySdk: true);
 #pragma warning restore CA2000 // Dispose objects before losing scope - IDisposable ModuleAuthenticationWithHsm is disposed when the client is disposed.
 
                 Debug.WriteLine("EdgeModuleClientFactory setupTrustBundle from service");

--- a/iothub/device/src/HsmAuthentication/ModuleAuthenticationWithHsm.cs
+++ b/iothub/device/src/HsmAuthentication/ModuleAuthenticationWithHsm.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication
             string generationId,
             TimeSpan sasTokenTimeToLive,
             int sasTokenRenewalBuffer,
-            bool disposalBySdk)
-            : base(deviceId, moduleId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer, disposalBySdk)
+            bool disposeWithClient)
+            : base(deviceId, moduleId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer, disposeWithClient)
         {
             _signatureProvider = signatureProvider ?? throw new ArgumentNullException(nameof(signatureProvider));
             _generationId = generationId ?? throw new ArgumentNullException(nameof(generationId));

--- a/iothub/device/src/HsmAuthentication/ModuleAuthenticationWithHsm.cs
+++ b/iothub/device/src/HsmAuthentication/ModuleAuthenticationWithHsm.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication
             string moduleId,
             string generationId,
             TimeSpan sasTokenTimeToLive,
-            int sasTokenRenewalBuffer) : base(deviceId, moduleId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer)
+            int sasTokenRenewalBuffer,
+            bool disposalBySdk)
+            : base(deviceId, moduleId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer, disposalBySdk)
         {
             _signatureProvider = signatureProvider ?? throw new ArgumentNullException(nameof(signatureProvider));
             _generationId = generationId ?? throw new ArgumentNullException(nameof(generationId));

--- a/iothub/device/src/IotHubConnectionString.cs
+++ b/iothub/device/src/IotHubConnectionString.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices.Client
                 if (ModuleId.IsNullOrWhiteSpace())
                 {
                     // Since the sdk creates the instance of disposable DeviceAuthenticationWithSakRefresh, the sdk needs to dispose it once the client is disposed.
-                    TokenRefresher = new DeviceAuthenticationWithSakRefresh(DeviceId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer, disposalBySdk: true);
+                    TokenRefresher = new DeviceAuthenticationWithSakRefresh(DeviceId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer, disposeWithClient: true);
 
                     if (Logging.IsEnabled)
                     {
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Devices.Client
                 else
                 {
                     // Since the sdk creates the instance of disposable ModuleAuthenticationWithSakRefresh, the sdk needs to dispose it once the client is disposed.
-                    TokenRefresher = new ModuleAuthenticationWithSakRefresh(DeviceId, ModuleId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer, disposalBySdk: true);
+                    TokenRefresher = new ModuleAuthenticationWithSakRefresh(DeviceId, ModuleId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer, disposeWithClient: true);
 
                     if (Logging.IsEnabled)
                     {

--- a/iothub/device/src/IotHubConnectionString.cs
+++ b/iothub/device/src/IotHubConnectionString.cs
@@ -52,11 +52,8 @@ namespace Microsoft.Azure.Devices.Client
             {
                 if (ModuleId.IsNullOrWhiteSpace())
                 {
-                    TokenRefresher = new DeviceAuthenticationWithSakRefresh(DeviceId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer)
-                    {
-                        // Since the sdk creates the instance of disposable DeviceAuthenticationWithSakRefresh, the sdk needs to dispose it once the client is diposed.
-                        InstanceCreatedBySdk = true,
-                    };
+                    // Since the sdk creates the instance of disposable DeviceAuthenticationWithSakRefresh, the sdk needs to dispose it once the client is disposed.
+                    TokenRefresher = new DeviceAuthenticationWithSakRefresh(DeviceId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer, disposalBySdk: true);
 
                     if (Logging.IsEnabled)
                     {
@@ -65,11 +62,8 @@ namespace Microsoft.Azure.Devices.Client
                 }
                 else
                 {
-                    TokenRefresher = new ModuleAuthenticationWithSakRefresh(DeviceId, ModuleId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer)
-                    {
-                        // Since the sdk creates the instance of disposable ModuleAuthenticationWithSakRefresh, the sdk needs to dispose it once the client is diposed.
-                        InstanceCreatedBySdk = true,
-                    };
+                    // Since the sdk creates the instance of disposable ModuleAuthenticationWithSakRefresh, the sdk needs to dispose it once the client is disposed.
+                    TokenRefresher = new ModuleAuthenticationWithSakRefresh(DeviceId, ModuleId, this, builder.SasTokenTimeToLive, builder.SasTokenRenewalBuffer, disposalBySdk: true);
 
                     if (Logging.IsEnabled)
                     {

--- a/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
+++ b/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Azure.Devices.Client
             IotHubConnectionString connectionString,
             TimeSpan sasTokenTimeToLive,
             int sasTokenRenewalBuffer,
-            bool disposalBySdk)
-            : base(deviceId, moduleId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer, disposalBySdk)
+            bool disposeWithClient)
+            : base(deviceId, moduleId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer, disposeWithClient)
         {
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
         }

--- a/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
+++ b/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.Client
             IotHubConnectionString connectionString,
             TimeSpan sasTokenTimeToLive,
             int sasTokenRenewalBuffer,
-            bool disposalBySdk = true)
+            bool disposalBySdk)
             : base(deviceId, moduleId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer, disposalBySdk)
         {
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));

--- a/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
+++ b/iothub/device/src/ModuleAuthenticationWithSakRefresh.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Azure.Devices.Client
         public ModuleAuthenticationWithSakRefresh(
             string deviceId,
             string moduleId,
-            IotHubConnectionString connectionString) : base(deviceId, moduleId)
+            IotHubConnectionString connectionString)
+            : base(deviceId, moduleId)
         {
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
         }
@@ -26,7 +27,9 @@ namespace Microsoft.Azure.Devices.Client
             string moduleId,
             IotHubConnectionString connectionString,
             TimeSpan sasTokenTimeToLive,
-            int sasTokenRenewalBuffer) : base(deviceId, moduleId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer)
+            int sasTokenRenewalBuffer,
+            bool disposalBySdk = true)
+            : base(deviceId, moduleId, (int)sasTokenTimeToLive.TotalSeconds, sasTokenRenewalBuffer, disposalBySdk)
         {
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
         }

--- a/iothub/device/src/ModuleAuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/ModuleAuthenticationWithTokenRefresh.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Azure.Devices.Client
         /// Initializes a new instance of the <see cref="ModuleAuthenticationWithTokenRefresh"/> class using default
         /// TTL and TTL buffer time settings.
         /// </summary>
+        /// <remarks>
+        /// This constructor will create an authentication method instance that will be disposed when its
+        /// associated module client instance is disposed. To reuse the authentication method instance across multiple client instance lifetimes,
+        /// use <see cref="ModuleAuthenticationWithTokenRefresh(string, string, int, int, bool)"/> constructor and set <c>disposalBySdk</c> to <c>false</c>.
+        /// </remarks>
         /// <param name="deviceId">The Id of the device.</param>
         /// <param name="moduleId">The Id of the module.</param>
         public ModuleAuthenticationWithTokenRefresh(string deviceId, string moduleId)
@@ -38,6 +43,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="ModuleAuthenticationWithTokenRefresh"/> class.
         /// </summary>
+        /// <remarks>
+        /// This constructor will create an authentication method instance that will be disposed when its
+        /// associated module client instance is disposed. To reuse the authentication method instance across multiple client instance lifetimes,
+        /// use <see cref="ModuleAuthenticationWithTokenRefresh(string, string, int, int, bool)"/> constructor and set <c>disposalBySdk</c> to <c>false</c>.
+        /// </remarks>
         /// <param name="deviceId">The device Id.</param>
         /// <param name="moduleId">The module Id.</param>
         /// <param name="suggestedTimeToLiveSeconds">

--- a/iothub/device/src/ModuleAuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/ModuleAuthenticationWithTokenRefresh.cs
@@ -53,7 +53,31 @@ namespace Microsoft.Azure.Devices.Client
             string moduleId,
             int suggestedTimeToLiveSeconds,
             int timeBufferPercentage)
-            : base(SetSasTokenSuggestedTimeToLiveSeconds(suggestedTimeToLiveSeconds), SetSasTokenRenewalBufferPercentage(timeBufferPercentage))
+            : this(deviceId, moduleId, suggestedTimeToLiveSeconds, timeBufferPercentage, true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModuleAuthenticationWithTokenRefresh"/> class.
+        /// </summary>
+        /// <param name="deviceId">The device Id.</param>
+        /// <param name="moduleId">The module Id.</param>
+        /// <param name="suggestedTimeToLiveSeconds">
+        /// The suggested time to live value for the generated SAS tokens.
+        /// The default value is 1 hour.
+        /// </param>
+        /// <param name="timeBufferPercentage">
+        /// The time buffer before expiry when the token should be renewed, expressed as a percentage of the time to live.
+        /// The default behavior is that the token will be renewed when it has 15% or less of its lifespan left.
+        /// <param name="disposalBySdk">True if the authentication method should be disposed of by sdk; false if you intend to reuse the authentication method.</param>
+        ///</param>
+        public ModuleAuthenticationWithTokenRefresh(
+            string deviceId,
+            string moduleId,
+            int suggestedTimeToLiveSeconds,
+            int timeBufferPercentage,
+            bool disposalBySdk)
+            : base(SetSasTokenSuggestedTimeToLiveSeconds(suggestedTimeToLiveSeconds), SetSasTokenRenewalBufferPercentage(timeBufferPercentage), disposalBySdk)
         {
             if (moduleId.IsNullOrWhiteSpace())
             {

--- a/iothub/device/src/ModuleAuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/ModuleAuthenticationWithTokenRefresh.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// This constructor will create an authentication method instance that will be disposed when its
         /// associated module client instance is disposed. To reuse the authentication method instance across multiple client instance lifetimes,
-        /// use <see cref="ModuleAuthenticationWithTokenRefresh(string, string, int, int, bool)"/> constructor and set <c>disposalBySdk</c> to <c>false</c>.
+        /// use <see cref="ModuleAuthenticationWithTokenRefresh(string, string, int, int, bool)"/> constructor and set <c>disposeWithClient</c> to <c>false</c>.
         /// </remarks>
         /// <param name="deviceId">The Id of the device.</param>
         /// <param name="moduleId">The Id of the module.</param>
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// This constructor will create an authentication method instance that will be disposed when its
         /// associated module client instance is disposed. To reuse the authentication method instance across multiple client instance lifetimes,
-        /// use <see cref="ModuleAuthenticationWithTokenRefresh(string, string, int, int, bool)"/> constructor and set <c>disposalBySdk</c> to <c>false</c>.
+        /// use <see cref="ModuleAuthenticationWithTokenRefresh(string, string, int, int, bool)"/> constructor and set <c>disposeWithClient</c> to <c>false</c>.
         /// </remarks>
         /// <param name="deviceId">The device Id.</param>
         /// <param name="moduleId">The module Id.</param>
@@ -79,15 +79,18 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="timeBufferPercentage">
         /// The time buffer before expiry when the token should be renewed, expressed as a percentage of the time to live.
         /// The default behavior is that the token will be renewed when it has 15% or less of its lifespan left.
-        /// <param name="disposalBySdk">True if the authentication method should be disposed of by sdk; false if you intend to reuse the authentication method.</param>
         ///</param>
+        ///<param name="disposeWithClient ">
+        ///<c>true</c> if the authentication method should be disposed of by the client
+        /// when the client using this instance is itself disposed; <c>false</c> if you intend to reuse the authentication method.
+        /// </param>
         public ModuleAuthenticationWithTokenRefresh(
             string deviceId,
             string moduleId,
             int suggestedTimeToLiveSeconds,
             int timeBufferPercentage,
-            bool disposalBySdk)
-            : base(SetSasTokenSuggestedTimeToLiveSeconds(suggestedTimeToLiveSeconds), SetSasTokenRenewalBufferPercentage(timeBufferPercentage), disposalBySdk)
+            bool disposeWithClient)
+            : base(SetSasTokenSuggestedTimeToLiveSeconds(suggestedTimeToLiveSeconds), SetSasTokenRenewalBufferPercentage(timeBufferPercentage), disposeWithClient)
         {
             if (moduleId.IsNullOrWhiteSpace())
             {

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                     if (deviceIdentity.AuthenticationModel == AuthenticationModel.SasGrouped
                         && !ReferenceEquals(amqpConnectionHolder.GetDeviceIdentityOfAuthenticationProvider(), deviceIdentity)
                         && deviceIdentity.IotHubConnectionString?.TokenRefresher != null
-                        && deviceIdentity.IotHubConnectionString.TokenRefresher.DisposalBySdk)
+                        && deviceIdentity.IotHubConnectionString.TokenRefresher.DisposalWithClient)
                     {
                         deviceIdentity.IotHubConnectionString.TokenRefresher.Dispose();
                     }

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                     if (deviceIdentity.AuthenticationModel == AuthenticationModel.SasGrouped
                         && !ReferenceEquals(amqpConnectionHolder.GetDeviceIdentityOfAuthenticationProvider(), deviceIdentity)
                         && deviceIdentity.IotHubConnectionString?.TokenRefresher != null
-                        && deviceIdentity.IotHubConnectionString.TokenRefresher.InstanceCreatedBySdk)
+                        && deviceIdentity.IotHubConnectionString.TokenRefresher.DisposalBySdk)
                     {
                         deviceIdentity.IotHubConnectionString.TokenRefresher.Dispose();
                     }

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotCbsTokenProvider.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotCbsTokenProvider.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
                 if (disposing)
                 {
                     if (_connectionString?.TokenRefresher != null
-                        && _connectionString.TokenRefresher.InstanceCreatedBySdk)
+                        && _connectionString.TokenRefresher.DisposalBySdk)
                     {
                         _connectionString.TokenRefresher.Dispose();
                     }

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotCbsTokenProvider.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotCbsTokenProvider.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
                 if (disposing)
                 {
                     if (_connectionString?.TokenRefresher != null
-                        && _connectionString.TokenRefresher.DisposalBySdk)
+                        && _connectionString.TokenRefresher.DisposalWithClient)
                     {
                         _connectionString.TokenRefresher.Dispose();
                     }

--- a/iothub/device/src/Transport/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/HttpClientHelper.cs
@@ -550,7 +550,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (_isClientPrimaryTransportHandler
                     && _authenticationHeaderProvider is IotHubConnectionString iotHubConnectionString
                     && iotHubConnectionString.TokenRefresher != null
-                    && iotHubConnectionString.TokenRefresher.InstanceCreatedBySdk)
+                    && iotHubConnectionString.TokenRefresher.DisposalBySdk)
                 {
                     iotHubConnectionString.TokenRefresher.Dispose();
                 }

--- a/iothub/device/src/Transport/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/HttpClientHelper.cs
@@ -550,7 +550,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (_isClientPrimaryTransportHandler
                     && _authenticationHeaderProvider is IotHubConnectionString iotHubConnectionString
                     && iotHubConnectionString.TokenRefresher != null
-                    && iotHubConnectionString.TokenRefresher.DisposalBySdk)
+                    && iotHubConnectionString.TokenRefresher.DisposalWithClient)
                 {
                     iotHubConnectionString.TokenRefresher.Dispose();
                 }

--- a/iothub/device/src/Transport/Mqtt/ClientWebSocketChannel.cs
+++ b/iothub/device/src/Transport/Mqtt/ClientWebSocketChannel.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             public override Task ConnectAsync(EndPoint remoteAddress, EndPoint localAddress)
             {
-                throw new NotSupportedException("ClientWebSocketChannel does not support BindAsync()");
+                throw new NotSupportedException("ClientWebSocketChannel does not support ConnectAsync()");
             }
 
             protected override void Flush0()

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -1019,7 +1019,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             {
                 if (_passwordProvider is IotHubConnectionString iotHubConnectionString
                     && iotHubConnectionString.TokenRefresher != null
-                    && iotHubConnectionString.TokenRefresher.DisposalBySdk)
+                    && iotHubConnectionString.TokenRefresher.DisposalWithClient)
                 {
                     iotHubConnectionString.TokenRefresher.Dispose();
                 }

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -1019,7 +1019,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             {
                 if (_passwordProvider is IotHubConnectionString iotHubConnectionString
                     && iotHubConnectionString.TokenRefresher != null
-                    && iotHubConnectionString.TokenRefresher.InstanceCreatedBySdk)
+                    && iotHubConnectionString.TokenRefresher.DisposalBySdk)
                 {
                     iotHubConnectionString.TokenRefresher.Dispose();
                 }


### PR DESCRIPTION
Update `AuthenticationWithTokenRefresh` to be disposed by the sdk, by default, but make the setting configurable.

Linked: #1954, #1911 