### PR TITLE
Rename E2ETests.Configuration to TestConfiguration to avoid SDK type conflict

### DIFF
--- a/e2e/test/Helpers/StorageContainer.cs
+++ b/e2e/test/Helpers/StorageContainer.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
         private async Task InitializeAsync()
         {
-            CloudStorageAccount storageAccount = CloudStorageAccount.Parse(Configuration.Storage.ConnectionString);
+            CloudStorageAccount storageAccount = CloudStorageAccount.Parse(TestConfiguration.Storage.ConnectionString);
             CloudBlobClient cloudBlobClient = storageAccount.CreateCloudBlobClient();
             CloudBlobContainer = cloudBlobClient.GetContainerReference(ContainerName);
             await CloudBlobContainer.CreateIfNotExistsAsync().ConfigureAwait(false);

--- a/e2e/test/Helpers/TestDevice.cs
+++ b/e2e/test/Helpers/TestDevice.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             string deviceName = "E2E_" + prefix + Guid.NewGuid();
 
             // Delete existing devices named this way and create a new one.
-            using var rm = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var rm = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             s_logger.Trace($"{nameof(GetTestDeviceAsync)}: Creating device {deviceName} with type {type}.");
 
             Client.IAuthenticationMethod auth = null;
@@ -84,11 +84,11 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                 {
                     X509Thumbprint = new X509Thumbprint
                     {
-                        PrimaryThumbprint = Configuration.IoTHub.GetCertificateWithPrivateKey().Thumbprint
+                        PrimaryThumbprint = TestConfiguration.IoTHub.GetCertificateWithPrivateKey().Thumbprint
                     }
                 };
 
-                auth = new DeviceAuthenticationWithX509Certificate(deviceName, Configuration.IoTHub.GetCertificateWithPrivateKey());
+                auth = new DeviceAuthenticationWithX509Certificate(deviceName, TestConfiguration.IoTHub.GetCertificateWithPrivateKey());
             }
 
             Device device = null;
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         {
             get
             {
-                string iotHubHostName = GetHostName(Configuration.IoTHub.ConnectionString);
+                string iotHubHostName = GetHostName(TestConfiguration.IoTHub.ConnectionString);
                 return $"HostName={iotHubHostName};DeviceId={Device.Id};SharedAccessKey={Device.Authentication.SymmetricKey.PrimaryKey}";
             }
         }
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         /// <summary>
         /// Used in conjunction with DeviceClient.Create()
         /// </summary>
-        public string IoTHubHostName => GetHostName(Configuration.IoTHub.ConnectionString);
+        public string IoTHubHostName => GetHostName(TestConfiguration.IoTHub.ConnectionString);
 
         /// <summary>
         /// Device Id
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                 }
                 else
                 {
-                    deviceClient = DeviceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString, Device.Id, transportSettings, options);
+                    deviceClient = DeviceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString, Device.Id, transportSettings, options);
                     s_logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from IoTHub connection string: ID={TestLogger.IdOf(deviceClient)}");
                 }
             }
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
         public async Task RemoveDeviceAsync()
         {
-            using var rm = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var rm = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             await rm.RemoveDeviceAsync(Id).ConfigureAwait(false);
         }
     }

--- a/e2e/test/Helpers/TestModule.cs
+++ b/e2e/test/Helpers/TestModule.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             string deviceName = testDevice.Id;
             string moduleName = "E2E_" + moduleNamePrefix + Guid.NewGuid();
 
-            using var rm = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var rm = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             logger.Trace($"{nameof(GetTestModuleAsync)}: Creating module for device {deviceName}.");
 
             var requestModule = new Module(deviceName, moduleName);
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         {
             get
             {
-                string iotHubHostName = GetHostName(Configuration.IoTHub.ConnectionString);
+                string iotHubHostName = GetHostName(TestConfiguration.IoTHub.ConnectionString);
                 return $"HostName={iotHubHostName};DeviceId={_module.DeviceId};ModuleId={_module.Id};SharedAccessKey={_module.Authentication.SymmetricKey.PrimaryKey}";
             }
         }

