### PR TITLE
fix(iot-svc): Cleanup and deprecation warning of code in CryptoKeyGenerator

### DIFF
--- a/e2e/test/helpers/CryptoKeyGenerator.cs
+++ b/e2e/test/helpers/CryptoKeyGenerator.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Security.Cryptography;
+
+#if !NET451
+
+using System.Linq;
+
+#endif
+
+namespace Microsoft.Azure.Devices.E2ETests
+{
+    /// <summary>
+    /// Utility methods for generating cryptographically secure keys and passwords.
+    /// </summary>
+    internal static class CryptoKeyGenerator
+    {
+#if NET451
+        private const int DefaultPasswordLength = 16;
+        private const int GuidLength = 16;
+#endif
+
+        /// <summary>
+        /// Size of the SHA 512 key.
+        /// </summary>
+        internal const int Sha512KeySize = 64;
+
+        /// <summary>
+        /// Generate a key with a specified key size.
+        /// </summary>
+        /// <param name="keySize">The size of the key.</param>
+        /// <returns>Byte array representing the key.</returns>
+        internal static byte[] GenerateKeyBytes(int keySize)
+        {
+#if NET451
+            byte[] keyBytes = new byte[keySize];
+            using var cyptoProvider = new RNGCryptoServiceProvider();
+            cyptoProvider.GetNonZeroBytes(keyBytes);
+#else
+            byte[] keyBytes = new byte[keySize];
+            using var cyptoProvider = RandomNumberGenerator.Create();
+            while (keyBytes.Contains(byte.MinValue))
+            {
+                cyptoProvider.GetBytes(keyBytes);
+            }
+#endif
+            return keyBytes;
+        }
+
+        /// <summary>
+        /// Generates a key of the specified size.
+        /// </summary>
+        /// <param name="keySize">Desired key size.</param>
+        /// <returns>A generated key.</returns>
+        internal static string GenerateKey(int keySize)
+        {
+            return Convert.ToBase64String(GenerateKeyBytes(keySize));
+        }
+    }
+}

--- a/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Tracing;
 using System.Net;
 using System.Threading.Tasks;
-using Microsoft.Azure.Devices.Common;
 using Microsoft.Azure.Devices.Provisioning.Security.Samples;
 using Microsoft.Azure.Devices.Provisioning.Service;
 using Microsoft.Azure.Devices.Shared;

--- a/iothub/service/src/Common/Security/CryptoKeyGenerator.cs
+++ b/iothub/service/src/Common/Security/CryptoKeyGenerator.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.Devices.Common
         /// </summary>
         /// <param name="keySize">The size of the key.</param>
         /// <returns>Byte array representing the key.</returns>
