### PR TITLE
cherrypick parent scopes for LTS patch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Track1 .NET Azure IoT Hub and DPS SDKs
 
-*	@drwill-ms @timtay-microsoft @abhipsaMisra @vinagesh @azabbasi @bikamani @barustum @jamdavi
+*	@drwill-ms @timtay-microsoft @abhipsaMisra @vinagesh @azabbasi @barustum @jamdavi

--- a/iothub/service/src/ClientApiVersionHelper.cs
+++ b/iothub/service/src/ClientApiVersionHelper.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 namespace Microsoft.Azure.Devices
 {
     /// <summary>
@@ -11,7 +9,7 @@ namespace Microsoft.Azure.Devices
     internal class ClientApiVersionHelper
     {
         private const string ApiVersionQueryPrefix = "api-version=";
-        private const string ApiVersionDefault = "2020-09-30";
+        private const string ApiVersionDefault = "2021-04-12";
 
         /// <summary>
         /// The default API version to use for all data-plane service calls

--- a/iothub/service/src/Device.cs
+++ b/iothub/service/src/Device.cs
@@ -114,7 +114,9 @@ namespace Microsoft.Azure.Devices
         /// relationship.
         /// </summary>
         /// <remarks>
-        /// For leaf devices, the value to set a parent edge device can be retrieved from the parent edge device's <see cref="Scope"/> property.
+        /// For leaf devices, the value to set a parent edge device can be retrieved from the parent edge device's Scope property.
+        ///
+        /// For more information, see <see href="https://docs.microsoft.com/azure/iot-edge/iot-edge-as-gateway?view=iotedge-2020-11#parent-and-child-relationships"/>.
         /// </remarks>
         [JsonProperty(PropertyName = "deviceScope", NullValueHandling = NullValueHandling.Ignore)]
         public virtual string Scope { get; set; }

--- a/iothub/service/src/Device.cs
+++ b/iothub/service/src/Device.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Azure.Devices.Shared;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -109,9 +110,26 @@ namespace Microsoft.Azure.Devices
         public virtual DeviceCapabilities Capabilities { get; set; }
 
         /// <summary>
-        /// Scope to which this device instance belongs to
+        /// The scope of the device. For edge devices, this is auto-generated and immutable. For leaf devices, set this to create child/parent
+        /// relationship.
         /// </summary>
+        /// <remarks>
+        /// For leaf devices, the value to set a parent edge device can be retrieved from the parent edge device's <see cref="Scope"/> property.
+        /// </remarks>
         [JsonProperty(PropertyName = "deviceScope", NullValueHandling = NullValueHandling.Ignore)]
         public virtual string Scope { get; set; }
+
+        /// <summary>
+        /// The scopes of the upper level edge devices if applicable.
+        /// </summary>
+        /// <remarks>
+        /// For edge devices, the value to set a parent edge device can be retrieved from the parent edge device's <see cref="Scope"/> property.
+        ///
+        /// For leaf devices, this could be set to the same value as <see cref="Scope"/> or left for the service to copy over.
+        ///
+        /// For now, this list can only have 1 element in the collection.
+        /// </remarks>
+        [JsonProperty(PropertyName = "parentScopes", NullValueHandling = NullValueHandling.Ignore)]
+        public virtual IList<string> ParentScopes { get; internal set; } = new List<string>();
     }
 }

