### PR TITLE
[PnP] Update PayloadCollection to accept dictionary of values

### DIFF
--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -44,8 +44,16 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="componentName">The component with the property to add.</param>
         /// <param name="propertyName">The name of the property to add.</param>
         /// <param name="propertyValue">The value of the property to add.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="componentName"/> or <paramref name="propertyName"/> is <c>null</c>.</exception>
         public void AddComponentProperty(string componentName, string propertyName, object propertyValue)
-            => AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName, false);
+        {
+            if (componentName == null)
+            {
+                throw new ArgumentNullException(nameof(componentName));
+            }
+
+            AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName, false);
+        }
 
         /// <inheritdoc path="/remarks" cref="AddRootProperty(string, object)" />
         /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
@@ -55,8 +63,16 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="componentName">The component with the properties to add.</param>
         /// <param name="properties">A collection of properties to add.</param>
         /// <exception cref="ArgumentException">A property name in <paramref name="properties"/> already exists in the collection.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="componentName"/> or a property name in <paramref name="properties"/> is <c>null</c>.</exception>
         public void AddComponentProperties(string componentName, IDictionary<string, object> properties)
-            => AddInternal(properties, componentName, true);
+        {
+            if (componentName == null)
+            {
+                throw new ArgumentNullException(nameof(componentName));
+            }
+
+            AddInternal(properties, componentName, false);
+        }
 
         /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/exception" cref="AddRootProperty(string, object)" />
@@ -100,9 +116,16 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="componentName">The component with the property to add or update.</param>
         /// <param name="propertyName">The name of the property to add or update.</param>
         /// <param name="propertyValue">The value of the property to add or update.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="componentName"/> or <paramref name="propertyName"/> is <c>null</c>.</exception>
         public void AddOrUpdateComponentProperty(string componentName, string propertyName, object propertyValue)
-            => AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName, true);
+        {
+            if (componentName == null)
+            {
+                throw new ArgumentNullException(nameof(componentName));
+            }
+
+            AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName, true);
+        }
 
         /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
@@ -116,8 +139,16 @@ namespace Microsoft.Azure.Devices.Client
         /// </remarks>
         /// <param name="componentName">The component with the properties to add or update.</param>
         /// <param name="properties">A collection of properties to add or update.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="componentName"/> or a property name in <paramref name="properties"/> is <c>null</c>.</exception>
         public void AddOrUpdateComponentProperties(string componentName, IDictionary<string, object> properties)
-            => AddInternal(properties, componentName, true);
+        {
+            if (componentName == null)
+            {
+                throw new ArgumentNullException(nameof(componentName));
+            }
+
+            AddInternal(properties, componentName, true);
+        }
 
         /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
         /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
@@ -133,9 +164,16 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="properties">A collection of properties to add or update.</param>
         /// <exception cref="ArgumentNullException"><paramref name="properties"/> is <c>null</c>.</exception>
         public void AddOrUpdateRootProperties(IDictionary<string, object> properties)
-            => properties
+        {
+            if (properties == null)
+            {
+                throw new ArgumentNullException(nameof(properties));
+            }
+
+            properties
                 .ToList()
                 .ForEach(entry => Collection[entry.Key] = entry.Value);
+        }
 
         /// <summary>
         /// Determines whether the specified property is present.
@@ -426,14 +464,14 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="componentName">The component with the properties to add or update.</param>
         /// <param name="forceUpdate">Forces the collection to use the Add or Update behavior.
         /// Setting to true will simply overwrite the value. Setting to false will use <see cref="IDictionary{TKey, TValue}.Add(TKey, TValue)"/></param>
