### PR TITLE
fix(iot-device): Update MQTT layer to subscribe to topics with QoS of 1

### DIFF
--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -823,7 +823,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_001:  `EnableMethodsAsync` shall subscribe using the '$iothub/methods/POST/' topic filter.
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_002:  `EnableMethodsAsync` shall wait for a SUBACK for the subscription request.
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_003:  `EnableMethodsAsync` shall return failure if the subscription request fails.
-            await _channel.WriteAsync(new SubscribePacket(0, new SubscriptionRequest(MethodPostTopicFilter, QualityOfService.AtMostOnce))).ConfigureAwait(true);
+            await _channel.WriteAsync(new SubscribePacket(0, new SubscriptionRequest(MethodPostTopicFilter, QualityOfService.AtLeastOnce))).ConfigureAwait(true);
         }
 
         public override async Task DisableMethodsAsync(CancellationToken cancellationToken)
@@ -887,7 +887,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_010: `EnableTwinPatchAsync` shall subscribe using the '$iothub/twin/PATCH/properties/desired/#' topic filter.
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_011: `EnableTwinPatchAsync` shall wait for a SUBACK on the subscription request.
             // Codes_SRS_CSHARP_MQTT_TRANSPORT_18_012: `EnableTwinPatchAsync` shall return failure if the subscription request fails.
-            await _channel.WriteAsync(new SubscribePacket(0, new SubscriptionRequest(TwinPatchTopicFilter, QualityOfService.AtMostOnce))).ConfigureAwait(true);
+            await _channel.WriteAsync(new SubscribePacket(0, new SubscriptionRequest(TwinPatchTopicFilter, QualityOfService.AtLeastOnce))).ConfigureAwait(true);
 
             if (Logging.IsEnabled)
                 Logging.Exit(this, cancellationToken, nameof(EnableTwinPatchAsync));
@@ -1095,7 +1095,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     0,
                     new SubscriptionRequest(
                         TwinResponseTopicFilter,
-                        QualityOfService.AtMostOnce)));
+                        QualityOfService.AtLeastOnce)));
         }
 
         private bool ParseResponseTopic(string topicName, out string rid, out int status)


### PR DESCRIPTION
Our MS docs call out that device SDKs should subscribe to topics with a QoS of 1 (at least once), but we had a couple of topics being subscribed to with QoS of 0 (at most once): https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support#using-the-device-sdks

QoS of 0 = at most once = message delivery is attempted at most once. The publisher does not wait for an ack, meaning that the message delivery is not ack'ed or guaranteed. This is also called "fire and forget".
QoS of 1 = at least once = message delivery is attempted and the publisher waits for an ack from the subscriber. This QoS guarantees delivery of message at least once. 

Nice write-up about QoS: https://www.hivemq.com/blog/mqtt-essentials-part-6-mqtt-quality-of-service-levels/

The impact of this change will be that our messaging should be more reliable (prevent loss of messages), albeit a _bit_ slower (since calls will now wait for an ack rather than completing immediately).