### PR TITLE
TryGetValue methods should check for the component identifier when applicable and should not throw any exceptions

### DIFF
--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.Devices.Client
                     // First verify that the retrieved dictionary contains the component identifier { "__t": "c" }.
                     // If not, then the retrieved nested dictionary is actually a root-level property of type map.
                     if (nestedDictionary.TryGetValue(ConventionBasedConstants.ComponentIdentifierKey, out object componentIdentifierValue)
-                        && componentIdentifierValue == ConventionBasedConstants.ComponentIdentifierValue)
+                        && componentIdentifierValue.ToString() == ConventionBasedConstants.ComponentIdentifierValue)
                     {
                         if (nestedDictionary.TryGetValue(propertyName, out object dictionaryElement))
                         {

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.Devices.Client
             }
 
             // If either the component name or the property name is null, empty or whitespace,
-            // then return unsuccessfully (false) with the default value of the type <T> passed in.
+            // then return false with the default value of the type <T> passed in.
             if (string.IsNullOrWhiteSpace(componentName) || string.IsNullOrWhiteSpace(propertyName))
             {
                 propertyValue = default;
@@ -201,11 +201,11 @@ namespace Microsoft.Azure.Devices.Client
                     // First verify that the retrieved dictionary contains the component identifier { "__t": "c" }.
                     // If not, then the retrieved nested dictionary is actually a root-level property of type map.
                     if (nestedDictionary.TryGetValue(ConventionBasedConstants.ComponentIdentifierKey, out object componentIdentifierValue)
-                        && componentIdentifierValue.Equals(ConventionBasedConstants.ComponentIdentifierValue))
+                        && componentIdentifierValue == ConventionBasedConstants.ComponentIdentifierValue)
                     {
                         if (nestedDictionary.TryGetValue(propertyName, out object dictionaryElement))
                         {
-                            // If the value associated with the key is null, then return successfully (true) with the default value of the type <T> passed in.
+                            // If the value associated with the key is null, then return true with the default value of the type <T> passed in.
                             if (dictionaryElement == null)
                             {
                                 propertyValue = default;
@@ -234,7 +234,7 @@ namespace Microsoft.Azure.Devices.Client
                         if (Convention
                             .PayloadSerializer
                             .TryGetNestedObjectValue(componentProperties, ConventionBasedConstants.ComponentIdentifierKey, out string componentIdentifierValue)
-                            && componentIdentifierValue.Equals(ConventionBasedConstants.ComponentIdentifierValue))
+                            && componentIdentifierValue == ConventionBasedConstants.ComponentIdentifierValue)
                         {
                             // Since the value cannot be cast to <T> directly, we need to try to convert it using the serializer.
                             // If it can be successfully converted, go ahead and return it.
@@ -245,7 +245,7 @@ namespace Microsoft.Azure.Devices.Client
                     catch
                     {
                         // In case the value cannot be converted using the serializer,
-                        // then return unsuccessfully (false) with the default value of the type <T> passed in.
+                        // then return false with the default value of the type <T> passed in.
                     }
                 }
             }

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -206,9 +206,16 @@ namespace Microsoft.Azure.Devices.Client
                 }
                 else
                 {
-                    // If it's not, we need to try to convert it using the serializer.
-                    Convention.PayloadSerializer.TryGetNestedObjectValue<T>(componentProperties, propertyName, out propertyValue);
-                    return true;
+                    try
+                    {
+                        // If it's not, we need to try to convert it using the serializer.
+                        Convention.PayloadSerializer.TryGetNestedObjectValue<T>(componentProperties, propertyName, out propertyValue);
+                        return true;
+                    }
+                    catch
+                    {
+                        // In case the value cannot be converted using the serializer, TryGetValue should return the default value.
+                    }
                 }
             }
 

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -170,8 +170,8 @@ namespace Microsoft.Azure.Devices.Client
         /// <typeparam name="T">The type to cast the object to.</typeparam>
         /// <param name="componentName">The component which holds the required property.</param>
         /// <param name="propertyName">The property to get.</param>
