### PR TITLE
[PnP] Renaming StatusCodes and add a comment to highlight ClientOptions behavior

### DIFF
--- a/iothub/device/devdoc/Convention-based operations.md
+++ b/iothub/device/devdoc/Convention-based operations.md
@@ -6,6 +6,14 @@
 public class ClientOptions {
 +    public PayloadConvention PayloadConvention { get; set; }
 }
+
+public class DeviceClient : IDisposable {
++    public PayloadConvention PayloadConvention { get; }
+}
+
+public class ModuleClient : IDisposable {
++    public PayloadConvention PayloadConvention { get; }
+}
 ```
 
 ```csharp
@@ -85,12 +93,12 @@ public static class ConventionBasedConstants {
     public const string ValuePropertyName = "value";
 }
 
-public class StatusCodes {
-    public StatusCodes();
-    public static int Accepted { get; }
-    public static int BadRequest { get; }
-    public static int NotFound { get; }
-    public static int OK { get; }
+public class CommonClientResponseCodes {
+    public const int Accepted = 202;
+    public const int BadRequest = 400;
+    public const int NotFound = 404;
+    public const int OK = 200;
+    public CommonClientResponseCodes();
 }
 ```
 

--- a/iothub/device/samples/convention-based-samples/TemperatureController/TemperatureControllerSample.cs
+++ b/iothub/device/samples/convention-based-samples/TemperatureController/TemperatureControllerSample.cs
@@ -132,14 +132,14 @@ namespace Microsoft.Azure.Devices.Client.Samples
             IWritablePropertyResponse writableResponse = _deviceClient
                 .PayloadConvention
                 .PayloadSerializer
-                .CreateWritablePropertyResponse(_temperature[componentName], StatusCodes.OK, version, "Successfully updated target temperature.");
+                .CreateWritablePropertyResponse(_temperature[componentName], CommonClientResponseCodes.OK, version, "Successfully updated target temperature.");
 
             var reportedProperty = new ClientPropertyCollection();
             reportedProperty.AddComponentProperty(componentName, targetTemperatureProperty, writableResponse);
 
             ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperty);
 
-            _logger.LogDebug($"Property: Update - component=\"{componentName}\", {reportedProperty.GetSerializedString()} is {nameof(StatusCodes.OK)} " +
+            _logger.LogDebug($"Property: Update - component=\"{componentName}\", {reportedProperty.GetSerializedString()} is {nameof(CommonClientResponseCodes.OK)} " +
                 $"with a version of {updateResponse.Version}.");
         }
 
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                             _logger.LogWarning($"Received a command request that isn't" +
                             $" implemented - component name = {commandRequest.ComponentName}, command name = {commandRequest.CommandName}");
 
-                            return Task.FromResult(new CommandResponse(StatusCodes.NotFound));
+                            return Task.FromResult(new CommandResponse(CommonClientResponseCodes.NotFound));
                     }
 
                 // For the default case, first check if CommandRequest.ComponentName is null.
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                                 _logger.LogWarning($"Received a command request that isn't" +
                                     $" implemented - command name = {commandRequest.CommandName}");
 
-                                return Task.FromResult(new CommandResponse(StatusCodes.NotFound));
+                                return Task.FromResult(new CommandResponse(CommonClientResponseCodes.NotFound));
                         }
                     }
                     else
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                         _logger.LogWarning($"Received a command request that isn't" +
                             $" implemented - component name = {commandRequest.ComponentName}, command name = {commandRequest.CommandName}");
 
-                        return Task.FromResult(new CommandResponse(StatusCodes.NotFound));
+                        return Task.FromResult(new CommandResponse(CommonClientResponseCodes.NotFound));
                     }
             }
         }
@@ -214,12 +214,12 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 _temperatureReadingsDateTimeOffset.Clear();
                 _logger.LogDebug($"Command: Reboot completed.");
 
-                return new CommandResponse(StatusCodes.OK);
+                return new CommandResponse(CommonClientResponseCodes.OK);
             }
             catch (JsonReaderException ex)
             {
                 _logger.LogDebug($"Command input for {commandRequest.CommandName} is invalid: {ex.Message}.");
-                return new CommandResponse(StatusCodes.BadRequest);
+                return new CommandResponse(CommonClientResponseCodes.BadRequest);
             }
         }
 
@@ -254,25 +254,25 @@ namespace Microsoft.Azure.Devices.Client.Samples
                             $" maxTemp={report.MaximumTemperature}, minTemp={report.MinimumTemperature}, avgTemp={report.AverageTemperature}, " +
                             $"startTime={report.StartTime.LocalDateTime}, endTime={report.EndTime.LocalDateTime}");
 
-                        return Task.FromResult(new CommandResponse(report, StatusCodes.OK));
+                        return Task.FromResult(new CommandResponse(report, CommonClientResponseCodes.OK));
                     }
 
                     _logger.LogDebug($"Command: component=\"{commandRequest.ComponentName}\"," +
                         $" no relevant readings found since {sinceInUtc.LocalDateTime}, cannot generate any report.");
 
-                    return Task.FromResult(new CommandResponse(StatusCodes.NotFound));
+                    return Task.FromResult(new CommandResponse(CommonClientResponseCodes.NotFound));
                 }
 
                 _logger.LogDebug($"Command: component=\"{commandRequest.ComponentName}\", no temperature readings sent yet," +
                     $" cannot generate any report.");
 
-                return Task.FromResult(new CommandResponse(StatusCodes.NotFound));
+                return Task.FromResult(new CommandResponse(CommonClientResponseCodes.NotFound));
             }
             catch (JsonReaderException ex)
             {
                 _logger.LogError($"Command input for {commandRequest.CommandName} is invalid: {ex.Message}.");
 
-                return Task.FromResult(new CommandResponse(StatusCodes.BadRequest));
+                return Task.FromResult(new CommandResponse(CommonClientResponseCodes.BadRequest));
             }
         }
 

--- a/iothub/device/samples/convention-based-samples/Thermostat/ThermostatSample.cs
+++ b/iothub/device/samples/convention-based-samples/Thermostat/ThermostatSample.cs
@@ -82,14 +82,14 @@ namespace Microsoft.Azure.Devices.Client.Samples
                         IWritablePropertyResponse writableResponse = _deviceClient
                             .PayloadConvention
                             .PayloadSerializer
-                            .CreateWritablePropertyResponse(_temperature, StatusCodes.OK, writableProperties.Version, "Successfully updated target temperature");
+                            .CreateWritablePropertyResponse(_temperature, CommonClientResponseCodes.OK, writableProperties.Version, "Successfully updated target temperature");
 
                         var reportedProperty = new ClientPropertyCollection();
                         reportedProperty.AddRootProperty(targetTemperatureProperty, writableResponse);
 
                         ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperty);
 
-                        _logger.LogDebug($"Property: Update - {reportedProperty.GetSerializedString()} is {nameof(StatusCodes.OK)} " +
+                        _logger.LogDebug($"Property: Update - {reportedProperty.GetSerializedString()} is {nameof(CommonClientResponseCodes.OK)} " +
                             $"with a version of {updateResponse.Version}.");
 
                         break;
@@ -133,25 +133,25 @@ namespace Microsoft.Azure.Devices.Client.Samples
                                 $" maxTemp={report.MaximumTemperature}, minTemp={report.MinimumTemperature}, avgTemp={report.AverageTemperature}, " +
                                 $"startTime={report.StartTime.LocalDateTime}, endTime={report.EndTime.LocalDateTime}");
 
-                            return Task.FromResult(new CommandResponse(report, StatusCodes.OK));
+                            return Task.FromResult(new CommandResponse(report, CommonClientResponseCodes.OK));
                         }
 
                         _logger.LogDebug($"Command: No relevant readings found since {sinceInUtc.LocalDateTime}, cannot generate any report.");
 
-                        return Task.FromResult(new CommandResponse(StatusCodes.NotFound));
+                        return Task.FromResult(new CommandResponse(CommonClientResponseCodes.NotFound));
                     }
                     catch (JsonReaderException ex)
                     {
                         _logger.LogError($"Command input for {commandRequest.CommandName} is invalid: {ex.Message}.");
 
-                        return Task.FromResult(new CommandResponse(StatusCodes.BadRequest));
+                        return Task.FromResult(new CommandResponse(CommonClientResponseCodes.BadRequest));
                     }
 
                 default:
                     _logger.LogWarning($"Received a command request that isn't" +
                         $" implemented - command name = {commandRequest.CommandName}");
 
-                    return Task.FromResult(new CommandResponse(StatusCodes.NotFound));
+                    return Task.FromResult(new CommandResponse(CommonClientResponseCodes.NotFound));
             }
         }
 
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
             ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperties);
 
-            _logger.LogDebug($"Property: Update - {reportedProperties.GetSerializedString()} is {nameof(StatusCodes.OK)} " +
+            _logger.LogDebug($"Property: Update - {reportedProperties.GetSerializedString()} is {nameof(CommonClientResponseCodes.OK)} " +
                 $"with a version of {updateResponse.Version}.");
         }
 

--- a/iothub/device/src/ClientOptions.cs
+++ b/iothub/device/src/ClientOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Devices.Client
 {
     /// <summary>
     /// Options that allow configuration of the device or module client instance during initialization.
-    /// These options cannot be updated once the client has been initialized.
+    /// Updating these options after the client has been initialized will not change the behavior of the client.
     /// </summary>
     public class ClientOptions
     {

--- a/iothub/device/src/ClientOptions.cs
+++ b/iothub/device/src/ClientOptions.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Devices.Client
 {
     /// <summary>
     /// Options that allow configuration of the device or module client instance during initialization.
+    /// These options cannot be updated once the client has been initialized.
     /// </summary>
     public class ClientOptions
     {

--- a/iothub/device/tests/ClientPropertyCollectionTests.cs
+++ b/iothub/device/tests/ClientPropertyCollectionTests.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
         {
             var clientProperties = new ClientPropertyCollection();
 
-            var writableResponse = new NewtonsoftJsonWritablePropertyResponse(StringPropertyValue, StatusCodes.OK, 2, WritablePropertyDescription);
+            var writableResponse = new NewtonsoftJsonWritablePropertyResponse(StringPropertyValue, CommonClientResponseCodes.OK, 2, WritablePropertyDescription);
             clientProperties.AddRootProperty(StringPropertyName, writableResponse);
 
             clientProperties.TryGetValue(StringPropertyName, out NewtonsoftJsonWritablePropertyResponse outValue);
@@ -286,7 +286,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
         {
             var clientProperties = new ClientPropertyCollection();
 
-            var writableResponse = new NewtonsoftJsonWritablePropertyResponse(StringPropertyValue, StatusCodes.OK, 2, WritablePropertyDescription);
+            var writableResponse = new NewtonsoftJsonWritablePropertyResponse(StringPropertyValue, CommonClientResponseCodes.OK, 2, WritablePropertyDescription);
             clientProperties.AddComponentProperty(ComponentName, StringPropertyName, writableResponse);
 
             clientProperties.TryGetValue(ComponentName, StringPropertyName, out NewtonsoftJsonWritablePropertyResponse outValue);

--- a/iothub/device/tests/ClientPropertyCollectionTestsNewtonsoft.cs
+++ b/iothub/device/tests/ClientPropertyCollectionTestsNewtonsoft.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
         // Create a writable property response with the expected values.
         private static readonly IWritablePropertyResponse s_writablePropertyResponse = new NewtonsoftJsonWritablePropertyResponse(
             propertyValue: StringPropertyValue,
-            ackCode: StatusCodes.OK,
+            ackCode: CommonClientResponseCodes.OK,
             ackVersion: 2,
             ackDescription: "testableWritablePropertyDescription");
 

--- a/shared/src/CommonClientResponseCodes.cs
+++ b/shared/src/CommonClientResponseCodes.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Azure.Devices.Shared
 {
@@ -10,21 +11,25 @@ namespace Microsoft.Azure.Devices.Shared
     /// <remarks>
     /// These status codes are based on the HTTP status codes listed here <see href="http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml"/>
     /// </remarks>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1052:Static holder types should be Static or NotInheritable", Justification = "To allow customers to extend this class we need to not mark it static.")]
-    public class StatusCodes
+    [SuppressMessage("Design", "CA1052:Static holder types should be Static or NotInheritable",
+        Justification = "To allow customers to extend this class we need to not mark it static.")]
+    public class CommonClientResponseCodes
     {
         /// <summary>
         /// Status code 200.
         /// </summary>
         public static int OK => 200;
+
         /// <summary>
         /// Status code 202.
         /// </summary>
         public static int Accepted => 202;
+
         /// <summary>
         /// Status code 400.
         /// </summary>
         public static int BadRequest => 400;
+
         /// <summary>
         /// Status code 404.
         /// </summary>

--- a/shared/src/CommonClientResponseCodes.cs
+++ b/shared/src/CommonClientResponseCodes.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Devices.Shared
     /// A list of common status codes to represent the response from the client.
     /// </summary>
     /// <remarks>
-    /// These status codes are based on the HTTP status codes listed here <see href="http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml"/>
+    /// These status codes are based on the HTTP status codes listed here <see href="http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml"/>.
     /// </remarks>
     [SuppressMessage("Design", "CA1052:Static holder types should be Static or NotInheritable",
         Justification = "To allow customers to extend this class we need to not mark it static.")]

--- a/shared/src/CommonClientResponseCodes.cs
+++ b/shared/src/CommonClientResponseCodes.cs
@@ -16,23 +16,28 @@ namespace Microsoft.Azure.Devices.Shared
     public class CommonClientResponseCodes
     {
         /// <summary>
-        /// Status code 200.
+        /// As per HTTP semantics this code indicates that the request has succeeded.
         /// </summary>
-        public static int OK => 200;
+        public const int OK = 200;
 
         /// <summary>
-        /// Status code 202.
+        /// As per HTTP semantics this code indicates that the request has been
+        /// accepted for processing, but the processing has not been completed.
         /// </summary>
-        public static int Accepted => 202;
+        public const int Accepted = 202;
 
         /// <summary>
-        /// Status code 400.
+        /// As per HTTP semantics this code indicates that the server cannot or
+        /// will not process the request due to something that is perceived to be a client error
+        /// (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
         /// </summary>
-        public static int BadRequest => 400;
+        public const int BadRequest = 400;
 
         /// <summary>
-        /// Status code 404.
+        /// As per HTTP semantics this code indicates that the origin server did
+        /// not find a current representation for the target resource or is not
+        /// willing to disclose that one exists.
         /// </summary>
-        public static int NotFound => 404;
+        public const int NotFound = 404;
     }
 }


### PR DESCRIPTION
- Addresses comments from #1992 :
  - `ClientOptions.PayloadConvention` readonly => making it readonly would require the user to initialize it via a constructor. Technically all properties inside `ClientOptions` can be updated as many times as the caller wants, but only until it is actually passed to a DeviceClient/ ModuleClient instance during initialization. For this reason, instead of making the properties read-only, I added a code comment to the class that highlights the actual behavior.
  - Rename `StatusCodes` => since these are response codes that a client would send to service, either through a command response or a writable property response, I felt `CommonClientResponseCodes` represented the purpose of this class.