### PR TITLE
fix(iot-device): Add checks to verify that client property update response has version

### DIFF
--- a/iothub/device/src/ClientPropertiesUpdateResponse.cs
+++ b/iothub/device/src/ClientPropertiesUpdateResponse.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// For clients communicating with IoT hub via IoT Edge, since the patch isn't applied immediately an updated version number is not returned.
         /// You can call <see cref="ModuleClient.GetClientPropertiesAsync(System.Threading.CancellationToken)"/>
-        /// and verify <see cref="ClientProperties.ReportedFromClient"/> to check if your patch is successfully applied.
+        /// and verify <see cref="ClientPropertyCollection.Version"/> from <see cref="ClientProperties.ReportedFromClient"/> to check if your patch is successfully applied.
         /// </remarks>
         public long Version { get; internal set; }
     }

--- a/iothub/device/src/ClientPropertiesUpdateResponse.cs
+++ b/iothub/device/src/ClientPropertiesUpdateResponse.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// The updated version after the property patch has been applied.
         /// </summary>
+        /// <remarks>
+        /// For clients communicating to IoT hub via IoT Edge, since the patch isn't applied immediately an updated version number is not returned.
+        /// You can call <see cref="ModuleClient.GetClientPropertiesAsync(System.Threading.CancellationToken)"/>
+        /// and verify <see cref="ClientProperties.ReportedFromClient"/> to know when your patch is successfully applied.
+        /// </remarks>
         public long Version { get; internal set; }
     }
 }

--- a/iothub/device/src/ClientPropertiesUpdateResponse.cs
+++ b/iothub/device/src/ClientPropertiesUpdateResponse.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// For clients communicating with IoT hub via IoT Edge, since the patch isn't applied immediately an updated version number is not returned.
         /// You can call <see cref="ModuleClient.GetClientPropertiesAsync(System.Threading.CancellationToken)"/>
-        /// and verify <see cref="ClientProperties.ReportedFromClient"/> to know when your patch is successfully applied.
+        /// and verify <see cref="ClientProperties.ReportedFromClient"/> to check if your patch is successfully applied.
         /// </remarks>
         public long Version { get; internal set; }
     }

--- a/iothub/device/src/ClientPropertiesUpdateResponse.cs
+++ b/iothub/device/src/ClientPropertiesUpdateResponse.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.Client
         /// The updated version after the property patch has been applied.
         /// </summary>
         /// <remarks>
-        /// For clients communicating to IoT hub via IoT Edge, since the patch isn't applied immediately an updated version number is not returned.
+        /// For clients communicating with IoT hub via IoT Edge, since the patch isn't applied immediately an updated version number is not returned.
         /// You can call <see cref="ModuleClient.GetClientPropertiesAsync(System.Threading.CancellationToken)"/>
         /// and verify <see cref="ClientProperties.ReportedFromClient"/> to know when your patch is successfully applied.
         /// </remarks>

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -35,8 +35,7 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <inheritdoc path="/remarks" cref="AddRootProperty(string, object)" />
         /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentNullException']" cref="AddRootProperty(string, object)" />
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddRootProperty(string, object)" />
+        /// <inheritdoc path="/exception" cref="AddRootProperty(string, object)" />
         /// <summary>
         /// Adds the value to the collection.
         /// </summary>
@@ -48,17 +47,17 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <inheritdoc path="/remarks" cref="AddRootProperty(string, object)" />
         /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddRootProperty(string, object)" />
         /// <summary>
         /// Adds the value to the collection.
         /// </summary>
         /// <param name="componentName">The component with the properties to add.</param>
         /// <param name="properties">A collection of properties to add.</param>
+        /// <exception cref="ArgumentException">A property name in <paramref name="properties"/> already exists in the collection.</exception>
         public void AddComponentProperties(string componentName, IDictionary<string, object> properties)
             => AddInternal(properties, componentName, true);
 
         /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddRootProperty(string, object)" />
+        /// <inheritdoc path="/exception" cref="AddRootProperty(string, object)" />
         /// <summary>
         /// Adds the collection of root-level property values to the collection.
         /// </summary>