-        /// <param name="propertyValue">When this method returns successfully, this contains the value of the component-level property.
-        /// When this method returns unsuccessfully, this contains the default value of the type <c>T</c> passed in.</param>
+        /// <param name="propertyValue">When this method returns true, this contains the value of the component-level property.
+        /// When this method returns false, this contains the default value of the type <c>T</c> passed in.</param>
         /// <returns>True if a component-level property of type <c>T</c> with the specified key was found; otherwise, it returns false.</returns>
         public virtual bool TryGetValue<T>(string componentName, string propertyName, out T propertyValue)
         {

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -107,9 +107,6 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Gets the value of the object from the collection.
         /// </summary>
-        /// <remarks>
-        /// This class is used for both sending and receiving properties for the device.
-        /// </remarks>
         /// <typeparam name="T">The type to cast the object to.</typeparam>
         /// <param name="key">The key of the property to get.</param>
         /// <param name="value">When this method returns successfully, this contains the value of the object from the collection.
@@ -123,8 +120,8 @@ namespace Microsoft.Azure.Devices.Client
                     $"TryGetValue will attempt to get the property value but may not behave as expected.", nameof(TryGetValue));
             }
 
-            // If the key is null, then return unsuccessfully (false) with the default value of the type <T> passed in.
-            if (key == null)
+            // If the key is null, empty or whitespace, then return unsuccessfully (false) with the default value of the type <T> passed in.
+            if (string.IsNullOrWhiteSpace(key))
             {
                 value = default;
                 return false;

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.Devices.Client
 
                 try
                 {
-                    // If it's not, we need to try to convert it using the serializer.
+                    // If the value cannot be cast to <T> directly, we need to try to convert it using the serializer.
                     // If it can be successfully converted, go ahead and return it.
                     value = Convention.PayloadSerializer.ConvertFromObject<T>(Collection[key]);
                     return true;

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.Client
                     $"TryGetValue will attempt to get the property value but may not behave as expected.", nameof(TryGetValue));
             }
 
-            // If the key is null, empty or whitespace, then return unsuccessfully (false) with the default value of the type <T> passed in.
+            // If the key is null, empty or whitespace, then return false with the default value of the type <T> passed in.
             if (string.IsNullOrWhiteSpace(key))
             {
                 value = default;
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Devices.Client
 
             if (Collection.ContainsKey(key))
             {
-                // If the value associated with the key is null, then return successfully (true) with the default value of the type <T> passed in.
+                // If the value associated with the key is null, then return true with the default value of the type <T> passed in.
                 if (Collection[key] == null)
                 {
                     value = default;
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Devices.Client
                 catch
                 {
                     // In case the value cannot be converted using the serializer,
-                    // then return unsuccessfully (false) with the default value of the type <T> passed in.
+                    // then return false with the default value of the type <T> passed in.
                 }
             }
 

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -112,8 +112,9 @@ namespace Microsoft.Azure.Devices.Client
         /// </remarks>
         /// <typeparam name="T">The type to cast the object to.</typeparam>
         /// <param name="key">The key of the property to get.</param>
-        /// <param name="value">The value of the object from the collection.</param>
-        /// <returns>True if the collection contains an element with the specified key; otherwise, it returns false.</returns>
+        /// <param name="value">When this method returns successfully, this contains the value of the object from the collection.
+        /// When this method returns unsuccessfully, this contains the default value of the type <c>T</c> passed in.</param>
+        /// <returns>True if a value of type <c>T</c> with the specified key was found; otherwise, it returns false.</returns>
         public bool TryGetValue<T>(string key, out T value)
         {
             if (Logging.IsEnabled && Convention == null)
@@ -122,9 +123,16 @@ namespace Microsoft.Azure.Devices.Client
                     $"TryGetValue will attempt to get the property value but may not behave as expected.", nameof(TryGetValue));
             }
 
+            // If the key is null, then return unsuccessfully (false) with the default value of the type <T> passed in.
+            if (key == null)
+            {
+                value = default;
+                return false;
+            }
+
             if (Collection.ContainsKey(key))
             {
-                // If the value is null, go ahead and return it.
+                // If the value associated with the key is null, then return successfully (true) with the default value of the type <T> passed in.
                 if (Collection[key] == null)
                 {
                     value = default;
@@ -142,12 +150,14 @@ namespace Microsoft.Azure.Devices.Client
                 try
                 {
                     // If it's not, we need to try to convert it using the serializer.
+                    // If it can be successfully converted, go ahead and return it.
                     value = Convention.PayloadSerializer.ConvertFromObject<T>(Collection[key]);
                     return true;
                 }
                 catch
                 {
-                    // In case the value cannot be converted using the serializer, TryGetValue should return the default value.
+                    // In case the value cannot be converted using the serializer,
+                    // then return unsuccessfully (false) with the default value of the type <T> passed in.
                 }
             }
 

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -139,9 +139,16 @@ namespace Microsoft.Azure.Devices.Client
                     return true;
                 }
 
-                // If it's not, we need to try to convert it using the serializer.
-                value = Convention.PayloadSerializer.ConvertFromObject<T>(Collection[key]);
-                return true;
+                try
+                {
+                    // If it's not, we need to try to convert it using the serializer.
+                    value = Convention.PayloadSerializer.ConvertFromObject<T>(Collection[key]);
+                    return true;
+                }
+                catch
+                {
+                    // In case the value cannot be converted using the serializer, TryGetValue should return the default value.
+                }
             }
 
             value = default;

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -109,8 +109,8 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <typeparam name="T">The type to cast the object to.</typeparam>
         /// <param name="key">The key of the property to get.</param>
