### PR TITLE
Fix doc comment list bullets

### DIFF
--- a/provisioning/service/src/Query.cs
+++ b/provisioning/service/src/Query.cs
@@ -3,14 +3,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net;
+using System.Globalization;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Common;
-using Newtonsoft.Json;
 using Microsoft.Azure.Devices.Common.Service.Auth;
-using System.Globalization;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Provisioning.Service
 {
@@ -20,38 +19,38 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// <remarks>
     /// The <see cref="Query"/> iterator is the result of the query factory for
     /// <list type="bullet">
-    ///     <item><b>IndividualEnrollment:</b>
-    ///         <see cref="ProvisioningServiceClient.CreateIndividualEnrollmentQuery(QuerySpecification, int)"/>
-    ///     </item>
-    ///     <item><b>EnrollmentGroup:</b>
-    ///         <see cref="ProvisioningServiceClient.CreateEnrollmentGroupQuery(QuerySpecification, int)"/>
-    ///     </item>    
-    ///     <item><b>RegistrationStatus:</b>
-    ///         <see cref="ProvisioningServiceClient.CreateEnrollmentGroupRegistrationStateQuery(QuerySpecification, String, int)"/>
-    ///     </item>
+    ///     <item><term>
+    ///         <see cref="ProvisioningServiceClient.CreateIndividualEnrollmentQuery(QuerySpecification, int)">IndividualEnrollment</see>
+    ///     </term></item>
+    ///     <item><term>
+    ///         <see cref="ProvisioningServiceClient.CreateEnrollmentGroupQuery(QuerySpecification, int)">EnrollmentGroup</see>
+    ///     </term></item>
+    ///     <item><term>
+    ///     <see cref="ProvisioningServiceClient.CreateEnrollmentGroupRegistrationStateQuery(QuerySpecification, String, int)">RegistrationStatus</see>
+    ///     </term></item>
     /// </list>
     /// On all cases, the <see cref="QuerySpecification"/> contains a SQL query that must follow the
     ///     Query Language for the Device Provisioning Service.
     ///
-    /// Optionally, an <code>Integer</code> with the <b>page size</b>, can determine the maximum number of the items in the
+    /// Optionally, an <c>Integer</c> with the <b>page size</b>, can determine the maximum number of the items in the
     ///     <see cref="QueryResult"/> returned by the <see cref="NextAsync()"/>. It must be any positive integer, and if it 
     ///     contains 0, the Device Provisioning Service will ignore it and use a standard page size.
     ///
-    /// You can use this Object as a standard iterator, just using the <code>HasNext</code> and <code>NextAsync</code> in a
-    ///     <code>while</code> loop, up to the point where the <code>HasNext</code> contains <code>false</code>. But, keep 
-    ///     in mind that the <see cref="QueryResult"/> can contain a empty list, even if the <code>HasNext</code> contained 
-    ///     <code>true</code>. For example, image that you have 10 IndividualEnrollment in the Device Provisioning Service 
-    ///     and you created new query with the <code>PageSize</code> equals 5. In the first iteration, <code>HasNext</code> 
-    ///     will contains <code>true</code>, and the first <code>NextAsync</code> will return a <code>QueryResult</code> with 
-    ///     5 items. After, your code will check the <code>HasNext</code>, which will contains <code>true</code> again. Now, 
+    /// You can use this Object as a standard iterator, just using the <c>HasNext</c> and <c>NextAsync</c> in a
+    ///     <c>while</c> loop, up to the point where the <c>HasNext</c> contains <c>false</c>. But, keep 
+    ///     in mind that the <see cref="QueryResult"/> can contain a empty list, even if the <c>HasNext</c> contained 
+    ///     <c>true</c>. For example, image that you have 10 IndividualEnrollment in the Device Provisioning Service 
+    ///     and you created new query with the <c>PageSize</c> equals 5. In the first iteration, <c>HasNext</c> 
+    ///     will contains <c>true</c>, and the first <c>NextAsync</c> will return a <c>QueryResult</c> with 
+    ///     5 items. After, your code will check the <c>HasNext</c>, which will contains <c>true</c> again. Now, 
     ///     before you get the next page, somebody deletes all the IndividualEnrollment. What happened, when you call the 
-    ///     <code>NextAsync</code>, it will return a valid <code>QueryResult</code>, but the <see cref="QueryResult.Items"/> 
+    ///     <c>NextAsync</c>, it will return a valid <c>QueryResult</c>, but the <see cref="QueryResult.Items"/> 
     ///     will contain an empty list.
     ///
-    /// Besides the <code>Items</code>, the <code>QueryResult</code> contains the <see cref="QueryResult.ContinuationToken"/>.
+    /// Besides the <c>Items</c>, the <c>QueryResult</c> contains the <see cref="QueryResult.ContinuationToken"/>.
     ///     You can also store a query context (QuerySpecification + ContinuationToken) and restart it in the future, from
     ///     the point where you stopped. Just recreating the query with the same <see cref="QuerySpecification"/> and calling
-    ///     the <see cref="NextAsync(string)"/> passing the stored <code>ContinuationToken</code>.
+    ///     the <see cref="NextAsync(string)"/> passing the stored <c>ContinuationToken</c>.
     /// </remarks>
     public class Query : IDisposable
     {
@@ -61,10 +60,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         private const string QueryUriFormat = "{0}/query?{1}";
 
 
-        private string _querySpecificationJson;
+        private readonly string _querySpecificationJson;
         private IContractApiHttp _contractApiHttp;
-        private Uri _queryPath;
-        private CancellationToken _cancellationToken;
+        private readonly Uri _queryPath;
+        private readonly CancellationToken _cancellationToken;
         private bool _hasNext;
 
         internal Query(
@@ -162,10 +161,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Getter for has next
         /// </summary>
         /// <remarks>
-        /// Contains <code>true</code> if the query is not finished in the Device Provisioning Service, and another
+        /// Contains <c>true</c> if the query is not finished in the Device Provisioning Service, and another
         ///     iteration with <see cref="NextAsync()"/> may return more items. Call <see cref="NextAsync()"/> after 
-        ///     a <code>true</code> <code>HasNext</code> will result in a <see cref="QueryResult"/> that can or 
-        ///     cannot contains elements. But call <see cref="NextAsync()"/> after a <code>false</code> <code>HasNext</code> 
+        ///     a <c>true</c> <c>HasNext</c> will result in a <see cref="QueryResult"/> that can or 
+        ///     cannot contains elements. But call <see cref="NextAsync()"/> after a <c>false</c> <c>HasNext</c> 
         ///     will result in a exception.
         /// </remarks>
         public bool HasNext()
@@ -186,7 +185,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <summary>
         /// Return the next page of result for the query using a new continuationToken.
         /// </summary>
-        /// <param name="continuationToken">the <code>String</code> with the previous continuationToken. It cannot be <code>null</code> or empty.</param>
+        /// <param name="continuationToken">the <c>String</c> with the previous continuationToken. It cannot be <c>null</c> or empty.</param>
         /// <returns>The <see cref="QueryResult"/> with the next page of items for the query.</returns>
         /// <exception cref="IndexOutOfRangeException">if the query does no have more pages to return.</exception>
         public async Task<QueryResult> NextAsync(string continuationToken)

--- a/provisioning/service/src/Query.cs
+++ b/provisioning/service/src/Query.cs
@@ -19,15 +19,21 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// <remarks>
     /// The <see cref="Query"/> iterator is the result of the query factory for
     /// <list type="bullet">
-    ///     <item><term>
+    ///     <item>
+    ///         <description>
     ///         <see cref="ProvisioningServiceClient.CreateIndividualEnrollmentQuery(QuerySpecification, int)">IndividualEnrollment</see>
-    ///     </term></item>
-    ///     <item><term>
+        ///     </description>
+        ///     </item>
+    ///     <item>
+    ///         <description>
     ///         <see cref="ProvisioningServiceClient.CreateEnrollmentGroupQuery(QuerySpecification, int)">EnrollmentGroup</see>
-    ///     </term></item>
-    ///     <item><term>
-    ///     <see cref="ProvisioningServiceClient.CreateEnrollmentGroupRegistrationStateQuery(QuerySpecification, String, int)">RegistrationStatus</see>
-    ///     </term></item>
+    ///         </description>
+    ///     </item>
+    ///     <item>
+    ///         <description>
+    ///         <see cref="ProvisioningServiceClient.CreateEnrollmentGroupRegistrationStateQuery(QuerySpecification, String, int)">RegistrationStatus</see>
+    ///         </description>
+    ///     </item>
     /// </list>
     /// On all cases, the <see cref="QuerySpecification"/> contains a SQL query that must follow the
     ///     Query Language for the Device Provisioning Service.


### PR DESCRIPTION
Per email from Jimaco, these aren't showing up right at https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.devices.provisioning.service.query?view=azure-dotnet#remarks, directed me to spec at https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/examples#math-class-example.

I don't see that we have any description to include; hopefully this works fine.