@@ -87,19 +86,19 @@ namespace Microsoft.Azure.Devices.Client
         /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/remarks" cref="AddOrUpdateComponentProperties(string, IDictionary{string, object})" />
         /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentNullException']" cref="AddRootProperty(string, object)" />
         /// <param name="propertyName">The name of the property to add or update.</param>
         /// <param name="propertyValue">The value of the property to add or update.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c>.</exception>
         public void AddOrUpdateRootProperty(string propertyName, object propertyValue)
             => AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, null, true);
 
         /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/remarks" cref="AddOrUpdateComponentProperties(string, IDictionary{string, object})" />
         /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentNullException']" cref="AddRootProperty(string, object)" />
         /// <param name="componentName">The component with the property to add or update.</param>
         /// <param name="propertyName">The name of the property to add or update.</param>
         /// <param name="propertyValue">The value of the property to add or update.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c>.</exception>
         public void AddOrUpdateComponentProperty(string componentName, string propertyName, object propertyValue)
             => AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName, true);
 
@@ -120,8 +119,7 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentException']" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception['ArgumentNullException']" cref="AddRootProperties(IDictionary{string, object})"/>
+        /// <inheritdoc path="/exception" cref="AddInternal(IDictionary{string, object}, string, bool)" />
         /// <remarks>
         /// If the collection has a key that matches this will overwrite the current value. Otherwise it will attempt to add this to the collection.
         /// <para>
@@ -131,6 +129,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </para>
         /// </remarks>
         /// <param name="properties">A collection of properties to add or update.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="properties"/> is <c>null</c>.</exception>
         public void AddOrUpdateRootProperties(IDictionary<string, object> properties)
             => properties
                 .ToList()

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -1020,11 +1020,21 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             request.MqttTopicName = TwinPatchTopic.FormatInvariant(rid);
 
             using Message message = await SendTwinRequestAsync(request, rid, cancellationToken).ConfigureAwait(false);
-            return new ClientPropertiesUpdateResponse
+
+            bool requestIdPresent = message.Properties.TryGetValue(RequestIdKey, out string requestIdRetrieved);
+            bool versionPresent = message.Properties.TryGetValue(VersionKey, out string versionRetrievedAsString);
+
+            var response = new ClientPropertiesUpdateResponse();
+            if (requestIdPresent)
             {
-                RequestId = message.Properties[RequestIdKey],
-                Version = long.Parse(message.Properties[VersionKey], CultureInfo.InvariantCulture)
-            };
+                response.RequestId = requestIdRetrieved;
+            }
+            if (versionPresent)
+            {
+                response.Version = long.Parse(versionRetrievedAsString, CultureInfo.InvariantCulture);
+            }
+
+            return response;
         }
 
         private async Task OpenInternalAsync(CancellationToken cancellationToken)

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -1021,15 +1021,12 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             using Message message = await SendTwinRequestAsync(request, rid, cancellationToken).ConfigureAwait(false);
 
-            bool requestIdPresent = message.Properties.TryGetValue(RequestIdKey, out string requestIdRetrieved);
-            bool versionPresent = message.Properties.TryGetValue(VersionKey, out string versionRetrievedAsString);
-
             var response = new ClientPropertiesUpdateResponse();
-            if (requestIdPresent)
+            if (message.Properties.TryGetValue(RequestIdKey, out string requestIdRetrieved))
             {
                 response.RequestId = requestIdRetrieved;
             }
-            if (versionPresent)
+            if (message.Properties.TryGetValue(VersionKey, out string versionRetrievedAsString))
             {
                 response.Version = long.Parse(versionRetrievedAsString, CultureInfo.InvariantCulture);
             }


### PR DESCRIPTION
For a twin update operation, not all responses have the request Id and version no. 
Eg. we know that request Id is only relevant for MQTT based operations.

Based on #2095 , it looks like module client operations with IoT Edge might be missing the version no. in the response.

This PR adds a check to see if the request Id and version are a part of the service returned response, and if yes, only then returns it to the device app.

