### PR TITLE
Replace xUnit in Shared.Tests with MSTest

### DIFF
--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7" />
+    <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
   </ItemGroup>
 
   <!-- Legacy .NET 4.5.1 -->

--- a/iothub/device/tests/Edge/EdgeModuleClientFactoryTest.cs
+++ b/iothub/device/tests/Edge/EdgeModuleClientFactoryTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         }
 
         [TestMethod]
-        public async void TestCreate_FromConnectionStringEnvironment_ShouldCreateClient()
+        public async Task TestCreate_FromConnectionStringEnvironment_ShouldCreateClient()
         {
             Environment.SetEnvironmentVariable(EdgehubConnectionstringVariableName, this._iotHubConnectionString);
             ModuleClient dc = await ModuleClient.CreateFromEnvironmentAsync();
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         }
 
         [TestMethod]
-        public async void TestCreate_FromConnectionStringEnvironment_ShouldCreateClientWithOptions()
+        public async Task TestCreate_FromConnectionStringEnvironment_ShouldCreateClientWithOptions()
         {
             // setup
             var clientOptions = new ClientOptions
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         }
 
         [TestMethod]
-        public async void TestCreate_FromConnectionStringEnvironment_SetTransportType_ShouldCreateClient()
+        public async Task TestCreate_FromConnectionStringEnvironment_SetTransportType_ShouldCreateClient()
         {
             Environment.SetEnvironmentVariable(EdgehubConnectionstringVariableName, this._iotHubConnectionString);
             ModuleClient dc = await ModuleClient.CreateFromEnvironmentAsync(TransportType.Mqtt_Tcp_Only);
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         }
 
         [TestMethod]
-        public async void TestCreate_FromConnectionStringEnvironment_SetTransportSettings_ShouldCreateClient()
+        public async Task TestCreate_FromConnectionStringEnvironment_SetTransportSettings_ShouldCreateClient()
         {
             Environment.SetEnvironmentVariable(EdgehubConnectionstringVariableName, this._iotHubConnectionString);
             ModuleClient dc = await ModuleClient.CreateFromEnvironmentAsync(new ITransportSettings[] { new MqttTransportSettings(TransportType.Mqtt_Tcp_Only) });
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         }
 
         [TestMethod]
-        public async void TestCreate_FromEnvironment_ShouldCreateClient()
+        public async Task TestCreate_FromEnvironment_ShouldCreateClient()
         {
             Environment.SetEnvironmentVariable(IotEdgedUriVariableName, this._serverUrl);
             Environment.SetEnvironmentVariable(IotHubHostnameVariableName, "iothub.test");
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         }
 
         [TestMethod]
-        public async void TestCreate_FromEnvironment_SetTransportSettings_ShouldCreateClient()
+        public async Task TestCreate_FromEnvironment_SetTransportSettings_ShouldCreateClient()
         {
             Environment.SetEnvironmentVariable(IotEdgedUriVariableName, this._serverUrl);
             Environment.SetEnvironmentVariable(IotHubHostnameVariableName, "iothub.test");
@@ -261,7 +261,6 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableEventReceiveAsync(false, default).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
-
 
             await moduleClient.SetInputMessageHandlerAsync("endpoint2", null, null).ConfigureAwait(false);
             await innerHandler.Received(1).EnableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);

--- a/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.Tests.csproj
+++ b/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.Tests.csproj
@@ -5,7 +5,6 @@
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
     <IsTestProject Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
-    <!-- FXCop TODO: #176 re-enable warnings as errors. -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <!-- Suppress framework end of life warnings as we have to keep supporting these frameworks for our customers -->

--- a/shared/tests/Microsoft.Azure.Devices.Shared.Tests.csproj
+++ b/shared/tests/Microsoft.Azure.Devices.Shared.Tests.csproj
@@ -14,37 +14,15 @@
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net451'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
-    <!-- Do not upgrade these packages or net451 tests will fail to be discovered -->
-    <!-- https://github.com/xunit/xunit/issues/1130 -->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170123-02" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\shared\src\Microsoft.Azure.Devices.Shared.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 </Project>

