### PR TITLE
Update the internal method names as per functionality

### DIFF
--- a/iothub/device/src/ClientPropertiesAsDictionary.cs
+++ b/iothub/device/src/ClientPropertiesAsDictionary.cs
@@ -7,14 +7,8 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Client
 {
-    internal class ClientTwinProperties
+    internal class ClientPropertiesAsDictionary
     {
-        internal ClientTwinProperties()
-        {
-            Desired = new Dictionary<string, object>();
-            Reported = new Dictionary<string, object>();
-        }
-
         [JsonProperty(PropertyName = "desired", DefaultValueHandling = DefaultValueHandling.Ignore)]
         internal IDictionary<string, object> Desired { get; set; }
 
@@ -23,8 +17,8 @@ namespace Microsoft.Azure.Devices.Client
 
         internal ClientProperties ToClientProperties(PayloadConvention payloadConvention)
         {
-            ClientPropertyCollection writablePropertyRequestCollection = ClientPropertyCollection.FromClientTwinDictionary(Desired, payloadConvention);
-            ClientPropertyCollection clientReportedPropertyCollection = ClientPropertyCollection.FromClientTwinDictionary(Reported, payloadConvention);
+            ClientPropertyCollection writablePropertyRequestCollection = ClientPropertyCollection.FromClientPropertiesAsDictionary(Desired, payloadConvention);
+            ClientPropertyCollection clientReportedPropertyCollection = ClientPropertyCollection.FromClientPropertiesAsDictionary(Reported, payloadConvention);
 
             return new ClientProperties(writablePropertyRequestCollection, clientReportedPropertyCollection);
         }

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -256,11 +256,12 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Converts a <see cref="TwinCollection"/> collection to a properties collection.
         /// </summary>
-        /// <remarks>This internal class is aware of the implementation of the TwinCollection.</remarks>
+        /// <remarks>This method is used to translate the twin desired properties into writable property update requests.
+        /// This internal class is aware of the implementation of the TwinCollection.</remarks>
         /// <param name="twinCollection">The TwinCollection object to convert.</param>
         /// <param name="payloadConvention">A convention handler that defines the content encoding and serializer to use for the payload.</param>
         /// <returns>A new instance of the class from an existing <see cref="TwinProperties"/> using an optional <see cref="PayloadConvention"/>.</returns>
-        internal static ClientPropertyCollection FromTwinCollection(TwinCollection twinCollection, PayloadConvention payloadConvention)
+        internal static ClientPropertyCollection WritablePropertyUpdateRequestsFromTwinCollection(TwinCollection twinCollection, PayloadConvention payloadConvention)
         {
             if (twinCollection == null)
             {
@@ -282,11 +283,12 @@ namespace Microsoft.Azure.Devices.Client
             return propertyCollectionToReturn;
         }
 
-        internal static ClientPropertyCollection FromClientTwinDictionary(IDictionary<string, object> clientTwinPropertyDictionary, PayloadConvention payloadConvention)
+        // This method is used to convert the received twin into client properties (reported + desired).
+        internal static ClientPropertyCollection FromClientPropertiesAsDictionary(IDictionary<string, object> clientProperties, PayloadConvention payloadConvention)
         {
-            if (clientTwinPropertyDictionary == null)
+            if (clientProperties == null)
             {
-                throw new ArgumentNullException(nameof(clientTwinPropertyDictionary));
+                throw new ArgumentNullException(nameof(clientProperties));
             }
 
             var propertyCollectionToReturn = new ClientPropertyCollection
@@ -294,7 +296,7 @@ namespace Microsoft.Azure.Devices.Client
                 Convention = payloadConvention,
             };
 
-            foreach (KeyValuePair<string, object> property in clientTwinPropertyDictionary)
+            foreach (KeyValuePair<string, object> property in clientProperties)
             {
                 // The version information should not be a part of the enumerable ProperyCollection, but rather should be
                 // accessible through its dedicated accessor.

--- a/iothub/device/src/IDelegatingHandler.cs
+++ b/iothub/device/src/IDelegatingHandler.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Devices.Client
 
         // Convention driven operations.
 
-        Task<ClientProperties> GetPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken);
+        Task<ClientProperties> GetClientPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken);
 
         Task<ClientPropertiesUpdateResponse> SendPropertyPatchAsync(ClientPropertyCollection reportedProperties, CancellationToken cancellationToken);
     }

--- a/iothub/device/src/InternalClient.ConventionBasedOperations.cs
+++ b/iothub/device/src/InternalClient.ConventionBasedOperations.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices.Client
         {
             try
             {
-                return await InnerHandler.GetPropertiesAsync(PayloadConvention, cancellationToken).ConfigureAwait(false);
+                return await InnerHandler.GetClientPropertiesAsync(PayloadConvention, cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.Client
             var desiredPropertyUpdateCallback = new DesiredPropertyUpdateCallback((twinCollection, userContext) =>
             {
                 // convert a TwinCollection to PropertyCollection
-                var propertyCollection = ClientPropertyCollection.FromTwinCollection(twinCollection, PayloadConvention);
+                var propertyCollection = ClientPropertyCollection.WritablePropertyUpdateRequestsFromTwinCollection(twinCollection, PayloadConvention);
                 callback.Invoke(propertyCollection, userContext);
 
                 return TaskHelpers.CompletedTask;

--- a/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
@@ -523,7 +523,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         #region Convention-based operations
 
-        public override Task<ClientProperties> GetPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken)
+        public override Task<ClientProperties> GetClientPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken)
         {
             throw new NotImplementedException("This operation is currently not supported over AMQP, please use MQTT protocol instead. " +
                 "Note that you can still retrieve a client's properties using DeviceClient.GetTwinAsync(CancellationToken cancellationToken) or " +

--- a/iothub/device/src/Transport/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Transport/DefaultDelegatingHandler.cs
@@ -202,10 +202,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return InnerHandler?.DisableEventReceiveAsync(cancellationToken) ?? TaskHelpers.CompletedTask;
         }
 
-        public virtual Task<ClientProperties> GetPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken)
+        public virtual Task<ClientProperties> GetClientPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
-            return InnerHandler?.GetPropertiesAsync(payloadConvention, cancellationToken) ?? Task.FromResult<ClientProperties>(null);
+            return InnerHandler?.GetClientPropertiesAsync(payloadConvention, cancellationToken) ?? Task.FromResult<ClientProperties>(null);
         }
 
         public virtual Task<ClientPropertiesUpdateResponse> SendPropertyPatchAsync(ClientPropertyCollection reportedProperties, CancellationToken cancellationToken)

--- a/iothub/device/src/Transport/ErrorDelegatingHandler.cs
+++ b/iothub/device/src/Transport/ErrorDelegatingHandler.cs
@@ -145,9 +145,9 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return ExecuteWithErrorHandlingAsync(() => base.SendMethodResponseAsync(methodResponse, cancellationToken));
         }
 
-        public override Task<ClientProperties> GetPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken)
+        public override Task<ClientProperties> GetClientPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken)
         {
-            return ExecuteWithErrorHandlingAsync(() => base.GetPropertiesAsync(payloadConvention, cancellationToken));
+            return ExecuteWithErrorHandlingAsync(() => base.GetClientPropertiesAsync(payloadConvention, cancellationToken));
         }
 
         public override Task<ClientPropertiesUpdateResponse> SendPropertyPatchAsync(ClientPropertyCollection reportedProperties, CancellationToken cancellationToken)

