### PR TITLE
fix(readme): Update the tag format for LTS patch release

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,7 @@ Below is a table showing the mapping of the LTS branches to the packages release
 
 | Release                                                                                       | Github Branch | LTS Status  | LTS Start Date | Maintenance End Date | LTS End Date | 
 | :-------------------------------------------------------------------------------------------: | :-----------: | :--------:  | :------------: | :------------------: | :----------: | 
-| [2021-6-22](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2021-6-22)         | lts_2021_03   | Active      | 2020-03-18     | 2022-03-18           | 2024-03-17   |                                   
+| [2021-6-23](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2021-3-18_patch1)  | lts_2021_03   | Active      | 2020-03-18     | 2022-03-18           | 2024-03-17   |                                   
 | [2021-3-18](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2021-3-18)         | lts_2021_03   | Active      | 2020-03-18     | 2022-03-18           | 2024-03-17   | 
 | [2020-9-23](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2020-8-19_patch1)  | lts_2020_08   | Active      | 2020-08-19     | 2021-08-19           | 2023-08-19   | 
 | [2020-8-19](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2020-8-19)         | lts_2020_08   | Active      | 2020-08-19     | 2021-08-19           | 2023-08-19   | 


### PR DESCRIPTION
Turns out the tags for LTS patch releases have historically followed a different format. I've updated the format in our 1N.
I also pushed the release date by another day.