### PR TITLE
fix(tools): Fix readme for ConsoleEventListener usage

### DIFF
--- a/tools/CaptureLogs/readme.md
+++ b/tools/CaptureLogs/readme.md
@@ -9,13 +9,18 @@ On Linux and OSX LTTNG and perfcollect can be used to collect traces. For more i
 ## Console logging
 Logging can be added to console. Note that this method will substantially slow down execution.
 
-  1. Add `e2e\test\Helpers\ConsoleEventListener.cs` to your project.
+  1. Add [`e2e\test\helpers\ConsoleEventListener.cs`](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/e2e/test/helpers/ConsoleEventListener.cs) to your project.
   2. Instantiate the listener. Add one or more filters (e.g. `Microsoft-Azure-` or `DotNetty-`):
 
-```C#
-	private readonly ConsoleEventListener _listener = new ConsoleEventListener("Microsoft-Azure-");
+```csharp
+	private static readonly ConsoleEventListener _listener = new ConsoleEventListener();
 ```
-  3. See the `ConsoleEventListener.cs` file to enable colorized logs within Visual Studio Code.
+> NOTE: 
+> 1. `static` fields are optimized for runtime performance and are initialized prior to their first usage. If `_listener` is the only static field initialized in your class, you'll need to provide a static constructor that initializes them when the class is loaded.
+> 2. `ConsoleEventListener.cs` logs the following events by default. If you want to log specific event providers, modify the [event filter](https://github.com/Azure/azure-iot-sdk-csharp/blob/4b5e0147f3768761cacaf4913ab6be707425f9da/e2e/test/helpers/ConsoleEventListener.cs#L20) list to include only your desired event providers.
+> ```csharp
+> private static readonly string[] s_eventFilter = new string[] { "DotNetty-Default", "Microsoft-Azure-Devices", "Azure-Core", "Azure-Identity" };
+> ```
 
 ## Azure IoT SDK providers
 


### PR DESCRIPTION
We no longer accept the event provider filter through `ConsoleEventListener` constructor. The readme is updated to reflect that.

Readme: https://github.com/Azure/azure-iot-sdk-csharp/blob/abmisr/logReadme/tools/CaptureLogs/readme.md