--- a/iothub/device/src/Transport/HttpTransportHandler.cs
+++ b/iothub/device/src/Transport/HttpTransportHandler.cs
@@ -403,7 +403,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 cancellationToken);
         }
 
-        public override Task<ClientProperties> GetPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken)
+        public override Task<ClientProperties> GetClientPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken)
         {
             throw new NotImplementedException("Property operations are not supported over HTTP. Please use MQTT protocol instead.");
         }

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -977,7 +977,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             await SendTwinRequestAsync(request, rid, cancellationToken).ConfigureAwait(false);
         }
 
-        public override async Task<ClientProperties> GetPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken)
+        public override async Task<ClientProperties> GetClientPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             EnsureValidState();
@@ -993,8 +993,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             try
             {
-                ClientTwinProperties twinProperties = JsonConvert.DeserializeObject<ClientTwinProperties>(body);
-                var properties = twinProperties.ToClientProperties(payloadConvention);
+                ClientPropertiesAsDictionary clientPropertiesAsDictionary = JsonConvert.DeserializeObject<ClientPropertiesAsDictionary>(body);
+                var properties = clientPropertiesAsDictionary.ToClientProperties(payloadConvention);
                 return properties;
             }
             catch (JsonReaderException ex)

--- a/iothub/device/src/Transport/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Transport/RetryDelegatingHandler.cs
@@ -606,7 +606,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
-        public override async Task<ClientProperties> GetPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken)
+        public override async Task<ClientProperties> GetClientPropertiesAsync(PayloadConvention payloadConvention, CancellationToken cancellationToken)
         {
             try
             {
@@ -617,7 +617,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         async () =>
                         {
                             await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
-                            return await base.GetPropertiesAsync(payloadConvention, cancellationToken).ConfigureAwait(false);
+                            return await base.GetClientPropertiesAsync(payloadConvention, cancellationToken).ConfigureAwait(false);
                         },
                         cancellationToken)
                     .ConfigureAwait(false);

--- a/iothub/device/tests/ClientPropertyCollectionTestsNewtonsoft.cs
+++ b/iothub/device/tests/ClientPropertyCollectionTestsNewtonsoft.cs
@@ -16,20 +16,32 @@ namespace Microsoft.Azure.Devices.Client.Test
     [TestCategory("Unit")]
     // These tests test the deserialization of the service response to a ClientPropertyCollection.
     // This flow is convention aware and uses NewtonSoft.Json for deserialization.
-    // For the purpose of these tests we will create an instance of a Twin class to simulate the service response.
     public class ClientPropertyCollectionTestsNewtonsoft
     {
-        internal const string BoolPropertyName = "boolPropertyName";
-        internal const string DoublePropertyName = "doublePropertyName";
-        internal const string FloatPropertyName = "floatPropertyName";
-        internal const string IntPropertyName = "intPropertyName";
-        internal const string ShortPropertyName = "shortPropertyName";
-        internal const string StringPropertyName = "stringPropertyName";
-        internal const string ObjectPropertyName = "objectPropertyName";
-        internal const string ArrayPropertyName = "arrayPropertyName";
-        internal const string MapPropertyName = "mapPropertyName";
-        internal const string DateTimePropertyName = "dateTimePropertyName";
+        internal const string RootBoolPropertyName = "rootBoolPropertyName";
+        internal const string RootDoublePropertyName = "rootDoublePropertyName";
+        internal const string RootFloatPropertyName = "rootFloatPropertyName";
+        internal const string RootIntPropertyName = "rootIntPropertyName";
+        internal const string RootShortPropertyName = "rootShortPropertyName";
+        internal const string RootStringPropertyName = "rootStringPropertyName";
+        internal const string RootObjectPropertyName = "rootObjectPropertyName";
+        internal const string RootArrayPropertyName = "rootArrayPropertyName";
+        internal const string RootMapPropertyName = "rootMapPropertyName";
+        internal const string RootDateTimePropertyName = "rootDateTimePropertyName";
+        internal const string RootWritablePropertyName = "rootWritablePropertyName";
+
         internal const string ComponentName = "testableComponent";
+        internal const string ComponentBoolPropertyName = "componentBoolPropertyName";
+        internal const string ComponentDoublePropertyName = "componentDoublePropertyName";
+        internal const string ComponentFloatPropertyName = "componentFloatPropertyName";
+        internal const string ComponentIntPropertyName = "componentIntPropertyName";
+        internal const string ComponentShortPropertyName = "componentShortPropertyName";
+        internal const string ComponentStringPropertyName = "componentStringPropertyName";
+        internal const string ComponentObjectPropertyName = "componentObjectPropertyName";
+        internal const string ComponentArrayPropertyName = "componentArrayPropertyName";
+        internal const string ComponentMapPropertyName = "componentMapPropertyName";
+        internal const string ComponentDateTimePropertyName = "componentDateTimePropertyName";
+        internal const string ComponentWritablePropertyName = "componentWritablePropertyName";
 
         private const bool BoolPropertyValue = false;
         private const double DoublePropertyValue = 1.001;
@@ -58,8 +70,15 @@ namespace Microsoft.Azure.Devices.Client.Test
             { "key3", s_objectPropertyValue }
         };
 
-        // Create an object that represents all of the properties as top-level properties.
-        private static readonly RootLevelProperties s_rootLevelProperties = new RootLevelProperties
+        // Create a writable property response with the expected values.
+        private static readonly IWritablePropertyResponse s_writablePropertyResponse = new NewtonsoftJsonWritablePropertyResponse(
+            propertyValue: StringPropertyValue,
+            ackCode: CommonClientResponseCodes.OK,
+            ackVersion: 2,
+            ackDescription: "testableWritablePropertyDescription");
+
+        // Create an object that represents a client instance having top-level and component-level properties.
+        private static readonly TestProperties s_testClientProperties = new TestProperties
         {
             BooleanProperty = BoolPropertyValue,
             DoubleProperty = DoublePropertyValue,
@@ -70,14 +89,9 @@ namespace Microsoft.Azure.Devices.Client.Test
             ObjectProperty = s_objectPropertyValue,
             ArrayProperty = s_arrayPropertyValue,
             MapProperty = s_mapPropertyValue,
-            DateTimeProperty = s_dateTimePropertyValue
-        };
-
-        // Create an object that represents all of the properties as component-level properties.
-        // This adds the "__t": "c" component identifier as a part of "ComponentProperties" class declaration.
-        private static readonly ComponentLevelProperties s_componentLevelProperties = new ComponentLevelProperties
-        {
-            Properties = new ComponentProperties
+            DateTimeProperty = s_dateTimePropertyValue,
+            WritablePropertyResponse = s_writablePropertyResponse,
+            ComponentProperties = new ComponentProperties
             {
                 BooleanProperty = BoolPropertyValue,
                 DoubleProperty = DoublePropertyValue,
@@ -88,77 +102,56 @@ namespace Microsoft.Azure.Devices.Client.Test
                 ObjectProperty = s_objectPropertyValue,
                 ArrayProperty = s_arrayPropertyValue,
                 MapProperty = s_mapPropertyValue,
-                DateTimeProperty = s_dateTimePropertyValue
-            },
+                DateTimeProperty = s_dateTimePropertyValue,
+                WritablePropertyResponse = s_writablePropertyResponse,
+            }
         };
 
