### PR TITLE
Fix enumerator implementation to return key-value pairs

### DIFF
--- a/iothub/device/devdoc/Convention-based operations.md
+++ b/iothub/device/devdoc/Convention-based operations.md
@@ -66,7 +66,7 @@ public class NewtonsoftJsonPayloadSerializer : PayloadSerializer {
     public override bool TryGetNestedObjectValue<T>(object nestedObject, string propertyName, out T outValue);
 }
 
-public abstract class PayloadCollection : IEnumerable, IEnumerable<object> {
+public abstract class PayloadCollection : IEnumerable, IEnumerable<KeyValuePair<string, object>> {
     protected PayloadCollection();
     public IDictionary<string, object> Collection { get; private set; }
     public PayloadConvention Convention { get; internal set; }
@@ -75,7 +75,7 @@ public abstract class PayloadCollection : IEnumerable, IEnumerable<object> {
     public virtual void AddOrUpdate(string key, object value);
     public void ClearCollection();
     public bool Contains(string key);
-    public IEnumerator<object> GetEnumerator();
+    public IEnumerator<KeyValuePair<string, object>> GetEnumerator();
     public virtual byte[] GetPayloadObjectBytes();
     public virtual string GetSerializedString();
     protected void SetCollection(PayloadCollection payloadCollection);

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.Client
     /// This classes uses the <see cref="NewtonsoftJsonPayloadSerializer"/> and
     /// <see cref="Utf8PayloadEncoder"/> based <see cref="DefaultPayloadConvention"/> by default.
     /// </remarks>
-    public abstract class PayloadCollection : IEnumerable<object>
+    public abstract class PayloadCollection : IEnumerable<KeyValuePair<string, object>>
     {
         /// <summary>
         /// The underlying collection for the payload.
@@ -166,9 +166,9 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         ///  <inheritdoc />
-        public IEnumerator<object> GetEnumerator()
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {
-            foreach (object property in Collection)
+            foreach (KeyValuePair<string, object> property in Collection)
             {
                 yield return property;
             }

--- a/iothub/device/tests/ClientPropertiesTests.cs
+++ b/iothub/device/tests/ClientPropertiesTests.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Devices.Client.Tests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class ClientPropertiesTests
+    {
+        private const string BoolPropertyName = "boolPropertyName";
+        private const string DoublePropertyName = "doublePropertyName";
+        private const string FloatPropertyName = "floatPropertyName";
+        private const string StringPropertyName = "stringPropertyName";
+        private const string ObjectPropertyName = "objectPropertyName";
+        private const string MapPropertyName = "mapPropertyName";
+
+        private const bool BoolPropertyValue = false;
+        private const double DoublePropertyValue = 1.001;
+        private const float FloatPropertyValue = 1.2f;
+        private const string StringPropertyValue = "propertyValue";
+
+        private const string ComponentName = "testableComponent";
+
+        private static readonly CustomClientProperty s_objectPropertyValue = new CustomClientProperty { Id = 123, Name = "testName" };
+
+        private static readonly Dictionary<string, object> s_mapPropertyValue = new Dictionary<string, object>
+        {
+            { "key1", "value1" },
+            { "key2", 123 },
+            { "key3", s_objectPropertyValue }
+        };
+
+        [TestMethod]
+        public void ClientPropertyCollection_CanEnumerateClientProperties()
+        {
+            // arrange
+            var deviceReportedProperties = new ClientPropertyCollection();
+            deviceReportedProperties.AddRootProperty(StringPropertyName, StringPropertyValue);
+            deviceReportedProperties.AddRootProperty(ObjectPropertyName, s_objectPropertyValue);
+            deviceReportedProperties.AddComponentProperty(ComponentName, BoolPropertyName, BoolPropertyValue);
+
+            var serviceUpdateRequestedProperties = new ClientPropertyCollection();
+            serviceUpdateRequestedProperties.AddRootProperty(DoublePropertyName, DoublePropertyValue);
+            serviceUpdateRequestedProperties.AddRootProperty(MapPropertyName, s_mapPropertyValue);
+            serviceUpdateRequestedProperties.AddComponentProperty(ComponentName, FloatPropertyName, FloatPropertyValue);
+
+            // act
+            // The test makes a call to the internal constructor.
+            // The users will retrieve client properties by calling DeviceClient.GetClientProperties()/ ModuleClient.GetClientProperties().
+            var clientProperties = new ClientProperties(serviceUpdateRequestedProperties, deviceReportedProperties);
+
+            // assert
+            // These are the device reported property values.
+            foreach (var deviceReportedKeyValuePairs in clientProperties)
+            {
+                if (deviceReportedKeyValuePairs.Key.Equals(StringPropertyName))
+                {
+                    deviceReportedKeyValuePairs.Value.Should().Be(StringPropertyValue);
+                }
+                else if (deviceReportedKeyValuePairs.Key.Equals(ObjectPropertyName))
+                {
+                    deviceReportedKeyValuePairs.Value.Should().BeEquivalentTo(s_objectPropertyValue);
+                }
+                else if (deviceReportedKeyValuePairs.Key.Equals(ComponentName))
+                {
+                    deviceReportedKeyValuePairs.Value.Should().BeOfType(typeof(Dictionary<string, object>));
+                    var componentDictionary = deviceReportedKeyValuePairs.Value;
+
+                    componentDictionary.As<Dictionary<string, object>>().TryGetValue(BoolPropertyName, out object outValue).Should().BeTrue();
+                    outValue.Should().Be(BoolPropertyValue);
+                }
+            }
+
+            // These are the property values for which service has requested an update.
+            foreach (var updateRequestedKeyValuePairs in clientProperties.Writable)
+            {
+                if (updateRequestedKeyValuePairs.Key.Equals(DoublePropertyName))
+                {
+                    updateRequestedKeyValuePairs.Value.Should().Be(DoublePropertyValue);
+                }
+                else if (updateRequestedKeyValuePairs.Key.Equals(MapPropertyName))
+                {
+                    updateRequestedKeyValuePairs.Value.Should().BeEquivalentTo(s_mapPropertyValue);
+                }
+                else if (updateRequestedKeyValuePairs.Key.Equals(ComponentName))
+                {
+                    updateRequestedKeyValuePairs.Value.Should().BeOfType(typeof(Dictionary<string, object>));
+                    var componentDictionary = updateRequestedKeyValuePairs.Value;
+
+                    componentDictionary.As<Dictionary<string, object>>().TryGetValue(FloatPropertyName, out object outValue).Should().BeTrue();
+                    outValue.Should().Be(FloatPropertyValue);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
`PayloadCollection` was previously defined to be an `IEnumerable<object>`, but we can make it more specific to be an `IEnumerable<KeyValuePair<string, object>>`. The backing field that this collection actually iterates over is a `Dictionary<string, object>()`.