### PR TITLE
Add convenience method for acknowledging writable property update requests

### DIFF
--- a/configure_tls_protocol_version_and_ciphers.md
+++ b/configure_tls_protocol_version_and_ciphers.md
@@ -24,9 +24,9 @@ For more information, check out this article about [best practices with .NET and
 Also follow the instructions on how to [enable and disable ciphers].
 
 [.NET Framework 4.5.1 is no longer supported]: https://devblogs.microsoft.com/dotnet/support-ending-for-the-net-framework-4-4-5-and-4-5-1/
-[TLS registry settings]: https://docs.microsoft.com/en-us/windows-server/security/tls/tls-registry-settings
-[best practices with .NEt and TLS]: https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls
-[enable and disable ciphers]: https://support.microsoft.com/en-us/help/245030/how-to-restrict-the-use-of-certain-cryptographic-algorithms-and-protoc
+[TLS registry settings]: https://docs.microsoft.com/windows-server/security/tls/tls-registry-settings
+[best practices with .NEt and TLS]: https://docs.microsoft.com/dotnet/framework/network-programming/tls
+[enable and disable ciphers]: https://support.microsoft.com/help/245030/how-to-restrict-the-use-of-certain-cryptographic-algorithms-and-protoc
 
 ### Linux Instructions
 

--- a/e2e/test/iothub/properties/PropertiesE2ETests.cs
+++ b/e2e/test/iothub/properties/PropertiesE2ETests.cs
@@ -119,6 +119,42 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
         }
 
         [LoggedTestMethod]