-        // Create a writable property response with the expected values.
-        private static readonly IWritablePropertyResponse s_writablePropertyResponse = new NewtonsoftJsonWritablePropertyResponse(
-            propertyValue: StringPropertyValue,
-            ackCode: CommonClientResponseCodes.OK,
-            ackVersion: 2,
-            ackDescription: "testableWritablePropertyDescription");
+        private static string getClientPropertiesStringResponse = JsonConvert.SerializeObject(new Dictionary<string, object> { { "reported", s_testClientProperties } });
 
-        // Create a JObject instance that represents a writable property response sent for a top-level property.
-        private static readonly JObject s_writablePropertyResponseJObject = new JObject(
-            new JProperty(StringPropertyName, JObject.FromObject(s_writablePropertyResponse)));
-
-        // Create a JObject instance that represents a writable property response sent for a component-level property.
-        // This adds the "__t": "c" component identifier to the constructed JObject.
-        private static readonly JObject s_writablePropertyResponseWithComponentJObject = new JObject(
-            new JProperty(ComponentName, new JObject(
-                new JProperty(ConventionBasedConstants.ComponentIdentifierKey, ConventionBasedConstants.ComponentIdentifierValue),
-                new JProperty(StringPropertyName, JObject.FromObject(s_writablePropertyResponse)))));
-
-        // The above constructed json objects are used for initializing a twin response.
-        // This is because we are using a Twin instance to simulate the service response.
-
-        private static TwinCollection collectionToRoundTrip = new TwinCollection(JsonConvert.SerializeObject(s_rootLevelProperties));
-        private static TwinCollection collectionWithComponentToRoundTrip = new TwinCollection(JsonConvert.SerializeObject(s_componentLevelProperties));
-        private static TwinCollection collectionWritablePropertyToRoundTrip = new TwinCollection(s_writablePropertyResponseJObject, null);
-        private static TwinCollection collectionWritablePropertyWithComponentToRoundTrip = new TwinCollection(s_writablePropertyResponseWithComponentJObject, null);
+        private static ClientPropertiesAsDictionary clientPropertiesAsDictionary = JsonConvert.DeserializeObject<ClientPropertiesAsDictionary>(getClientPropertiesStringResponse);
 
         [TestMethod]
         public void ClientPropertyCollectionNewtonsoft_CanGetValue()
         {
             // arrange
-            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionToRoundTrip, DefaultPayloadConvention.Instance);
+            var clientProperties = ClientPropertyCollection.FromClientPropertiesAsDictionary(clientPropertiesAsDictionary.Reported, DefaultPayloadConvention.Instance);
 
             // act, assert
 
