### PR TITLE
Update the amqp layer to inspect the inner exception for am amqp error code

### DIFF
--- a/e2e/test/iothub/messaging/MessageSendE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageSendE2ETests.cs
@@ -20,11 +20,20 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
     public partial class MessageSendE2ETests : E2EMsTestBase
     {
         private const int MessageBatchCount = 5;
-        private const int LargeMessageSizeInBytes = 255 * 1024; // The maximum message size for device to cloud messages is 256 KB. We are allowing 1 KB of buffer for message header information etc.
-        private const int ExceedAllowedMessageSizeInBytes = 3000 * 1024;
-        private readonly string DevicePrefix = $"{nameof(MessageSendE2ETests)}_";
-        private readonly string ModulePrefix = $"{nameof(MessageSendE2ETests)}_";
-        private static string ProxyServerAddress = TestConfiguration.IoTHub.ProxyServerAddress;
+
+        // The maximum message size for device to cloud messages is 256 KB. We are allowing 1 KB of buffer for message header information etc.
+        private const int LargeMessageSizeInBytes = 255 * 1024;
+
+        // The size of a device to cloud message. This exceeds the the maximum message size set by the hub; 256 KB.
+        private const int ExceedAllowedMessageSizeInBytes = 300 * 1024;
+
+        // The size of a device to cloud message. This overly exceeds the maximum message size set by the hub, which is 256 KB. The reason why we are testing for this case is because
+        // we noticed a different behavior between this case, and the case where the message size is less than 1 MB.
+        private const int OverlyExceedAllowedMessageSizeInBytes = 3000 * 1024;
+
+        private readonly string _devicePrefix = $"{nameof(MessageSendE2ETests)}_";
+        private readonly string _modulePrefix = $"{nameof(MessageSendE2ETests)}_";
+        private static string s_proxyServerAddress = TestConfiguration.IoTHub.ProxyServerAddress;
 
         [LoggedTestMethod]
         public async Task Message_DeviceSendSingleMessage_Amqp()
@@ -81,7 +90,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         public async Task Message_DeviceSendSingleMessage_Http_WithProxy()
         {
             Client.Http1TransportSettings httpTransportSettings = new Client.Http1TransportSettings();
-            httpTransportSettings.Proxy = new WebProxy(ProxyServerAddress);
+            httpTransportSettings.Proxy = new WebProxy(s_proxyServerAddress);
             ITransportSettings[] transportSettings = new ITransportSettings[] { httpTransportSettings };
 
             await SendSingleMessage(TestDeviceType.Sasl, transportSettings).ConfigureAwait(false);
@@ -106,7 +115,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         public async Task Message_DeviceSendSingleMessage_AmqpWs_WithProxy()
         {
             Client.AmqpTransportSettings amqpTransportSettings = new Client.AmqpTransportSettings(Client.TransportType.Amqp_WebSocket_Only);
-            amqpTransportSettings.Proxy = new WebProxy(ProxyServerAddress);
+            amqpTransportSettings.Proxy = new WebProxy(s_proxyServerAddress);
             ITransportSettings[] transportSettings = new ITransportSettings[] { amqpTransportSettings };
 
             await SendSingleMessage(TestDeviceType.Sasl, transportSettings).ConfigureAwait(false);
@@ -118,7 +127,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         {
             Client.Transport.Mqtt.MqttTransportSettings mqttTransportSettings =
                 new Client.Transport.Mqtt.MqttTransportSettings(Client.TransportType.Mqtt_WebSocket_Only);
-            mqttTransportSettings.Proxy = new WebProxy(ProxyServerAddress);
+            mqttTransportSettings.Proxy = new WebProxy(s_proxyServerAddress);
             ITransportSettings[] transportSettings = new ITransportSettings[] { mqttTransportSettings };
 
             await SendSingleMessage(TestDeviceType.Sasl, transportSettings).ConfigureAwait(false);
@@ -129,7 +138,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         public async Task Message_ModuleSendSingleMessage_AmqpWs_WithProxy()
         {
             Client.AmqpTransportSettings amqpTransportSettings = new Client.AmqpTransportSettings(Client.TransportType.Amqp_WebSocket_Only);
-            amqpTransportSettings.Proxy = new WebProxy(ProxyServerAddress);
+            amqpTransportSettings.Proxy = new WebProxy(s_proxyServerAddress);
             ITransportSettings[] transportSettings = new ITransportSettings[] { amqpTransportSettings };
 
             await SendSingleMessageModule(transportSettings).ConfigureAwait(false);
@@ -141,7 +150,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         {
             Client.Transport.Mqtt.MqttTransportSettings mqttTransportSettings =
                 new Client.Transport.Mqtt.MqttTransportSettings(Client.TransportType.Mqtt_WebSocket_Only);
-            mqttTransportSettings.Proxy = new WebProxy(ProxyServerAddress);
+            mqttTransportSettings.Proxy = new WebProxy(s_proxyServerAddress);
             ITransportSettings[] transportSettings = new ITransportSettings[] { mqttTransportSettings };
 
             await SendSingleMessageModule(transportSettings).ConfigureAwait(false);
@@ -213,7 +222,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [ExpectedException(typeof(MessageTooLargeException))]
         public async Task Message_ClientThrowsForMqttTopicNameTooLong()
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -260,7 +269,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await SendSingleMessage(TestDeviceType.Sasl, Client.TransportType.Amqp_WebSocket_Only, ExceedAllowedMessageSizeInBytes).ConfigureAwait(false);
         }
 
-        // MQTT protocol will throw an InvalidOperationException if the PUBLISH packet is greater than Hub limits: https://github.com/Azure/azure-iot-sdk-csharp/blob/d46e0f07fe8d80e21e07b41c2e75b0bd1fcb8f80/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs#L1175
+        // MQTT protocol will throw an InvalidOperationException if the PUBLISH packet is greater than
+        // Hub limits: https://github.com/Azure/azure-iot-sdk-csharp/blob/d46e0f07fe8d80e21e07b41c2e75b0bd1fcb8f80/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs#L1175
         // This flow is a bit different from other protocols where we do not inspect the packet being sent but rather rely on service validating it
         // and throwing a MessageTooLargeException, if relevant.
         [LoggedTestMethod]
@@ -270,7 +280,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await SendSingleMessage(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only, ExceedAllowedMessageSizeInBytes).ConfigureAwait(false);
         }
 
-        // MQTT protocol will throw an InvalidOperationException if the PUBLISH packet is greater than Hub limits: https://github.com/Azure/azure-iot-sdk-csharp/blob/d46e0f07fe8d80e21e07b41c2e75b0bd1fcb8f80/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs#L1175
+        // MQTT protocol will throw an InvalidOperationException if the PUBLISH packet is greater than
+        // Hub limits: https://github.com/Azure/azure-iot-sdk-csharp/blob/d46e0f07fe8d80e21e07b41c2e75b0bd1fcb8f80/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs#L1175
         // This flow is a bit different from other protocols where we do not inspect the packet being sent but rather rely on service validating it
         // and throwing a MessageTooLargeException, if relevant.
         [LoggedTestMethod]
@@ -287,9 +298,52 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await SendSingleMessage(TestDeviceType.Sasl, Client.TransportType.Http1, ExceedAllowedMessageSizeInBytes).ConfigureAwait(false);
         }
 
+        [LoggedTestMethod]
+        [ExpectedException(typeof(MessageTooLargeException))]
+        public async Task Message_DeviceSendMessageWayOverAllowedSize_Amqp()
+        {
+            await SendSingleMessage(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only, OverlyExceedAllowedMessageSizeInBytes).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        [ExpectedException(typeof(MessageTooLargeException))]
+        public async Task Message_DeviceSendMessageWayOverAllowedSize_AmqpWs()
+        {
+            await SendSingleMessage(TestDeviceType.Sasl, Client.TransportType.Amqp_WebSocket_Only, OverlyExceedAllowedMessageSizeInBytes).ConfigureAwait(false);
+        }
+
+        // MQTT protocol will throw an InvalidOperationException if the PUBLISH packet is greater than
+        // Hub limits: https://github.com/Azure/azure-iot-sdk-csharp/blob/d46e0f07fe8d80e21e07b41c2e75b0bd1fcb8f80/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs#L1175
+        // This flow is a bit different from other protocols where we do not inspect the packet being sent but rather rely on service validating it
+        // and throwing a MessageTooLargeException, if relevant.
+        [LoggedTestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public async Task Message_DeviceSendMessageWayOverAllowedSize_Mqtt()
+        {
+            await SendSingleMessage(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only, OverlyExceedAllowedMessageSizeInBytes).ConfigureAwait(false);
+        }
+
+        // MQTT protocol will throw an InvalidOperationException if the PUBLISH packet is greater than
+        // Hub limits: https://github.com/Azure/azure-iot-sdk-csharp/blob/d46e0f07fe8d80e21e07b41c2e75b0bd1fcb8f80/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs#L1175
+        // This flow is a bit different from other protocols where we do not inspect the packet being sent but rather rely on service validating it
+        // and throwing a MessageTooLargeException, if relevant.
+        [LoggedTestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public async Task Message_DeviceSendMessageWayOverAllowedSize_MqttWs()
+        {
+            await SendSingleMessage(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only, OverlyExceedAllowedMessageSizeInBytes).ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        [ExpectedException(typeof(MessageTooLargeException))]
+        public async Task Message_DeviceSendMessageWayOverAllowedSize_Http()
+        {
+            await SendSingleMessage(TestDeviceType.Sasl, Client.TransportType.Http1, OverlyExceedAllowedMessageSizeInBytes).ConfigureAwait(false);
+        }
+
         private async Task SendSingleMessage(TestDeviceType type, Client.TransportType transport, int messageSize = 0)
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix, type).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix, type).ConfigureAwait(false);
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -299,7 +353,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         private async Task SendBatchMessages(TestDeviceType type, Client.TransportType transport)
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix, type).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix, type).ConfigureAwait(false);
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -309,7 +363,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         private async Task SendSingleMessage(TestDeviceType type, ITransportSettings[] transportSettings, int messageSize = 0)
         {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix, type).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix, type).ConfigureAwait(false);
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(transportSettings);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -319,7 +373,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         private async Task SendSingleMessageModule(ITransportSettings[] transportSettings)
         {
-            TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix, Logger).ConfigureAwait(false);
+            TestModule testModule = await TestModule.GetTestModuleAsync(_devicePrefix, _modulePrefix, Logger).ConfigureAwait(false);
             using var moduleClient = ModuleClient.CreateFromConnectionString(testModule.ConnectionString, transportSettings);
 
             await moduleClient.OpenAsync().ConfigureAwait(false);

--- a/e2e/test/iothub/messaging/MessageSendE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageSendE2ETests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
     {
         private const int MessageBatchCount = 5;
         private const int LargeMessageSizeInBytes = 255 * 1024; // The maximum message size for device to cloud messages is 256 KB. We are allowing 1 KB of buffer for message header information etc.
-        private const int ExceedAllowedMessageSizeInBytes = 300 * 1024;
+        private const int ExceedAllowedMessageSizeInBytes = 3000 * 1024;
         private readonly string DevicePrefix = $"{nameof(MessageSendE2ETests)}_";
         private readonly string ModulePrefix = $"{nameof(MessageSendE2ETests)}_";
         private static string ProxyServerAddress = TestConfiguration.IoTHub.ProxyServerAddress;

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotExceptionAdapter.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotExceptionAdapter.cs
@@ -19,6 +19,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
             {
                 return new UnauthorizedException(exception.Message, exception);
             }
+            else if (exception is OperationCanceledException)
+            {
+                var innerAmqpException = exception.InnerException as AmqpException;
+                return innerAmqpException == null
+                    ? exception
+                    : AmqpIotErrorAdapter.ToIotHubClientContract(innerAmqpException);
+            }
             else
             {
                 var amqpException = exception as AmqpException;

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotExceptionAdapter.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotExceptionAdapter.cs
@@ -15,24 +15,26 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
             {
                 return new IotHubCommunicationException(exception.Message, exception);
             }
-            else if (exception is UnauthorizedAccessException)
+
+            if (exception is UnauthorizedAccessException)
             {
                 return new UnauthorizedException(exception.Message, exception);
             }
-            else if (exception is OperationCanceledException)
+
+            if (exception is OperationCanceledException
+                && exception.InnerException is AmqpException innerAmqpException
+                && innerAmqpException != null)
             {
-                var innerAmqpException = exception.InnerException as AmqpException;
-                return innerAmqpException == null
-                    ? exception
-                    : AmqpIotErrorAdapter.ToIotHubClientContract(innerAmqpException);
+                return AmqpIotErrorAdapter.ToIotHubClientContract(innerAmqpException);
             }
-            else
+
+            if (exception is AmqpException amqpException
+                && amqpException != null)
             {
-                var amqpException = exception as AmqpException;
-                return amqpException == null
-                    ? exception
-                    : AmqpIotErrorAdapter.ToIotHubClientContract(amqpException);
+                return AmqpIotErrorAdapter.ToIotHubClientContract(amqpException);
             }
+
+            return exception;
         }
 
         internal static Exception ConvertToIotHubException(Exception exception, AmqpObject source)

--- a/iothub/device/src/Transport/ProtocolRoutingDelegatingHandler.cs
+++ b/iothub/device/src/Transport/ProtocolRoutingDelegatingHandler.cs
@@ -10,8 +10,8 @@ using Microsoft.Azure.Devices.Shared;
 namespace Microsoft.Azure.Devices.Client.Transport
 {
     /// <summary>
-    /// Transport handler router. 
-    /// Tries to open the connection in the protocol order it was set. 
+    /// Transport handler router.
+    /// Tries to open the connection in the protocol order it was set.
     /// If fails tries to open the next one, etc.
     /// </summary>
     internal class ProtocolRoutingDelegatingHandler : DefaultDelegatingHandler
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         /// After we've verified that we could open the transport for any operation, we will stop attempting others in the list.
         /// </summary>
         private bool _transportSelectionComplete;
+
         private int _nextTransportIndex;
 
         private SemaphoreSlim _handlerLock = new SemaphoreSlim(1, 1);

--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,7 @@ Below is a table showing the mapping of the LTS branches to the packages release
 
 | Release                                                                                       | Github Branch | LTS Status  | LTS Start Date | Maintenance End Date | LTS End Date | 
 | :-------------------------------------------------------------------------------------------: | :-----------: | :--------:  | :------------: | :------------------: | :----------: | 
+| [2021-6-23](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2021-3-18_patch1)  | lts_2021_03   | Active      | 2020-03-18     | 2022-03-18           | 2024-03-17   |                                   
 | [2021-3-18](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2021-3-18)         | lts_2021_03   | Active      | 2020-03-18     | 2022-03-18           | 2024-03-17   | 
 | [2020-9-23](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2020-8-19_patch1)  | lts_2020_08   | Active      | 2020-08-19     | 2021-08-19           | 2023-08-19   | 
 | [2020-8-19](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2020-8-19)         | lts_2020_08   | Active      | 2020-08-19     | 2021-08-19           | 2023-08-19   | 


### PR DESCRIPTION
When link detaches are initiated by the amqp library on service side, the initiated operation is cancelled ungracefully. This results in an `OperationCancelledException` being thrown. The actual amqp error is present as an inner exception, though.

Since we've not been inspecting these inner exceptions for an amqp error code, this inspection can now be done in three stages:
- If exception thrown is `OperationCancelledException` and inner amqp error code is `AmqpErrorCode.MessageSizeExceeded` -> throw a `MessageTooLargeException`. 
    - Previously - `OperationCancelledException` was thrown. It is a transient exception which was retried. This is a bug.
    - Now - `MessageTooLargeException` will be thrown. It is a terminal exception. 
    This is _technically_ a breaking change since previously customers would be receiving an `OperationCancelledException` but now they'd be receiving a `MessageTooLargeException`. However, behavior wise, the client wouldn't ever succeed previously, nor would it succeed now. Additionally, previously it would retry needlessly, while now it would fail-fast.

- If exception thrown is `OperationCancelledException` and inner exception is an `AmqpException` -> throw the exception based on inner exception.
    - Previously - `OperationCancelledException` was thrown. It is a transient exception which was retried. This could be the correct behavior for some scenarios while incorrect for others.
    - Now - Depending on the inner `AmqpExeception` the operation will be retried.
    This is a wider breaking change since previously customers would be receiving an `OperationCancelledException` but now they'd be receiving an exception depending on what the inner exception is.
        - Inner exception is not `AmqpExeception` -> sdk retries, no behavior change.
        - Inner exception is `AmqpExeception` and is transient -> sdk retries, no behavior change.
        - Inner exception is `AmqpExeception` and is terminal -> sdk will not retry. This would have always failed, however previously customers would have received an `OperationCancelledException` while now they'd be receiving a different exception based on the inner exception.
 
- For all non `AmqpException` exceptions, if inner exception is an `AmqpException` -> throw the exception based on inner exception.
    - Previously - whatever exception was caught would have been retried or rethrown.
    - Now - Depending on the inner `AmqpExeception` the operation will be retried.
    Ideally we should have done this from the beginning, but doing this now can potentially have the most breaking change effect. Based on how many scenarios actually have the exception nested in an inner exception, all those cases might now throw a different exception. Even though I think the end result will be desirable, i.e. the sdk will retry based more information that is provided to it; the extent of change in behavior might be too large.

This PR implements option (2), where I think the cost-return is a bit more balanced (not specific to the one message size exceeded scenario).