--- a/shared/tests/TlsVersionsTests.cs
+++ b/shared/tests/TlsVersionsTests.cs
@@ -1,31 +1,32 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Net;
 using System.Security.Authentication;
 using FluentAssertions;
 using Microsoft.Azure.Devices.Shared;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.Devices.Shared.Tests
 {
-    // By setting a collection, it causes xunit to not run in parallel, which we need because these test a static object
-    [Collection("TlsVersions")]
-    [Trait("TestCategory", "Unit")]
+    [TestClass]
+    [TestCategory("Unit")]
     public class TlsVersionsTests
     {
-        [Fact]
+        [TestMethod]
         public void MinimumTlsVersions_DefaultsToTls12()
         {
             // assert
             new TlsVersions().MinimumTlsVersions.Should().Be(SslProtocols.Tls12);
         }
 
-        [Fact]
+        [TestMethod]
         public void Preferred_DefaultsToNone()
         {
             // assert
             new TlsVersions().Preferred.Should().Be(SslProtocols.None);
         }
 
-        [Fact]
+        [TestMethod]
         public void CheckCertificationList_DefaultsToFalse()
         {
             // assert
@@ -33,7 +34,7 @@ namespace Microsoft.Azure.Devices.Shared.Tests
         }
 
 #if NET451
-        [Fact]
+        [TestMethod]
         public void SetLegacyAcceptableVersions_Sets()
         {
             // arrange
@@ -47,7 +48,7 @@ namespace Microsoft.Azure.Devices.Shared.Tests
         }
 #endif
 
-        [Fact]
+        [TestMethod]
         public void SetMinimumTlsVersions_CanSetToNone()
         {
             // arrange
@@ -64,7 +65,7 @@ namespace Microsoft.Azure.Devices.Shared.Tests
             tlsVersions.Preferred.Should().Be(SslProtocols.None);
         }
 
-        [Fact]
+        [TestMethod]
         public void SetMinimumTlsVersions_CanSetToTls12()
         {
             // arrange
@@ -79,11 +80,11 @@ namespace Microsoft.Azure.Devices.Shared.Tests
             tlsVersions.Preferred.Should().Be(expected);
         }
 
-        [Theory]
-        [InlineData(SslProtocols.Tls)]
-        [InlineData(SslProtocols.Tls11)]
-        [InlineData(SslProtocols.Tls | SslProtocols.Tls11)]
-        [InlineData(SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12)]
+        [TestMethod]
+        [DataRow(SslProtocols.Tls)]
+        [DataRow(SslProtocols.Tls11)]
+        [DataRow(SslProtocols.Tls | SslProtocols.Tls11)]
+        [DataRow(SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12)]
         public void SetMinimumTlsVersions_CanSetToOlderTls(SslProtocols protocol)
         {
             // arrange
@@ -100,10 +101,10 @@ namespace Microsoft.Azure.Devices.Shared.Tests
 
 #pragma warning disable 0618
 
-        [Theory]
-        [InlineData(SslProtocols.Ssl2)]
-        [InlineData(SslProtocols.Ssl3)]
-        [InlineData(SslProtocols.Ssl2 | SslProtocols.Ssl3)]
+        [TestMethod]
+        [DataRow(SslProtocols.Ssl2)]
+        [DataRow(SslProtocols.Ssl3)]
+        [DataRow(SslProtocols.Ssl2 | SslProtocols.Ssl3)]
         public void SetMinimumTlsVersions_CannotSetOther(SslProtocols protocol)
         {
             // arrange

--- a/shared/tests/xunit.runner.json
+++ b/shared/tests/xunit.runner.json
@@ -1,6 +1,0 @@
-﻿{
-  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "longRunningTestSeconds": 3,
-  "methodDisplay": "method",
-  "parallelizeAssembly":  true
-}


### PR DESCRIPTION
I originally wrote these tests in xUnit as an evaluation on whether we should move to a generally considered richer test framework.

However, we soon learned that xUnit doesn't fully support 4.5.1 (which we have to) and test discovery doesn't work. The work around at the time was to reference a beta version of xUnit with hope they'd eventually fix it for real. Well, the GitHub issue we saved shows they chose instead to close it and not worry about it given net451 is such an old framework.

So let's just get rid of this xUnit usage and consolidate on the MS unit test framework.