-        /// <param name="value">When this method returns successfully, this contains the value of the object from the collection.
-        /// When this method returns unsuccessfully, this contains the default value of the type <c>T</c> passed in.</param>
+        /// <param name="value">When this method returns true, this contains the value of the object from the collection.
+        /// When this method returns false, this contains the default value of the type <c>T</c> passed in.</param>
         /// <returns>True if a value of type <c>T</c> with the specified key was found; otherwise, it returns false.</returns>
         public bool TryGetValue<T>(string key, out T value)
         {

--- a/iothub/device/tests/ClientPropertyCollectionTests.cs
+++ b/iothub/device/tests/ClientPropertyCollectionTests.cs
@@ -161,23 +161,45 @@ namespace Microsoft.Azure.Devices.Client.Tests
         }
 
         [TestMethod]
+        public void ClientPropertyCollection_TryGetValueShouldReturnFalseIfValueNotFound()
+        {
+            var clientProperties = new ClientPropertyCollection();
+            clientProperties.AddRootProperty(StringPropertyName, StringPropertyValue);
+
+            bool isValueRetrieved = clientProperties.TryGetValue(IntPropertyName, out int outIntValue);
+            isValueRetrieved.Should().BeFalse();
+            outIntValue.Should().Be(default);
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_TryGetValueShouldReturnFalseIfValueCouldNotBeDeserialized()
+        {
+            var clientProperties = new ClientPropertyCollection();
+            clientProperties.AddRootProperty(StringPropertyName, StringPropertyValue);
+
+            bool isValueRetrieved = clientProperties.TryGetValue(StringPropertyName, out int outIntValue);
+            isValueRetrieved.Should().BeFalse();
+            outIntValue.Should().Be(default);
+        }
+
+        [TestMethod]
         public void ClientPropertyCollection_CanAddSimpleObjectWithComponentAndGetBackWithoutDeviceClient()
         {
-            var clientProperties = new ClientPropertyCollection
+            var componentLevelProperties = new Dictionary<string, object>
             {
-                { ComponentName, new Dictionary<string, object> {
-                    { StringPropertyName, StringPropertyValue },
-                    { BoolPropertyName, BoolPropertyValue },
-                    { DoublePropertyName, DoublePropertyValue },
-                    { FloatPropertyName, FloatPropertyValue },
-                    { IntPropertyName, IntPropertyValue },
-                    { ShortPropertyName, ShortPropertyValue },
-                    { ObjectPropertyName, s_objectPropertyValue },
-                    { ArrayPropertyName, s_arrayPropertyValue },
-                    { MapPropertyName, s_mapPropertyValue },
-                    { DateTimePropertyName, s_dateTimePropertyValue } }
-                }
+                { StringPropertyName, StringPropertyValue },
+                { BoolPropertyName, BoolPropertyValue },
+                { DoublePropertyName, DoublePropertyValue },
+                { FloatPropertyName, FloatPropertyValue },
+                { IntPropertyName, IntPropertyValue },
+                { ShortPropertyName, ShortPropertyValue },
+                { ObjectPropertyName, s_objectPropertyValue },
+                { ArrayPropertyName, s_arrayPropertyValue },
+                { MapPropertyName, s_mapPropertyValue },
+                { DateTimePropertyName, s_dateTimePropertyValue }
             };
+            var clientProperties = new ClientPropertyCollection();
+            clientProperties.AddComponentProperties(ComponentName, componentLevelProperties);
 
             clientProperties.TryGetValue(ComponentName, StringPropertyName, out string stringOutValue);
             stringOutValue.Should().Be(StringPropertyValue);
@@ -307,6 +329,41 @@ namespace Microsoft.Azure.Devices.Client.Tests
 
             outValue.Should().Be(StringPropertyValue);
             componentOut.Should().Be(ConventionBasedConstants.ComponentIdentifierValue);
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_TryGetValueWithComponentShouldReturnFalseIfValueNotFound()
+        {
+            var clientProperties = new ClientPropertyCollection();
+            clientProperties.AddComponentProperty(ComponentName, StringPropertyName, StringPropertyValue);
+
+            bool isValueRetrieved = clientProperties.TryGetValue(ComponentName, IntPropertyName, out int outIntValue);
+            isValueRetrieved.Should().BeFalse();
+            outIntValue.Should().Be(default);
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_TryGetValueWithComponentShouldReturnFalseIfValueCouldNotBeDeserialized()
+        {
+            var clientProperties = new ClientPropertyCollection();
+            clientProperties.AddComponentProperty(ComponentName, StringPropertyName, StringPropertyValue);
+
+            bool isValueRetrieved = clientProperties.TryGetValue(ComponentName, StringPropertyName, out int outIntValue);
+            isValueRetrieved.Should().BeFalse();
+            outIntValue.Should().Be(default);
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_TryGetValueWithComponentShouldReturnFalseIfNotAComponent()
+        {
+            var clientProperties = new ClientPropertyCollection();
+            clientProperties.AddRootProperty(MapPropertyName, s_mapPropertyValue);
+
+            string incorrectComponentName = MapPropertyName;
+            string incorrectComponentPropertyName = "key1";
+            bool isValueRetrieved = clientProperties.TryGetValue(incorrectComponentName, incorrectComponentPropertyName, out object propertyValue);
+            isValueRetrieved.Should().BeFalse();
+            propertyValue.Should().Be(default);
         }
     }
 

--- a/iothub/device/tests/ClientPropertyCollectionTests.cs
+++ b/iothub/device/tests/ClientPropertyCollectionTests.cs
@@ -359,9 +359,9 @@ namespace Microsoft.Azure.Devices.Client.Tests
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddRootProperty(MapPropertyName, s_mapPropertyValue);
 
-            string incorrectComponentName = MapPropertyName;
-            string incorrectComponentPropertyName = "key1";
-            bool isValueRetrieved = clientProperties.TryGetValue(incorrectComponentName, incorrectComponentPropertyName, out object propertyValue);
+            string incorrectlyMappedComponentName = MapPropertyName;
+            string incorrectlyMappedComponentPropertyName = "key1";
+            bool isValueRetrieved = clientProperties.TryGetValue(incorrectlyMappedComponentName, incorrectlyMappedComponentPropertyName, out object propertyValue);
             isValueRetrieved.Should().BeFalse();
             propertyValue.Should().Be(default);
         }

--- a/iothub/device/tests/ClientPropertyCollectionTests.cs
+++ b/iothub/device/tests/ClientPropertyCollectionTests.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_CanAddSimpleObjectsAndGetBackWithoutDeviceClient()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection
             {
                 { StringPropertyName, StringPropertyValue },
@@ -69,6 +70,8 @@ namespace Microsoft.Azure.Devices.Client.Tests
                 { MapPropertyName, s_mapPropertyValue },
                 { DateTimePropertyName, s_dateTimePropertyValue }
             };
+
+            // act, assert
 
             clientProperties.TryGetValue(StringPropertyName, out string stringOutValue);
             stringOutValue.Should().Be(StringPropertyValue);
@@ -107,26 +110,35 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_AddSimpleObjectAgainThrowsException()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection
             {
                 { StringPropertyName, StringPropertyValue }
             };
 
+            // act
             Action act = () => clientProperties.AddRootProperty(StringPropertyName, StringPropertyValue);
+
+            // assert
             act.Should().Throw<ArgumentException>("\"Add\" method does not support adding a key that already exists in the collection.");
         }
 
         [TestMethod]
         public void ClientPropertyCollection_CanUpdateSimpleObjectAndGetBackWithoutDeviceClient()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection
             {
                 { StringPropertyName, StringPropertyValue }
             };
+
+            // act, assert
+
             clientProperties.TryGetValue(StringPropertyName, out string outValue);
             outValue.Should().Be(StringPropertyValue);
 
             clientProperties.AddOrUpdateRootProperty(StringPropertyName, UpdatedPropertyValue);
+
             clientProperties.TryGetValue(StringPropertyName, out string outValueChanged);
             outValueChanged.Should().Be(UpdatedPropertyValue, "\"AddOrUpdate\" should overwrite the value if the key already exists in the collection.");
         }
