### PR TITLE
fix(iot-device): Fix params passed into ObjectDisposedException

### DIFF
--- a/iothub/device/src/AuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/AuthenticationWithTokenRefresh.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Client
         {
             if (_isDisposed)
             {
-                throw new ObjectDisposedException("The authentication method instance has already been disposed, so this client is no longer usable. " +
+                throw new ObjectDisposedException(GetType().Name, "The authentication method instance has already been disposed, so this client is no longer usable. " +
                     "Please close and dispose your current client instance. To continue carrying out operations from your device/ module, " +
                     "create a new authentication method instance and use it for reinitializing your client.");
             }


### PR DESCRIPTION
Constructors for `ObjectDisposedException`:

```csharp
public ObjectDisposedException(string objectName);
public ObjectDisposedException(string message, Exception innerException);
public ObjectDisposedException(string objectName, string message);
protected ObjectDisposedException(SerializationInfo info, StreamingContext context);
```

We were calling the first constructor but had incorrectly passed in the `message` instead of `objectName`. This PR fixes that.
While this is technically breaking since the string inside `ObjectName` will now change (from an error description message to the type name), this is still a desired change.