### PR TITLE
Bump version for lts_2021_03 patch release

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.1;netstandard2.0;net472;net451</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.36.0</Version>
+    <Version>1.36.1</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/readme.md
+++ b/readme.md
@@ -198,6 +198,7 @@ Below is a table showing the mapping of the LTS branches to the packages release
 
 | Release                                                                                       | Github Branch | LTS Status  | LTS Start Date | Maintenance End Date | LTS End Date | 
 | :-------------------------------------------------------------------------------------------: | :-----------: | :--------:  | :------------: | :------------------: | :----------: | 
+| [2021-6-22](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2021-6-22)         | lts_2021_03   | Active      | 2020-03-18     | 2022-03-18           | 2024-03-17   |                                   
 | [2021-3-18](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2021-3-18)         | lts_2021_03   | Active      | 2020-03-18     | 2022-03-18           | 2024-03-17   | 
 | [2020-9-23](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2020-8-19_patch1)  | lts_2020_08   | Active      | 2020-08-19     | 2021-08-19           | 2023-08-19   | 
 | [2020-8-19](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2020-8-19)         | lts_2020_08   | Active      | 2020-08-19     | 2021-08-19           | 2023-08-19   | 

--- a/versions.csv
+++ b/versions.csv
@@ -1,5 +1,5 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.36.0
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.36.1
 iothub\service\src\Microsoft.Azure.Devices.csproj, 1.31.0
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.27.0
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.3


### PR DESCRIPTION
Draft release notes:

## Microsoft Azure IoT Hub SDK for .NET LTS patch Release 2021-06-22

This release is a patch for the [2021-3-18](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2021-3-18) LTS release.

## Microsoft.Azure.Devices.Client.1.36.1

### Bug fixes:
- Update IoT Hub CONNACK timeout to be 60 seconds (#2043, #2044)