@@ -134,10 +146,12 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_CanAddNullPropertyAndGetBackWithoutDeviceClient()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddRootProperty(StringPropertyName, StringPropertyValue);
             clientProperties.AddRootProperty(IntPropertyName, null);
 
+            // act, assert
             clientProperties.TryGetValue(StringPropertyName, out string outStringValue);
             outStringValue.Should().Be(StringPropertyValue);
 
@@ -149,9 +163,12 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_CanAddMultiplePropertyAndGetBackWithoutDeviceClient()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddRootProperty(StringPropertyName, StringPropertyValue);
             clientProperties.AddRootProperty(IntPropertyName, IntPropertyValue);
+
+            // act, assert
 
             clientProperties.TryGetValue(StringPropertyName, out string outStringValue);
             outStringValue.Should().Be(StringPropertyValue);
@@ -163,10 +180,14 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_TryGetValueShouldReturnFalseIfValueNotFound()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddRootProperty(StringPropertyName, StringPropertyValue);
 
+            // act
             bool isValueRetrieved = clientProperties.TryGetValue(IntPropertyName, out int outIntValue);
+
+            // assert
             isValueRetrieved.Should().BeFalse();
             outIntValue.Should().Be(default);
         }
@@ -174,10 +195,14 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_TryGetValueShouldReturnFalseIfValueCouldNotBeDeserialized()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddRootProperty(StringPropertyName, StringPropertyValue);
 
