### PR TITLE
DeviceClient: Fix issue with hanging thread after dispose.

### DIFF
--- a/iothub/device/src/Transport/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Transport/RetryDelegatingHandler.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerSemaphore.Release();
+                                _handlerSemaphore?.Release();
                             }
                         },
                         cancellationToken)
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerSemaphore.Release();
+                                _handlerSemaphore?.Release();
                             }
                         },
                         cancellationToken)
@@ -291,7 +291,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerSemaphore.Release();
+                                _handlerSemaphore?.Release();
                             }
                         },
                         cancellationToken)
@@ -324,7 +324,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerSemaphore.Release();
+                                _handlerSemaphore?.Release();
                             }
                         },
                         cancellationToken)
@@ -356,7 +356,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerSemaphore.Release();
+                                _handlerSemaphore?.Release();
                             }
                         },
                         cancellationToken)
@@ -388,7 +388,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerSemaphore.Release();
+                                _handlerSemaphore?.Release();
                             }
                         },
                         cancellationToken)
@@ -420,7 +420,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerSemaphore.Release();
+                                _handlerSemaphore?.Release();
                             }
                         },
                         cancellationToken)
@@ -452,7 +452,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerSemaphore.Release();
+                                _handlerSemaphore?.Release();
                             }
                         },
                         cancellationToken)
@@ -484,7 +484,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _handlerSemaphore.Release();
+                                _handlerSemaphore?.Release();
                             }
                         },
                         cancellationToken)
@@ -630,7 +630,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             {
                 Logging.Exit(this, cancellationToken, nameof(CloseAsync));
 
-                _handlerSemaphore.Release();
+                _handlerSemaphore?.Release();
                 Dispose(true);
             }
         }
@@ -690,7 +690,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
             finally
             {
-                _handlerSemaphore.Release();
+                _handlerSemaphore?.Release();
             }
         }
 
@@ -743,7 +743,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
             finally
             {
-                _handlerSemaphore.Release();
+                _handlerSemaphore?.Release();
             }
         }
 
@@ -914,7 +914,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
             finally
             {
-                _handlerSemaphore.Release();
+                _handlerSemaphore?.Release();
             }
         }
 
@@ -966,7 +966,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             {
                 _handleDisconnectCts?.Cancel();
                 _handleDisconnectCts?.Dispose();
-
+                _handlerSemaphore?.Release();
                 _handlerSemaphore?.Dispose();
                 _handlerSemaphore = null;
             }


### PR DESCRIPTION
If the device client gets disposed and the RetryDelegationHandler is waiting on the semaphore to be released during `EnsureOpenAsync`, the thread will hang with no resolutions. This fix will release the semaphore before disposing it so all the hanging threads will continue. 