### PR TITLE
Bump versions for 2021-10-08 .NET preview release

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.38.0-preview-001</Version>
+    <Version>1.38.1-preview-001</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.35.0-preview-001</Version>
+    <Version>1.35.0-preview-002</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.18.0-preview-001</Version>
+    <Version>1.18.0-preview-002</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.18.0-preview-001</Version>
+    <Version>1.18.0-preview-002</Version>
     <Title>Microsoft Azure IoT Provisioning Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.15.0-preview-001</Version>
+    <Version>1.15.0-preview-002</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client AMQP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
+++ b/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.14.0-preview-001</Version>
+    <Version>1.14.0-preview-002</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client HTTP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
+++ b/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.16.0-preview-001</Version>
+    <Version>1.16.0-preview-002</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client MQTT Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
+++ b/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>1.14.0-preview-001</Version>
+    <Version>1.14.0-preview-002</Version>
     <Title>Microsoft Azure IoT Provisioning Device Security TPM Client</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/shared/src/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/src/Microsoft.Azure.Devices.Shared.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.29.0-preview-001</Version>
+    <Version>1.29.0-preview-002</Version>
     <Title>Microsoft Azure IoT Devices Shared</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,10 +1,10 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj,1.38.0-preview-001
-iothub\service\src\Microsoft.Azure.Devices.csproj,1.35.0-preview-001
-shared\src\Microsoft.Azure.Devices.Shared.csproj,1.29.0-preview-001
-provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj,1.18.0-preview-001
-provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj,1.15.0-preview-001
-provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj,1.14.0-preview-001
-provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj,1.16.0-preview-001
-security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj,1.14.0-preview-001
-provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj,1.18.0-preview-001
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj,1.38.1-preview-001
+iothub\service\src\Microsoft.Azure.Devices.csproj,1.35.0-preview-002
+shared\src\Microsoft.Azure.Devices.Shared.csproj,1.29.0-preview-002
+provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj,1.18.0-preview-002
+provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj,1.15.0-preview-002
+provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj,1.14.0-preview-002
+provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj,1.16.0-preview-002
+security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj,1.14.0-preview-002
+provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj,1.18.0-preview-002


### PR DESCRIPTION
Version bump guidelines followed:
- Devices.Client - API surface changed specifically for preview = patch version of the "main" version updated.
- All other packages - API surface changed as a result of main -> preview merge = patch version of the "preview" part of the version updated.

==== DRAFT NOTES ====

# SDK updates from `main` branch.

This release is bringing changes from the main release [2021-08-11](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2021-8-11).
The previous preview release was based on the main release  [2021-05-13](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2021-05-13).

## Microsoft.Azure.Devices.Shared 1.29.0-preview-002

- Updates from `GA release` [2021-08-11](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2021-8-11).

## Microsoft.Azure.Devices.Client 1.38.1-preview-001

- Updates from `GA release` [2021-08-11](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2021-8-11).
- Update native Azure IoT Plug and Play (PnP) APIs:
    - Update the `TryGetValue` methods to return `false` instead of throwing exceptions for some corner cases (#2111).
    - Expose both client reported and service requested properties under their specific accessors - `ClientProperties.ReportedFromClient` and `ClientProperties.WritablePropertyRequests` respectively (#2114)
    - Add checks for `ClientPropertiesUpdateResponse` initialization (#2115).
    - Add convenience method for acknowledging writable property update requests (#2157).
    - Update PayloadCollection to accept dictionary of values (#2171).
    - Add support over AMQP (#2180).

## Microsoft.Azure.Devices 1.35.0-preview-002

- Updates from `GA release` [2021-08-11](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2021-8-11).

## Microsoft.Azure.Devices.Provisioning.Client 1.18.0-preview-002

- Updates from `GA release` [2021-08-11](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2021-8-11).

## Microsoft.Azure.Devices.Provisioning.Transport.Mqtt 1.16.0-preview-002

- Updates from `GA release` [2021-08-11](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2021-8-11).

## Microsoft.Azure.Devices.Provisioning.Transport.Amqp 1.15.0-preview-002

- Updates from `GA release` [2021-08-11](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2021-8-11).

## Microsoft.Azure.Devices.Provisioning.Client.Transport.Http 1.14.0-preview-002

- Updates from `GA release` [2021-08-11](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2021-8-11).

## Microsoft.Azure.Devices.Provisioning.Security.Tpm 1.14.0-preview-002

- Updates from `GA release` [2021-08-11](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2021-8-11).

## Microsoft.Azure.Devices.Provisioning.Service 1.18.0-preview-002

- Updates from `GA release` [2021-08-11](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2021-8-11).