+        [Obsolete("This method will be deprecated in a future version.")]
         public static byte[] GenerateKeyBytes(int keySize)
         {
 #if NET451
@@ -61,6 +62,7 @@ namespace Microsoft.Azure.Devices.Common
         /// </summary>
         /// <param name="keySize">Desired key size.</param>
         /// <returns>A generated key.</returns>
+        [Obsolete("This method will be deprecated in a future version.")]
         public static string GenerateKey(int keySize)
         {
             return Convert.ToBase64String(GenerateKeyBytes(keySize));
@@ -72,6 +74,7 @@ namespace Microsoft.Azure.Devices.Common
         /// </summary>
         /// <param name="keySize">Desired key size.</param>
         /// <returns>A generated hexadecimal key.</returns>
+        [Obsolete("This method will not be carried forward to newer .NET targets.")]
         public static string GenerateKeyInHex(int keySize)
         {
             byte[] keyBytes = new byte[keySize];
@@ -85,6 +88,7 @@ namespace Microsoft.Azure.Devices.Common
         /// Generate a GUID using random bytes from the framework's cryptograpically strong RNG (Random Number Generator).
         /// </summary>
         /// <returns>A cryptographically secure GUID.</returns>
+        [Obsolete("This method will not be carried forward to newer .NET targets.")]
         public static Guid GenerateGuid()
         {
             byte[] bytes = new byte[GuidLength];
@@ -116,6 +120,7 @@ namespace Microsoft.Azure.Devices.Common
         /// Generate a unique password with a default length and without converting it to Base64String.
         /// </summary>
         /// <returns>A unique password.</returns>
+        [Obsolete("This method will not be carried forward to newer .NET targets.")]
         public static string GeneratePassword()
         {
             return GeneratePassword(DefaultPasswordLength, false);
@@ -127,6 +132,7 @@ namespace Microsoft.Azure.Devices.Common
         /// <param name="length">Desired length of the password.</param>
         /// <param name="base64Encoding">Encode the password if set to True. False otherwise.</param>
         /// <returns>A generated password.</returns>
+        [Obsolete("This method will not be carried forward to newer .NET targets.")]
         public static string GeneratePassword(int length, bool base64Encoding)
         {
             string password = Membership.GeneratePassword(length, length / 2);

--- a/iothub/service/src/Common/Security/CryptoKeyGenerator.cs
+++ b/iothub/service/src/Common/Security/CryptoKeyGenerator.cs
@@ -5,7 +5,7 @@ using System;
 using System.Text;
 using System.Security.Cryptography;
 
-#if NET451 || NET472
+#if NET451
 
 using System.Web.Security;
 
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Common
     /// </summary>
     static public class CryptoKeyGenerator
     {
-#if NET451 || NET472
+#if NET451
         private const int DefaultPasswordLength = 16;
         private const int GuidLength = 16;
 #endif
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Devices.Common
             return Convert.ToBase64String(GenerateKeyBytes(keySize));
         }
 
-#if NET451 || NET472
+#if NET451
         /// <summary>
         /// Generate a hexadecimal key of the specified size.
         /// </summary>

--- a/iothub/service/src/Common/Security/CryptoKeyGenerator.cs
+++ b/iothub/service/src/Common/Security/CryptoKeyGenerator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Devices.Common
     /// <summary>
     /// Utility methods for generating cryptographically secure keys and passwords.
     /// </summary>
-    static public class CryptoKeyGenerator
+    public static class CryptoKeyGenerator
     {
 #if NET451
         private const int DefaultPasswordLength = 16;

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -151,6 +151,7 @@
 
   <!-- net472 -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <Reference Include="System.Web" Version="4.0.0.0" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -151,7 +151,6 @@
 
   <!-- net472 -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <Reference Include="System.Web" Version="4.0.0.0" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/iothub/service/tests/CryptoKeyGenerator.cs
+++ b/iothub/service/tests/CryptoKeyGenerator.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Security.Cryptography;
+
+#if !NET451
+
+using System.Linq;
+
+#endif
+
+namespace Microsoft.Azure.Devices.Tests
+{
+    /// <summary>
+    /// Utility methods for generating cryptographically secure keys and passwords.
+    /// </summary>
+    internal static class CryptoKeyGenerator
+    {
+#if NET451
+        private const int DefaultPasswordLength = 16;
+        private const int GuidLength = 16;
+#endif
+
+        /// <summary>
+        /// Size of the SHA 512 key.
+        /// </summary>
+        internal const int Sha512KeySize = 64;
+
+        /// <summary>
+        /// Generate a key with a specified key size.
+        /// </summary>
+        /// <param name="keySize">The size of the key.</param>
+        /// <returns>Byte array representing the key.</returns>
+        internal static byte[] GenerateKeyBytes(int keySize)
+        {
+#if NET451
+            byte[] keyBytes = new byte[keySize];
+            using var cyptoProvider = new RNGCryptoServiceProvider();
+            cyptoProvider.GetNonZeroBytes(keyBytes);
+#else
+            byte[] keyBytes = new byte[keySize];
+            using var cyptoProvider = RandomNumberGenerator.Create();
+            while (keyBytes.Contains(byte.MinValue))
+            {
+                cyptoProvider.GetBytes(keyBytes);
+            }
+#endif
+            return keyBytes;
+        }
+
+        /// <summary>
+        /// Generates a key of the specified size.
+        /// </summary>
+        /// <param name="keySize">Desired key size.</param>
+        /// <returns>A generated key.</returns>
+        internal static string GenerateKey(int keySize)
+        {
+            return Convert.ToBase64String(GenerateKeyBytes(keySize));
+        }
+    }
+}

--- a/iothub/service/tests/DeviceAuthenticationTests.cs
+++ b/iothub/service/tests/DeviceAuthenticationTests.cs
@@ -7,7 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.Devices.Common;
+using Microsoft.Azure.Devices.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 


### PR DESCRIPTION
A service team member pointed out they like to use this method we have `GeneratePassword` for testing, but they are on net472 and it doesn't work for them.

Consequently, the method we call to generate the password, off the `System.Web.Security.Membership` is not available after net472, so even if we do expand support for this method to net472, we can't offer it for newer .net targets unless we find another way to do it.

The service team member was happy to copy the code and use it locally, so this isn't urgent.

> Edit: team decided to not expand support, and mark existing methods as obsolete.