+            // act
             bool isValueRetrieved = clientProperties.TryGetValue(StringPropertyName, out int outIntValue);
+
+            // assert
             isValueRetrieved.Should().BeFalse();
             outIntValue.Should().Be(default);
         }
@@ -185,6 +210,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_CanAddSimpleObjectWithComponentAndGetBackWithoutDeviceClient()
         {
+            // arrange
             var componentLevelProperties = new Dictionary<string, object>
             {
                 { StringPropertyName, StringPropertyValue },
@@ -200,6 +226,8 @@ namespace Microsoft.Azure.Devices.Client.Tests
             };
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddComponentProperties(ComponentName, componentLevelProperties);
+
+            // act, assert
 
             clientProperties.TryGetValue(ComponentName, StringPropertyName, out string stringOutValue);
             stringOutValue.Should().Be(StringPropertyValue);
@@ -238,18 +266,25 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_AddSimpleObjectWithComponentAgainThrowsException()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddComponentProperty(ComponentName, StringPropertyName, StringPropertyValue);
 
+            // act
             Action act = () => clientProperties.AddComponentProperty(ComponentName, StringPropertyName, StringPropertyValue);
+
+            // assert
             act.Should().Throw<ArgumentException>("\"Add\" method does not support adding a key that already exists in the collection.");
         }
 
         [TestMethod]
         public void ClientPropertyCollection_CanUpdateSimpleObjectWithComponentAndGetBackWithoutDeviceClient()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddComponentProperty(ComponentName, StringPropertyName, StringPropertyValue);
+
+            // act, assert
 
             clientProperties.TryGetValue(ComponentName, StringPropertyName, out string outValue);
             outValue.Should().Be(StringPropertyValue);
@@ -262,9 +297,12 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_CanAddNullPropertyWithComponentAndGetBackWithoutDeviceClient()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddComponentProperty(ComponentName, StringPropertyName, StringPropertyValue);
             clientProperties.AddComponentProperty(ComponentName, IntPropertyName, null);
+
+            // act, assert
 
             clientProperties.TryGetValue(ComponentName, StringPropertyName, out string outStringValue);
             outStringValue.Should().Be(StringPropertyValue);
@@ -277,9 +315,12 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_CanAddMultiplePropertyWithComponentAndGetBackWithoutDeviceClient()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddComponentProperty(ComponentName, StringPropertyName, StringPropertyValue);
             clientProperties.AddComponentProperty(ComponentName, IntPropertyName, IntPropertyValue);
+
+            // act, assert
 
             clientProperties.TryGetValue(ComponentName, StringPropertyName, out string outStringValue);
             outStringValue.Should().Be(StringPropertyValue);
@@ -291,12 +332,15 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_CanAddSimpleWritablePropertyAndGetBackWithoutDeviceClient()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
-
             var writableResponse = new NewtonsoftJsonWritablePropertyResponse(StringPropertyValue, CommonClientResponseCodes.OK, 2, WritablePropertyDescription);
             clientProperties.AddRootProperty(StringPropertyName, writableResponse);
 
+            // act
             clientProperties.TryGetValue(StringPropertyName, out NewtonsoftJsonWritablePropertyResponse outValue);
+
+            // assert
             outValue.Value.Should().Be(writableResponse.Value);
             outValue.AckCode.Should().Be(writableResponse.AckCode);
             outValue.AckVersion.Should().Be(writableResponse.AckVersion);