-        /// <exception cref="ArgumentNullException"><paramref name="properties"/> is <c>null</c> for a top-level property operation.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="properties"/> is <c>null</c>.</exception>
         private void AddInternal(IDictionary<string, object> properties, string componentName = default, bool forceUpdate = false)
         {
             // If the componentName is null then simply add the key-value pair to Collection dictionary.
             // This will either insert a property or overwrite it if it already exists.
             if (componentName == null)
             {
-                // If both the component name and properties collection are null then throw a ArgumentNullException.
+                // If both the component name and properties collection are null then throw an ArgumentNullException.
                 // This is not a valid use-case.
                 if (properties == null)
                 {
@@ -442,6 +480,12 @@ namespace Microsoft.Azure.Devices.Client
 
                 foreach (KeyValuePair<string, object> entry in properties)
                 {
+                    // A null property key is not allowed. Throw an ArgumentNullException.
+                    if (entry.Key == null)
+                    {
+                        throw new ArgumentNullException(nameof(entry.Key));
+                    }
+
                     if (forceUpdate)
                     {
                         Collection[entry.Key] = entry.Value;
@@ -471,6 +515,12 @@ namespace Microsoft.Azure.Devices.Client
 
                     foreach (KeyValuePair<string, object> entry in properties)
                     {
+                        // A null property key is not allowed. Throw an ArgumentNullException.
+                        if (entry.Key == null)
+                        {
+                            throw new ArgumentNullException(nameof(entry.Key));
+                        }
+
                         if (forceUpdate)
                         {
                             componentProperties[entry.Key] = entry.Value;

--- a/iothub/device/src/TelemetryCollection.cs
+++ b/iothub/device/src/TelemetryCollection.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Azure.Devices.Client
 {
@@ -31,6 +33,43 @@ namespace Microsoft.Azure.Devices.Client
         public override void AddOrUpdate(string telemetryName, object telemetryValue)
         {
             base.AddOrUpdate(telemetryName, telemetryValue);
+        }
+
+        /// <summary>
+        /// Adds the telemetry values to the telemetry collection.
+        /// </summary>
+        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['telemetryName']"/>
+        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['telemetryValue']"/>
+        /// <exception cref="ArgumentException">An element with the same key already exists in the collection.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="telemetryValues"/> is <c>null</c>.</exception>
+        public void Add(IDictionary<string, object> telemetryValues)
+        {
+            if (telemetryValues == null)
+            {
+                throw new ArgumentNullException(nameof(telemetryValues));
+            }
+
+            telemetryValues
+                .ToList()
+                .ForEach(entry => base.Add(entry.Key, entry.Value));
+        }
+
+        /// <summary>
+        /// Adds or updates the telemetry values in the telemetry collection.
+        /// </summary>
+        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['telemetryName']"/>
+        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['telemetryValue']"/>
+        /// <exception cref="ArgumentNullException"><paramref name="telemetryValues"/> is <c>null</c>.</exception>
+        public void AddOrUpdate(IDictionary<string, object> telemetryValues)
+        {
+            if (telemetryValues == null)
+            {
+                throw new ArgumentNullException(nameof(telemetryValues));
+            }
+
+            telemetryValues
+                .ToList()
+                .ForEach(entry => base.AddOrUpdate(entry.Key, entry.Value));
         }
     }
 }

--- a/iothub/device/tests/ClientPropertyCollectionTests.cs
+++ b/iothub/device/tests/ClientPropertyCollectionTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.Azure.Devices.Shared;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Client.Test
 {
@@ -800,6 +801,31 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool isValue2Retrieved = testPropertyCollection.TryGetValue<int>("testComponent", "abc", out int value2Retrieved);
             isValue2Retrieved.Should().BeTrue();
             value2Retrieved.Should().Be(2);
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollect_AddRawClassSuccess()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+            var propertyValues = new CustomClientProperty
+            {
+                Id = 12,
+                Name = "testProperty"
+            };
+            var propertyValuesAsDictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(propertyValues));
+
+            // act
+            testPropertyCollection.AddRootProperties(propertyValuesAsDictionary);
+
+            // assert
+            bool isIdPresent = testPropertyCollection.TryGetValue<int>("Id", out int id);
+            isIdPresent.Should().BeTrue();
+            id.Should().Be(12);
+
+            bool isNamePresent = testPropertyCollection.TryGetValue<string>("Name", out string name);
+            isNamePresent.Should().BeTrue();
+            name.Should().Be("testProperty");
         }
     }
 

--- a/iothub/device/tests/ClientPropertyCollectionTests.cs
+++ b/iothub/device/tests/ClientPropertyCollectionTests.cs
@@ -427,6 +427,380 @@ namespace Microsoft.Azure.Devices.Client.Test
             isValueRetrieved.Should().BeFalse();
             propertyValue.Should().Be(default);
         }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddNullPropertyNameThrows()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+
+            // act
+            Action testAction = () => testPropertyCollection.AddRootProperty(null, 123);
+
+            // assert
+            testAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddOrUpdateNullPropertyNameThrows()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+
+            // act
+            Action testAction = () => testPropertyCollection.AddOrUpdateRootProperty(null, 123);
+
+            // assert
+            testAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddNullPropertyValueSuccess()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+
+            // act
+            // This should add an entry in the dictionary with a null value.
+            // This patch would be interpreted by the service as the client wanting to remove property "abc" from its properties.
+            testPropertyCollection.AddRootProperty("abc", null);
+
+            // assert
+            bool isValueRetrieved = testPropertyCollection.TryGetValue<object>("abc", out object propertyValue);
+            isValueRetrieved.Should().BeTrue();
+            propertyValue.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddOrUpdateNullPropertyValueSuccess()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+
+            // act
+            // This should add an entry in the dictionary with a null value.
+            // This patch would be interpreted by the service as the client wanting to remove property "abc" from its properties.
+            testPropertyCollection.AddOrUpdateRootProperty("abc", null);
+
+            // assert
+            bool isValueRetrieved = testPropertyCollection.TryGetValue<object>("abc", out object propertyValue);
+            isValueRetrieved.Should().BeTrue();
+            propertyValue.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddPropertyValueAlreadyExistsThrows()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+            testPropertyCollection.AddRootProperty("abc", 123);
+
+            // act
+            Action testAction = () => testPropertyCollection.AddRootProperty("abc", 1);
+
+            // assert
+            testAction.Should().Throw<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddOrUpdatePropertyValueAlreadyExistsSuccess()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+            testPropertyCollection.AddRootProperty("abc", 123);
+
+            // act
+            testPropertyCollection.AddOrUpdateRootProperty("abc", 1);
+
+            // assert
+            bool isValueRetrieved = testPropertyCollection.TryGetValue<int>("abc", out int propertyValue);
+            isValueRetrieved.Should().BeTrue();
+            propertyValue.Should().Be(1);
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddNullClientPropertyCollectionThrows()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+
+            // act
+            Action testAction = () => testPropertyCollection.AddRootProperties(null);
+
+            // assert
+            testAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddOrUpdateNullClientPropertyCollectionThrows()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+
+            // act
+            Action testAction = () => testPropertyCollection.AddOrUpdateRootProperties(null);
+
+            // assert
+            testAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddClientPropertyCollectionAlreadyExistsThrows()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+            testPropertyCollection.AddRootProperty("abc", 123);
+            var propertyValues = new Dictionary<string, object>
+            {
+                { "qwe", 98 },
+                { "abc", 2 },
+            };
+
+            // act
+            Action testAction = () => testPropertyCollection.AddRootProperties(propertyValues);
+
+            // assert
+            testAction.Should().Throw<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddOrUpdateClientPropertyCollectionAlreadyExistsSuccess()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+            testPropertyCollection.AddRootProperty("abc", 123);
+            var propertyValues = new Dictionary<string, object>
+            {
+                { "qwe", 98 },
+                { "abc", 2 },
+            };
+
+            // act
+            testPropertyCollection.AddOrUpdateRootProperties(propertyValues);
+
+            // assert
+            bool isValue1Retrieved = testPropertyCollection.TryGetValue<int>("qwe", out int value1Retrieved);
+            isValue1Retrieved.Should().BeTrue();
+            value1Retrieved.Should().Be(98);
+
+            bool isValue2Retrieved = testPropertyCollection.TryGetValue<int>("abc", out int value2Retrieved);
+            isValue2Retrieved.Should().BeTrue();
+            value2Retrieved.Should().Be(2);
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddNullPropertyNameWithComponentThrows()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+
+            // act
+            Action testAction = () => testPropertyCollection.AddComponentProperty("testComponent", null, 123);
+
+            // assert
+            testAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddOrUpdateNullPropertyNameWithComponentThrows()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+
+            // act
+            Action testAction = () => testPropertyCollection.AddOrUpdateComponentProperty("testComponent", null, 123);
+
+            // assert
+            testAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddNullComponentNameThrows()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+
+            // act
+            Action testAction = () => testPropertyCollection.AddComponentProperty(null, "abc", 123);
+
+            // assert
+            testAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddOrUpdateNullComponentNameThrows()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+
+            // act
+            Action testAction = () => testPropertyCollection.AddOrUpdateComponentProperty(null, "abc", 123);
+
+            // assert
+            testAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddNullPropertyValueWithComponentSuccess()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+            testPropertyCollection.AddComponentProperty("testComponent", "qwe", 123);
+
+            // act
+            // This should add an entry in the dictionary with a null value.
+            // This patch would be interpreted by the service as the client wanting to remove property "abc" from its properties.
+            testPropertyCollection.AddComponentProperty("testComponent", "abc", null);
+
+            // assert
+            bool isValue1Retrieved = testPropertyCollection.TryGetValue<int>("testComponent", "qwe", out int property1Value);
+            isValue1Retrieved.Should().BeTrue();
+            property1Value.Should().Be(123);
+
+            bool isValue2Retrieved = testPropertyCollection.TryGetValue<object>("testComponent", "abc", out object property2Value);
+            isValue2Retrieved.Should().BeTrue();
+            property2Value.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddOrUpdateNullPropertyValueWithComponentSuccess()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+            testPropertyCollection.AddComponentProperty("testComponent", "qwe", 123);
+
+            // act
+            // This should add an entry in the dictionary with a null value.
+            // This patch would be interpreted by the service as the client wanting to remove property "abc" from its properties.
+            testPropertyCollection.AddOrUpdateComponentProperty("testComponent", "abc", null);
+
+            // assert
+            bool isValue1Retrieved = testPropertyCollection.TryGetValue<int>("testComponent", "qwe", out int property1Value);
+            isValue1Retrieved.Should().BeTrue();
+            property1Value.Should().Be(123);
+
+            bool isValue2Retrieved = testPropertyCollection.TryGetValue<object>("testComponent", "abc", out object property2Value);
+            isValue2Retrieved.Should().BeTrue();
+            property2Value.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddNullClientPropertyCollectionWithComponentSuccess()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+            testPropertyCollection.Convention = DefaultPayloadConvention.Instance;
+            testPropertyCollection.AddComponentProperty("testComponent", "qwe", 98);
+
+            // act
+            // This should add an entry in the dictionary with a null value.
+            // This patch would be interpreted by the service as the client wanting to remove component "testComponent" from its properties.
+            testPropertyCollection.AddComponentProperties("testComponent", null);
+
+            // assert
+            bool iscomponentValueRetrieved = testPropertyCollection.TryGetValue<int>("testComponent", "qwe", out int property2Value);
+            iscomponentValueRetrieved.Should().BeFalse();
+
+            bool iscomponentRetrieved = testPropertyCollection.TryGetValue<object>("testComponent", out object componentValue);
+            iscomponentRetrieved.Should().BeTrue();
+            componentValue.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddOrUpdateNullClientPropertyCollectionWithComponentThrows()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+            testPropertyCollection.Convention = DefaultPayloadConvention.Instance;
+            testPropertyCollection.AddComponentProperty("testComponent", "qwe", 98);
+
+            // act
+            // This should add an entry in the dictionary with a null value.
+            // This patch would be interpreted by the service as the client wanting to remove component "testComponent" from its properties.
+            testPropertyCollection.AddOrUpdateComponentProperties("testComponent", null);
+
+            // assert
+            bool iscomponentValueRetrieved = testPropertyCollection.TryGetValue<int>("testComponent", "qwe", out int property2Value);
+            iscomponentValueRetrieved.Should().BeFalse();
+
+            bool iscomponentRetrieved = testPropertyCollection.TryGetValue<object>("testComponent", out object componentValue);
+            iscomponentRetrieved.Should().BeTrue();
+            componentValue.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddPropertyValueAlreadyExistsWithComponentThrows()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+            testPropertyCollection.AddComponentProperty("testComponent", "abc", 123);
+
+            // act
+            Action testAction = () => testPropertyCollection.AddComponentProperty("testComponent", "abc", 1);
+
+            // assert
+            testAction.Should().Throw<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddOrUpdatePropertyValueAlreadyExistsWithComponentSuccess()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+            testPropertyCollection.AddComponentProperty("testComponent", "abc", 123);
+
+            // act
+            testPropertyCollection.AddOrUpdateComponentProperty("testComponent", "abc", 1);
+
+            // assert
+            bool isValueRetrieved = testPropertyCollection.TryGetValue<int>("testComponent", "abc", out int propertyValue);
+            isValueRetrieved.Should().BeTrue();
+            propertyValue.Should().Be(1);
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddClientPropertyCollectionAlreadyExistsWithComponentThrows()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+            testPropertyCollection.AddComponentProperty("testComponent", "abc", 123);
+            var propertyValues = new Dictionary<string, object>
+            {
+                { "qwe", 98 },
+                { "abc", 2 },
+            };
+
+            // act
+            Action testAction = () => testPropertyCollection.AddComponentProperties("testComponent", propertyValues);
+
+            // assert
+            testAction.Should().Throw<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void ClientPropertyCollection_AddOrUpdateClientPropertyCollectionAlreadyExistsWithComponentSuccess()
+        {
+            // arrange
+            var testPropertyCollection = new ClientPropertyCollection();
+            testPropertyCollection.AddComponentProperty("testComponent", "abc", 123);
+            var propertyValues = new Dictionary<string, object>
+            {
+                { "qwe", 98 },
+                { "abc", 2 },
+            };
+
+            // act
+            testPropertyCollection.AddOrUpdateComponentProperties("testComponent", propertyValues);
+
+            // assert
+            bool isValue1Retrieved = testPropertyCollection.TryGetValue<int>("testComponent", "qwe", out int value1Retrieved);
+            isValue1Retrieved.Should().BeTrue();
+            value1Retrieved.Should().Be(98);
+
+            bool isValue2Retrieved = testPropertyCollection.TryGetValue<int>("testComponent", "abc", out int value2Retrieved);
+            isValue2Retrieved.Should().BeTrue();
+            value2Retrieved.Should().Be(2);
+        }
     }
 
     internal class CustomClientProperty

--- a/iothub/device/tests/TelemetryCollectionTests.cs
+++ b/iothub/device/tests/TelemetryCollectionTests.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Devices.Client.Test
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class TelemetryCollectionTests
+    {
+        [TestMethod]
+        public void AddNullTelemetryNameThrows()
+        {
+            // arrange
+            var testTelemetryCollection = new TelemetryCollection();
+
+            // act
+            Action testAction = () => testTelemetryCollection.Add(null, 123);
+
+            // assert
+            testAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void AddOrUpdateNullTelemetryNameThrows()
+        {
+            // arrange
+            var testTelemetryCollection = new TelemetryCollection();
+
+            // act
+            Action testAction = () => testTelemetryCollection.AddOrUpdate(null, 123);
+
+            // assert
+            testAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void AddNullTelemetryValueSuccess()
+        {
+            // arrange
+            var testTelemetryCollection = new TelemetryCollection();
+
+            // act
+            testTelemetryCollection.Add("abc", null);
+
+            // assert
+            testTelemetryCollection["abc"].Should().BeNull();
+        }
+
+        [TestMethod]
+        public void AddOrUpdateNullTelemetryValueSuccess()
+        {
+            // arrange
+            var testTelemetryCollection = new TelemetryCollection();
+
+            // act
+            testTelemetryCollection.AddOrUpdate("abc", null);
+
+            // assert
+            testTelemetryCollection["abc"].Should().BeNull();
+        }
+
+        [TestMethod]
+        public void AddTelemetryValueAlreadyExistsThrows()
+        {
+            // arrange
+            var testTelemetryCollection = new TelemetryCollection();
+            testTelemetryCollection.Add("abc", 123);
+
+            // act
+            Action testAction = () => testTelemetryCollection.Add("abc", 1);
+
+            // assert
+            testAction.Should().Throw<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void AddOrUpdateTelemetryValueAlreadyExistsSuccess()
+        {
+            // arrange
+            var testTelemetryCollection = new TelemetryCollection();
+            testTelemetryCollection.Add("abc", 123);
+
+            // act
+            testTelemetryCollection.AddOrUpdate("abc", 1);
+
+            // assert
+            testTelemetryCollection["abc"].Should().Be(1);
+        }
+
+        [TestMethod]
+        public void AddNullTelemetryCollectionThrows()
+        {
+            // arrange
+            var testTelemetryCollection = new TelemetryCollection();
+
+            // act
+            Action testAction = () => testTelemetryCollection.Add(null);
+
+            // assert
+            testAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void AddOrUpdateNullTelemetryCollectionThrows()
+        {
+            // arrange
+            var testTelemetryCollection = new TelemetryCollection();
+
+            // act
+            Action testAction = () => testTelemetryCollection.AddOrUpdate(null);
+
+            // assert
+            testAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void AddTelemetryCollectionAlreadyExistsThrows()
+        {
+            // arrange
+            var testTelemetryCollection = new TelemetryCollection();
+            testTelemetryCollection.AddOrUpdate("abc", 123);
+            var telemetryValues = new Dictionary<string, object>
+            {
+                { "qwe", 98 },
+                { "abc", 2 },
+            };
+
+            // act
+            Action testAction = () => testTelemetryCollection.Add(telemetryValues);
+
+            // assert
+            testAction.Should().Throw<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void AddOrUpdateTelemetryCollectionAlreadyExistsSuccess()
+        {
+            // arrange
+            var testTelemetryCollection = new TelemetryCollection();
+            testTelemetryCollection.AddOrUpdate("abc", 123);
+            var telemetryValues = new Dictionary<string, object>
+            {
+                { "qwe", 98 },
+                { "abc", 2 },
+            };
+
+            // act
+            testTelemetryCollection.AddOrUpdate(telemetryValues);
+
+            // assert
+            testTelemetryCollection["qwe"].Should().Be(98);
+            testTelemetryCollection["abc"].Should().Be(2);
+        }
+    }
+}


### PR DESCRIPTION
This update allows users to pass in a collection of values for TelemetryPayload and PropertyPayload.

While we currently don't have an implementation to accept raw classes as payload values, it can easily be achieved by serializing the raw class and deserializing it into a dictionary.

We'll can add support for it if customers ask for it.