+        public async Task Properties_ServiceSetsWritablePropertyAndDeviceReceivesEventAndResponds_Mqtt()
+        {
+            await Properties_ServiceSetsWritablePropertyAndDeviceReceivesEventAndRespondsAsync(
+                    Client.TransportType.Mqtt_Tcp_Only,
+                    Guid.NewGuid().ToString())
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Properties_ServiceSetsWritablePropertyAndDeviceReceivesEventAndResponds_MqttWs()
+        {
+            await Properties_ServiceSetsWritablePropertyAndDeviceReceivesEventAndRespondsAsync(
+                    Client.TransportType.Mqtt_WebSocket_Only,
+                    Guid.NewGuid().ToString())
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Properties_ServiceSetsWritablePropertyMapAndDeviceReceivesEventAndResponds_Mqtt()
+        {
+            await Properties_ServiceSetsWritablePropertyAndDeviceReceivesEventAndRespondsAsync(
+                    Client.TransportType.Mqtt_Tcp_Only,
+                    s_mapOfPropertyValues)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task Properties_ServiceSetsWritablePropertyMapAndDeviceReceivesEventAndResponds_MqttWs()
+        {
+            await Properties_ServiceSetsWritablePropertyAndDeviceReceivesEventAndRespondsAsync(
+                    Client.TransportType.Mqtt_WebSocket_Only,
+                    s_mapOfPropertyValues)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
         public async Task Properties_ServiceSetsWritablePropertyAndDeviceReceivesItOnNextGet_Mqtt()
         {
             await Properties_ServiceSetsWritablePropertyAndDeviceReceivesItOnNextGetAsync(
@@ -303,6 +339,82 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
 
             await deviceClient.SubscribeToWritablePropertyUpdateRequestsAsync(null, null).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);
+        }
+
+        private async Task Properties_ServiceSetsWritablePropertyAndDeviceReceivesEventAndRespondsAsync<T>(Client.TransportType transport, T propValue)
+        {
+            using var cts = new CancellationTokenSource(s_maxWaitTimeForCallback);
+            string propName = Guid.NewGuid().ToString();
+
+            Logger.Trace($"{nameof(Properties_ServiceSetsWritablePropertyAndDeviceReceivesEventAsync)}: name={propName}, value={propValue}");
+
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+
+            var writablePropertyCallbackSemaphore = new SemaphoreSlim(0, 1);
+            await deviceClient
+                .SubscribeToWritablePropertyUpdateRequestsAsync(
+                    async (writableProperties, userContext) =>
+                    {
+                        try
+                        {
+                            bool isPropertyPresent = writableProperties.TryGetValue(propName, out T propertyFromCollection);
+
+                            isPropertyPresent.Should().BeTrue();
+                            propertyFromCollection.Should().BeEquivalentTo(propValue);
+                            userContext.Should().BeNull();
+
+                            var writablePropertyAcks = new ClientPropertyCollection();
+                            foreach (KeyValuePair<string, object> writableProperty in writableProperties)
+                            {
+                                if (writableProperty.Value is WritableClientProperty writableClientProperty)
+                                {
+                                    writablePropertyAcks.Add(writableProperty.Key, writableClientProperty.AcknowledgeWith(CommonClientResponseCodes.OK));
+                                }
+                            }
+
+                            await deviceClient.UpdateClientPropertiesAsync(writablePropertyAcks).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            writablePropertyCallbackSemaphore.Release();
+                        }
+                    },
+                    null,
+                    cts.Token)
+                .ConfigureAwait(false);
+
+            using var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
+
+            await Task
+                .WhenAll(
+                    RegistryManagerUpdateWritablePropertyAsync(testDevice.Id, propName, propValue),
+                    writablePropertyCallbackSemaphore.WaitAsync(cts.Token))
+                .ConfigureAwait(false);
+
+            // Validate the updated properties from the device-client
+            ClientProperties clientProperties = await deviceClient.GetClientPropertiesAsync().ConfigureAwait(false);
+
+            // Validate that the writable property update request was received
+            bool isWritablePropertyRequestPresent = clientProperties.WritablePropertyRequests.TryGetValue(propName, out T writablePropertyRequest);
+            isWritablePropertyRequestPresent.Should().BeTrue();
+            writablePropertyRequest.Should().BeEquivalentTo(propValue);
+
+            // Validate that the writable property update request was acknowledged
+
+            bool isWritablePropertyAckPresent = clientProperties.ReportedFromClient.TryGetValue(propName, out IWritablePropertyResponse writablePropertyAck);
+            isWritablePropertyAckPresent.Should().BeTrue();
+            // TryGetValue doesn't have nested deserialization, so we'll compare the serialized values
+            JsonConvert.SerializeObject(writablePropertyAck.Value).Should().Be(JsonConvert.SerializeObject(propValue));
+
+            bool isWritablePropertyAckPresentSpecific = clientProperties.ReportedFromClient.TryGetValue(propName, out NewtonsoftJsonWritablePropertyResponse writablePropertyAckNewtonSoft);
+            isWritablePropertyAckPresentSpecific.Should().BeTrue();
+            // TryGetValue doesn't have nested deserialization, so we'll compare the serialized values
+            JsonConvert.SerializeObject(writablePropertyAckNewtonSoft.Value).Should().Be(JsonConvert.SerializeObject(propValue));
+
+            bool isWritablePropertyAckPresentAsValue = clientProperties.ReportedFromClient.TryGetValue(propName, out T writablePropertyAckValue);
+            isWritablePropertyAckPresentAsValue.Should().BeTrue();
+            writablePropertyAckValue.Should().BeEquivalentTo(propValue);
         }
 
         private async Task Properties_ServiceSetsWritablePropertyAndDeviceReceivesItOnNextGetAsync(Client.TransportType transport)

--- a/e2e/test/iothub/properties/PropertiesE2ETests.cs
+++ b/e2e/test/iothub/properties/PropertiesE2ETests.cs
@@ -404,13 +404,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
 
             bool isWritablePropertyAckPresent = clientProperties.ReportedFromClient.TryGetValue(propName, out IWritablePropertyResponse writablePropertyAck);
             isWritablePropertyAckPresent.Should().BeTrue();
-            // TryGetValue doesn't have nested deserialization, so we'll compare the serialized values
-            JsonConvert.SerializeObject(writablePropertyAck.Value).Should().Be(JsonConvert.SerializeObject(propValue));
+            // TryGetValue doesn't have nested deserialization, so we'll have to deserialize the retrieved value
+            deviceClient.PayloadConvention.PayloadSerializer.ConvertFromObject<T>(writablePropertyAck.Value).Should().BeEquivalentTo(propValue);
 
             bool isWritablePropertyAckPresentSpecific = clientProperties.ReportedFromClient.TryGetValue(propName, out NewtonsoftJsonWritablePropertyResponse writablePropertyAckNewtonSoft);
             isWritablePropertyAckPresentSpecific.Should().BeTrue();
-            // TryGetValue doesn't have nested deserialization, so we'll compare the serialized values
-            JsonConvert.SerializeObject(writablePropertyAckNewtonSoft.Value).Should().Be(JsonConvert.SerializeObject(propValue));
+            // TryGetValue doesn't have nested deserialization, so we'll have to deserialize the retrieved value
+            deviceClient.PayloadConvention.PayloadSerializer.ConvertFromObject<T>(writablePropertyAckNewtonSoft.Value).Should().BeEquivalentTo(propValue);
 
             bool isWritablePropertyAckPresentAsValue = clientProperties.ReportedFromClient.TryGetValue(propName, out T writablePropertyAckValue);
             isWritablePropertyAckPresentAsValue.Should().BeTrue();

--- a/e2e/test/iothub/properties/PropertiesWithComponentsE2ETests.cs
+++ b/e2e/test/iothub/properties/PropertiesWithComponentsE2ETests.cs
@@ -184,6 +184,42 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
                 .ConfigureAwait(false);
         }
 
+        [LoggedTestMethod]
+        public async Task PropertiesWithComponents_ServiceSetsWritablePropertyAndDeviceReceivesEventAndResponds_Mqtt()
+        {
+            await PropertiesWithComponents_ServiceSetsWritablePropertyAndDeviceReceivesEventAndRespondsAsync(
+                    Client.TransportType.Mqtt_Tcp_Only,
+                    Guid.NewGuid().ToString())
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task PropertiesWithComponents_ServiceSetsWritablePropertyAndDeviceReceivesEventAndResponds_MqttWs()
+        {
+            await PropertiesWithComponents_ServiceSetsWritablePropertyAndDeviceReceivesEventAndRespondsAsync(
+                    Client.TransportType.Mqtt_WebSocket_Only,
+                    Guid.NewGuid().ToString())
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task PropertiesWithComponents_ServiceSetsWritablePropertyMapAndDeviceReceivesEventAndResponds_Mqtt()
+        {
+            await PropertiesWithComponents_ServiceSetsWritablePropertyAndDeviceReceivesEventAndRespondsAsync(
+                    Client.TransportType.Mqtt_Tcp_Only,
+                    s_mapOfPropertyValues)
+                .ConfigureAwait(false);
+        }
+
+        [LoggedTestMethod]
+        public async Task PropertiesWithComponents_ServiceSetsWritablePropertyMapAndDeviceReceivesEventAndResponds_MqttWs()
+        {
+            await PropertiesWithComponents_ServiceSetsWritablePropertyAndDeviceReceivesEventAndRespondsAsync(
+                    Client.TransportType.Mqtt_WebSocket_Only,
+                    s_mapOfPropertyValues)
+                .ConfigureAwait(false);
+        }
+
         private async Task PropertiesWithComponents_DeviceSetsPropertyAndGetsItBackSingleDeviceAsync(Client.TransportType transport)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
@@ -310,6 +346,88 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
 
             await deviceClient.SubscribeToWritablePropertyUpdateRequestsAsync(null, null).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);
+        }
+
+        private async Task PropertiesWithComponents_ServiceSetsWritablePropertyAndDeviceReceivesEventAndRespondsAsync<T>(Client.TransportType transport, T propValue)
+        {
+            using var cts = new CancellationTokenSource(s_maxWaitTimeForCallback);
+            string propName = Guid.NewGuid().ToString();
+
+            Logger.Trace($"{nameof(PropertiesWithComponents_ServiceSetsWritablePropertyAndDeviceReceivesEventAndRespondsAsync)}: name={propName}, value={propValue}");
+
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+
+            var writablePropertyCallbackSemaphore = new SemaphoreSlim(0, 1);
+            await deviceClient
+                .SubscribeToWritablePropertyUpdateRequestsAsync(
+                    async (writableProperties, userContext) =>
+                    {
+                        try
+                        {
+                            bool isPropertyPresent = writableProperties.TryGetValue(ComponentName, propName, out T propertyFromCollection);
+
+                            isPropertyPresent.Should().BeTrue();
+                            propertyFromCollection.Should().BeEquivalentTo(propValue);
+                            userContext.Should().BeNull();
+
+                            var writablePropertyAcks = new ClientPropertyCollection();
+                            foreach (KeyValuePair<string, object> writableProperty in writableProperties)
+                            {
+                                if (writableProperty.Value is IDictionary<string, object> componentProperties)
+                                {
+                                    foreach (KeyValuePair<string, object> componentProperty in componentProperties)
+                                    {
+                                        if (componentProperty.Value is WritableClientProperty writableClientProperty)
+                                        {
+                                            writablePropertyAcks.AddComponentProperty(writableProperty.Key, componentProperty.Key, writableClientProperty.AcknowledgeWith(CommonClientResponseCodes.OK));
+                                        }
+                                    }
+                                }
+                            }
+
+                            await deviceClient.UpdateClientPropertiesAsync(writablePropertyAcks).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            writablePropertyCallbackSemaphore.Release();
+                        }
+                    },
+                    null,
+                    cts.Token)
+                .ConfigureAwait(false);
+
+            using var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
+
+            await Task
+                .WhenAll(
+                    RegistryManagerUpdateWritablePropertyAsync(testDevice.Id, ComponentName, propName, propValue),
+                    writablePropertyCallbackSemaphore.WaitAsync(cts.Token))
+                .ConfigureAwait(false);
+
+            // Validate the updated properties from the device-client
+            ClientProperties clientProperties = await deviceClient.GetClientPropertiesAsync().ConfigureAwait(false);
+
+            // Validate that the writable property update request was received
+            bool isWritablePropertyRequestPresent = clientProperties.WritablePropertyRequests.TryGetValue(ComponentName, propName, out T writablePropertyRequest);
+            isWritablePropertyRequestPresent.Should().BeTrue();
+            writablePropertyRequest.Should().BeEquivalentTo(propValue);
+
+            // Validate that the writable property update request was acknowledged
+
+            bool isWritablePropertyAckPresent = clientProperties.ReportedFromClient.TryGetValue(ComponentName, propName, out IWritablePropertyResponse writablePropertyAck);
+            isWritablePropertyAckPresent.Should().BeTrue();
+            // TryGetValue doesn't have nested deserialization, so we'll compare the serialized values
+            JsonConvert.SerializeObject(writablePropertyAck.Value).Should().Be(JsonConvert.SerializeObject(propValue));
+
+            bool isWritablePropertyAckPresentSpecific = clientProperties.ReportedFromClient.TryGetValue(ComponentName, propName, out NewtonsoftJsonWritablePropertyResponse writablePropertyAckNewtonSoft);
+            isWritablePropertyAckPresentSpecific.Should().BeTrue();
+            // TryGetValue doesn't have nested deserialization, so we'll compare the serialized values
+            JsonConvert.SerializeObject(writablePropertyAckNewtonSoft.Value).Should().Be(JsonConvert.SerializeObject(propValue));
+
+            bool isWritablePropertyAckPresentAsValue = clientProperties.ReportedFromClient.TryGetValue(ComponentName, propName, out T writablePropertyAckValue);
+            isWritablePropertyAckPresentAsValue.Should().BeTrue();
+            writablePropertyAckValue.Should().BeEquivalentTo(propValue);
         }
 
         private async Task PropertiesWithComponents_ServiceSetsWritablePropertyAndDeviceReceivesItOnNextGetAsync(Client.TransportType transport)

--- a/e2e/test/iothub/properties/PropertiesWithComponentsE2ETests.cs
+++ b/e2e/test/iothub/properties/PropertiesWithComponentsE2ETests.cs
@@ -417,13 +417,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
 
             bool isWritablePropertyAckPresent = clientProperties.ReportedFromClient.TryGetValue(ComponentName, propName, out IWritablePropertyResponse writablePropertyAck);
             isWritablePropertyAckPresent.Should().BeTrue();
-            // TryGetValue doesn't have nested deserialization, so we'll compare the serialized values
-            JsonConvert.SerializeObject(writablePropertyAck.Value).Should().Be(JsonConvert.SerializeObject(propValue));
+            // TryGetValue doesn't have nested deserialization, so we'll have to deserialize the retrieved value
+            deviceClient.PayloadConvention.PayloadSerializer.ConvertFromObject<T>(writablePropertyAck.Value).Should().BeEquivalentTo(propValue);
 
             bool isWritablePropertyAckPresentSpecific = clientProperties.ReportedFromClient.TryGetValue(ComponentName, propName, out NewtonsoftJsonWritablePropertyResponse writablePropertyAckNewtonSoft);
             isWritablePropertyAckPresentSpecific.Should().BeTrue();
-            // TryGetValue doesn't have nested deserialization, so we'll compare the serialized values
-            JsonConvert.SerializeObject(writablePropertyAckNewtonSoft.Value).Should().Be(JsonConvert.SerializeObject(propValue));
+            // TryGetValue doesn't have nested deserialization, so we'll have to deserialize the retrieved value
+            deviceClient.PayloadConvention.PayloadSerializer.ConvertFromObject<T>(writablePropertyAckNewtonSoft.Value).Should().BeEquivalentTo(propValue);
 
             bool isWritablePropertyAckPresentAsValue = clientProperties.ReportedFromClient.TryGetValue(ComponentName, propName, out T writablePropertyAckValue);
             isWritablePropertyAckPresentAsValue.Should().BeTrue();

--- a/iothub/device/devdoc/Convention-based operations.md
+++ b/iothub/device/devdoc/Convention-based operations.md
@@ -154,7 +154,6 @@ public class ClientPropertyCollection : PayloadCollection {
 }
 
 public class WritableClientProperty {
-    public WritableClientProperty();
     public object Value { get; internal set; }
     public long Version { get; internal set; }
     public IWritablePropertyResponse AcknowledgeWith(int statusCode, string description = null);
@@ -176,7 +175,6 @@ public sealed class NewtonsoftJsonWritablePropertyResponse : IWritablePropertyRe
 }
 
 public class ClientPropertiesUpdateResponse {
-    public ClientPropertiesUpdateResponse();
     public string RequestId { get; internal set; }
     public long Version { get; internal set; }
 }

--- a/iothub/device/devdoc/Convention-based operations.md
+++ b/iothub/device/devdoc/Convention-based operations.md
@@ -79,7 +79,6 @@ public abstract class PayloadCollection : IEnumerable, IEnumerable<KeyValuePair<
     public IEnumerator<KeyValuePair<string, object>> GetEnumerator();
     public virtual byte[] GetPayloadObjectBytes();
     public virtual string GetSerializedString();
-    protected void SetCollection(PayloadCollection payloadCollection);
     IEnumerator System.Collections.IEnumerable.GetEnumerator();
     public bool TryGetValue<T>(string key, out T value);
 }
@@ -127,15 +126,16 @@ public Task<ClientPropertiesUpdateResponse> UpdateClientPropertiesAsync(ClientPr
 /// <param name="callback">The global call back to handle all writable property updates.</param>
 /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
 /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-public Task SubscribeToWritablePropertiesEventAsync(Func<ClientPropertyCollection, object, Task> callback, object userContext, CancellationToken cancellationToken = default);
+public Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, object, Task> callback, object userContext, CancellationToken cancellationToken = default);
 ```
 
 #### All related types
 
 ```csharp
-public class ClientProperties : ClientPropertyCollection {
+public class ClientProperties {
     public ClientProperties();
-    public ClientPropertyCollection Writable { get; private set; }
+    public ClientPropertyCollection ReportedFromClient { get; private set; }
+    public ClientPropertyCollection WritablePropertyRequests { get; private set; }
 }
 
 public class ClientPropertyCollection : PayloadCollection {
@@ -151,6 +151,13 @@ public class ClientPropertyCollection : PayloadCollection {
     public void AddRootProperty(string propertyName, object propertyValue);
     public bool Contains(string componentName, string propertyName);
     public virtual bool TryGetValue<T>(string componentName, string propertyName, out T propertyValue);
+}
+
+public class WritableClientProperty {
+    public WritableClientProperty();
+    public object Value { get; internal set; }
+    public long Version { get; internal set; }
+    public IWritablePropertyResponse AcknowledgeWith(int statusCode, string description = null);
 }
 
 public interface IWritablePropertyResponse {

--- a/iothub/device/src/ClientPropertiesUpdateResponse.cs
+++ b/iothub/device/src/ClientPropertiesUpdateResponse.cs
@@ -8,6 +8,10 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     public class ClientPropertiesUpdateResponse
     {
+        internal ClientPropertiesUpdateResponse()
+        {
+        }
+
         /// <summary>
         /// The request Id that is associated with the <see cref="InternalClient.UpdateClientPropertiesAsync(ClientPropertyCollection, System.Threading.CancellationToken)"/> operation.
         /// </summary>

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -237,9 +237,19 @@ namespace Microsoft.Azure.Devices.Client
                             {
                                 // Case 2:
                                 // Check if the retrieved value is a writable property update request
-                                if (dictionaryElement is WritableClientProperty<T> writableClientProperty)
+                                if (dictionaryElement is WritableClientProperty writableClientProperty)
                                 {
-                                    propertyValue = writableClientProperty.Value;
+                                    object writableClientPropertyValue = writableClientProperty.Value;
+
+                                    // If the object is of type T or can be cast to type T, go ahead and return it.
+                                    if (ObjectCastHelpers.TryCast(writableClientPropertyValue, out propertyValue))
+                                    {
+                                        return true;
+                                    }
+
+                                    // If the cannot be cast to <T> directly we need to try to convert it using the serializer.
+                                    // If it can be successfully converted, go ahead and return it.
+                                    propertyValue = Convention.PayloadSerializer.ConvertFromObject<T>(writableClientPropertyValue);
                                     return true;
                                 }
                             }
@@ -363,7 +373,7 @@ namespace Microsoft.Azure.Devices.Client
                         }
                         else
                         {
-                            individualPropertyValue = new WritableClientProperty<object>
+                            individualPropertyValue = new WritableClientProperty
                             {
                                 Convention = payloadConvention,
                                 Value = payloadConvention.PayloadSerializer.DeserializeToType<object>(JsonConvert.SerializeObject(componentProperty.Value)),
@@ -376,7 +386,7 @@ namespace Microsoft.Azure.Devices.Client
                 }
                 else
                 {
-                    var writableProperty = new WritableClientProperty<object>
+                    var writableProperty = new WritableClientProperty
                     {
                         Convention = payloadConvention,
                         Value = payloadConvention.PayloadSerializer.DeserializeToType<object>(Newtonsoft.Json.JsonConvert.SerializeObject(propertyValueAsObject)),

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -295,8 +295,10 @@ namespace Microsoft.Azure.Devices.Client
                             // Case 3b, 3c:
                             // Since the value cannot be cast to <T> directly, we need to try to convert it using the serializer.
                             // If it can be successfully converted, go ahead and return it.
-                            Convention.PayloadSerializer.TryGetNestedObjectValue<T>(componentProperties, propertyName, out propertyValue);
-                            return true;
+                            if (Convention.PayloadSerializer.TryGetNestedObjectValue<T>(componentProperties, propertyName, out propertyValue))
+                            {
+                                return true;
+                            }
                         }
                     }
                     catch

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.Devices.Shared;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.Devices.Client
 {
@@ -188,6 +189,17 @@ namespace Microsoft.Azure.Devices.Client
                 return false;
             }
 
+            // While retrieving the property value from the collection:
+            // 1. A property collection constructed by the client application - can be retrieved using dictionary indexer.
+            // 2. Client property received through writable property update callbacks - stored internally as a WritableClientProperty.
+            // 3. Client property returned through GetClientProperties:
+            //  a. Client reported properties sent by the client application in response to writable property update requests - stored as a JSON object
+            //      and needs to be converted to an IWritablePropertyResponse implementation using the payload serializer.
+            //  b. Client reported properties sent by the client application - stored as a JSON object
+            //      and needs to be converted to the expected type using the payload serializer.
+            //  c. Writable property update request received - stored as a JSON object
+            //      and needs to be converted to the expected type using the payload serializer.
+
             if (Contains(componentName, propertyName))
             {
                 object componentProperties = Collection[componentName];
@@ -211,21 +223,44 @@ namespace Microsoft.Azure.Devices.Client
                                 return true;
                             }
 
+                            // Case 1:
                             // If the object is of type T or can be cast to type T, go ahead and return it.
                             if (dictionaryElement is T valueRef
-                                || NumericHelpers.TryCastNumericTo(dictionaryElement, out valueRef))
+                                || ObjectCastHelpers.TryCastNumericTo(dictionaryElement, out valueRef))
                             {
                                 propertyValue = valueRef;
                                 return true;
+                            }
+
+                            try
+                            {
+                                // Case 2:
+                                // Check if the retrieved value is a writable property update request
+                                if (dictionaryElement is WritableClientProperty writableClientProperty)
+                                {
+                                    object writableClientPropertyValue = writableClientProperty.Value;
+
+                                    // If the object is of type T or can be cast to type T, go ahead and return it.
+                                    if (ObjectCastHelpers.TryCast(writableClientPropertyValue, out propertyValue))
+                                    {
+                                        return true;
+                                    }
+
+                                    // If the cannot be cast to <T> directly we need to try to convert it using the serializer.
+                                    // If it can be successfully converted, go ahead and return it.
+                                    propertyValue = Convention.PayloadSerializer.ConvertFromObject<T>(writableClientPropertyValue);
+                                    return true;
+                                }
+                            }
+                            catch
+                            {
+                                // In case of an exception ignore it and continue.
                             }
                         }
                     }
                 }
                 else
                 {
-                    // If the ClientPropertyCollection was constructed by the SDK (eg. when retrieving the client properties)
-                    // then the componentProperties are retrieved as the json object that is defined in the PayloadConvention.
-                    // The required property value then needs to be deserialized accordingly.
                     try
                     {
                         // First verify that the retrieved dictionary contains the component identifier { "__t": "c" }.
@@ -235,6 +270,45 @@ namespace Microsoft.Azure.Devices.Client
                             .TryGetNestedObjectValue(componentProperties, ConventionBasedConstants.ComponentIdentifierKey, out string componentIdentifierValue)
                             && componentIdentifierValue == ConventionBasedConstants.ComponentIdentifierValue)
                         {
+                            Convention.PayloadSerializer.TryGetNestedObjectValue(componentProperties, propertyName, out object retrievedPropertyValue);
+
+                            try
+                            {
+                                // Case 3a:
+                                // Check if the retrieved value is a writable property update acknowledgment
+                                var newtonsoftWritablePropertyResponse = Convention.PayloadSerializer.ConvertFromObject<NewtonsoftJsonWritablePropertyResponse>(retrievedPropertyValue);
+
+                                if (typeof(IWritablePropertyResponse).IsAssignableFrom(typeof(T)))
+                                {
+                                    // If T is IWritablePropertyResponse the property value should be of type IWritablePropertyResponse as defined in the PayloadSerializer.
+                                    // We'll convert the json object to NewtonsoftJsonWritablePropertyResponse and then convert it to the appropriate IWritablePropertyResponse object.
+                                    propertyValue = (T)Convention.PayloadSerializer.CreateWritablePropertyResponse(
+                                        newtonsoftWritablePropertyResponse.Value,
+                                        newtonsoftWritablePropertyResponse.AckCode,
+                                        newtonsoftWritablePropertyResponse.AckVersion,
+                                        newtonsoftWritablePropertyResponse.AckDescription);
+                                    return true;
+                                }
+
+                                var writablePropertyValue = newtonsoftWritablePropertyResponse.Value;
+
+                                // If the object is of type T or can be cast to type T, go ahead and return it.
+                                if (ObjectCastHelpers.TryCast(writablePropertyValue, out propertyValue))
+                                {
+                                    return true;
+                                }
+
+                                // If the cannot be cast to <T> directly we need to try to convert it using the serializer.
+                                // If it can be successfully converted, go ahead and return it.
+                                propertyValue = Convention.PayloadSerializer.ConvertFromObject<T>(writablePropertyValue);
+                                return true;
+                            }
+                            catch
+                            {
+                                // In case of an exception ignore it and continue.
+                            }
+
+                            // Case 3b, 3c:
                             // Since the value cannot be cast to <T> directly, we need to try to convert it using the serializer.
                             // If it can be successfully converted, go ahead and return it.
                             Convention.PayloadSerializer.TryGetNestedObjectValue<T>(componentProperties, propertyName, out propertyValue);
@@ -275,7 +349,50 @@ namespace Microsoft.Azure.Devices.Client
 
             foreach (KeyValuePair<string, object> property in twinCollection)
             {
-                propertyCollectionToReturn.Add(property.Key, payloadConvention.PayloadSerializer.DeserializeToType<object>(Newtonsoft.Json.JsonConvert.SerializeObject(property.Value)));
+                object propertyValueAsObject = property.Value;
+
+                // Check if the property value is for a root property or a component property.
+                // A component property be a JObject and will have the "__t": "c" identifiers.
+                bool isComponentProperty = propertyValueAsObject is JObject
+                    && payloadConvention.PayloadSerializer.TryGetNestedObjectValue(propertyValueAsObject, ConventionBasedConstants.ComponentIdentifierKey, out string _);
+
+                if (isComponentProperty)
+                {
+                    var collectionDictionary = new Dictionary<string, object>();
+
+                    // If this is a component property then the collection is a JObject with each individual property as a writable property update request.
+                    var propertyValueAsJObject = (JObject)propertyValueAsObject;
+
+                    foreach (KeyValuePair<string, JToken> componentProperty in propertyValueAsJObject)
+                    {
+                        object individualPropertyValue;
+                        if (componentProperty.Key == ConventionBasedConstants.ComponentIdentifierKey)
+                        {
+                            individualPropertyValue = componentProperty.Value;
+                        }
+                        else
+                        {
+                            individualPropertyValue = new WritableClientProperty
+                            {
+                                Convention = payloadConvention,
+                                Value = payloadConvention.PayloadSerializer.DeserializeToType<object>(Newtonsoft.Json.JsonConvert.SerializeObject(componentProperty.Value)),
+                                Version = twinCollection.Version,
+                            };
+                        }
+                        collectionDictionary.Add(componentProperty.Key, individualPropertyValue);
+                    }
+                    propertyCollectionToReturn.Add(property.Key, collectionDictionary);
+                }
+                else
+                {
+                    var writableProperty = new WritableClientProperty
+                    {
+                        Convention = payloadConvention,
+                        Value = payloadConvention.PayloadSerializer.DeserializeToType<object>(Newtonsoft.Json.JsonConvert.SerializeObject(propertyValueAsObject)),
+                        Version = twinCollection.Version,
+                    };
+                    propertyCollectionToReturn.Add(property.Key, writableProperty);
+                }
             }
             // The version information is not accessible via the enumerator, so assign it separately.
             propertyCollectionToReturn.Version = twinCollection.Version;

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Azure.Devices.Client
                     var writableProperty = new WritableClientProperty
                     {
                         Convention = payloadConvention,
-                        Value = payloadConvention.PayloadSerializer.DeserializeToType<object>(Newtonsoft.Json.JsonConvert.SerializeObject(propertyValueAsObject)),
+                        Value = payloadConvention.PayloadSerializer.DeserializeToType<object>(JsonConvert.SerializeObject(propertyValueAsObject)),
                         Version = twinCollection.Version,
                     };
                     propertyCollectionToReturn.Add(property.Key, writableProperty);
@@ -407,7 +407,7 @@ namespace Microsoft.Azure.Devices.Client
                 }
                 else
                 {
-                    propertyCollectionToReturn.Add(property.Key, payloadConvention.PayloadSerializer.DeserializeToType<object>(Newtonsoft.Json.JsonConvert.SerializeObject(property.Value)));
+                    propertyCollectionToReturn.Add(property.Key, payloadConvention.PayloadSerializer.DeserializeToType<object>(JsonConvert.SerializeObject(property.Value)));
                 }
             }
 

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -351,11 +351,12 @@ namespace Microsoft.Azure.Devices.Client
             foreach (KeyValuePair<string, object> property in twinCollection)
             {
                 object propertyValueAsObject = property.Value;
+                string propertyValueAsString = DefaultPayloadConvention.Instance.PayloadSerializer.SerializeToString(propertyValueAsObject);
 
                 // Check if the property value is for a root property or a component property.
                 // A component property be a JObject and will have the "__t": "c" identifiers.
                 bool isComponentProperty = propertyValueAsObject is JObject
-                    && payloadConvention.PayloadSerializer.TryGetNestedObjectValue(propertyValueAsObject, ConventionBasedConstants.ComponentIdentifierKey, out string _);
+                    && payloadConvention.PayloadSerializer.TryGetNestedObjectValue(propertyValueAsString, ConventionBasedConstants.ComponentIdentifierKey, out string _);
 
                 if (isComponentProperty)
                 {

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.Devices.Shared;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.Devices.Client
@@ -358,10 +359,9 @@ namespace Microsoft.Azure.Devices.Client
 
                 if (isComponentProperty)
                 {
-                    var collectionDictionary = new Dictionary<string, object>();
-
                     // If this is a component property then the collection is a JObject with each individual property as a writable property update request.
                     var propertyValueAsJObject = (JObject)propertyValueAsObject;
+                    var collectionDictionary = new Dictionary<string, object>(propertyValueAsJObject.Count);
 
                     foreach (KeyValuePair<string, JToken> componentProperty in propertyValueAsJObject)
                     {
@@ -375,7 +375,7 @@ namespace Microsoft.Azure.Devices.Client
                             individualPropertyValue = new WritableClientProperty
                             {
                                 Convention = payloadConvention,
-                                Value = payloadConvention.PayloadSerializer.DeserializeToType<object>(Newtonsoft.Json.JsonConvert.SerializeObject(componentProperty.Value)),
+                                Value = payloadConvention.PayloadSerializer.DeserializeToType<object>(JsonConvert.SerializeObject(componentProperty.Value)),
                                 Version = twinCollection.Version,
                             };
                         }

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -237,19 +237,9 @@ namespace Microsoft.Azure.Devices.Client
                             {
                                 // Case 2:
                                 // Check if the retrieved value is a writable property update request
-                                if (dictionaryElement is WritableClientProperty writableClientProperty)
+                                if (dictionaryElement is WritableClientProperty<T> writableClientProperty)
                                 {
-                                    object writableClientPropertyValue = writableClientProperty.Value;
-
-                                    // If the object is of type T or can be cast to type T, go ahead and return it.
-                                    if (ObjectCastHelpers.TryCast(writableClientPropertyValue, out propertyValue))
-                                    {
-                                        return true;
-                                    }
-
-                                    // If the cannot be cast to <T> directly we need to try to convert it using the serializer.
-                                    // If it can be successfully converted, go ahead and return it.
-                                    propertyValue = Convention.PayloadSerializer.ConvertFromObject<T>(writableClientPropertyValue);
+                                    propertyValue = writableClientProperty.Value;
                                     return true;
                                 }
                             }
@@ -373,7 +363,7 @@ namespace Microsoft.Azure.Devices.Client
                         }
                         else
                         {
-                            individualPropertyValue = new WritableClientProperty
+                            individualPropertyValue = new WritableClientProperty<object>
                             {
                                 Convention = payloadConvention,
                                 Value = payloadConvention.PayloadSerializer.DeserializeToType<object>(JsonConvert.SerializeObject(componentProperty.Value)),
@@ -386,7 +376,7 @@ namespace Microsoft.Azure.Devices.Client
                 }
                 else
                 {
-                    var writableProperty = new WritableClientProperty
+                    var writableProperty = new WritableClientProperty<object>
                     {
                         Convention = payloadConvention,
                         Value = payloadConvention.PayloadSerializer.DeserializeToType<object>(Newtonsoft.Json.JsonConvert.SerializeObject(propertyValueAsObject)),

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <remarks>
         /// You cannot Reject or Abandon messages over MQTT protocol.
-        /// For more details, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
+        /// For more details, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
         /// </remarks>
         /// <returns>The receive message or null if there was no message until the default timeout</returns>
         public Task<Message> ReceiveAsync() => InternalClient.ReceiveAsync();
@@ -312,7 +312,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <remarks>
         /// You cannot Reject or Abandon messages over MQTT protocol.
-        /// For more details, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
+        /// For more details, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
         /// </remarks>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
@@ -326,7 +326,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <remarks>
         /// You cannot Reject or Abandon messages over MQTT protocol.
-        /// For more details, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
+        /// For more details, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
         /// </remarks>
         /// <returns>The receive message or null if there was no message until the specified time has elapsed</returns>
         public Task<Message> ReceiveAsync(TimeSpan timeout) => InternalClient.ReceiveAsync(timeout);
@@ -380,7 +380,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <remarks>
         /// You cannot Abandon a message over MQTT protocol.
-        /// For more details, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
+        /// For more details, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
         /// </remarks>
         /// <param name="lockToken">The message lockToken.</param>
         /// <returns>The previously received message</returns>
@@ -391,7 +391,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <remarks>
         /// You cannot Abandon a message over MQTT protocol.
-        /// For more details, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
+        /// For more details, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
         /// </remarks>
         /// <param name="lockToken">The message lockToken.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
@@ -404,7 +404,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <remarks>
         /// You cannot Abandon a message over MQTT protocol.
-        /// For more details, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
+        /// For more details, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
         /// </remarks>
         /// <param name="message">The message.</param>
         /// <returns>The lock identifier for the previously received message</returns>
@@ -415,7 +415,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <remarks>
         /// You cannot Abandon a message over MQTT protocol.
-        /// For more details, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
+        /// For more details, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
         /// </remarks>
         /// <param name="message">The message.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
@@ -428,7 +428,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <remarks>
         /// You cannot Reject a message over MQTT protocol.
-        /// For more details, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
+        /// For more details, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
         /// </remarks>
         /// <param name="lockToken">The message lockToken.</param>
         /// <returns>The previously received message</returns>
@@ -439,7 +439,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <remarks>
         /// You cannot Reject a message over MQTT protocol.
-        /// For more details, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
+        /// For more details, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
         /// </remarks>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <param name="lockToken">The message lockToken.</param>
@@ -452,7 +452,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <remarks>
         /// You cannot Reject a message over MQTT protocol.
-        /// For more details, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
+        /// For more details, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
         /// </remarks>
         /// <param name="message">The message.</param>
         /// <returns>The lock identifier for the previously received message</returns>
@@ -463,7 +463,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <remarks>
         /// You cannot Reject a message over MQTT protocol.
-        /// For more details, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
+        /// For more details, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle.
         /// </remarks>
         /// <param name="message">The message.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
@@ -527,7 +527,7 @@ namespace Microsoft.Azure.Devices.Client
             InternalClient.UploadToBlobAsync(blobName, source, cancellationToken);
 
         /// <summary>
-        /// Get a file upload SAS URI which the Azure Storage SDK can use to upload a file to blob for this device. See <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-file-upload#initialize-a-file-upload">this documentation for more details</see>
+        /// Get a file upload SAS URI which the Azure Storage SDK can use to upload a file to blob for this device. See <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload#initialize-a-file-upload">this documentation for more details</see>
         /// </summary>
         /// <param name="request">The request details for getting the SAS URI, including the destination blob name.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
@@ -536,7 +536,7 @@ namespace Microsoft.Azure.Devices.Client
             InternalClient.GetFileUploadSasUriAsync(request, cancellationToken);
 
         /// <summary>
-        /// Notify IoT Hub that a device's file upload has finished. See <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-file-upload#notify-iot-hub-of-a-completed-file-upload">this documentation for more details</see>
+        /// Notify IoT Hub that a device's file upload has finished. See <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload#notify-iot-hub-of-a-completed-file-upload">this documentation for more details</see>
         /// </summary>
         /// <param name="notification">The notification details, including if the file upload succeeded.</param>
         /// <param name="cancellationToken">The cancellation token.</param>

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -360,7 +360,7 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <summary>
         /// Sends a batch of events to IoT hub. Use AMQP or HTTPs for a true batch operation. MQTT will just send the messages one after the other.
-        /// For more information on IoT Edge module routing <see href="https://docs.microsoft.com/en-us/azure/iot-edge/module-composition?view=iotedge-2018-06#declare-routes"/>
+        /// For more information on IoT Edge module routing <see href="https://docs.microsoft.com/azure/iot-edge/module-composition?view=iotedge-2018-06#declare-routes"/>
         /// </summary>
         /// <param name="messages">The messages.</param>
         /// <returns>The task containing the event</returns>
@@ -368,7 +368,7 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <summary>
         /// Sends a batch of events to IoT hub. Use AMQP or HTTPs for a true batch operation. MQTT will just send the messages one after the other.
-        /// For more information on IoT Edge module routing <see href="https://docs.microsoft.com/en-us/azure/iot-edge/module-composition?view=iotedge-2018-06#declare-routes"/>/// Sends a batch of events to IoT hub. Requires AMQP or AMQP over WebSockets.
+        /// For more information on IoT Edge module routing <see href="https://docs.microsoft.com/azure/iot-edge/module-composition?view=iotedge-2018-06#declare-routes"/>/// Sends a batch of events to IoT hub. Requires AMQP or AMQP over WebSockets.
         /// </summary>
         /// <param name="messages">An IEnumerable set of Message objects.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
@@ -539,7 +539,7 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <summary>
         /// Sends a batch of events to IoT hub. Use AMQP or HTTPs for a true batch operation. MQTT will just send the messages one after the other.
-        /// For more information on IoT Edge module routing <see href="https://docs.microsoft.com/en-us/azure/iot-edge/module-composition?view=iotedge-2018-06#declare-routes"/>
+        /// For more information on IoT Edge module routing <see href="https://docs.microsoft.com/azure/iot-edge/module-composition?view=iotedge-2018-06#declare-routes"/>
         /// </summary>
         /// <param name="outputName">The output target for sending the given message</param>
         /// <param name="messages">A list of one or more messages to send</param>
@@ -550,7 +550,7 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <summary>
         /// Sends a batch of events to IoT hub. Use AMQP or HTTPs for a true batch operation. MQTT will just send the messages one after the other.
-        /// For more information on IoT Edge module routing <see href="https://docs.microsoft.com/en-us/azure/iot-edge/module-composition?view=iotedge-2018-06#declare-routes"/>
+        /// For more information on IoT Edge module routing <see href="https://docs.microsoft.com/azure/iot-edge/module-composition?view=iotedge-2018-06#declare-routes"/>
         /// </summary>
         /// <param name="outputName">The output target for sending the given message</param>
         /// <param name="messages">A list of one or more messages to send</param>

--- a/iothub/device/src/ObjectCastHelpers.cs
+++ b/iothub/device/src/ObjectCastHelpers.cs
@@ -6,8 +6,21 @@ using System.Globalization;
 
 namespace Microsoft.Azure.Devices.Client
 {
-    internal class NumericHelpers
+    internal class ObjectCastHelpers
     {
+        internal static bool TryCast<T>(object objectToCast, out T value)
+        {
+            if (objectToCast is T valueRef
+                || TryCastNumericTo(objectToCast, out valueRef))
+            {
+                value = valueRef;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
         internal static bool TryCastNumericTo<T>(object input, out T result)
         {
             if (TryGetNumeric(input))

--- a/iothub/device/src/ObjectConversionHelpers.cs
+++ b/iothub/device/src/ObjectConversionHelpers.cs
@@ -3,11 +3,35 @@
 
 using System;
 using System.Globalization;
+using Microsoft.Azure.Devices.Shared;
 
 namespace Microsoft.Azure.Devices.Client
 {
-    internal class ObjectCastHelpers
+    internal class ObjectConversionHelpers
     {
+        internal static bool TryCastOrConvert<T>(object objectToCastOrConvert, PayloadConvention payloadConvention, out T value)
+        {
+            // If the object is of type T or can be cast to type T, go ahead and return it.
+            if (TryCast(objectToCastOrConvert, out value))
+            {
+                return true;
+            }
+
+            try
+            {
+                // If the cannot be cast to <T> directly we need to try to convert it using the serializer.
+                // If it can be successfully converted, go ahead and return it.
+                value = payloadConvention.PayloadSerializer.ConvertFromObject<T>(objectToCastOrConvert);
+                return true;
+            }
+            catch
+            {
+            }
+
+            value = default;
+            return false;
+        }
+
         internal static bool TryCast<T>(object objectToCast, out T value)
         {
             if (objectToCast is T valueRef

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -151,38 +151,26 @@ namespace Microsoft.Azure.Devices.Client
 
                 // Case 1:
                 // If the object is of type T or can be cast to type T, go ahead and return it.
-                if (ObjectCastHelpers.TryCast(retrievedPropertyValue, out value))
+                if (ObjectConversionHelpers.TryCast(retrievedPropertyValue, out value))
                 {
                     return true;
                 }
 
+                // Case 2:
+                // Check if the retrieved value is a writable property update request
+                if (retrievedPropertyValue is WritableClientProperty writableClientProperty)
+                {
+                    object writableClientPropertyValue = writableClientProperty.Value;
+
+                    // If the object is of type T or can be cast or converted to type T, go ahead and return it.
+                    if (ObjectConversionHelpers.TryCastOrConvert(writableClientPropertyValue, Convention, out value))
+                    {
+                        return true;
+                    }
+                }
+
                 try
                 {
-                    try
-                    {
-                        // Case 2:
-                        // Check if the retrieved value is a writable property update request
-                        if (retrievedPropertyValue is WritableClientProperty writableClientProperty)
-                        {
-                            object writableClientPropertyValue = writableClientProperty.Value;
-
-                            // If the object is of type T or can be cast to type T, go ahead and return it.
-                            if (ObjectCastHelpers.TryCast(writableClientPropertyValue, out value))
-                            {
-                                return true;
-                            }
-
-                            // If the cannot be cast to <T> directly we need to try to convert it using the serializer.
-                            // If it can be successfully converted, go ahead and return it.
-                            value = Convention.PayloadSerializer.ConvertFromObject<T>(writableClientPropertyValue);
-                            return true;
-                        }
-                    }
-                    catch
-                    {
-                        // In case of an exception ignore it and continue.
-                    }
-
                     try
                     {
                         // Case 3a:
@@ -203,16 +191,11 @@ namespace Microsoft.Azure.Devices.Client
 
                         var writablePropertyValue = newtonsoftWritablePropertyResponse.Value;
 
-                        // If the object is of type T or can be cast to type T, go ahead and return it.
-                        if (ObjectCastHelpers.TryCast(writablePropertyValue, out value))
+                        // If the object is of type T or can be cast or converted to type T, go ahead and return it.
+                        if (ObjectConversionHelpers.TryCastOrConvert(writablePropertyValue, Convention, out value))
                         {
                             return true;
                         }
-
-                        // If the cannot be cast to <T> directly we need to try to convert it using the serializer.
-                        // If it can be successfully converted, go ahead and return it.
-                        value = Convention.PayloadSerializer.ConvertFromObject<T>(writablePropertyValue);
-                        return true;
                     }
                     catch
                     {

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -162,9 +162,19 @@ namespace Microsoft.Azure.Devices.Client
                     {
                         // Case 2:
                         // Check if the retrieved value is a writable property update request
-                        if (retrievedPropertyValue is WritableClientProperty<T> writableClientProperty)
+                        if (retrievedPropertyValue is WritableClientProperty writableClientProperty)
                         {
-                            value = writableClientProperty.Value;
+                            object writableClientPropertyValue = writableClientProperty.Value;
+
+                            // If the object is of type T or can be cast to type T, go ahead and return it.
+                            if (ObjectCastHelpers.TryCast(writableClientPropertyValue, out value))
+                            {
+                                return true;
+                            }
+
+                            // If the cannot be cast to <T> directly we need to try to convert it using the serializer.
+                            // If it can be successfully converted, go ahead and return it.
+                            value = Convention.PayloadSerializer.ConvertFromObject<T>(writableClientPropertyValue);
                             return true;
                         }
                     }

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -162,19 +162,9 @@ namespace Microsoft.Azure.Devices.Client
                     {
                         // Case 2:
                         // Check if the retrieved value is a writable property update request
-                        if (retrievedPropertyValue is WritableClientProperty writableClientProperty)
+                        if (retrievedPropertyValue is WritableClientProperty<T> writableClientProperty)
                         {
-                            object writableClientPropertyValue = writableClientProperty.Value;
-
-                            // If the object is of type T or can be cast to type T, go ahead and return it.
-                            if (ObjectCastHelpers.TryCast(writableClientPropertyValue, out value))
-                            {
-                                return true;
-                            }
-
-                            // If the cannot be cast to <T> directly we need to try to convert it using the serializer.
-                            // If it can be successfully converted, go ahead and return it.
-                            value = Convention.PayloadSerializer.ConvertFromObject<T>(writableClientPropertyValue);
+                            value = writableClientProperty.Value;
                             return true;
                         }
                     }

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -127,28 +127,102 @@ namespace Microsoft.Azure.Devices.Client
                 return false;
             }
 
+            // While retrieving the telemetry value from the collection, a simple dictionary indexer should work.
+            // While retrieving the property value from the collection:
+            // 1. A property collection constructed by the client application - can be retrieved using dictionary indexer.
+            // 2. Client property received through writable property update callbacks - stored internally as a WritableClientProperty.
+            // 3. Client property returned through GetClientProperties:
+            //  a. Client reported properties sent by the client application in response to writable property update requests - stored as a JSON object
+            //      and needs to be converted to an IWritablePropertyResponse implementation using the payload serializer.
+            //  b. Client reported properties sent by the client application - stored as a JSON object
+            //      and needs to be converted to the expected type using the payload serializer.
+            //  c. Writable property update request received - stored as a JSON object
+            //      and needs to be converted to the expected type using the payload serializer.
             if (Collection.ContainsKey(key))
             {
+                object retrievedPropertyValue = Collection[key];
+
                 // If the value associated with the key is null, then return true with the default value of the type <T> passed in.
-                if (Collection[key] == null)
+                if (retrievedPropertyValue == null)
                 {
                     value = default;
                     return true;
                 }
 
+                // Case 1:
                 // If the object is of type T or can be cast to type T, go ahead and return it.
-                if (Collection[key] is T valueRef
-                    || NumericHelpers.TryCastNumericTo(Collection[key], out valueRef))
+                if (ObjectCastHelpers.TryCast(retrievedPropertyValue, out value))
                 {
-                    value = valueRef;
                     return true;
                 }
 
                 try
                 {
-                    // If the value cannot be cast to <T> directly, we need to try to convert it using the serializer.
+                    try
+                    {
+                        // Case 2:
+                        // Check if the retrieved value is a writable property update request
+                        if (retrievedPropertyValue is WritableClientProperty writableClientProperty)
+                        {
+                            object writableClientPropertyValue = writableClientProperty.Value;
+
+                            // If the object is of type T or can be cast to type T, go ahead and return it.
+                            if (ObjectCastHelpers.TryCast(writableClientPropertyValue, out value))
+                            {
+                                return true;
+                            }
+
+                            // If the cannot be cast to <T> directly we need to try to convert it using the serializer.
+                            // If it can be successfully converted, go ahead and return it.
+                            value = Convention.PayloadSerializer.ConvertFromObject<T>(writableClientPropertyValue);
+                            return true;
+                        }
+                    }
+                    catch
+                    {
+                        // In case of an exception ignore it and continue.
+                    }
+
+                    try
+                    {
+                        // Case 3a:
+                        // Check if the retrieved value is a writable property update acknowledgment
+                        var newtonsoftWritablePropertyResponse = Convention.PayloadSerializer.ConvertFromObject<NewtonsoftJsonWritablePropertyResponse>(retrievedPropertyValue);
+
+                        if (typeof(IWritablePropertyResponse).IsAssignableFrom(typeof(T)))
+                        {
+                            // If T is IWritablePropertyResponse the property value should be of type IWritablePropertyResponse as defined in the PayloadSerializer.
+                            // We'll convert the json object to NewtonsoftJsonWritablePropertyResponse and then convert it to the appropriate IWritablePropertyResponse object.
+                            value = (T)Convention.PayloadSerializer.CreateWritablePropertyResponse(
+                                newtonsoftWritablePropertyResponse.Value,
+                                newtonsoftWritablePropertyResponse.AckCode,
+                                newtonsoftWritablePropertyResponse.AckVersion,
+                                newtonsoftWritablePropertyResponse.AckDescription);
+                            return true;
+                        }
+
+                        var writablePropertyValue = newtonsoftWritablePropertyResponse.Value;
+
+                        // If the object is of type T or can be cast to type T, go ahead and return it.
+                        if (ObjectCastHelpers.TryCast(writablePropertyValue, out value))
+                        {
+                            return true;
+                        }
+
+                        // If the cannot be cast to <T> directly we need to try to convert it using the serializer.
+                        // If it can be successfully converted, go ahead and return it.
+                        value = Convention.PayloadSerializer.ConvertFromObject<T>(writablePropertyValue);
+                        return true;
+                    }
+                    catch
+                    {
+                        // In case of an exception ignore it and continue.
+                    }
+
+                    // Case 3b, 3c:
+                    // If the value is neither a writable property nor can be cast to <T> directly, we need to try to convert it using the serializer.
                     // If it can be successfully converted, go ahead and return it.
-                    value = Convention.PayloadSerializer.ConvertFromObject<T>(Collection[key]);
+                    value = Convention.PayloadSerializer.ConvertFromObject<T>(retrievedPropertyValue);
                     return true;
                 }
                 catch

--- a/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportSettings.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         /// Setting a will message is a way for clients to notify other subscribed clients about ungraceful disconnects in an appropriate way.
         /// In response to the ungraceful disconnect, the service will send the last-will message to the configured telemetry channel.
         /// The telemetry channel can be either the default Events endpoint or a custom endpoint defined by IoT Hub routing.
-        /// For more details, refer to https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support#using-the-mqtt-protocol-directly-as-a-device.
+        /// For more details, refer to https://docs.microsoft.com/azure/iot-hub/iot-hub-mqtt-support#using-the-mqtt-protocol-directly-as-a-device.
         /// </remarks>
         public bool HasWill { get; set; }
 
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         /// </summary>
         /// <remarks>
         /// The telemetry channel can be either the default Events endpoint or a custom endpoint defined by IoT Hub routing.
-        /// For more details, refer to https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support#using-the-mqtt-protocol-directly-as-a-device.
+        /// For more details, refer to https://docs.microsoft.com/azure/iot-hub/iot-hub-mqtt-support#using-the-mqtt-protocol-directly-as-a-device.
         /// </remarks>
         public IWillMessage WillMessage { get; set; }
 

--- a/iothub/device/src/WritableClientProperty.cs
+++ b/iothub/device/src/WritableClientProperty.cs
@@ -13,12 +13,18 @@ namespace Microsoft.Azure.Devices.Client
     /// This type contains a convenience method to format the reported property as per IoT Plug and Play convention.
     /// For more details see <see href="https://docs.microsoft.com/azure/iot-develop/concepts-convention#writable-properties"/>.
     /// </remarks>
-    public class WritableClientProperty
+    public class WritableClientProperty<T>
     {
+        private T _value;
+
         /// <summary>
         /// The value of the writable property update request.
         /// </summary>
-        public object Value { get; internal set; }
+        public T Value
+        {
+            get => Convention.PayloadSerializer.ConvertFromObject<T>(_value);
+            internal set => _value = value;
+        }
 
         /// <summary>
         /// The version number associated with the writable property update request.

--- a/iothub/device/src/WritableClientProperty.cs
+++ b/iothub/device/src/WritableClientProperty.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Azure.Devices.Client
     {
         internal WritableClientProperty()
         {
-
         }
 
         /// <summary>

--- a/iothub/device/src/WritableClientProperty.cs
+++ b/iothub/device/src/WritableClientProperty.cs
@@ -13,18 +13,12 @@ namespace Microsoft.Azure.Devices.Client
     /// This type contains a convenience method to format the reported property as per IoT Plug and Play convention.
     /// For more details see <see href="https://docs.microsoft.com/azure/iot-develop/concepts-convention#writable-properties"/>.
     /// </remarks>
-    public class WritableClientProperty<T>
+    public class WritableClientProperty
     {
-        private T _value;
-
         /// <summary>
         /// The value of the writable property update request.
         /// </summary>
-        public T Value
-        {
-            get => Convention.PayloadSerializer.ConvertFromObject<T>(_value);
-            internal set => _value = value;
-        }
+        public object Value { get; internal set; }
 
         /// <summary>
         /// The version number associated with the writable property update request.

--- a/iothub/device/src/WritableClientProperty.cs
+++ b/iothub/device/src/WritableClientProperty.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Azure.Devices.Client
     /// </remarks>
     public class WritableClientProperty
     {
+        internal WritableClientProperty()
+        {
+
+        }
+
         /// <summary>
         /// The value of the writable property update request.
         /// </summary>

--- a/iothub/device/src/WritableClientProperty.cs
+++ b/iothub/device/src/WritableClientProperty.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices.Client
     /// <remarks>
     /// A writable property update request should be acknowledged by the device or module by sending a reported property.
     /// This type contains a convenience method to format the reported property as per IoT Plug and Play convention.
-    /// For more details see <see href="https://docs.microsoft.com/en-us/azure/iot-develop/concepts-convention#writable-properties"/>.
+    /// For more details see <see href="https://docs.microsoft.com/azure/iot-develop/concepts-convention#writable-properties"/>.
     /// </remarks>
     public class WritableClientProperty
     {
@@ -34,11 +34,11 @@ namespace Microsoft.Azure.Devices.Client
         /// This writable property update response will contain the property value and version supplied in the writable property update request.
         /// If you would like to construct your own writable property update response with custom value and version number, you can
         /// create an instance of <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>.
-        /// See <see href="https://docs.microsoft.com/en-us/azure/iot-develop/concepts-convention#writable-properties"/> for more details.
+        /// See <see href="https://docs.microsoft.com/azure/iot-develop/concepts-convention#writable-properties"/> for more details.
         /// </remarks>
         /// <param name="statusCode">An acknowledgment code that uses an HTTP status code.</param>
         /// <param name="description">An optional acknowledgment description.</param>
-        /// <returns></returns>
+        /// <returns>A writable property update response that can be reported back to the service.</returns>
         public IWritablePropertyResponse AcknowledgeWith(int statusCode, string description = default)
         {
             return Convention.PayloadSerializer.CreateWritablePropertyResponse(Value, statusCode, Version, description);

--- a/iothub/device/src/WritableClientProperty.cs
+++ b/iothub/device/src/WritableClientProperty.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Shared;
+
+namespace Microsoft.Azure.Devices.Client
+{
+    /// <summary>
+    /// The writable property update request received from service.
+    /// </summary>
+    /// <remarks>
+    /// A writable property update request should be acknowledged by the device or module by sending a reported property.
+    /// This type contains a convenience method to format the reported property as per IoT Plug and Play convention.
+    /// For more details see <see href="https://docs.microsoft.com/en-us/azure/iot-develop/concepts-convention#writable-properties"/>.
+    /// </remarks>
+    public class WritableClientProperty
+    {
+        /// <summary>
+        /// The value of the writable property update request.
+        /// </summary>
+        public object Value { get; internal set; }
+
+        /// <summary>
+        /// The version number associated with the writable property update request.
+        /// </summary>
+        public long Version { get; internal set; }
+
+        internal PayloadConvention Convention { get; set; }
+
+        /// <summary>
+        /// Creates a writable property update response that can be reported back to the service.
+        /// </summary>
+        /// <remarks>
+        /// This writable property update response will contain the property value and version supplied in the writable property update request.
+        /// If you would like to construct your own writable property update response with custom value and version number, you can
+        /// create an instance of <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>.
+        /// See <see href="https://docs.microsoft.com/en-us/azure/iot-develop/concepts-convention#writable-properties"/> for more details.
+        /// </remarks>
+        /// <param name="statusCode">An acknowledgment code that uses an HTTP status code.</param>
+        /// <param name="description">An optional acknowledgment description.</param>
+        /// <returns></returns>
+        public IWritablePropertyResponse AcknowledgeWith(int statusCode, string description = default)
+        {
+            return Convention.PayloadSerializer.CreateWritablePropertyResponse(Value, statusCode, Version, description);
+        }
+    }
+}

--- a/iothub/device/tests/DeviceClientTests.cs
+++ b/iothub/device/tests/DeviceClientTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         // This is for the scenario where an IoT Edge device is defined as the downstream device's transparent gateway.
-        // For more details, see https://docs.microsoft.com/en-us/azure/iot-edge/how-to-authenticate-downstream-device#retrieve-and-modify-connection-string
+        // For more details, see https://docs.microsoft.com/azure/iot-edge/how-to-authenticate-downstream-device#retrieve-and-modify-connection-string
         [TestMethod]
         public void DeviceClient_Params_GatewayAuthMethod_Works()
         {
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         // This is for the scenario where an IoT Edge device is defined as the downstream device's transparent gateway.
-        // For more details, see https://docs.microsoft.com/en-us/azure/iot-edge/how-to-authenticate-downstream-device#retrieve-and-modify-connection-string
+        // For more details, see https://docs.microsoft.com/azure/iot-edge/how-to-authenticate-downstream-device#retrieve-and-modify-connection-string
         [TestMethod]
         public void DeviceClient_ParamsGatewayAuthMethodTransport_Works()
         {
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         // This is for the scenario where an IoT Edge device is defined as the downstream device's transparent gateway.
-        // For more details, see https://docs.microsoft.com/en-us/azure/iot-edge/how-to-authenticate-downstream-device#retrieve-and-modify-connection-string
+        // For more details, see https://docs.microsoft.com/azure/iot-edge/how-to-authenticate-downstream-device#retrieve-and-modify-connection-string
         [TestMethod]
         public void DeviceClient_ParamsGatewayAuthMethodTransportArray_Works()
         {

--- a/iothub/device/tests/ObjectCastHelpersTests.cs
+++ b/iothub/device/tests/ObjectCastHelpersTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
         private void TestNumericConversion<T>(object input, bool canConvertExpected, T resultExpected)
         {
-            bool canConvertActual = ObjectCastHelpers.TryCastNumericTo<T>(input, out T result);
+            bool canConvertActual = ObjectConversionHelpers.TryCastNumericTo<T>(input, out T result);
 
             canConvertActual.Should().Be(canConvertExpected);
             result.Should().Be(resultExpected);

--- a/iothub/device/tests/ObjectCastHelpersTests.cs
+++ b/iothub/device/tests/ObjectCastHelpersTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 {
     [TestClass]
     [TestCategory("Unit")]
-    public class NumericHelpersTests
+    public class ObjectCastHelpersTests
     {
         [TestMethod]
         public void CanConvertNumericTypes()
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
         private void TestNumericConversion<T>(object input, bool canConvertExpected, T resultExpected)
         {
-            bool canConvertActual = NumericHelpers.TryCastNumericTo<T>(input, out T result);
+            bool canConvertActual = ObjectCastHelpers.TryCastNumericTo<T>(input, out T result);
 
             canConvertActual.Should().Be(canConvertExpected);
             result.Should().Be(resultExpected);

--- a/iothub/service/src/Common/Data/AccessRights.cs
+++ b/iothub/service/src/Common/Data/AccessRights.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Devices.Common.Data
 {
     /// <summary>
     /// Shared access policy permissions of IoT hub.
-    /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#iot-hub-permissions"/>.
+    /// For more information, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-security#iot-hub-permissions"/>.
     /// </summary>
     [Flags]
     [JsonConverter(typeof(StringEnumConverter))]
@@ -19,14 +19,14 @@ namespace Microsoft.Azure.Devices.Common.Data
         /// <summary>
         /// Grants read access to the identity registry.
         /// Identity registry stores information about the devices and modules permitted to connect to the IoT hub.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry"/>.
         /// </summary>
         RegistryRead = 1,
 
         /// <summary>
         /// Grants read and write access to the identity registry.
         /// Identity registry stores information about the devices and modules permitted to connect to the IoT hub.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry"/>.
         /// </summary>
         RegistryWrite = RegistryRead | 2,
 

--- a/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices
         /// <param name="handlers">The delegating handlers to add to the http client pipeline. You can add handlers for tracing, implementing a retry strategy, routing requests through a proxy, etc.</param>
         /// <returns>An instance of <see cref="DigitalTwinClient"/>.</returns>
         /// <remarks>
-        /// For more information on configuring IoT hub with Azure Active Directory, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-dev-guide-azure-ad-rbac"/>
+        /// For more information on configuring IoT hub with Azure Active Directory, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-dev-guide-azure-ad-rbac"/>
         /// </remarks>
         public static DigitalTwinClient Create(
             string hostName,
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Devices
 
         /// <summary>
         /// Updates a digital twin.
-        /// <para>For further information on how to create the json-patch, see <see href="https://docs.microsoft.com/en-us/azure/iot-pnp/howto-manage-digital-twin"/></para>
+        /// <para>For further information on how to create the json-patch, see <see href="https://docs.microsoft.com/azure/iot-pnp/howto-manage-digital-twin"/></para>
         /// </summary>
         /// <param name="digitalTwinId">The Id of the digital twin.</param>
         /// <param name="digitalTwinUpdateOperations">The application/json-patch+json operations to be performed on the specified digital twin.</param>

--- a/iothub/service/src/DigitalTwin/Serialization/UpdateOperationsUtility.cs
+++ b/iothub/service/src/DigitalTwin/Serialization/UpdateOperationsUtility.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Serialization
 
         /// <summary>
         /// Include an add property operation.
-        /// Learn more about managing digital twins here <see href="https://docs.microsoft.com/en-us/azure/iot-pnp/howto-manage-digital-twin"/>.
+        /// Learn more about managing digital twins here <see href="https://docs.microsoft.com/azure/iot-pnp/howto-manage-digital-twin"/>.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Devices.Serialization
 
         /// <summary>
         /// Include a replace property operation.
-        /// Learn more about managing digital twins here <see href="https://docs.microsoft.com/en-us/azure/iot-pnp/howto-manage-digital-twin"/>.
+        /// Learn more about managing digital twins here <see href="https://docs.microsoft.com/azure/iot-pnp/howto-manage-digital-twin"/>.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.Serialization
 
         /// <summary>
         /// Include a remove operation.
-        /// Learn more about managing digital twins here <see href="https://docs.microsoft.com/en-us/azure/iot-pnp/howto-manage-digital-twin"/>.
+        /// Learn more about managing digital twins here <see href="https://docs.microsoft.com/azure/iot-pnp/howto-manage-digital-twin"/>.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Devices.Serialization
 
         /// <summary>
         /// Include an add component operation.
-        /// Learn more about managing digital twins here <see href="https://docs.microsoft.com/en-us/azure/iot-pnp/howto-manage-digital-twin"/>.
+        /// Learn more about managing digital twins here <see href="https://docs.microsoft.com/azure/iot-pnp/howto-manage-digital-twin"/>.
         /// </summary>
         /// <remarks>
         /// This utility appends the "$metadata" identifier to the property values,
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.Devices.Serialization
 
         /// <summary>
         /// Include a replace component operation.
-        /// Learn more about managing digital twins here <see href="https://docs.microsoft.com/en-us/azure/iot-pnp/howto-manage-digital-twin"/>.
+        /// Learn more about managing digital twins here <see href="https://docs.microsoft.com/azure/iot-pnp/howto-manage-digital-twin"/>.
         /// </summary>
         /// <remarks>
         /// This utility appends the "$metadata" identifier to the property values,

--- a/iothub/service/src/FeedbackStatusCode.cs
+++ b/iothub/service/src/FeedbackStatusCode.cs
@@ -14,32 +14,32 @@ namespace Microsoft.Azure.Devices
     {
         /// <summary>
         /// Indicates that the cloud-to-device message was successfully delivered to the device.
-        /// For information on cloud-to-device message life cycle, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
+        /// For information on cloud-to-device message life cycle, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
         /// </summary>
         Success = 0,
 
         /// <summary>
         /// Indicates that the cloud-to-device message expired before it could be delivered to the device.
-        /// For information on cloud-to-device message life cycle, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
+        /// For information on cloud-to-device message life cycle, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
         /// </summary>
         Expired = 1,
 
         /// <summary>
         /// Indicates that the cloud-to-device message has been placed in a dead-lettered state.
         /// This happens when the message reaches the maximum count for the number of times it can transition between enqueued and invisible states.
-        /// For information on cloud-to-device message life cycle, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
+        /// For information on cloud-to-device message life cycle, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
         /// </summary>
         DeliveryCountExceeded = 2,
 
         /// <summary>
         /// Indicates that the cloud-to-device message was rejected by the device.
-        /// For information on cloud-to-device message life cycle, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
+        /// For information on cloud-to-device message life cycle, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
         /// </summary>
         Rejected = 3,
 
         /// <summary>
         /// Indicates that the cloud-to-device message was purged from IoT Hub.
-        /// For information on cloud-to-device message life cycle, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
+        /// For information on cloud-to-device message life cycle, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
         /// </summary>
         Purged = 4
     }

--- a/iothub/service/src/JobClient/JobClient.cs
+++ b/iothub/service/src/JobClient/JobClient.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices
         /// <param name="transportSettings">The HTTP transport settings.</param>
         /// <returns>An instance of <see cref="JobClient"/>.</returns>
         /// <remarks>
-        /// For more information on configuring IoT hub with Azure Active Directory, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-dev-guide-azure-ad-rbac"/>
+        /// For more information on configuring IoT hub with Azure Active Directory, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-dev-guide-azure-ad-rbac"/>
         /// </remarks>
         public static JobClient Create(
             string hostName,

--- a/iothub/service/src/JobProperties.cs
+++ b/iothub/service/src/JobProperties.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Devices
 {
     /// <summary>
     /// Contains properties of a Job.
-    /// See online <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/createimportexportjob">documentation</a> for more infomration.
+    /// See online <a href="https://docs.microsoft.com/rest/api/iothub/service/createimportexportjob">documentation</a> for more infomration.
     /// </summary>
     public class JobProperties
     {

--- a/iothub/service/src/ManagedIdentity.cs
+++ b/iothub/service/src/ManagedIdentity.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Azure.Devices
 {
     /// <summary>
     /// The managed identity used to access the storage account for IoT hub import and export jobs.
-    /// For more information on managed identity configuration on IoT hub, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-managed-identity"/>.
-    /// For more information on managed identities, see <see href="https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview"/>
+    /// For more information on managed identity configuration on IoT hub, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-managed-identity"/>.
+    /// For more information on managed identities, see <see href="https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview"/>
     /// </summary>
     public class ManagedIdentity
     {

--- a/iothub/service/src/MessageSystemPropertyNames.cs
+++ b/iothub/service/src/MessageSystemPropertyNames.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// The number of times a message can transition between the Enqueued and Invisible states.
         /// After the maximum number of transitions, the IoT hub sets the state of the message to dead-lettered.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>
+        /// For more information, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>
         /// </summary>
         public const string DeliveryCount = "iothub-deliverycount";
 

--- a/iothub/service/src/RegistryManager.cs
+++ b/iothub/service/src/RegistryManager.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Devices
         /// <param name="transportSettings">The HTTP transport settings.</param>
         /// <returns>An instance of <see cref="RegistryManager"/>.</returns>
         /// <remarks>
-        /// For more information on configuring IoT hub with Azure Active Directory, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-dev-guide-azure-ad-rbac"/>
+        /// For more information on configuring IoT hub with Azure Active Directory, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-dev-guide-azure-ad-rbac"/>
         /// </remarks>
         public static RegistryManager Create(
             string hostName,

--- a/iothub/service/src/ServiceClient.cs
+++ b/iothub/service/src/ServiceClient.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Devices
         /// <param name="options">The options that allow configuration of the service client instance during initialization.</param>
         /// <returns>An instance of <see cref="ServiceClient"/>.</returns>
         /// <remarks>
-        /// For more information on configuring IoT hub with Azure Active Directory, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-dev-guide-azure-ad-rbac"/>
+        /// For more information on configuring IoT hub with Azure Active Directory, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-dev-guide-azure-ad-rbac"/>
         /// </remarks>
         public static ServiceClient Create(
             string hostName,
@@ -385,7 +385,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Get the <see cref="FeedbackReceiver{FeedbackBatch}"/> which can deliver acknowledgments for messages sent to a device/module from IoT Hub.
         /// This call is made over AMQP.
-        /// For more information see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d#message-feedback"/>.
+        /// For more information see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#message-feedback"/>.
         /// </summary>
         /// <returns>An instance of <see cref="FeedbackReceiver{FeedbackBatch}"/>.</returns>
         public virtual FeedbackReceiver<FeedbackBatch> GetFeedbackReceiver()
@@ -396,7 +396,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Get the <see cref="FileNotificationReceiver{FileNotification}"/> which can deliver notifications for file upload operations.
         /// This call is made over AMQP.
-        /// For more information see <see href = "https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-file-upload#file-upload-notifications"/>.
+        /// For more information see <see href = "https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload#file-upload-notifications"/>.
         /// </summary>
         /// <returns>An instance of <see cref="FileNotificationReceiver{FileNotification}"/>.</returns>
         public virtual FileNotificationReceiver<FileNotification> GetFileNotificationReceiver()

--- a/provisioning/device/src/PlugAndPlay/PnpConvention.cs
+++ b/provisioning/device/src/PlugAndPlay/PnpConvention.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.PlugAndPlay
         /// </summary>
         /// <remarks>
         /// For more information on device provisioning service and plug and play compatibility,
-        /// and PnP device certification, see <see href="https://docs.microsoft.com/en-us/azure/iot-pnp/howto-certify-device"/>.
+        /// and PnP device certification, see <see href="https://docs.microsoft.com/azure/iot-pnp/howto-certify-device"/>.
         /// The DPS payload should be in the format:
         /// <code>
         /// {

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ Due to security considerations, build logs are not publicly available.
 | Microsoft.Azure.Devices.DigitalTwin.Service           | N/A                                                       | [![NuGet][pnp-service-prerelease]][pnp-service-nuget]         |
 
 > Note:  
-> Device streaming feature is not being included in our newer preview releases as there is no active development going on in the service. For more details on the feature, see [here](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-device-streams-overview). It is not recommended to take dependency on preview nugets for production applications as breaking changes can be introduced in preview nugets.  
+> Device streaming feature is not being included in our newer preview releases as there is no active development going on in the service. For more details on the feature, see [here](https://docs.microsoft.com/azure/iot-hub/iot-hub-device-streams-overview). It is not recommended to take dependency on preview nugets for production applications as breaking changes can be introduced in preview nugets.  
 >  
 > The feature has not been included in any preview release after [2020-10-14](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/preview_2020-10-14). However, the feature is still available under previews/deviceStreaming branch.  
 >  

--- a/shared/src/NewtonsoftJsonPayloadSerializer.cs
+++ b/shared/src/NewtonsoftJsonPayloadSerializer.cs
@@ -54,10 +54,23 @@ namespace Microsoft.Azure.Devices.Shared
             {
                 return false;
             }
-            if (((JObject)nestedObject).TryGetValue(propertyName, out JToken element))
+
+            try
             {
-                outValue = element.ToObject<T>();
-                return true;
+                // The supplied nested object is either a JObject or the string representation of a JObject.
+                JObject nestedObjectAsJObject = nestedObject.GetType() == typeof(string)
+                    ? DeserializeToType<JObject>((string)nestedObject)
+                    : nestedObject as JObject;
+
+                if (nestedObjectAsJObject != null && nestedObjectAsJObject.TryGetValue(propertyName, out JToken element))
+                {
+                    outValue = element.ToObject<T>();
+                    return true;
+                }
+            }
+            catch
+            {
+                // Catch and ignore any exceptions caught
             }
             return false;
         }

--- a/shared/src/PayloadSerializer.cs
+++ b/shared/src/PayloadSerializer.cs
@@ -56,7 +56,8 @@ namespace Microsoft.Azure.Devices.Shared
         /// An example of this would be a property under the component.
         /// </remarks>
         /// <typeparam name="T">The type to convert the retrieved property to.</typeparam>
-        /// <param name="nestedObject">The object that might contain the nested property.</param>
+        /// <param name="nestedObject">The object that might contain the nested property.
+        /// This needs to be in the json object equivalent format as required by the serializer or the string representation of it.</param>
         /// <param name="propertyName">The name of the property to be retrieved.</param>
         /// <returns>True if the nested object contains an element with the specified key; otherwise, it returns false.</returns>
         /// <param name="outValue"></param>

--- a/supported_platforms.md
+++ b/supported_platforms.md
@@ -35,7 +35,7 @@ OS name: "windows server 2016", version: "10.0", arch: "amd64", family: "windows
 
 ## Ubuntu 1604
 
-Note that, while we only directly test on Ubuntu 1604, we do generally support other [Linux distributions supported by .NET core](https://docs.microsoft.com/en-us/dotnet/core/install/linux). 
+Note that, while we only directly test on Ubuntu 1604, we do generally support other [Linux distributions supported by .NET core](https://docs.microsoft.com/dotnet/core/install/linux). 
 
 Nightly test platform details:
 


### PR DESCRIPTION
Fix for #2065 , #2097 , #2100 

As highlighted in the above feature requests, constructing the _correct_ `IWritablePropertyResponse` for writable property update requests was not easily discoverable.
This PR aims to make the flow more convenient.

- On subscribing to `SubscribeToWritablePropertyUpdateRequestsAsync`, a client application will receive the writable property update requests as a collection of `WritableClientProperty` values.
- `WritableClientProperty` has a convenience method to "ack" these property update requests. 
- The "ack'ed" response is formatted in the format as required by IoT plug and play.

You can now do:

```csharp
await deviceClient
    .SubscribeToWritablePropertyUpdateRequestsAsync(
        async (writableProperties, userContext) =>
        {
            var writablePropertyAcks = new ClientPropertyCollection();
            foreach (KeyValuePair<string, object> writableProperty in writableProperties)
            {
                if (writableProperty.Value is WritableClientProperty rootLevelWritableClientProperty)
                {
                    string rootLevelPropertyName = writableProperty.Key;
                    writablePropertyAcks.Add(rootLevelPropertyName, rootLevelWritableClientProperty.AcknowledgeWith(CommonClientResponseCodes.OK));
                }
                else if (writableProperty.Value is IDictionary<string, object> componentProperties)
                {
                    string componentName = writableProperty.Key;
                    foreach (KeyValuePair<string, object> componentProperty in componentProperties)
                    {
                        if (componentProperty.Value is WritableClientProperty componentLevelwritableClientProperty)
                        {
                            string componentLevelPropertyName = componentProperty.Key;
                            writablePropertyAcks.AddComponentProperty(componentName, componentLevelPropertyName, componentLevelwritableClientProperty.AcknowledgeWith(CommonClientResponseCodes.OK));
                        }
                    }
                }
            }

            await deviceClient.UpdateClientPropertiesAsync(writablePropertyAcks).ConfigureAwait(false);
        },
        null,
        cts.Token)
    .ConfigureAwait(false);
```

Note: In earlier discussions we had contemplated updating:
```csharp
public Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, object, Task> callback, object userContext, CancellationToken cancellationToken = default);
```
to 
```csharp
public Task RespondToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, object, Task<ClientPropertyCollection>> callback, object userContext, CancellationToken cancellationToken = default);
```

However, we decided against doing this because this would associate each writable property request with a response (reported property update) API call. Instead, we are formatting the response that the user can then add to a `ClientPropertyCollection` and issue the update call themselves.