@@ -306,12 +350,15 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_CanAddWritablePropertyWithComponentAndGetBackWithoutDeviceClient()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
-
             var writableResponse = new NewtonsoftJsonWritablePropertyResponse(StringPropertyValue, CommonClientResponseCodes.OK, 2, WritablePropertyDescription);
             clientProperties.AddComponentProperty(ComponentName, StringPropertyName, writableResponse);
 
+            // act
             clientProperties.TryGetValue(ComponentName, StringPropertyName, out NewtonsoftJsonWritablePropertyResponse outValue);
+
+            // assert
             outValue.Value.Should().Be(writableResponse.Value);
             outValue.AckCode.Should().Be(writableResponse.AckCode);
             outValue.AckVersion.Should().Be(writableResponse.AckVersion);
@@ -321,12 +368,15 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_AddingComponentAddsComponentIdentifier()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddComponentProperty(ComponentName, StringPropertyName, StringPropertyValue);
 
+            // act
             clientProperties.TryGetValue(ComponentName, StringPropertyName, out string outValue);
             clientProperties.TryGetValue(ComponentName, ConventionBasedConstants.ComponentIdentifierKey, out string componentOut);
 
+            // assert
             outValue.Should().Be(StringPropertyValue);
             componentOut.Should().Be(ConventionBasedConstants.ComponentIdentifierValue);
         }
@@ -334,10 +384,14 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_TryGetValueWithComponentShouldReturnFalseIfValueNotFound()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddComponentProperty(ComponentName, StringPropertyName, StringPropertyValue);
 
+            // act
             bool isValueRetrieved = clientProperties.TryGetValue(ComponentName, IntPropertyName, out int outIntValue);
+
+            // assert
             isValueRetrieved.Should().BeFalse();
             outIntValue.Should().Be(default);
         }
@@ -345,10 +399,14 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_TryGetValueWithComponentShouldReturnFalseIfValueCouldNotBeDeserialized()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddComponentProperty(ComponentName, StringPropertyName, StringPropertyValue);
 
+            // act
             bool isValueRetrieved = clientProperties.TryGetValue(ComponentName, StringPropertyName, out int outIntValue);
+
+            // assert
             isValueRetrieved.Should().BeFalse();
             outIntValue.Should().Be(default);
         }
@@ -356,12 +414,16 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollection_TryGetValueWithComponentShouldReturnFalseIfNotAComponent()
         {
+            // arrange
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddRootProperty(MapPropertyName, s_mapPropertyValue);
-
             string incorrectlyMappedComponentName = MapPropertyName;
             string incorrectlyMappedComponentPropertyName = "key1";
+
+            // act
             bool isValueRetrieved = clientProperties.TryGetValue(incorrectlyMappedComponentName, incorrectlyMappedComponentPropertyName, out object propertyValue);
+
+            // assert
             isValueRetrieved.Should().BeFalse();
             propertyValue.Should().Be(default);
         }

--- a/iothub/device/tests/ClientPropertyCollectionTestsNewtonsoft.cs
+++ b/iothub/device/tests/ClientPropertyCollectionTestsNewtonsoft.cs
@@ -281,9 +281,9 @@ namespace Microsoft.Azure.Devices.Client.Tests
         {
             var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionToRoundTrip, DefaultPayloadConvention.Instance);
 
-            string incorrectComponentName = MapPropertyName;
-            string incorrectComponentPropertyName = "key1";
-            bool isValueRetrieved = clientProperties.TryGetValue(incorrectComponentName, incorrectComponentPropertyName, out object propertyValue);
+            string incorrectlyMappedComponentName = MapPropertyName;
+            string incorrectlyMappedComponentPropertyName = "key1";
+            bool isValueRetrieved = clientProperties.TryGetValue(incorrectlyMappedComponentName, incorrectlyMappedComponentPropertyName, out object propertyValue);
             isValueRetrieved.Should().BeFalse();
             propertyValue.Should().Be(default);
         }

--- a/iothub/device/tests/ClientPropertyCollectionTestsNewtonsoft.cs
+++ b/iothub/device/tests/ClientPropertyCollectionTestsNewtonsoft.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
 
             bool isValueRetrieved = clientProperties.TryGetValue("thisPropertyDoesNotExist", out int outIntValue);
             isValueRetrieved.Should().BeFalse();
-            outIntValue.Should().Be(default(int));
+            outIntValue.Should().Be(default);
         }
 
         [TestMethod]