-            clientProperties.TryGetValue(StringPropertyName, out string stringOutValue);
+            clientProperties.TryGetValue(RootStringPropertyName, out string stringOutValue);
             stringOutValue.Should().Be(StringPropertyValue);
 
-            clientProperties.TryGetValue(BoolPropertyName, out bool boolOutValue);
+            clientProperties.TryGetValue(RootBoolPropertyName, out bool boolOutValue);
             boolOutValue.Should().Be(BoolPropertyValue);
 
-            clientProperties.TryGetValue(DoublePropertyName, out double doubleOutValue);
+            clientProperties.TryGetValue(RootDoublePropertyName, out double doubleOutValue);
             doubleOutValue.Should().Be(DoublePropertyValue);
 
-            clientProperties.TryGetValue(FloatPropertyName, out float floatOutValue);
+            clientProperties.TryGetValue(RootFloatPropertyName, out float floatOutValue);
             floatOutValue.Should().Be(FloatPropertyValue);
 
-            clientProperties.TryGetValue(IntPropertyName, out int intOutValue);
+            clientProperties.TryGetValue(RootIntPropertyName, out int intOutValue);
             intOutValue.Should().Be(IntPropertyValue);
 
-            clientProperties.TryGetValue(ShortPropertyName, out short shortOutValue);
+            clientProperties.TryGetValue(RootShortPropertyName, out short shortOutValue);
             shortOutValue.Should().Be(ShortPropertyValue);
 
