### PR TITLE
(e2e): fix FileUpload E2E Tests

### DIFF
--- a/e2e/test/iothub/FileUploadE2ETests.cs
+++ b/e2e/test/iothub/FileUploadE2ETests.cs
@@ -117,18 +117,21 @@ namespace Microsoft.Azure.Devices.E2ETests
                 x509auth ? TestDeviceType.X509 : TestDeviceType.Sasl).ConfigureAwait(false);
 
             DeviceClient deviceClient;
+            var clientOptions = new ClientOptions()
+            {
+                FileUploadTransportSettings = fileUploadTransportSettings
+            };
 
             if (x509auth)
             {
                 X509Certificate2 cert = Configuration.IoTHub.GetCertificateWithPrivateKey();
 
                 var auth = new DeviceAuthenticationWithX509Certificate(testDevice.Id, cert);
-
                 deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, auth, Client.TransportType.Http1);
             }
             else
             {
-                deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, Client.TransportType.Http1);
+                deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, Client.TransportType.Http1, clientOptions);
             }
 
             var fileUploadSasUriRequest = new FileUploadSasUriRequest()

--- a/e2e/test/iothub/FileUploadE2ETests.cs
+++ b/e2e/test/iothub/FileUploadE2ETests.cs
@@ -117,10 +117,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 x509auth ? TestDeviceType.X509 : TestDeviceType.Sasl).ConfigureAwait(false);
 
             DeviceClient deviceClient;
-            var clientOptions = new ClientOptions()
-            {
-                FileUploadTransportSettings = fileUploadTransportSettings
-            };
 
             if (x509auth)
             {
@@ -128,11 +124,11 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 var auth = new DeviceAuthenticationWithX509Certificate(testDevice.Id, cert);
 
-                deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, auth, Client.TransportType.Http1, clientOptions);
+                deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, auth, Client.TransportType.Http1);
             }
             else
             {
-                deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, Client.TransportType.Http1, clientOptions);
+                deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, Client.TransportType.Http1);
             }
 
             var fileUploadSasUriRequest = new FileUploadSasUriRequest()


### PR DESCRIPTION
Since we are using the X509 authentication mechanism, we no longer need the client options to pass in the cert. There is left over code that still assigned the client options without specifying the cert and that would break the test.

<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [ ] This pull-request is submitted against the `master` branch.
<!-- If not against master, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
