### PR TITLE
fix(iot-serv): Fix bug where device scope and parent scopes set to device weren't used in bulk add operations

### DIFF
--- a/e2e/test/iothub/service/RegistryManagerE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryManagerE2ETests.cs
@@ -135,9 +135,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
 
             foreach (Device device in devices)
             {
-                Device retrievedDevice = await registryManager.GetDeviceAsync(device.Id).ConfigureAwait(false);
-                
                 // After a bulk add, every device should be able to be retrieved
+                Device retrievedDevice = await registryManager.GetDeviceAsync(device.Id).ConfigureAwait(false);
                 Assert.IsNotNull(retrievedDevice.Id);
                 Assert.AreEqual(device.Scope, retrievedDevice.Scope);
                 Assert.AreEqual(1, retrievedDevice.ParentScopes.Count);

--- a/e2e/test/iothub/service/RegistryManagerE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryManagerE2ETests.cs
@@ -121,7 +121,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             var devices = new List<Device>();
             for (int i = 0; i < bulkCount; i++)
             {
-                devices.Add(new Device(_devicePrefix + Guid.NewGuid()));
+                var device = new Device(_devicePrefix + Guid.NewGuid());
+                device.Scope = "someScope" + Guid.NewGuid();
+                device.ParentScopes.Add("someParentScope" + Guid.NewGuid());
+                devices.Add(device);
             }
 
             using RegistryManager registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
@@ -132,8 +135,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
 
             foreach (Device device in devices)
             {
+                Device retrievedDevice = await registryManager.GetDeviceAsync(device.Id).ConfigureAwait(false);
+                
                 // After a bulk add, every device should be able to be retrieved
-                Assert.IsNotNull(await registryManager.GetDeviceAsync(device.Id).ConfigureAwait(false));
+                Assert.IsNotNull(retrievedDevice.Id);
+                Assert.AreEqual(device.Scope, retrievedDevice.Scope);
+                Assert.AreEqual(1, retrievedDevice.ParentScopes.Count);
+                Assert.AreEqual(device.ParentScopes.ElementAt(0), retrievedDevice.ParentScopes.ElementAt(0));
             }
 
             var twins = new List<Twin>();

--- a/iothub/service/src/ExportImportDevice.cs
+++ b/iothub/service/src/ExportImportDevice.cs
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Azure.Devices.Shared;
 using Newtonsoft.Json;
@@ -64,6 +65,8 @@ namespace Microsoft.Azure.Devices
             StatusReason = device.StatusReason;
             Authentication = device.Authentication;
             Capabilities = device.Capabilities;
+            DeviceScope = device.Scope;
+            ParentScopes = device.ParentScopes;
         }
 
         /// <summary>
@@ -151,6 +154,21 @@ namespace Microsoft.Azure.Devices
         /// </remarks>
         [JsonProperty(PropertyName = "deviceScope", NullValueHandling = NullValueHandling.Include)]
         public string DeviceScope { get; set; }
+
+        /// <summary>
+        /// The scopes of the upper level edge devices if applicable.
+        /// </summary>
+        /// <remarks>
+        /// For edge devices, the value to set a parent edge device can be retrieved from the parent edge device's <see cref="DeviceScope"/> property.
+        ///
+        /// For leaf devices, this could be set to the same value as <see cref="DeviceScope"/> or left for the service to copy over.
+        ///
+        /// For now, this list can only have 1 element in the collection.
+        ///
+        /// For more information, see <see href="https://docs.microsoft.com/azure/iot-edge/iot-edge-as-gateway?view=iotedge-2020-11#parent-and-child-relationships"/>.
+        /// </remarks>
+        [JsonProperty(PropertyName = "parentScopes", NullValueHandling = NullValueHandling.Ignore)]
+        public IList<string> ParentScopes { get; internal set; } = new List<string>();
 
         private static string SanitizeETag(string eTag)
         {


### PR DESCRIPTION
#2184 