-            clientProperties.TryGetValue(ObjectPropertyName, out CustomClientProperty objectOutValue);
+            clientProperties.TryGetValue(RootObjectPropertyName, out CustomClientProperty objectOutValue);
             objectOutValue.Id.Should().Be(s_objectPropertyValue.Id);
             objectOutValue.Name.Should().Be(s_objectPropertyValue.Name);
 
             // The two lists won't be exactly equal since TryGetValue doesn't implement nested deserialization
             // => the complex object inside the list is deserialized to a JObject.
-            clientProperties.TryGetValue(ArrayPropertyName, out List<object> arrayOutValue);
+            clientProperties.TryGetValue(RootArrayPropertyName, out List<object> arrayOutValue);
             arrayOutValue.Should().HaveSameCount(s_arrayPropertyValue);
 
             // The two dictionaries won't be exactly equal since TryGetValue doesn't implement nested deserialization
             // => the complex object inside the dictionary is deserialized to a JObject.
-            clientProperties.TryGetValue(MapPropertyName, out Dictionary<string, object> mapOutValue);
+            clientProperties.TryGetValue(RootMapPropertyName, out Dictionary<string, object> mapOutValue);
             mapOutValue.Should().HaveSameCount(s_mapPropertyValue);
 
-            clientProperties.TryGetValue(DateTimePropertyName, out DateTimeOffset dateTimeOutValue);
+            clientProperties.TryGetValue(RootDateTimePropertyName, out DateTimeOffset dateTimeOutValue);
             dateTimeOutValue.Should().Be(s_dateTimePropertyValue);
         }
 
@@ -166,43 +159,43 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void ClientPropertyCollectionNewtonsoft_CanGetValueWithComponent()
         {
             // arrange
-            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWithComponentToRoundTrip, DefaultPayloadConvention.Instance);
+            var clientProperties = ClientPropertyCollection.FromClientPropertiesAsDictionary(clientPropertiesAsDictionary.Reported, DefaultPayloadConvention.Instance);
 
             // act, assert
 
-            clientProperties.TryGetValue(ComponentName, StringPropertyName, out string stringOutValue);
+            clientProperties.TryGetValue(ComponentName, ComponentStringPropertyName, out string stringOutValue);
             stringOutValue.Should().Be(StringPropertyValue);
 