--- a/e2e/test/config/TestConfiguration.AzureSecurityCenterForIoTLogAnalytics.cs
+++ b/e2e/test/config/TestConfiguration.AzureSecurityCenterForIoTLogAnalytics.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Azure.Devices.E2ETests
 {
-    public static partial class Configuration
+    public static partial class TestConfiguration
     {
         public static class AzureSecurityCenterForIoTLogAnalytics
         {

--- a/e2e/test/config/TestConfiguration.IoTHub.cs
+++ b/e2e/test/config/TestConfiguration.IoTHub.cs
@@ -19,7 +19,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.Devices.E2ETests
 {
-    public static partial class Configuration
+    public static partial class TestConfiguration
     {
         public static partial class IoTHub
         {

--- a/e2e/test/config/TestConfiguration.Provisioning.cs
+++ b/e2e/test/config/TestConfiguration.Provisioning.cs
@@ -6,7 +6,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Azure.Devices.E2ETests
 {
-    public static partial class Configuration
+    public static partial class TestConfiguration
     {
         public static partial class Provisioning
         {

--- a/e2e/test/config/TestConfiguration.Storage.cs
+++ b/e2e/test/config/TestConfiguration.Storage.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Azure.Devices.E2ETests
 {
-    public static partial class Configuration
+    public static partial class TestConfiguration
     {
         public static class Storage
         {
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             static Storage()
             {
-                ConnectionString = Configuration.GetValue("STORAGE_ACCOUNT_CONNECTION_STRING");
+                ConnectionString = TestConfiguration.GetValue("STORAGE_ACCOUNT_CONNECTION_STRING");
                 Name = s_saName.Match(ConnectionString).Value;
                 Key = s_saKey.Match(ConnectionString).Value;
             }

--- a/e2e/test/config/TestConfiguration.cs
+++ b/e2e/test/config/TestConfiguration.cs
@@ -6,7 +6,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Azure.Devices.E2ETests
 {
-    public static partial class Configuration
+    public static partial class TestConfiguration
     {
         private static string GetValue(string envName, string defaultValue = null)
         {

--- a/e2e/test/iothub/CombinedClientOperationsPoolAmqpTests.cs
+++ b/e2e/test/iothub/CombinedClientOperationsPoolAmqpTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device)
         {
             // Initialize service client for service-side operations
-            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             // Message payload and properties for C2D operation
             var messagesSent = new Dictionary<string, Tuple<Message, string>>();

--- a/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix + $"_{Guid.NewGuid()}").ConfigureAwait(false);
             string deviceConnectionString = testDevice.ConnectionString;
 
-            var config = new Configuration.IoTHub.ConnectionStringParser(deviceConnectionString);
+            var config = new TestConfiguration.IoTHub.ConnectionStringParser(deviceConnectionString);
             string deviceId = config.DeviceID;
 
             ConnectionStatus? status = null;
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 Assert.IsNotNull(twin);
 
                 // Delete/disable the device in IoT Hub. This should trigger the ConnectionStatusChangesHandler.
-                using (RegistryManager registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString))
+                using (RegistryManager registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString))
                 {
                     await registryManagerOperation(registryManager, deviceId).ConfigureAwait(false);
                 }
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 Assert.IsNotNull(twin);
 
                 // Delete/disable the device in IoT Hub.
-                using (RegistryManager registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString))
+                using (RegistryManager registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString))
                 {
                     await registryManagerOperation(registryManager, testModule.DeviceId).ConfigureAwait(false);
                 }

--- a/e2e/test/iothub/DeviceClientX509AuthenticationE2ETests.cs
+++ b/e2e/test/iothub/DeviceClientX509AuthenticationE2ETests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         public DeviceClientX509AuthenticationE2ETests()
         {
-            _hostName = GetHostName(Configuration.IoTHub.ConnectionString);
+            _hostName = GetHostName(TestConfiguration.IoTHub.ConnectionString);
         }
 
         [LoggedTestMethod]
@@ -148,12 +148,12 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             // arrange
             var chainCerts = new X509Certificate2Collection();
-            chainCerts.Add(Configuration.IoTHub.GetRootCACertificate());
-            chainCerts.Add(Configuration.IoTHub.GetIntermediate1Certificate());
-            chainCerts.Add(Configuration.IoTHub.GetIntermediate2Certificate());
+            chainCerts.Add(TestConfiguration.IoTHub.GetRootCACertificate());
+            chainCerts.Add(TestConfiguration.IoTHub.GetIntermediate1Certificate());
+            chainCerts.Add(TestConfiguration.IoTHub.GetIntermediate2Certificate());
             var auth = new DeviceAuthenticationWithX509Certificate(
-                Configuration.IoTHub.X509ChainDeviceName,
-                Configuration.IoTHub.GetChainDeviceCertificateWithPrivateKey(),
+                TestConfiguration.IoTHub.X509ChainDeviceName,
+                TestConfiguration.IoTHub.GetChainDeviceCertificateWithPrivateKey(),
                 chainCerts);
             using var deviceClient = DeviceClient.Create(
                 _hostName,
@@ -173,12 +173,12 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             // arrange
             var chainCerts = new X509Certificate2Collection();
-            chainCerts.Add(Configuration.IoTHub.GetRootCACertificate());
-            chainCerts.Add(Configuration.IoTHub.GetIntermediate1Certificate());
-            chainCerts.Add(Configuration.IoTHub.GetIntermediate2Certificate());
+            chainCerts.Add(TestConfiguration.IoTHub.GetRootCACertificate());
+            chainCerts.Add(TestConfiguration.IoTHub.GetIntermediate1Certificate());
+            chainCerts.Add(TestConfiguration.IoTHub.GetIntermediate2Certificate());
             var auth = new DeviceAuthenticationWithX509Certificate(
-                Configuration.IoTHub.X509ChainDeviceName,
-                Configuration.IoTHub.GetChainDeviceCertificateWithPrivateKey(),
+                TestConfiguration.IoTHub.X509ChainDeviceName,
+                TestConfiguration.IoTHub.GetChainDeviceCertificateWithPrivateKey(),
                 chainCerts);
             using var deviceClient = DeviceClient.Create(
                 _hostName,
@@ -293,7 +293,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         private DeviceClient CreateDeviceClientWithInvalidId(Client.TransportType transportType)
         {
             string deviceName = $"DEVICE_NOT_EXIST_{Guid.NewGuid()}";
-            var auth = new DeviceAuthenticationWithX509Certificate(deviceName, Configuration.IoTHub.GetCertificateWithPrivateKey());
+            var auth = new DeviceAuthenticationWithX509Certificate(deviceName, TestConfiguration.IoTHub.GetCertificateWithPrivateKey());
             return DeviceClient.Create(_hostName, auth, transportType);
         }
     }

--- a/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
 
-            var config = new Configuration.IoTHub.ConnectionStringParser(testDevice.ConnectionString);
+            var config = new TestConfiguration.IoTHub.ConnectionStringParser(testDevice.ConnectionString);
             using (DeviceClient deviceClient = DeviceClient.CreateFromConnectionString($"HostName={config.IotHubHostName};DeviceId=device_id_not_exist;SharedAccessKey={config.SharedAccessKey}", Client.TransportType.Amqp_Tcp_Only))
             {
                 await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
 
-            var config = new Configuration.IoTHub.ConnectionStringParser(testDevice.ConnectionString);
+            var config = new TestConfiguration.IoTHub.ConnectionStringParser(testDevice.ConnectionString);
             string invalidKey = Convert.ToBase64String(Encoding.UTF8.GetBytes("invalid_key"));
             using (DeviceClient deviceClient = DeviceClient.CreateFromConnectionString($"HostName={config.IotHubHostName};DeviceId={config.DeviceID};SharedAccessKey={invalidKey}", Client.TransportType.Amqp_Tcp_Only))
             {
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             string deviceConnectionString = testDevice.ConnectionString;
 
-            var config = new Configuration.IoTHub.ConnectionStringParser(deviceConnectionString);
+            var config = new TestConfiguration.IoTHub.ConnectionStringParser(deviceConnectionString);
             string iotHub = config.IotHubHostName;
             string deviceId = config.DeviceID;
             string key = config.SharedAccessKey;

--- a/e2e/test/iothub/FaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/FaultInjectionPoolAmqpTests.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Azure.Devices.E2ETests
     [TestCategory("LongRunning")]
     public partial class FaultInjectionPoolAmqpTests : E2EMsTestBase
     {
-        private static readonly string s_proxyServerAddress = Configuration.IoTHub.ProxyServerAddress;
+        private static readonly string s_proxyServerAddress = TestConfiguration.IoTHub.ProxyServerAddress;
     }
 }

--- a/e2e/test/iothub/FileUploadE2ETests.cs
+++ b/e2e/test/iothub/FileUploadE2ETests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             using var fileStreamSource = new FileStream(filename, FileMode.Open, FileAccess.Read);
             var fileUploadTransportSettings = new Http1TransportSettings()
             {
-                Proxy = new WebProxy(Configuration.IoTHub.ProxyServerAddress)
+                Proxy = new WebProxy(TestConfiguration.IoTHub.ProxyServerAddress)
             };
 
             await UploadFileGranularAsync(fileStreamSource, filename, fileUploadTransportSettings).ConfigureAwait(false);
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             if (x509auth)
             {
-                X509Certificate2 cert = Configuration.IoTHub.GetCertificateWithPrivateKey();
+                X509Certificate2 cert = TestConfiguration.IoTHub.GetCertificateWithPrivateKey();
 
                 var auth = new DeviceAuthenticationWithX509Certificate(testDevice.Id, cert);
                 deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, auth, Client.TransportType.Http1);
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             DeviceClient deviceClient;
             if (x509auth)
             {
-                X509Certificate2 cert = Configuration.IoTHub.GetCertificateWithPrivateKey();
+                X509Certificate2 cert = TestConfiguration.IoTHub.GetCertificateWithPrivateKey();
 
                 var auth = new DeviceAuthenticationWithX509Certificate(testDevice.Id, cert);
                 deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, auth, transport);
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             DeviceClient deviceClient;
             if (x509auth)
             {
-                X509Certificate2 cert = Configuration.IoTHub.GetCertificateWithPrivateKey();
+                X509Certificate2 cert = TestConfiguration.IoTHub.GetCertificateWithPrivateKey();
 
                 var auth = new DeviceAuthenticationWithX509Certificate(testDevice.Id, cert);
                 deviceClient = DeviceClient.Create(testDevice.IoTHubHostName, auth, transport);

--- a/e2e/test/iothub/SasCredentialAuthenticationTests.cs
+++ b/e2e/test/iothub/SasCredentialAuthenticationTests.cs
@@ -39,9 +39,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         public async Task RegistryManager_Http_SasCredentialAuth_Success()
         {
             // arrange
-            string signature = Configuration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
+            string signature = TestConfiguration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
             using var registryManager = RegistryManager.Create(
-                Configuration.IoTHub.GetIotHubHostName(),
+                TestConfiguration.IoTHub.GetIotHubHostName(),
                 new AzureSasCredential(signature));
 
             var device = new Device(Guid.NewGuid().ToString());
@@ -60,10 +60,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         public async Task RegistryManager_Http_SasCredentialAuth_Renewed_Success()
         {
             // arrange
-            string signature = Configuration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(-1));
+            string signature = TestConfiguration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(-1));
             var sasCredential = new AzureSasCredential(signature);
             using var registryManager = RegistryManager.Create(
-                Configuration.IoTHub.GetIotHubHostName(),
+                TestConfiguration.IoTHub.GetIotHubHostName(),
                 sasCredential);
 
             var device = new Device(Guid.NewGuid().ToString());
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             {
                 // Expected to be unauthorized exception.
             }
-            signature = Configuration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
+            signature = TestConfiguration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
             sasCredential.Update(signature);
             Device createdDevice = await registryManager.AddDeviceAsync(device).ConfigureAwait(false);
 
@@ -93,9 +93,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         public async Task JobClient_Http_SasCredentialAuth_Success()
         {
             // arrange
-            string signature = Configuration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
+            string signature = TestConfiguration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
             using var jobClient = JobClient.Create(
-                Configuration.IoTHub.GetIotHubHostName(),
+                TestConfiguration.IoTHub.GetIotHubHostName(),
                 new AzureSasCredential(signature));
 
             string jobId = "JOBSAMPLE" + Guid.NewGuid().ToString();
@@ -138,9 +138,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             // Call openAsync() to open the device's connection, so that the ModelId is sent over Mqtt CONNECT packet.
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
-            string signature = Configuration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
+            string signature = TestConfiguration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
             using var digitalTwinClient = DigitalTwinClient.Create(
-                Configuration.IoTHub.GetIotHubHostName(),
+                TestConfiguration.IoTHub.GetIotHubHostName(),
                 new AzureSasCredential(signature));
 
             // act
@@ -164,9 +164,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt);
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
-            string signature = Configuration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
+            string signature = TestConfiguration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
             using var serviceClient = ServiceClient.Create(
-                Configuration.IoTHub.GetIotHubHostName(),
+                TestConfiguration.IoTHub.GetIotHubHostName(),
                 new AzureSasCredential(signature),
                 TransportType.Amqp);
 
@@ -188,10 +188,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt);
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
-            string signature = Configuration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(-1));
+            string signature = TestConfiguration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(-1));
             var sasCredential = new AzureSasCredential(signature);
             using var serviceClient = ServiceClient.Create(
-                Configuration.IoTHub.GetIotHubHostName(),
+                TestConfiguration.IoTHub.GetIotHubHostName(),
                 sasCredential,
                 TransportType.Amqp);
 
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                 // Expected to get an unauthorized exception.
             }
 
-            signature = Configuration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
+            signature = TestConfiguration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
             sasCredential.Update(signature);
             await serviceClient.OpenAsync().ConfigureAwait(false);
             using var message = new Message(Encoding.ASCII.GetBytes("Hello, Cloud!"));

--- a/e2e/test/iothub/TokenCredentialAuthenticationTests.cs
+++ b/e2e/test/iothub/TokenCredentialAuthenticationTests.cs
@@ -40,8 +40,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         {
             // arrange
             using var registryManager = RegistryManager.Create(
-                Configuration.IoTHub.GetIotHubHostName(),
-                Configuration.IoTHub.GetClientSecretCredential());
+                TestConfiguration.IoTHub.GetIotHubHostName(),
+                TestConfiguration.IoTHub.GetClientSecretCredential());
 
             var device = new Device(Guid.NewGuid().ToString());
 
@@ -60,8 +60,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         {
             // arrange
             using var jobClient = JobClient.Create(
-                Configuration.IoTHub.GetIotHubHostName(),
-                Configuration.IoTHub.GetClientSecretCredential());
+                TestConfiguration.IoTHub.GetIotHubHostName(),
+                TestConfiguration.IoTHub.GetClientSecretCredential());
 
             string jobId = "JOBSAMPLE" + Guid.NewGuid().ToString();
             string jobDeviceId = "JobsSample_Device";
@@ -104,8 +104,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
             using var digitalTwinClient = DigitalTwinClient.Create(
-                Configuration.IoTHub.GetIotHubHostName(),
-                Configuration.IoTHub.GetClientSecretCredential());
+                TestConfiguration.IoTHub.GetIotHubHostName(),
+                TestConfiguration.IoTHub.GetClientSecretCredential());
 
             // act
             HttpOperationResponse<ThermostatTwin, DigitalTwinGetHeaders> response = await digitalTwinClient
@@ -129,8 +129,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
             using var serviceClient = ServiceClient.Create(
-                Configuration.IoTHub.GetIotHubHostName(),
-                Configuration.IoTHub.GetClientSecretCredential(),
+                TestConfiguration.IoTHub.GetIotHubHostName(),
+                TestConfiguration.IoTHub.GetClientSecretCredential(),
                 TransportType.Amqp);
 
             // act

--- a/e2e/test/iothub/messaging/AzureSecurityCenterForIoTLogAnalyticsClient.cs
+++ b/e2e/test/iothub/messaging/AzureSecurityCenterForIoTLogAnalyticsClient.cs
@@ -38,10 +38,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
     | where DeviceId == ""{0}""
     | where IoTRawEventId == ""{1}""";
 
-        private readonly string _workspaceId = Configuration.AzureSecurityCenterForIoTLogAnalytics.WorkspacedId;
-        private readonly string _aadTenant = Configuration.AzureSecurityCenterForIoTLogAnalytics.AadTenant;
-        private readonly string _appId = Configuration.AzureSecurityCenterForIoTLogAnalytics.AadAppId;
-        private readonly string _appCertificate = Configuration.AzureSecurityCenterForIoTLogAnalytics.AadAppCertificate;
+        private readonly string _workspaceId = TestConfiguration.AzureSecurityCenterForIoTLogAnalytics.WorkspacedId;
+        private readonly string _aadTenant = TestConfiguration.AzureSecurityCenterForIoTLogAnalytics.AadTenant;
+        private readonly string _appId = TestConfiguration.AzureSecurityCenterForIoTLogAnalytics.AadAppId;
+        private readonly string _appCertificate = TestConfiguration.AzureSecurityCenterForIoTLogAnalytics.AadAppCertificate;
 
         private readonly TimeSpan _polingInterval = TimeSpan.FromSeconds(20);
         private readonly TimeSpan _timeout = TimeSpan.FromMinutes(5);

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageReceiveFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageReceiveFaultInjectionPoolAmqpTests.cs
@@ -895,7 +895,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             string proxyAddress = null)
         {
             // Initialize the service client
-            var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
@@ -955,7 +955,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             string proxyAddress = null)
         {
             // Initialize the service client
-            var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler testDeviceCallbackHandler)
             {

--- a/e2e/test/iothub/messaging/MessageFeedbackE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageFeedbackE2ETests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(logger, s_devicePrefix, type).ConfigureAwait(false);
             using (DeviceClient deviceClient = testDevice.CreateDeviceClient(transport))
-            using (ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString))
+            using (ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString))
             {
                 await deviceClient.OpenAsync().ConfigureAwait(false);
 

--- a/e2e/test/iothub/messaging/MessageReceiveE2EPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2EPoolAmqpTests.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             var messagesSent = new Dictionary<string, Tuple<Message, string>>();
 
             // Initialize the service client
-            var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler _)
             {
@@ -253,7 +253,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device)
         {
             // Initialize the service client
-            var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler testDeviceCallbackHandler)
             {
@@ -301,7 +301,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device)
         {
             // Initialize the service client
-            var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler testDeviceCallbackHandler)
             {

--- a/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
@@ -623,7 +623,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
-            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await serviceClient.OpenAsync().ConfigureAwait(false);
@@ -667,7 +667,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
-            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await serviceClient.OpenAsync().ConfigureAwait(false);
@@ -733,7 +733,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
             using var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
 
-            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             (Message msg, string payload, string p1Value) = ComposeC2dTestMessage(Logger);
             using (msg)
@@ -760,7 +760,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
             using var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
 
-            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             // For Mqtt - we will need to subscribe to the Mqtt receive telemetry topic
             // before the device can begin receiving c2d messages.
@@ -837,7 +837,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
-            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             // Set the first C2D message handler.
             await deviceClient.SetReceiveMessageHandlerAsync(
@@ -896,7 +896,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
             var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
 
-            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             (Message msg, string payload, string p1Value) = ComposeC2dTestMessage(Logger);
 
@@ -939,7 +939,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             DeviceClient deviceClient = testDevice.CreateDeviceClient(settings);
             var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
 
-            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             (Message msg, string payload, string p1Value) = ComposeC2dTestMessage(Logger);
 

--- a/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
@@ -363,7 +363,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             TimeSpan delayInSec,
             string proxyAddress = null)
         {
-            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice)
             {
                 await serviceClient.OpenAsync().ConfigureAwait(false);
@@ -418,7 +418,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             string proxyAddress = null)
         {
             TestDeviceCallbackHandler testDeviceCallbackHandler = null;
-            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice)
             {

--- a/e2e/test/iothub/messaging/MessageSendE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageSendE2ETests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         private const int LargeMessageSizeInBytes = 255 * 1024; // The maximum message size for device to cloud messages is 256 KB. We are allowing 1 KB of buffer for message header information etc.
         private readonly string DevicePrefix = $"{nameof(MessageSendE2ETests)}_";
         private readonly string ModulePrefix = $"{nameof(MessageSendE2ETests)}_";
-        private static string ProxyServerAddress = Configuration.IoTHub.ProxyServerAddress;
+        private static string ProxyServerAddress = TestConfiguration.IoTHub.ProxyServerAddress;
 
         [LoggedTestMethod]
         public async Task Message_DeviceSendSingleMessage_Amqp()

--- a/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
     public partial class MessageSendFaultInjectionTests : E2EMsTestBase
     {
         private readonly string _devicePrefix = $"E2E_{nameof(MessageSendFaultInjectionTests)}_";
-        private static readonly string s_proxyServerAddress = Configuration.IoTHub.ProxyServerAddress;
+        private static readonly string s_proxyServerAddress = TestConfiguration.IoTHub.ProxyServerAddress;
 
         [LoggedTestMethod]
         public async Task Message_TcpConnectionLossSendRecovery_Amqp()

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
         {
             var serviceClientTransportSettings = new ServiceClientTransportSettings
             {
-                HttpProxy = new WebProxy(Configuration.IoTHub.ProxyServerAddress)
+                HttpProxy = new WebProxy(TestConfiguration.IoTHub.ProxyServerAddress)
             };
 
             await SendMethodAndRespondAsync(
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
         {
             var serviceClientTransportSettings = new ServiceClientTransportSettings
             {
-                HttpProxy = new WebProxy(Configuration.IoTHub.ProxyServerAddress)
+                HttpProxy = new WebProxy(TestConfiguration.IoTHub.ProxyServerAddress)
             };
 
             await SendMethodAndRespondAsync(
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
         public async Task Method_ServiceInvokeDeviceMethodWithUnknownDeviceThrows()
         {
             // setup
-            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             var methodInvocation = new CloudToDeviceMethod("SetTelemetryInterval");
             methodInvocation.SetPayloadJson("10");
 
@@ -233,7 +233,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
         {
             // setup
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, "ModuleNotFoundTest").ConfigureAwait(false);
-            using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             var methodInvocation = new CloudToDeviceMethod("SetTelemetryInterval");
             methodInvocation.SetPayloadJson("10");
 
@@ -282,7 +282,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                         null)
                     .ConfigureAwait(false);
 
-                using var serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+                using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
                 var c2dMethod = new CloudToDeviceMethod(commandName, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1)).SetPayloadJson(null);
 
                 // act
@@ -313,8 +313,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             ServiceClientTransportSettings serviceClientTransportSettings = default)
         {
             ServiceClient serviceClient = serviceClientTransportSettings == default
-                ? ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString)
-                : ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString, TransportType.Amqp, serviceClientTransportSettings);
+                ? ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString)
+                : ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString, TransportType.Amqp, serviceClientTransportSettings);
 
             TimeSpan methodTimeout = responseTimeout == default ? s_defaultMethodTimeoutMinutes : responseTimeout;
             logger.Trace($"{nameof(ServiceSendMethodAndVerifyResponseAsync)}: Invoke method {methodName}.");
@@ -346,8 +346,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             ServiceClientTransportSettings serviceClientTransportSettings = default)
         {
             ServiceClient serviceClient = serviceClientTransportSettings == default
-                ? ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString)
-                : ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString, TransportType.Amqp, serviceClientTransportSettings);
+                ? ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString)
+                : ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString, TransportType.Amqp, serviceClientTransportSettings);
             TimeSpan methodTimeout = responseTimeout == default ? s_defaultMethodTimeoutMinutes : responseTimeout;
             logger.Trace($"{nameof(ServiceSendMethodAndVerifyResponseAsync)}: Invoke method {methodName}.");
             CloudToDeviceMethodResult response =
@@ -375,8 +375,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             ServiceClientTransportSettings serviceClientTransportSettings = default)
         {
             ServiceClient serviceClient = serviceClientTransportSettings == default
-                ? ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString)
-                : ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString, TransportType.Amqp, serviceClientTransportSettings);
+                ? ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString)
+                : ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString, TransportType.Amqp, serviceClientTransportSettings);
 
             TimeSpan methodTimeout = responseTimeout == default ? s_defaultMethodTimeoutMinutes : responseTimeout;
 

--- a/e2e/test/iothub/method/MethodFaultInjectionTests.cs
+++ b/e2e/test/iothub/method/MethodFaultInjectionTests.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                 attempt++;
                 try
                 {
-                    using ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+                    using ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
                     Logger.Trace($"{nameof(ServiceSendMethodAndVerifyResponseAsync)}: Invoke method {methodName}.");
                     CloudToDeviceMethodResult response =

--- a/e2e/test/iothub/service/BulkOperationsE2ETests.cs
+++ b/e2e/test/iothub/service/BulkOperationsE2ETests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             var tagValue = Guid.NewGuid().ToString();
 
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             Twin twin = await registryManager.GetTwinAsync(testDevice.Id).ConfigureAwait(false);
 
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             var tagValue = Guid.NewGuid().ToString();
 
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             Twin twin = new Twin();
             twin.DeviceId = testDevice.Id;
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             var tagValue = Guid.NewGuid().ToString();
 
             TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix, Logger).ConfigureAwait(false);
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             Twin twin = await registryManager.GetTwinAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
 
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
 
             TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix, Logger).ConfigureAwait(false);
 
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             var twin = new Twin();
             twin.DeviceId = testModule.DeviceId;
             twin.ModuleId = testModule.Id;

--- a/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
+++ b/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         private const string TemperatureControllerModelId = "dtmi:com:example:TemperatureController;1";
 
         private readonly string _devicePrefix = $"E2E_{nameof(DigitalTwinClientE2ETests)}_";
-        private static readonly string s_connectionString = Configuration.IoTHub.ConnectionString;
+        private static readonly string s_connectionString = TestConfiguration.IoTHub.ConnectionString;
 
         [LoggedTestMethod]
         public async Task DigitalTwinWithOnlyRootComponentOperationsAsync()

--- a/e2e/test/iothub/service/IoTHubCertificateValidationE2ETest.cs
+++ b/e2e/test/iothub/service/IoTHubCertificateValidationE2ETest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         [LoggedTestMethod]
         public async Task RegistryManager_QueryDevicesInvalidServiceCertificateHttp_Fails()
         {
-            var rm = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionStringInvalidServiceCertificate);
+            var rm = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionStringInvalidServiceCertificate);
             IQuery query = rm.CreateQuery("select * from devices");
             var exception = await Assert.ThrowsExceptionAsync<IotHubCommunicationException>(
                 () => query.GetNextAsTwinAsync()).ConfigureAwait(false);
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         private static async Task TestServiceClientInvalidServiceCertificate(TransportType transport)
         {
             var service = ServiceClient.CreateFromConnectionString(
-                Configuration.IoTHub.ConnectionStringInvalidServiceCertificate,
+                TestConfiguration.IoTHub.ConnectionStringInvalidServiceCertificate,
                 transport);
             await service.SendAsync("testDevice1", new Message()).ConfigureAwait(false);
         }
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         [LoggedTestMethod]
         public async Task JobClient_ScheduleTwinUpdateInvalidServiceCertificateHttp_Fails()
         {
-            var job = JobClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionStringInvalidServiceCertificate);
+            var job = JobClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionStringInvalidServiceCertificate);
             var exception = await Assert.ThrowsExceptionAsync<IotHubCommunicationException>(
                 () => job.ScheduleTwinUpdateAsync(
                     "testDevice",
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         {
             using (DeviceClient deviceClient =
                 DeviceClient.CreateFromConnectionString(
-                    Configuration.IoTHub.DeviceConnectionStringInvalidServiceCertificate,
+                    TestConfiguration.IoTHub.DeviceConnectionStringInvalidServiceCertificate,
                     transport))
             {
                 await deviceClient.SendEventAsync(new Client.Message()).ConfigureAwait(false);

--- a/e2e/test/iothub/service/IoTHubServiceProxyE2ETests.cs
+++ b/e2e/test/iothub/service/IoTHubServiceProxyE2ETests.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         private readonly string DevicePrefix = $"{nameof(IoTHubServiceProxyE2ETests)}_";
         private const string JobDeviceId = "JobsSample_Device";
         private const string JobTestTagName = "JobsSample_Tag";
-        private static string s_connectionString = Configuration.IoTHub.ConnectionString;
-        private static string s_proxyServerAddress = Configuration.IoTHub.ProxyServerAddress;
+        private static string s_connectionString = TestConfiguration.IoTHub.ConnectionString;
+        private static string s_proxyServerAddress = TestConfiguration.IoTHub.ProxyServerAddress;
         private const int MaxIterationWait = 30;
         private static readonly TimeSpan _waitDuration = TimeSpan.FromSeconds(5);
 

--- a/e2e/test/iothub/service/PnpServiceTests.cs
+++ b/e2e/test/iothub/service/PnpServiceTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             // Act
 
             // Get device twin.
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             Twin twin = await registryManager.GetTwinAsync(testDevice.Device.Id).ConfigureAwait(false);
 
             // Assert
@@ -65,15 +65,15 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             {
                 ModelId = TestModelId,
             };
-            string hostName = HostNameHelper.GetHostName(Configuration.IoTHub.ConnectionString);
-            var auth = new DeviceAuthenticationWithX509Certificate(testDevice.Id, Configuration.IoTHub.GetCertificateWithPrivateKey());
+            string hostName = HostNameHelper.GetHostName(TestConfiguration.IoTHub.ConnectionString);
+            var auth = new DeviceAuthenticationWithX509Certificate(testDevice.Id, TestConfiguration.IoTHub.GetCertificateWithPrivateKey());
             using var deviceClient = DeviceClient.Create(hostName, auth, Client.TransportType.Mqtt_Tcp_Only, options);
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
             // Act
 
             // Get device twin.
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             Twin twin = await registryManager.GetTwinAsync(testDevice.Device.Id).ConfigureAwait(false);
 
             // Assert
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             // Act
 
             // Get module twin.
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             Twin twin = await registryManager.GetTwinAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
 
             // Assert

--- a/e2e/test/iothub/service/RegistryManagerE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryManagerE2ETests.cs
@@ -28,10 +28,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         {
             // arrange
             var registryManager = RegistryManager.CreateFromConnectionString(
-                Configuration.IoTHub.ConnectionString,
+                TestConfiguration.IoTHub.ConnectionString,
                 new HttpTransportSettings
                 {
-                    Proxy = new WebProxy(Configuration.IoTHub.InvalidProxyServerAddress),
+                    Proxy = new WebProxy(TestConfiguration.IoTHub.InvalidProxyServerAddress),
                 });
 
             // act
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             string edgeId2 = _devicePrefix + Guid.NewGuid();
             string deviceId = _devicePrefix + Guid.NewGuid();
 
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             try
             {
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         {
             string deviceId = _devicePrefix + Guid.NewGuid();
 
-            using (var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString))
+            using (var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString))
             {
                 var twin = new Twin
                 {
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                 devices.Add(new Device(_devicePrefix + Guid.NewGuid()));
             }
 
-            var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             // Test that you can create devices in bulk
             var bulkAddResult = await registryManager.AddDevices2Async(devices).ConfigureAwait(false);
@@ -176,10 +176,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             string deviceId = _devicePrefix + Guid.NewGuid();
             var transportSettings = new HttpTransportSettings
             {
-                Proxy = new WebProxy(Configuration.IoTHub.ProxyServerAddress)
+                Proxy = new WebProxy(TestConfiguration.IoTHub.ProxyServerAddress)
             };
 
-            using (var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString, transportSettings))
+            using (var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString, transportSettings))
             {
                 var device = new Device(deviceId);
                 await registryManager.AddDeviceAsync(device).ConfigureAwait(false);
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         public async Task RegistryManager_Query_Works()
         {
             // arrange
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             string deviceId = $"{_devicePrefix}{Guid.NewGuid()}";
 
             try
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             }
 
             Device device = null;
-            RegistryManager client = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            RegistryManager client = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             try
             {
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             string testDeviceId = $"IdentityLifecycleDevice{Guid.NewGuid()}";
             string testModuleId = $"IdentityLifecycleModule{Guid.NewGuid()}";
 
-            RegistryManager client = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            RegistryManager client = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             try
             {
@@ -328,7 +328,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         [LoggedTestMethod]
         public async Task ModulesClient_DeviceTwinLifecycle()
         {
-            RegistryManager client = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            RegistryManager client = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             var module = await TestModule.GetTestModuleAsync(_devicePrefix, _modulePrefix, Logger).ConfigureAwait(false);
 
             try

--- a/e2e/test/iothub/service/RegistryManagerExportDevicesTests.cs
+++ b/e2e/test/iothub/service/RegistryManagerExportDevicesTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
 
             StorageContainer storageContainer = null;
             string deviceId = $"{nameof(RegistryManager_ExportDevices)}-{StorageContainer.GetRandomSuffix(4)}";
-            var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             Logger.Trace($"Using deviceId {deviceId}");
 
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                         ManagedIdentity identity = null;
                         if (isUserAssignedMsi)
                         {
-                            string userAssignedMsiResourceId = Configuration.IoTHub.UserAssignedMsiResourceId;
+                            string userAssignedMsiResourceId = TestConfiguration.IoTHub.UserAssignedMsiResourceId;
                             identity = new ManagedIdentity
                             {
                                 userAssignedIdentity = userAssignedMsiResourceId

--- a/e2e/test/iothub/service/RegistryManagerImportDevicesTests.cs
+++ b/e2e/test/iothub/service/RegistryManagerImportDevicesTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
 
             StorageContainer storageContainer = null;
             string deviceId = $"{nameof(RegistryManager_ImportDevices)}-{StorageContainer.GetRandomSuffix(4)}";
-            var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             Logger.Trace($"Using deviceId {deviceId}");
 
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                         ManagedIdentity identity = null;
                         if (isUserAssignedMsi)
                         {
-                            string userAssignedMsiResourceId = Configuration.IoTHub.UserAssignedMsiResourceId;
+                            string userAssignedMsiResourceId = TestConfiguration.IoTHub.UserAssignedMsiResourceId;
                             identity = new ManagedIdentity
                             {
                                 userAssignedIdentity = userAssignedMsiResourceId

--- a/e2e/test/iothub/service/ServiceClientE2ETests.cs
+++ b/e2e/test/iothub/service/ServiceClientE2ETests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         private async Task TestTimeout(TimeSpan? timeout)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
-            using var sender = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var sender = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             Stopwatch sw = new Stopwatch();
             sw.Start();
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         {
             // arrange
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
-            using var sender = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString, transportType);
+            using var sender = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString, transportType);
             string messageId = Guid.NewGuid().ToString();
 
             // act and expect no exception
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         {
             // arrange
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
-            using var sender = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var sender = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             string messageId = Guid.NewGuid().ToString();
 
             // act
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             {
                 SdkAssignsMessageId = Shared.SdkAssignsMessageId.Never,
             };
-            using var sender = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString, options);
+            using var sender = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString, options);
             string messageId = Guid.NewGuid().ToString();
 
             // act
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             {
                 SdkAssignsMessageId = Shared.SdkAssignsMessageId.WhenUnset,
             };
-            using var sender = ServiceClient.CreateFromConnectionString(Configuration.IoTHub.ConnectionString, options);
+            using var sender = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString, options);
             string messageId = Guid.NewGuid().ToString();
 
             // act

--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
     {
         private readonly string _devicePrefix = $"E2E_{nameof(TwinE2ETests)}_";
 
-        private static readonly RegistryManager _registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+        private static readonly RegistryManager _registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
         private static readonly List<object> s_listOfPropertyValues = new List<object>
         {
@@ -523,7 +523,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
         public static async Task RegistryManagerUpdateDesiredPropertyAsync(string deviceId, string propName, object propValue)
         {
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             var twinPatch = new Twin();
             twinPatch.Properties.Desired[propName] = propValue;
@@ -602,7 +602,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             var propValue = Guid.NewGuid().ToString();
 
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
 
             var twinPatch = new Twin();
@@ -622,7 +622,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             var propValue = Guid.NewGuid().ToString();
 
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
 
             var patch = new TwinCollection();
@@ -643,7 +643,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             var propEmptyValue = "{}";
 
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
 
             await deviceClient
@@ -694,7 +694,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             var propName2 = Guid.NewGuid().ToString();
 
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
 
             var exceptionThrown = false;

--- a/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
+++ b/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
         private async Task RegistryManagerUpdateDesiredPropertyAsync(string deviceId, string propName, string propValue)
         {
-            using var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             var twinPatch = new Twin();
             twinPatch.Properties.Desired[propName] = propValue;
@@ -273,7 +273,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             string proxyAddress = null)
         {
             TestDeviceCallbackHandler testDeviceCallbackHandler = null;
-            var registryManager = RegistryManager.CreateFromConnectionString(Configuration.IoTHub.ConnectionString);
+            var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
             using var cts = new CancellationTokenSource(FaultInjection.RecoveryTime);
 
             var propName = Guid.NewGuid().ToString();

--- a/e2e/test/provisioning/ProvisioningCertificateValidationE2ETest.cs
+++ b/e2e/test/provisioning/ProvisioningCertificateValidationE2ETest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         public async Task ProvisioningServiceClient_QueryInvalidServiceCertificateHttp_Fails()
         {
             using var provisioningServiceClient = ProvisioningServiceClient.CreateFromConnectionString(
-                Configuration.Provisioning.ConnectionStringInvalidServiceCertificate);
+                TestConfiguration.Provisioning.ConnectionStringInvalidServiceCertificate);
             Query q = provisioningServiceClient.CreateEnrollmentGroupQuery(
                 new QuerySpecification("SELECT * FROM enrollmentGroups"));
 
@@ -97,9 +97,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         private static async Task TestInvalidServiceCertificate(ProvisioningTransportHandler transport)
         {
             using var security =
-                new SecurityProviderX509Certificate(Configuration.Provisioning.GetIndividualEnrollmentCertificate());
+                new SecurityProviderX509Certificate(TestConfiguration.Provisioning.GetIndividualEnrollmentCertificate());
             ProvisioningDeviceClient provisioningDeviceClient = ProvisioningDeviceClient.Create(
-                Configuration.Provisioning.GlobalDeviceEndpointInvalidServiceCertificate,
+                TestConfiguration.Provisioning.GlobalDeviceEndpointInvalidServiceCertificate,
                 "0ne00000001",
                 security,
                 transport);

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         private const string InvalidIdScope = "0neFFFFFFFF";
         private const string PayloadJsonData = "{\"testKey\":\"testValue\"}";
         private const string InvalidGlobalAddress = "httpbin.org";
-        private static readonly string s_globalDeviceEndpoint = Configuration.Provisioning.GlobalDeviceEndpoint;
-        private static readonly string s_proxyServerAddress = Configuration.IoTHub.ProxyServerAddress;
+        private static readonly string s_globalDeviceEndpoint = TestConfiguration.Provisioning.GlobalDeviceEndpoint;
+        private static readonly string s_proxyServerAddress = TestConfiguration.IoTHub.ProxyServerAddress;
 
         private readonly string _idPrefix = $"e2e-{nameof(ProvisioningE2ETests).ToLower()}-";
         private readonly VerboseTestLogger _verboseLog = VerboseTestLogger.GetInstance();
@@ -372,17 +372,17 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             bool setCustomProxy,
             string customServerProxy = null)
         {
-            var closeHostName = IotHubConnectionStringBuilder.Create(Configuration.IoTHub.ConnectionString).HostName;
+            var closeHostName = IotHubConnectionStringBuilder.Create(TestConfiguration.IoTHub.ConnectionString).HostName;
 
-            ICollection<string> iotHubsToProvisionTo = new List<string>() { closeHostName, Configuration.Provisioning.FarAwayIotHubHostName };
+            ICollection<string> iotHubsToProvisionTo = new List<string>() { closeHostName, TestConfiguration.Provisioning.FarAwayIotHubHostName };
             string expectedDestinationHub = "";
-            if (closeHostName.Length > Configuration.Provisioning.FarAwayIotHubHostName.Length)
+            if (closeHostName.Length > TestConfiguration.Provisioning.FarAwayIotHubHostName.Length)
             {
                 expectedDestinationHub = closeHostName;
             }
-            else if (closeHostName.Length < Configuration.Provisioning.FarAwayIotHubHostName.Length)
+            else if (closeHostName.Length < TestConfiguration.Provisioning.FarAwayIotHubHostName.Length)
             {
-                expectedDestinationHub = Configuration.Provisioning.FarAwayIotHubHostName;
+                expectedDestinationHub = TestConfiguration.Provisioning.FarAwayIotHubHostName;
             }
             else
             {
@@ -452,7 +452,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             string proxyServerAddress = null)
         {
             //Default reprovisioning settings: Hashed allocation, no reprovision policy, hub names, or custom allocation policy
-            var iothubs = new List<string>() { IotHubConnectionStringBuilder.Create(Configuration.IoTHub.ConnectionString).HostName };
+            var iothubs = new List<string>() { IotHubConnectionStringBuilder.Create(TestConfiguration.IoTHub.ConnectionString).HostName };
             await ProvisioningDeviceClientValidRegistrationIdRegisterOkAsync(
                     transportType,
                     attestationType,
@@ -500,7 +500,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
             var provClient = ProvisioningDeviceClient.Create(
                 s_globalDeviceEndpoint,
-                Configuration.Provisioning.IdScope,
+                TestConfiguration.Provisioning.IdScope,
                 security,
                 transport);
 
@@ -555,7 +555,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
             var customAllocationDefinition = new CustomAllocationDefinition
             {
-                WebhookUrl = Configuration.Provisioning.CustomAllocationPolicyWebhook,
+                WebhookUrl = TestConfiguration.Provisioning.CustomAllocationPolicyWebhook,
                 ApiVersion = "2019-03-31",
             };
 
@@ -578,7 +578,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
             var provClient = ProvisioningDeviceClient.Create(
                 s_globalDeviceEndpoint,
-                Configuration.Provisioning.IdScope,
+                TestConfiguration.Provisioning.IdScope,
                 security,
                 transport);
             using var cts = new CancellationTokenSource(PassingTimeoutMiliseconds);
@@ -645,7 +645,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             using SecurityProvider security = new SecurityProviderTpmSimulator("invalidregistrationid");
             var provClient = ProvisioningDeviceClient.Create(
                 s_globalDeviceEndpoint,
-                Configuration.Provisioning.IdScope,
+                TestConfiguration.Provisioning.IdScope,
                 security,
                 transport);
 
@@ -812,7 +812,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
             ProvisioningDeviceClient provClient = ProvisioningDeviceClient.Create(
                 InvalidGlobalAddress,
-                Configuration.Provisioning.IdScope,
+                TestConfiguration.Provisioning.IdScope,
                 security,
                 transport);
 
@@ -893,7 +893,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         {
             _verboseLog.WriteLine($"{nameof(CreateSecurityProviderFromNameAsync)}({attestationType})");
 
-            var provisioningServiceClient = ProvisioningServiceClient.CreateFromConnectionString(Configuration.Provisioning.ConnectionString);
+            var provisioningServiceClient = ProvisioningServiceClient.CreateFromConnectionString(TestConfiguration.Provisioning.ConnectionString);
 
             switch (attestationType)
             {
@@ -903,7 +903,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
                     string base64Ek = Convert.ToBase64String(tpmSim.GetEndorsementKey());
 
-                    var provisioningService = ProvisioningServiceClient.CreateFromConnectionString(Configuration.Provisioning.ConnectionString);
+                    var provisioningService = ProvisioningServiceClient.CreateFromConnectionString(TestConfiguration.Provisioning.ConnectionString);
 
                     Logger.Trace($"Getting enrollment: RegistrationID = {registrationId}");
                     IndividualEnrollment individualEnrollment = new IndividualEnrollment(registrationId, new TpmAttestation(base64Ek)) { AllocationPolicy = allocationPolicy, ReprovisionPolicy = reprovisionPolicy, IotHubs = iothubs, CustomAllocationDefinition = customAllocationDefinition, Capabilities = capabilities };
@@ -922,12 +922,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     switch (enrollmentType)
                     {
                         case EnrollmentType.Individual:
-                            certificate = Configuration.Provisioning.GetIndividualEnrollmentCertificate();
+                            certificate = TestConfiguration.Provisioning.GetIndividualEnrollmentCertificate();
                             break;
 
                         case EnrollmentType.Group:
-                            certificate = Configuration.Provisioning.GetGroupEnrollmentCertificate();
-                            collection = Configuration.Provisioning.GetGroupEnrollmentChain();
+                            certificate = TestConfiguration.Provisioning.GetGroupEnrollmentCertificate();
+                            collection = TestConfiguration.Provisioning.GetGroupEnrollmentChain();
                             break;
 
                         default:

--- a/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
     [TestCategory("DPS")]
     public class ProvisioningServiceClientE2ETests : E2EMsTestBase
     {
-        private static readonly string s_proxyServerAddress = Configuration.IoTHub.ProxyServerAddress;
+        private static readonly string s_proxyServerAddress = TestConfiguration.IoTHub.ProxyServerAddress;
         private static readonly string s_devicePrefix = $"E2E_{nameof(ProvisioningServiceClientE2ETests)}_";
 
 #pragma warning disable CA1823
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
         public async Task ProvisioningServiceClient_GetIndividualEnrollmentAttestation(AttestationMechanismType attestationType)
         {
-            ProvisioningServiceClient provisioningServiceClient = ProvisioningServiceClient.CreateFromConnectionString(Configuration.Provisioning.ConnectionString);
+            ProvisioningServiceClient provisioningServiceClient = ProvisioningServiceClient.CreateFromConnectionString(TestConfiguration.Provisioning.ConnectionString);
             IndividualEnrollment individualEnrollment = await CreateIndividualEnrollment(provisioningServiceClient, attestationType, null, AllocationPolicy.Static, null, null, null);
 
             AttestationMechanism attestationMechanism = await provisioningServiceClient.GetIndividualEnrollmentAttestationAsync(individualEnrollment.RegistrationId);
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
         public async Task ProvisioningServiceClient_GetEnrollmentGroupAttestation(AttestationMechanismType attestationType)
         {
-            ProvisioningServiceClient provisioningServiceClient = ProvisioningServiceClient.CreateFromConnectionString(Configuration.Provisioning.ConnectionString);
+            ProvisioningServiceClient provisioningServiceClient = ProvisioningServiceClient.CreateFromConnectionString(TestConfiguration.Provisioning.ConnectionString);
             string groupId = AttestationTypeToString(attestationType) + "-" + Guid.NewGuid();
             EnrollmentGroup enrollmentGroup = await CreateEnrollmentGroup(provisioningServiceClient, attestationType, groupId, null, AllocationPolicy.Static, null, null, null);
 
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     using (var tpmSim = new SecurityProviderTpmSimulator(registrationId))
                     {
                         string base64Ek = Convert.ToBase64String(tpmSim.GetEndorsementKey());
-                        var provisioningService = ProvisioningServiceClient.CreateFromConnectionString(Configuration.Provisioning.ConnectionString);
+                        var provisioningService = ProvisioningServiceClient.CreateFromConnectionString(TestConfiguration.Provisioning.ConnectionString);
                         individualEnrollment = new IndividualEnrollment(registrationId, new TpmAttestation(base64Ek))
                         {
                             Capabilities = capabilities,
@@ -347,7 +347,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                 transportSettings.Proxy = new WebProxy(proxyServerAddress);
             }
 
-            return ProvisioningServiceClient.CreateFromConnectionString(Configuration.Provisioning.ConnectionString, transportSettings);
+            return ProvisioningServiceClient.CreateFromConnectionString(TestConfiguration.Provisioning.ConnectionString, transportSettings);
         }
 
         /// <summary>

--- a/e2e/test/provisioning/ReprovisioningE2ETests.cs
+++ b/e2e/test/provisioning/ReprovisioningE2ETests.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
     public class ReprovisioningE2ETests : E2EMsTestBase
     {
         private const int PassingTimeoutMiliseconds = 10 * 60 * 1000;
-        private static readonly string s_globalDeviceEndpoint = Configuration.Provisioning.GlobalDeviceEndpoint;
-        private static string s_proxyServerAddress = Configuration.IoTHub.ProxyServerAddress;
+        private static readonly string s_globalDeviceEndpoint = TestConfiguration.Provisioning.GlobalDeviceEndpoint;
+        private static string s_proxyServerAddress = TestConfiguration.IoTHub.ProxyServerAddress;
         private readonly string _devicePrefix = $"E2E_{nameof(ProvisioningE2ETests)}_";
 
 #pragma warning disable CA1823
@@ -211,8 +211,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         /// </summary>
         private async Task ProvisioningDeviceClient_ReprovisioningFlow_ResetTwin(Client.TransportType transportProtocol, AttestationMechanismType attestationType, EnrollmentType enrollmentType, bool setCustomProxy, string customServerProxy = null)
         {
-            var connectionString = IotHubConnectionStringBuilder.Create(Configuration.IoTHub.ConnectionString);
-            ICollection<string> iotHubsToStartAt = new List<string>() { Configuration.Provisioning.FarAwayIotHubHostName };
+            var connectionString = IotHubConnectionStringBuilder.Create(TestConfiguration.IoTHub.ConnectionString);
+            ICollection<string> iotHubsToStartAt = new List<string>() { TestConfiguration.Provisioning.FarAwayIotHubHostName };
             ICollection<string> iotHubsToReprovisionTo = new List<string>() { connectionString.HostName };
             await ProvisioningDeviceClient_ReprovisioningFlow(transportProtocol, attestationType, enrollmentType, setCustomProxy, new ReprovisionPolicy { MigrateDeviceData = false, UpdateHubAssignment = true }, AllocationPolicy.Hashed, null, iotHubsToStartAt, iotHubsToReprovisionTo, customServerProxy).ConfigureAwait(false);
         }
@@ -223,8 +223,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         /// </summary>
         private async Task ProvisioningDeviceClient_ReprovisioningFlow_KeepTwin(Client.TransportType transportProtocol, AttestationMechanismType attestationType, EnrollmentType enrollmentType, bool setCustomProxy, string customServerProxy = null)
         {
-            var connectionString = IotHubConnectionStringBuilder.Create(Configuration.IoTHub.ConnectionString);
-            ICollection<string> iotHubsToStartAt = new List<string>() { Configuration.Provisioning.FarAwayIotHubHostName };
+            var connectionString = IotHubConnectionStringBuilder.Create(TestConfiguration.IoTHub.ConnectionString);
+            ICollection<string> iotHubsToStartAt = new List<string>() { TestConfiguration.Provisioning.FarAwayIotHubHostName };
             ICollection<string> iotHubsToReprovisionTo = new List<string>() { connectionString.HostName };
             await ProvisioningDeviceClient_ReprovisioningFlow(transportProtocol, attestationType, enrollmentType, setCustomProxy, new ReprovisionPolicy { MigrateDeviceData = true, UpdateHubAssignment = true }, AllocationPolicy.Hashed, null, iotHubsToStartAt, iotHubsToReprovisionTo, customServerProxy).ConfigureAwait(false);
         }
@@ -234,8 +234,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         /// </summary>
         private async Task ProvisioningDeviceClient_ReprovisioningFlow_DoNotReprovision(Client.TransportType transportProtocol, AttestationMechanismType attestationType, EnrollmentType enrollmentType, bool setCustomProxy, string customServerProxy = null)
         {
-            var connectionString = IotHubConnectionStringBuilder.Create(Configuration.IoTHub.ConnectionString);
-            ICollection<string> iotHubsToStartAt = new List<string>() { Configuration.Provisioning.FarAwayIotHubHostName };
+            var connectionString = IotHubConnectionStringBuilder.Create(TestConfiguration.IoTHub.ConnectionString);
+            ICollection<string> iotHubsToStartAt = new List<string>() { TestConfiguration.Provisioning.FarAwayIotHubHostName };
             ICollection<string> iotHubsToReprovisionTo = new List<string>() { connectionString.HostName };
             await ProvisioningDeviceClient_ReprovisioningFlow(transportProtocol, attestationType, enrollmentType, setCustomProxy, new ReprovisionPolicy { MigrateDeviceData = false, UpdateHubAssignment = false }, AllocationPolicy.Hashed, null, iotHubsToStartAt, iotHubsToReprovisionTo, customServerProxy).ConfigureAwait(false);
         }
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
             ProvisioningDeviceClient provClient = ProvisioningDeviceClient.Create(
                 s_globalDeviceEndpoint,
-                Configuration.Provisioning.IdScope,
+                TestConfiguration.Provisioning.IdScope,
                 security,
                 transport);
             using var cts = new CancellationTokenSource(PassingTimeoutMiliseconds);
@@ -348,7 +348,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         {
             _verboseLog.WriteLine($"{nameof(CreateSecurityProviderFromName)}({attestationType})");
 
-            var provisioningServiceClient = ProvisioningServiceClient.CreateFromConnectionString(Configuration.Provisioning.ConnectionString);
+            var provisioningServiceClient = ProvisioningServiceClient.CreateFromConnectionString(TestConfiguration.Provisioning.ConnectionString);
 
             switch (attestationType)
             {
@@ -358,7 +358,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
                     string base64Ek = Convert.ToBase64String(tpmSim.GetEndorsementKey());
 
-                    var provisioningService = ProvisioningServiceClient.CreateFromConnectionString(Configuration.Provisioning.ConnectionString);
+                    var provisioningService = ProvisioningServiceClient.CreateFromConnectionString(TestConfiguration.Provisioning.ConnectionString);
 
                     Logger.Trace($"Getting enrollment: RegistrationID = {registrationId}");
                     IndividualEnrollment individualEnrollment = new IndividualEnrollment(registrationId, new TpmAttestation(base64Ek)) { AllocationPolicy = allocationPolicy, ReprovisionPolicy = reprovisionPolicy, IotHubs = iothubs, CustomAllocationDefinition = customAllocationDefinition, Capabilities = capabilities };
@@ -377,12 +377,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     switch (enrollmentType)
                     {
                         case EnrollmentType.Individual:
-                            certificate = Configuration.Provisioning.GetIndividualEnrollmentCertificate();
+                            certificate = TestConfiguration.Provisioning.GetIndividualEnrollmentCertificate();
                             break;
 
                         case EnrollmentType.Group:
-                            certificate = Configuration.Provisioning.GetGroupEnrollmentCertificate();
-                            collection = Configuration.Provisioning.GetGroupEnrollmentChain();
+                            certificate = TestConfiguration.Provisioning.GetGroupEnrollmentCertificate();
+                            collection = TestConfiguration.Provisioning.GetGroupEnrollmentChain();
                             break;
 
                         default:
@@ -501,7 +501,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
                 if (allocationPolicy == AllocationPolicy.GeoLatency)
                 {
-                    Assert.AreNotEqual(result.AssignedHub, Configuration.Provisioning.FarAwayIotHubHostName);
+                    Assert.AreNotEqual(result.AssignedHub, TestConfiguration.Provisioning.FarAwayIotHubHostName);
                 }
             }
             else


### PR DESCRIPTION
While working on new support for import/export of configurations along with devices, I found a naming conflict for an E2E type called `Configuration`. So I'm renaming the test type to `TestConfiguration`.