### PR TITLE
feat(device): add support for DisposeAsync

### DIFF
--- a/iothub/service/src/Common/Security/SharedAccessSignature.cs
+++ b/iothub/service/src/Common/Security/SharedAccessSignature.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
-using Microsoft.Azure.Devices.Common.Data;
 
 namespace Microsoft.Azure.Devices.Common.Security
 {
@@ -73,7 +72,7 @@ namespace Microsoft.Azure.Devices.Common.Security
         public string Signature { get; private set; }
 
         /// <summary>
-        /// Parses a shared access signature string representation into a <see cref="SharedAccessSignature"/>./>
+        /// Parses a shared access signature string representation into a <see cref="SharedAccessSignature"/>.
         /// </summary>
         /// <param name="iotHubName">The IoT Hub name.</param>
         /// <param name="rawToken">The string representation of the SAS token to parse.</param>


### PR DESCRIPTION
To ensure clients call `CloseAsync` before disposing, we can make use of this new dispose pattern that comes with .NET 3.0 and up. It has been in the latest preview for a bit (original idea came from a customer) but we haven't had any feedback for it. Do we like having this as part of our client?

<https://docs.microsoft.com/en-us/dotnet/api/system.iasyncdisposable?view=net-5.0>