### PR TITLE
fix(device): Support standard x509=true for connection strings

### DIFF
--- a/iothub/device/src/IotHubConnectionStringBuilder.cs
+++ b/iothub/device/src/IotHubConnectionStringBuilder.cs
@@ -28,7 +28,15 @@ namespace Microsoft.Azure.Devices.Client
         private const string SharedAccessKeyPropertyName = "SharedAccessKey";
         private const string SharedAccessSignaturePropertyName = "SharedAccessSignature";
         private const string GatewayHostNamePropertyName = "GatewayHostName";
+
+        // For some reason, the .NET SDK originally expected "X509Cert=true" in a connection string to inform the SDK that it would not
+        // include a shared access key, and to not error when parsing a connection string. However, the other SDK languages all followed
+        // the same key/value pair of "x509=true".
+        // So now we're adding support for it to work either way, so we stay compliant with the past but can improve documentation so all
+        // SDK languages refer to the same key/value pair naming.
         private const string X509CertPropertyName = "X509Cert";
+
+        private const string CommonX509CertPropertyName = "x509";
 
         private const RegexOptions CommonRegexOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant;
         private static readonly TimeSpan s_regexTimeoutMilliseconds = TimeSpan.FromMilliseconds(500);
@@ -215,7 +223,7 @@ namespace Microsoft.Azure.Devices.Client
             stringBuilder.AppendKeyValuePairIfNotEmpty(SharedAccessKeyNamePropertyName, SharedAccessKeyName);
             stringBuilder.AppendKeyValuePairIfNotEmpty(SharedAccessKeyPropertyName, SharedAccessKey);
             stringBuilder.AppendKeyValuePairIfNotEmpty(SharedAccessSignaturePropertyName, SharedAccessSignature);
-            stringBuilder.AppendKeyValuePairIfNotEmpty(X509CertPropertyName, UsingX509Cert);
+            stringBuilder.AppendKeyValuePairIfNotEmpty(CommonX509CertPropertyName, UsingX509Cert);
             stringBuilder.AppendKeyValuePairIfNotEmpty(GatewayHostNamePropertyName, GatewayHostName);
             if (stringBuilder.Length > 0)
             {
@@ -235,7 +243,8 @@ namespace Microsoft.Azure.Devices.Client
             SharedAccessKeyName = GetConnectionStringOptionalValue(map, SharedAccessKeyNamePropertyName);
             SharedAccessKey = GetConnectionStringOptionalValue(map, SharedAccessKeyPropertyName);
             SharedAccessSignature = GetConnectionStringOptionalValue(map, SharedAccessSignaturePropertyName);
-            UsingX509Cert = GetConnectionStringOptionalValueOrDefault<bool>(map, X509CertPropertyName, ParseX509, true);
+            UsingX509Cert = GetConnectionStringOptionalValueOrDefault<bool>(map, X509CertPropertyName, ParseX509, true)
+                || GetConnectionStringOptionalValueOrDefault<bool>(map, CommonX509CertPropertyName, ParseX509, true);
             GatewayHostName = GetConnectionStringOptionalValue(map, GatewayHostNamePropertyName);
 
             Validate();
@@ -397,9 +406,9 @@ namespace Microsoft.Azure.Devices.Client
             return iotHubName;
         }
 
-        private static bool ParseX509(string input, bool ignoreCase, out bool usingX509Cert)
+        private static bool ParseX509(string input, bool ignoreCase, out bool isUsingX509Cert)
         {
-            usingX509Cert = false;
+            isUsingX509Cert = false;
 
             bool isMatch = string.Equals(
                 input,
@@ -409,7 +418,7 @@ namespace Microsoft.Azure.Devices.Client
                     : StringComparison.Ordinal);
             if (isMatch)
             {
-                usingX509Cert = true;
+                isUsingX509Cert = true;
             }
 
             // Always returns true, but must return a bool because it is used in a delegate that requires that return.

--- a/iothub/device/tests/ConnectionString/DeviceClientConnectionStringExceptionTests.cs
+++ b/iothub/device/tests/ConnectionString/DeviceClientConnectionStringExceptionTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
         [ExpectedException(typeof(ArgumentException))]
         public void DeviceClientConnectionStringDefaultScopeDefaultCredentialTypeMissingSharedAccessKeyExceptionTest()
         {
-            string connectionString = "HostName=acme.azure-devices.net;DeviceId=device1;SharedAccessKeyName=AllAccessKey"; 
+            string connectionString = "HostName=acme.azure-devices.net;DeviceId=device1;SharedAccessKeyName=AllAccessKey";
             var deviceClient = DeviceClient.CreateFromConnectionString(connectionString);
         }
 
@@ -94,9 +94,9 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             }
             catch (FormatException fe)
             {
-                Assert.IsTrue(fe.Message.Contains("Malformed Token"), "Exception should mention 'Malformed Token' Actual :" + fe.Message);             
+                Assert.IsTrue(fe.Message.Contains("Malformed Token"), "Exception should mention 'Malformed Token' Actual :" + fe.Message);
             }