-            clientProperties.TryGetValue(ComponentName, BoolPropertyName, out bool boolOutValue);
+            clientProperties.TryGetValue(ComponentName, ComponentBoolPropertyName, out bool boolOutValue);
             boolOutValue.Should().Be(BoolPropertyValue);
 
-            clientProperties.TryGetValue(ComponentName, DoublePropertyName, out double doubleOutValue);
+            clientProperties.TryGetValue(ComponentName, ComponentDoublePropertyName, out double doubleOutValue);
             doubleOutValue.Should().Be(DoublePropertyValue);
 
-            clientProperties.TryGetValue(ComponentName, FloatPropertyName, out float floatOutValue);
+            clientProperties.TryGetValue(ComponentName, ComponentFloatPropertyName, out float floatOutValue);
             floatOutValue.Should().Be(FloatPropertyValue);
 
-            clientProperties.TryGetValue(ComponentName, IntPropertyName, out int intOutValue);
+            clientProperties.TryGetValue(ComponentName, ComponentIntPropertyName, out int intOutValue);
             intOutValue.Should().Be(IntPropertyValue);
 
-            clientProperties.TryGetValue(ComponentName, ShortPropertyName, out short shortOutValue);
+            clientProperties.TryGetValue(ComponentName, ComponentShortPropertyName, out short shortOutValue);
             shortOutValue.Should().Be(ShortPropertyValue);
 
-            clientProperties.TryGetValue(ComponentName, ObjectPropertyName, out CustomClientProperty objectOutValue);
+            clientProperties.TryGetValue(ComponentName, ComponentObjectPropertyName, out CustomClientProperty objectOutValue);
             objectOutValue.Id.Should().Be(s_objectPropertyValue.Id);
             objectOutValue.Name.Should().Be(s_objectPropertyValue.Name);
 
             // The two lists won't be exactly equal since TryGetValue doesn't implement nested deserialization
             // => the complex object inside the list is deserialized to a JObject.
-            clientProperties.TryGetValue(ComponentName, ArrayPropertyName, out List<object> arrayOutValue);
+            clientProperties.TryGetValue(ComponentName, ComponentArrayPropertyName, out List<object> arrayOutValue);
             arrayOutValue.Should().HaveSameCount(s_arrayPropertyValue);
 
             // The two dictionaries won't be exactly equal since TryGetValue doesn't implement nested deserialization
             // => the complex object inside the dictionary is deserialized to a JObject.
-            clientProperties.TryGetValue(ComponentName, MapPropertyName, out Dictionary<string, object> mapOutValue);
+            clientProperties.TryGetValue(ComponentName, ComponentMapPropertyName, out Dictionary<string, object> mapOutValue);
             mapOutValue.Should().HaveSameCount(s_mapPropertyValue);
 
-            clientProperties.TryGetValue(ComponentName, DateTimePropertyName, out DateTimeOffset dateTimeOutValue);
+            clientProperties.TryGetValue(ComponentName, ComponentDateTimePropertyName, out DateTimeOffset dateTimeOutValue);
             dateTimeOutValue.Should().Be(s_dateTimePropertyValue);
         }
 
@@ -210,10 +203,10 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void ClientPropertyCollectionNewtonsoft_CanAddSimpleWritablePropertyAndGetBack()
         {
             // arrange
-            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWritablePropertyToRoundTrip, DefaultPayloadConvention.Instance);
+            var clientProperties = ClientPropertyCollection.FromClientPropertiesAsDictionary(clientPropertiesAsDictionary.Reported, DefaultPayloadConvention.Instance);
 
             // act
-            clientProperties.TryGetValue(StringPropertyName, out NewtonsoftJsonWritablePropertyResponse outValue);
+            clientProperties.TryGetValue(RootWritablePropertyName, out NewtonsoftJsonWritablePropertyResponse outValue);
 
             // assert
             outValue.Value.Should().Be(StringPropertyValue);