--- a/iothub/service/src/ExportImportDevice.cs
+++ b/iothub/service/src/ExportImportDevice.cs
@@ -5,13 +5,14 @@
 // ---------------------------------------------------------------
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Azure.Devices.Shared;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices
 {
     /// <summary>
-    /// Contains device properties specified during export/import operation
+    /// Contains device properties specified during export/import job operation.
     /// </summary>
     public sealed class ExportImportDevice
     {
@@ -21,7 +22,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Property container
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Public property. No behavior changes allowed.")]
+        [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Public property. No behavior changes allowed.")]
         public sealed class PropertyContainer
         {
             /// <summary>
@@ -38,14 +39,14 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <summary>
-        /// Create an ExportImportDevice <see cref="ExportImportDevice" />
+        /// Create an ExportImportDevice.
         /// </summary>
         public ExportImportDevice()
         {
         }
 
         /// <summary>
-        /// Create an ExportImportDevice <see cref="ExportImportDevice" />
+        /// Create an ExportImportDevice.
         /// </summary>
         /// <param name="device">Device properties</param>
         /// <param name="importmode">Identifies the behavior when merging a device to the registry during import actions.</param>
@@ -66,13 +67,13 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <summary>
-        /// Id of the device
+        /// Id of the device.
         /// </summary>
         [JsonProperty(PropertyName = "id", Required = Required.Always)]
         public string Id { get; set; }
 
         /// <summary>
-        /// Module Id for the object
+        /// Module Id for the object.
         /// </summary>
         [JsonProperty(PropertyName = "moduleId", NullValueHandling = NullValueHandling.Ignore)]
         public string ModuleId { get; set; }
@@ -88,31 +89,31 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <summary>
-        /// ImportMode of the device
+        /// Import mode of the device.
         /// </summary>
         [JsonProperty(PropertyName = "importMode", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public ImportMode ImportMode { get; set; }
 
         /// <summary>
-        /// Status of the device
+        /// Status of the device.
         /// </summary>
         [JsonProperty(PropertyName = "status", Required = Required.Always)]
         public DeviceStatus Status { get; set; }
 
         /// <summary>
-        /// StatusReason of the device
+        /// Status reason of the device.
         /// </summary>
         [JsonProperty(PropertyName = "statusReason", NullValueHandling = NullValueHandling.Ignore)]
         public string StatusReason { get; set; }
 
         /// <summary>
-        /// AuthenticationMechanism of the device
+        /// Authentication mechanism of the device.
         /// </summary>
         [JsonProperty(PropertyName = "authentication")]
         public AuthenticationMechanism Authentication { get; set; }
 
         /// <summary>
-        /// string representing a Twin ETag for the entity, as per RFC7232.
+        /// String representing a Twin ETag for the entity, as per RFC7232.
         /// </summary>
         [JsonProperty(PropertyName = "twinETag", NullValueHandling = NullValueHandling.Ignore)]
         public string TwinETag
@@ -128,16 +129,28 @@ namespace Microsoft.Azure.Devices
         public TwinCollection Tags { get; set; }
 
         /// <summary>
-        /// Desired and Reported property bags
+        /// Desired and reported property bags
         /// </summary>
         [JsonProperty(PropertyName = "properties", NullValueHandling = NullValueHandling.Ignore)]
         public PropertyContainer Properties { get; set; }
 
         /// <summary>
-        /// Status of Capabilities enabled on the device
+        /// Status of capabilities enabled on the device
         /// </summary>
         [JsonProperty(PropertyName = "capabilities", NullValueHandling = NullValueHandling.Ignore)]
         public DeviceCapabilities Capabilities { get; set; }
+
+        /// <summary>
+        /// The scope of the device. For edge devices, this is auto-generated and immutable. For leaf devices, set this to create child/parent
+        /// relationship.
+        /// </summary>
+        /// <remarks>
+        /// For leaf devices, the value to set a parent edge device can be retrieved from the parent edge device's device scope property.
+        ///
+        /// For more information, see <see href="https://docs.microsoft.com/azure/iot-edge/iot-edge-as-gateway?view=iotedge-2020-11#parent-and-child-relationships"/>.
+        /// </remarks>
+        [JsonProperty(PropertyName = "deviceScope", NullValueHandling = NullValueHandling.Include)]
+        public string DeviceScope { get; set; }
 
         private static string SanitizeETag(string eTag)
         {

--- a/shared/src/Twin.cs
+++ b/shared/src/Twin.cs
@@ -152,6 +152,19 @@ namespace Microsoft.Azure.Devices.Shared
         public X509Thumbprint X509Thumbprint { get; internal set; }
 
         /// <summary>
+        /// The scope of the device. Auto-generated and immutable for edge devices and modifiable in leaf devices to create child/parent relationship.
+        /// </summary>
+        [DefaultValue(null)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public string DeviceScope { get; internal set; }
+
+        /// <summary>
+        /// The scopes of the upper level edge devices if applicable. Only available for edge devices.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public virtual IReadOnlyList<string> ParentScopes { get; internal set; }
+
+        /// <summary>
         /// Gets the Twin as a JSON string
         /// </summary>
         /// <param name="formatting">Optional. Formatting for the output JSON string.</param>

--- a/shared/src/TwinJsonConverter.cs
+++ b/shared/src/TwinJsonConverter.cs
@@ -1,20 +1,17 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+
 namespace Microsoft.Azure.Devices.Shared
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Globalization;
-    using System.Reflection;
-    using System.Runtime.Serialization;
-    using Microsoft.Azure.Devices.Common;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
-    using Newtonsoft.Json.Linq;
-    using Newtonsoft.Json.Serialization;
-
     /// <summary>
     /// Converts <see cref="Twin"/> to Json
     /// </summary>
@@ -40,6 +37,8 @@ namespace Microsoft.Azure.Devices.Shared
         private const string AuthenticationTypeTag = "authenticationType";
         private const string X509ThumbprintTag = "x509Thumbprint";
         private const string ModelId = "modelId";
+        private const string DeviceScope = "deviceScope";
+        private const string ParentScopes = "parentScopes";
 
         /// <summary>
         /// Converts <see cref="Twin"/> to its equivalent Json representation.
@@ -173,6 +172,18 @@ namespace Microsoft.Azure.Devices.Shared
                 writer.WriteEndObject();
             }
 
+            if (twin.DeviceScope != null)
+            {
+                writer.WritePropertyName(DeviceScope);
+                serializer.Serialize(writer, twin.DeviceScope, typeof(string));
+            }
+
+            if (twin.ParentScopes != null && twin.ParentScopes.Any())
+            {
+                writer.WritePropertyName(ParentScopes);
+                serializer.Serialize(writer, twin.ParentScopes, typeof(IList<string>));
+            }
+
             writer.WriteEndObject();
         }
 
@@ -301,6 +312,14 @@ namespace Microsoft.Azure.Devices.Shared
 
                     case X509ThumbprintTag:
                         twin.X509Thumbprint = serializer.Deserialize<X509Thumbprint>(reader);
+                        break;
+
+                    case DeviceScope:
+                        twin.DeviceScope = serializer.Deserialize<string>(reader);
+                        break;
+
+                    case ParentScopes:
+                        twin.ParentScopes = serializer.Deserialize<IReadOnlyList<string>>(reader);
                         break;
 
                     default:


### PR DESCRIPTION
Edge has requested a couple of changes for LTS patch, including support for the ParentScopes feature. The second will come when there is an update to DotNetty package.