### PR TITLE
Fixes for preview release testing process

### DIFF
--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -66,17 +66,17 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(AZURE_IOT_LOCALPACKAGES)' != '' ">
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Shared" Version="1.*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.*" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.35.0-preview-*" />
+    <PackageReference Include="Microsoft.Azure.Devices.Shared" Version="1.29.0-preview-*" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.38.0-preview-*" />
   </ItemGroup>
   <ItemGroup Condition=" ('$(AZURE_IOT_LOCALPACKAGES.ToUpper())' != '') And ( '$(TargetFramework)' != 'net451' ) ">
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Amqp" Version="1.*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Http" Version="1.*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Security.Tpm" Version="1.*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Service" Version="1.*" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.18.0-preview-*" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Amqp" Version="1.15.0-preview-*" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Http" Version="1.14.0-preview-*" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.16.0-preview-*" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Security.Tpm" Version="1.14.0-preview-*" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Service" Version="1.18.0-preview-*" />
     <ProjectReference Include="$(RootDir)\security\tpm\samples\SecurityProviderTpmSimulator\SecurityProviderTpmSimulator.csproj" />
   </ItemGroup>
 </Project>

--- a/vsts/CredScanSuppressions.json
+++ b/vsts/CredScanSuppressions.json
@@ -3,31 +3,31 @@
     "suppressions": [
         {
             "placeholder": "dGVzdFN0cmluZzE=",
-            "_justification": "Dummy secret used in unit tests, it is fake"
+            "_justification": "Fake secret used in unit tests."
         },
         {
             "placeholder": "dGVzdFN0cmluZzI=",
-            "_justification": "Dummy secret used in unit tests, it is fake"
+            "_justification": "Fake secret used in unit tests."
         },
         {
             "placeholder": "dGVzdFN0cmluZzM=",
-            "_justification": "Dummy secret used in unit tests, it is fake"
+            "_justification": "Fake secret used in unit tests."
         },
         {
             "placeholder": "dGVzdFN0cmluZzQ=",
-            "_justification": "Dummy secret used in unit tests, it is fake"
+            "_justification": "Fake secret used in unit tests."
         },
         {
             "placeholder": "dGVzdFN0cmluZzU=",
-            "_justification": "Dummy secret used in unit tests, it is fake"
+            "_justification": "Fake secret used in unit tests."
         },
         {
             "placeholder": "dGVzdFN0cmluZzY=",
-            "_justification": "Dummy secret used in unit tests, it is fake"
+            "_justification": "Fake secret used in unit tests."
         },
         {
             "placeholder": "notsafe",
-            "_justification": "Dummy secret used in unit tests, it is fake"
+            "_justification": "Fake secret used in unit tests."
         }
     ]
 }

--- a/vsts/test-release-nuget.yaml
+++ b/vsts/test-release-nuget.yaml
@@ -26,7 +26,7 @@ jobs:
         inputs:
           buildType: 'specific'
           project: 'f9b79625-2860-4d92-a4ee-57b03fabfd10'
-          pipeline: '278' # csharp-release-build
+          pipeline: '355' # csharp-release-build-preview
           buildVersionToDownload: 'latest'
           downloadType: 'single'
           downloadPath: '$(System.ArtifactsDirectory)'
@@ -149,7 +149,7 @@ jobs:
         inputs:
           buildType: 'specific'
           project: 'f9b79625-2860-4d92-a4ee-57b03fabfd10' # azure-iot-sdk
-          pipeline: '278' # csharp-release-build
+          pipeline: '355' # csharp-release-build-preview
           buildVersionToDownload: 'latest'
           downloadType: 'single'
           downloadPath: '$(System.ArtifactsDirectory)'


### PR DESCRIPTION
We missed making these preview specific changes when we recreated the preview branch:
- The pre-release versioning needs to be specified in the E2E test project, otherwise "1.*" will resolve to our GA's nugets instead (since our GA nugets are at a higher version than our preview nugets).
- The "release-test-preview" pipeline needs to fetch the artifacts from the "release-sign-preview" pipeline (which is different from the "release-sign-GA" pipeline).