### PR TITLE
fix(e2e-tests): Update reference to devices client package for local-package testing

### DIFF
--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -68,7 +68,7 @@
   <ItemGroup Condition=" '$(AZURE_IOT_LOCALPACKAGES)' != '' ">
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.35.0-preview-*" />
     <PackageReference Include="Microsoft.Azure.Devices.Shared" Version="1.29.0-preview-*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.38.0-preview-*" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.38.1-preview-*" />
   </ItemGroup>
   <ItemGroup Condition=" ('$(AZURE_IOT_LOCALPACKAGES.ToUpper())' != '') And ( '$(TargetFramework)' != 'net451' ) ">
     <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.18.0-preview-*" />


### PR DESCRIPTION
Our local package testing for the release pipeline relies on the "main" part of the preview package version being explicitly specified.