@@ -253,7 +253,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
 
             bool isValueRetrieved = clientProperties.TryGetValue(ComponentName, "thisPropertyDoesNotExist", out int outIntValue);
             isValueRetrieved.Should().BeFalse();
-            outIntValue.Should().Be(default(int));
+            outIntValue.Should().Be(default);
         }
 
         [TestMethod]
@@ -263,7 +263,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
 
             bool isValueRetrieved = clientProperties.TryGetValue(StringPropertyName, out int outIntValue);
             isValueRetrieved.Should().BeFalse();
-            outIntValue.Should().Be(default(int));
+            outIntValue.Should().Be(default);
         }
 
         [TestMethod]
@@ -273,7 +273,19 @@ namespace Microsoft.Azure.Devices.Client.Tests
 
             bool isValueRetrieved = clientProperties.TryGetValue(ComponentName, StringPropertyName, out int outIntValue);
             isValueRetrieved.Should().BeFalse();
-            outIntValue.Should().Be(default(int));
+            outIntValue.Should().Be(default);
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollectionNewtonSoft_TryGetValueWithComponentShouldReturnFalseIfNotAComponent()
+        {
+            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionToRoundTrip, DefaultPayloadConvention.Instance);
+
+            string incorrectComponentName = MapPropertyName;
+            string incorrectComponentPropertyName = "key1";
+            bool isValueRetrieved = clientProperties.TryGetValue(incorrectComponentName, incorrectComponentPropertyName, out object propertyValue);
+            isValueRetrieved.Should().BeFalse();
+            propertyValue.Should().Be(default);
         }
     }
 

--- a/iothub/device/tests/ClientPropertyCollectionTestsNewtonsoft.cs
+++ b/iothub/device/tests/ClientPropertyCollectionTestsNewtonsoft.cs
@@ -121,7 +121,10 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollectionNewtonsoft_CanGetValue()
         {
+            // arrange
             var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionToRoundTrip, DefaultPayloadConvention.Instance);
+
+            // act, assert
 
             clientProperties.TryGetValue(StringPropertyName, out string stringOutValue);
             stringOutValue.Should().Be(StringPropertyValue);
@@ -162,7 +165,10 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollectionNewtonsoft_CanGetValueWithComponent()
         {
+            // arrange
             var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWithComponentToRoundTrip, DefaultPayloadConvention.Instance);
+
+            // act, assert
 
             clientProperties.TryGetValue(ComponentName, StringPropertyName, out string stringOutValue);
             stringOutValue.Should().Be(StringPropertyValue);
@@ -203,9 +209,13 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollectionNewtonsoft_CanAddSimpleWritablePropertyAndGetBack()
         {
+            // arrange
             var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWritablePropertyToRoundTrip, DefaultPayloadConvention.Instance);
 
+            // act
             clientProperties.TryGetValue(StringPropertyName, out NewtonsoftJsonWritablePropertyResponse outValue);
+
+            // assert
             outValue.Value.Should().Be(StringPropertyValue);
             outValue.AckCode.Should().Be(s_writablePropertyResponse.AckCode);
             outValue.AckVersion.Should().Be(s_writablePropertyResponse.AckVersion);
@@ -215,9 +225,13 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollectionNewtonsoft_CanAddWritablePropertyWithComponentAndGetBack()
         {
+            // arrange
             var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWritablePropertyWithComponentToRoundTrip, DefaultPayloadConvention.Instance);
 
+            // act
             clientProperties.TryGetValue(ComponentName, StringPropertyName, out NewtonsoftJsonWritablePropertyResponse outValue);
+
+            // assert
             outValue.Value.Should().Be(StringPropertyValue);
             outValue.AckCode.Should().Be(s_writablePropertyResponse.AckCode);
             outValue.AckVersion.Should().Be(s_writablePropertyResponse.AckVersion);
@@ -227,11 +241,14 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollectionNewtonsoft_CanGetComponentIdentifier()
         {
+            // arrange
             var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWithComponentToRoundTrip, DefaultPayloadConvention.Instance);
 
+            // act
             clientProperties.TryGetValue(ComponentName, StringPropertyName, out string outValue);
             clientProperties.TryGetValue(ComponentName, ConventionBasedConstants.ComponentIdentifierKey, out string componentOut);
 
+            // assert
             outValue.Should().Be(StringPropertyValue);
             componentOut.Should().Be(ConventionBasedConstants.ComponentIdentifierValue);
         }
@@ -239,9 +256,13 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollectionNewtonSoft_TryGetValueShouldReturnFalseIfValueNotFound()
         {
+            // arrange
             var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionToRoundTrip, DefaultPayloadConvention.Instance);
 