-         }
+        }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
@@ -126,15 +126,15 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
         [ExpectedException(typeof(ArgumentException))]
         public void DeviceClientConnectionStringSASKeyX509CertExceptionTest()
         {
-            string connectionString = "HostName=acme.azure-devices.net;X509Cert=true;DeviceId=device;SharedAccessKey=dGVzdFN0cmluZzE=";
+            string connectionString = "HostName=acme.azure-devices.net;X509=true;DeviceId=device;SharedAccessKey=dGVzdFN0cmluZzE=";
             var deviceClient = DeviceClient.CreateFromConnectionString(connectionString);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void DeviceClientConnectionStringSASSignatureX509ExceptionTest()
+        public void DeviceClientConnectionStringSasSignatureX509ExceptionTest()
         {
-            string connectionString = "HostName=acme.azure-devices.net;DeviceId=device1;X509Cert=true;SharedAccessSignature=SharedAccessSignature sr=dh%3a%2f%2facme.azure-devices.net&sig=dGVzdFN0cmluZzU=&se=87824124985&skn=AllAccessKey";
+            string connectionString = "HostName=acme.azure-devices.net;DeviceId=device1;X509=true;SharedAccessSignature=SharedAccessSignature sr=dh%3a%2f%2facme.azure-devices.net&sig=dGVzdFN0cmluZzU=&se=87824124985&skn=AllAccessKey";
             var deviceClient = DeviceClient.CreateFromConnectionString(connectionString);
         }
 
@@ -147,4 +147,3 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
         }
     }
 }
-

--- a/iothub/device/tests/ConnectionString/IotHubConnectionStringBuilderTests.cs
+++ b/iothub/device/tests/ConnectionString/IotHubConnectionStringBuilderTests.cs
@@ -99,9 +99,11 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
         }
 
         [TestMethod]
-        public void IotHubConnectionStringBuilder_ParamConnectionString_ParsesX509False()
+        [DataRow("X509Cert")]
+        [DataRow("X509")]
+        public void IotHubConnectionStringBuilder_ParamConnectionString_ParsesX509False(string x509)
         {
-            var connectionString = $"HostName={HostName};DeviceId={DeviceId};SharedAccessKey={SharedAccessKey};X509Cert=false";
+            var connectionString = $"HostName={HostName};DeviceId={DeviceId};SharedAccessKey={SharedAccessKey};{x509}=false";
             var csBuilder = IotHubConnectionStringBuilder.Create(connectionString);
 
             csBuilder.SharedAccessKey.Should().Be(SharedAccessKey);
@@ -157,9 +159,39 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
         [DataRow("true")]
         [DataRow("True")]
         [DataRow("TRUE")]
-        public void IotHubConnectionStringBuilder_ParamConnectionString_ParsesX509(string value)
+        public void IotHubConnectionStringBuilder_ParamConnectionString_ParsesX509BoolCaseInsensitive(string value)
         {
             var connectionString = $"HostName={HostName};DeviceId={DeviceId};X509Cert={value}";
+            var csBuilder = IotHubConnectionStringBuilder.Create(connectionString);
+
+            csBuilder.UsingX509Cert.Should().BeTrue();
+
+            csBuilder.SharedAccessKey.Should().BeNull();
+            csBuilder.SharedAccessKeyName.Should().BeNull();
+            csBuilder.SharedAccessSignature.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Ensure we support both and either x509Cert= and x509= in our connection string builder/parser, for backward compat and alignment with other SDKs.
+        /// If either is true, then we'll consider it true.
+        /// </summary>
+        [TestMethod]
+        [DataRow("true", "true")]
+        [DataRow("false", "true")]
+        [DataRow(null, "true")]
+        [DataRow("true", "false")]
+        [DataRow("true", null)]
+        public void IotHubConnectionStringBuilder_ParamConnectionString_ParsesX509Mix(string x509CertValue, string x509Value)
+        {
+            var connectionString = $"HostName={HostName};DeviceId={DeviceId}";
+            if (x509CertValue != null)
+            {
+                connectionString += $";X509Cert={x509CertValue}";
+            }
+            if (x509Value != null)
+            {
+                connectionString += $";x509={x509Value}";
+            }
             var csBuilder = IotHubConnectionStringBuilder.Create(connectionString);
 
             csBuilder.UsingX509Cert.Should().BeTrue();


### PR DESCRIPTION
For some reason, the .NET SDK originally expected "X509Cert=true" in a connection string to inform the SDK that it would not
include a shared access key, and to not error when parsing a connection string. However, the other SDK languages all followed
the same key-value-pair of "x509=true".
So now we're adding support for it to work either way, so we stay compliant with the past but can improve documentation so all
SDK languages refer to the same key-value-pair naming.
