### PR TITLE
fix(e2e): Setting e2e tests to be a specific version

### DIFF
--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -66,17 +66,17 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(AZURE_IOT_LOCALPACKAGES)' != '' ">
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.35.0-preview-*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Shared" Version="1.29.0-preview-*" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.35.0-preview-002" />
+    <PackageReference Include="Microsoft.Azure.Devices.Shared" Version="1.29.0-preview-002" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.38.1-preview-*" />
   </ItemGroup>
   <ItemGroup Condition=" ('$(AZURE_IOT_LOCALPACKAGES.ToUpper())' != '') And ( '$(TargetFramework)' != 'net451' ) ">
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.18.0-preview-*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Amqp" Version="1.15.0-preview-*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Http" Version="1.14.0-preview-*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.16.0-preview-*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Security.Tpm" Version="1.14.0-preview-*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Service" Version="1.18.0-preview-*" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.18.0-preview-002" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Amqp" Version="1.15.0-preview-002" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Http" Version="1.14.0-preview-002" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.16.0-preview-002" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Security.Tpm" Version="1.14.0-preview-002" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Service" Version="1.18.0-preview-002" />
     <ProjectReference Include="$(RootDir)\security\tpm\samples\SecurityProviderTpmSimulator\SecurityProviderTpmSimulator.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Since the versions of the packages are based off of existing versions present in the Nuget repository, Nuget will honor the non suffixed versions first.

See [semantic versioning](https://docs.microsoft.com/en-us/nuget/create-packages/prerelease-packages#semantic-versioning).

### Taken from the page above
Whatever suffixes you use, however, NuGet will give them precedence in reverse alphabetical order:

```
1.0.1
1.0.1-zzz
1.0.1-rc
1.0.1-open
1.0.1-beta.12
1.0.1-beta.5
1.0.1-beta
1.0.1-alpha.2
1.0.1-alpha
```
As shown, the version without any suffix will always take precedence over pre-release versions.

Leading 0s are not needed with semver2, but they are with the old version schema. If you use numerical suffixes with pre-release tags that might use double-digit numbers (or more), use leading zeroes as in beta.01 and beta.05 to ensure that they sort correctly when the numbers get larger. This recommendation only applies to the old version schema.