+            // act
             bool isValueRetrieved = clientProperties.TryGetValue("thisPropertyDoesNotExist", out int outIntValue);
+
+            // assert
             isValueRetrieved.Should().BeFalse();
             outIntValue.Should().Be(default);
         }
@@ -249,9 +270,13 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollectionNewtonSoft_TryGetValueWithComponentShouldReturnFalseIfValueNotFound()
         {
+            // arrange
             var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWithComponentToRoundTrip, DefaultPayloadConvention.Instance);
 
+            // act
             bool isValueRetrieved = clientProperties.TryGetValue(ComponentName, "thisPropertyDoesNotExist", out int outIntValue);
+
+            // assert
             isValueRetrieved.Should().BeFalse();
             outIntValue.Should().Be(default);
         }
@@ -269,9 +294,13 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollectionNewtonSoft_TryGetValueWithComponentShouldReturnFalseIfValueCouldNotBeDeserialized()
         {
+            // arrange
             var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWithComponentToRoundTrip, DefaultPayloadConvention.Instance);
 
+            // act
             bool isValueRetrieved = clientProperties.TryGetValue(ComponentName, StringPropertyName, out int outIntValue);
+
+            // assert
             isValueRetrieved.Should().BeFalse();
             outIntValue.Should().Be(default);
         }
@@ -279,11 +308,15 @@ namespace Microsoft.Azure.Devices.Client.Tests
         [TestMethod]
         public void ClientPropertyCollectionNewtonSoft_TryGetValueWithComponentShouldReturnFalseIfNotAComponent()
         {
+            // arrange
             var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionToRoundTrip, DefaultPayloadConvention.Instance);
-
             string incorrectlyMappedComponentName = MapPropertyName;
             string incorrectlyMappedComponentPropertyName = "key1";
+
+            // act
             bool isValueRetrieved = clientProperties.TryGetValue(incorrectlyMappedComponentName, incorrectlyMappedComponentPropertyName, out object propertyValue);
+
+            // assert
             isValueRetrieved.Should().BeFalse();
             propertyValue.Should().Be(default);
         }

--- a/iothub/device/tests/ClientPropertyCollectionTestsNewtonsoft.cs
+++ b/iothub/device/tests/ClientPropertyCollectionTestsNewtonsoft.cs
@@ -235,6 +235,46 @@ namespace Microsoft.Azure.Devices.Client.Tests
             outValue.Should().Be(StringPropertyValue);
             componentOut.Should().Be(ConventionBasedConstants.ComponentIdentifierValue);
         }
+
+        [TestMethod]
+        public void ClientPropertyCollectionNewtonSoft_TryGetValueShouldReturnFalseIfValueNotFound()
+        {
+            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionToRoundTrip, DefaultPayloadConvention.Instance);
+
+            bool isValueRetrieved = clientProperties.TryGetValue("thisPropertyDoesNotExist", out int outIntValue);
+            isValueRetrieved.Should().BeFalse();
+            outIntValue.Should().Be(default(int));
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollectionNewtonSoft_TryGetValueWithComponentShouldReturnFalseIfValueNotFound()
+        {
+            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWithComponentToRoundTrip, DefaultPayloadConvention.Instance);
+
+            bool isValueRetrieved = clientProperties.TryGetValue(ComponentName, "thisPropertyDoesNotExist", out int outIntValue);
+            isValueRetrieved.Should().BeFalse();
+            outIntValue.Should().Be(default(int));
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollectionNewtonSoft_TryGetValueShouldReturnFalseIfValueCouldNotBeDeserialized()
+        {
+            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionToRoundTrip, DefaultPayloadConvention.Instance);
+
+            bool isValueRetrieved = clientProperties.TryGetValue(StringPropertyName, out int outIntValue);
+            isValueRetrieved.Should().BeFalse();
+            outIntValue.Should().Be(default(int));
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollectionNewtonSoft_TryGetValueWithComponentShouldReturnFalseIfValueCouldNotBeDeserialized()
+        {
+            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWithComponentToRoundTrip, DefaultPayloadConvention.Instance);
+
+            bool isValueRetrieved = clientProperties.TryGetValue(ComponentName, StringPropertyName, out int outIntValue);
+            isValueRetrieved.Should().BeFalse();
+            outIntValue.Should().Be(default(int));
+        }
     }
 
     internal class RootLevelProperties


### PR DESCRIPTION
Fix for #2066 , #2067