@@ -226,10 +219,10 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void ClientPropertyCollectionNewtonsoft_CanAddWritablePropertyWithComponentAndGetBack()
         {
             // arrange
-            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWritablePropertyWithComponentToRoundTrip, DefaultPayloadConvention.Instance);
+            var clientProperties = ClientPropertyCollection.FromClientPropertiesAsDictionary(clientPropertiesAsDictionary.Reported, DefaultPayloadConvention.Instance);
 
             // act
-            clientProperties.TryGetValue(ComponentName, StringPropertyName, out NewtonsoftJsonWritablePropertyResponse outValue);
+            clientProperties.TryGetValue(ComponentName, ComponentWritablePropertyName, out NewtonsoftJsonWritablePropertyResponse outValue);
 
             // assert
             outValue.Value.Should().Be(StringPropertyValue);
@@ -242,10 +235,10 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void ClientPropertyCollectionNewtonsoft_CanGetComponentIdentifier()
         {
             // arrange
-            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWithComponentToRoundTrip, DefaultPayloadConvention.Instance);
+            var clientProperties = ClientPropertyCollection.FromClientPropertiesAsDictionary(clientPropertiesAsDictionary.Reported, DefaultPayloadConvention.Instance);
 
             // act
-            clientProperties.TryGetValue(ComponentName, StringPropertyName, out string outValue);
+            clientProperties.TryGetValue(ComponentName, ComponentStringPropertyName, out string outValue);
             clientProperties.TryGetValue(ComponentName, ConventionBasedConstants.ComponentIdentifierKey, out string componentOut);
 
             // assert
@@ -257,7 +250,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void ClientPropertyCollectionNewtonSoft_TryGetValueShouldReturnFalseIfValueNotFound()
         {
             // arrange
-            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionToRoundTrip, DefaultPayloadConvention.Instance);
+            var clientProperties = ClientPropertyCollection.FromClientPropertiesAsDictionary(clientPropertiesAsDictionary.Reported, DefaultPayloadConvention.Instance);
 
             // act
             bool isValueRetrieved = clientProperties.TryGetValue("thisPropertyDoesNotExist", out int outIntValue);
@@ -271,7 +264,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void ClientPropertyCollectionNewtonSoft_TryGetValueWithComponentShouldReturnFalseIfValueNotFound()
         {
             // arrange
-            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWithComponentToRoundTrip, DefaultPayloadConvention.Instance);
+            var clientProperties = ClientPropertyCollection.FromClientPropertiesAsDictionary(clientPropertiesAsDictionary.Reported, DefaultPayloadConvention.Instance);
 
             // act
             bool isValueRetrieved = clientProperties.TryGetValue(ComponentName, "thisPropertyDoesNotExist", out int outIntValue);
@@ -284,9 +277,13 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public void ClientPropertyCollectionNewtonSoft_TryGetValueShouldReturnFalseIfValueCouldNotBeDeserialized()
         {
-            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionToRoundTrip, DefaultPayloadConvention.Instance);
+            // arrange
+            var clientProperties = ClientPropertyCollection.FromClientPropertiesAsDictionary(clientPropertiesAsDictionary.Reported, DefaultPayloadConvention.Instance);
 
-            bool isValueRetrieved = clientProperties.TryGetValue(StringPropertyName, out int outIntValue);
+            // act
+            bool isValueRetrieved = clientProperties.TryGetValue(RootStringPropertyName, out int outIntValue);
+
+            // assert
             isValueRetrieved.Should().BeFalse();
             outIntValue.Should().Be(default);
         }
@@ -295,10 +292,10 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void ClientPropertyCollectionNewtonSoft_TryGetValueWithComponentShouldReturnFalseIfValueCouldNotBeDeserialized()
         {
             // arrange
-            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionWithComponentToRoundTrip, DefaultPayloadConvention.Instance);
+            var clientProperties = ClientPropertyCollection.FromClientPropertiesAsDictionary(clientPropertiesAsDictionary.Reported, DefaultPayloadConvention.Instance);
 
             // act
-            bool isValueRetrieved = clientProperties.TryGetValue(ComponentName, StringPropertyName, out int outIntValue);
+            bool isValueRetrieved = clientProperties.TryGetValue(ComponentName, ComponentStringPropertyName, out int outIntValue);
 
             // assert
             isValueRetrieved.Should().BeFalse();
