### PR TITLE
fix(iot-device): Update IoT Hub CONNACK timeout to be 60 seconds

### DIFF
--- a/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
@@ -26,7 +26,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         private const int DefaultMaxPendingInboundMessages = 50;
         private const QualityOfService DefaultPublishToServerQoS = QualityOfService.AtLeastOnce;
         private const QualityOfService DefaultReceivingQoS = QualityOfService.AtLeastOnce;
-        private static readonly TimeSpan s_defaultConnectArrivalTimeout = TimeSpan.FromSeconds(10);
+
+        // The CONNACK timeout has been chosen to be 60 seconds to be in alignment with the service implemented timeout for processing connection requests.
+        private static readonly TimeSpan s_defaultConnectArrivalTimeout = TimeSpan.FromSeconds(60);
+
         private static readonly TimeSpan s_defaultDeviceReceiveAckTimeout = TimeSpan.FromSeconds(300);
         private static readonly TimeSpan s_defaultReceiveTimeout = TimeSpan.FromMinutes(1);
 
@@ -157,8 +160,15 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         /// <summary>
         /// The time to wait for receiving an acknowledgment for a CONNECT packet.
-        /// The default is 10 seconds.
+        /// The default is 60 seconds.
         /// </summary>
+        /// <remarks>
+        /// In the event that IoT Hub receives burst traffic, it will implement traffic shaping in order to process the incoming requests.
+        /// In such cases, during client connection the CONNECT requests can have a delay in being acknowledged and processed by IoT Hub.
+        /// The <see cref="ConnectArrivalTimeout"/> governs the duration the client will wait for a CONNACK packet before disconnecting and reopening the connection.
+        /// To know more about IoT Hub's throttling limits and traffic shaping feature, see
+        /// <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-quotas-throttling#operation-throttles"/>.
+        /// </remarks>
         public TimeSpan ConnectArrivalTimeout { get; set; }
 
         /// <summary>

--- a/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
@@ -165,9 +165,9 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         /// <remarks>
         /// In the event that IoT Hub receives burst traffic, it will implement traffic shaping in order to process the incoming requests.
         /// In such cases, during client connection the CONNECT requests can have a delay in being acknowledged and processed by IoT Hub.
-        /// The <see cref="ConnectArrivalTimeout"/> governs the duration the client will wait for a CONNACK packet before disconnecting and reopening the connection.
+        /// The <c>ConnectArrivalTimeout</c> governs the duration the client will wait for a CONNACK packet before disconnecting and reopening the connection.
         /// To know more about IoT Hub's throttling limits and traffic shaping feature, see
-        /// <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-quotas-throttling#operation-throttles"/>.
+        /// <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-quotas-throttling#operation-throttles"/>.
         /// </remarks>
         public TimeSpan ConnectArrivalTimeout { get; set; }
 


### PR DESCRIPTION
This commit is being cherry-picked into our latest LTS release

Fix for #2043 