@@ -309,8 +306,8 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void ClientPropertyCollectionNewtonSoft_TryGetValueWithComponentShouldReturnFalseIfNotAComponent()
         {
             // arrange
-            var clientProperties = ClientPropertyCollection.FromTwinCollection(collectionToRoundTrip, DefaultPayloadConvention.Instance);
-            string incorrectlyMappedComponentName = MapPropertyName;
+            var clientProperties = ClientPropertyCollection.FromClientPropertiesAsDictionary(clientPropertiesAsDictionary.Reported, DefaultPayloadConvention.Instance);
+            string incorrectlyMappedComponentName = ComponentMapPropertyName;
             string incorrectlyMappedComponentPropertyName = "key1";
 
             // act
@@ -322,48 +319,81 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
     }
 
-    internal class RootLevelProperties
+    internal class TestProperties
     {
-        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.BoolPropertyName)]
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.RootBoolPropertyName)]
         public bool BooleanProperty { get; set; }
 
-        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.DoublePropertyName)]
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.RootDoublePropertyName)]
         public double DoubleProperty { get; set; }
 
-        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.FloatPropertyName)]
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.RootFloatPropertyName)]
         public float FloatProperty { get; set; }
 
-        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.IntPropertyName)]
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.RootIntPropertyName)]
         public int IntProperty { get; set; }
 
-        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ShortPropertyName)]
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.RootShortPropertyName)]
         public short ShortProperty { get; set; }
 
-        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.StringPropertyName)]
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.RootStringPropertyName)]
         public string StringProperty { get; set; }
 
-        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ObjectPropertyName)]
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.RootObjectPropertyName)]
         public object ObjectProperty { get; set; }
 
-        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ArrayPropertyName)]
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.RootArrayPropertyName)]
         public IList ArrayProperty { get; set; }
 
-        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.MapPropertyName)]
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.RootMapPropertyName)]
         public IDictionary MapProperty { get; set; }
 
-        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.DateTimePropertyName)]
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.RootDateTimePropertyName)]
         public DateTimeOffset DateTimeProperty { get; set; }
+
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.RootWritablePropertyName)]
+        public IWritablePropertyResponse WritablePropertyResponse { get; set; }
+
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ComponentName)]
+        public ComponentProperties ComponentProperties { get; set; }
     }
 
-    internal class ComponentProperties : RootLevelProperties
+    internal class ComponentProperties
     {
         [JsonProperty(ConventionBasedConstants.ComponentIdentifierKey)]
         public string ComponentIdentifier { get; } = ConventionBasedConstants.ComponentIdentifierValue;
-    }
 
-    internal class ComponentLevelProperties
-    {
-        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ComponentName)]
-        public ComponentProperties Properties { get; set; }
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ComponentBoolPropertyName)]
+        public bool BooleanProperty { get; set; }
+
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ComponentDoublePropertyName)]
+        public double DoubleProperty { get; set; }
+
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ComponentFloatPropertyName)]
+        public float FloatProperty { get; set; }
+
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ComponentIntPropertyName)]
+        public int IntProperty { get; set; }
+
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ComponentShortPropertyName)]
+        public short ShortProperty { get; set; }
+
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ComponentStringPropertyName)]
+        public string StringProperty { get; set; }
+
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ComponentObjectPropertyName)]
+        public object ObjectProperty { get; set; }
+
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ComponentArrayPropertyName)]
+        public IList ArrayProperty { get; set; }
+
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ComponentMapPropertyName)]
+        public IDictionary MapProperty { get; set; }
+
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ComponentDateTimePropertyName)]
+        public DateTimeOffset DateTimeProperty { get; set; }
+
+        [JsonProperty(ClientPropertyCollectionTestsNewtonsoft.ComponentWritablePropertyName)]
+        public IWritablePropertyResponse WritablePropertyResponse { get; set; }
     }
 }


### PR DESCRIPTION
- The `GetClientProperties()` call no longer relies on the previous "twin" flow but rather deserializes the returned response to a dictionary of (string, object). These renames captures that.
  - Rename `ClientTwinProperties` to `ClientPropertiesAsDictionary`
  - Rename `ClientPropertyCollection.FromClientTwinDictionary` to `ClientPropertyCollection.FromClientPropertiesAsDictionary`
- Rename the internal `GetPropertiesAsync` method to `GetClientPropertiesAsync`.