### PR TITLE
Update API surface for properties and commands callback APIs

### DIFF
--- a/e2e/test/helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/helpers/TestDeviceCallbackHandler.cs
@@ -177,13 +177,11 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
         public async Task SetClientPropertyUpdateCallbackHandlerAsync<T>(string expectedPropName, string componentName = default)
         {
-            string userContext = "myContext";
-
             await _deviceClient
                 .SubscribeToWritablePropertyUpdateRequestsAsync(
-                    (patch, context) =>
+                    patch =>
                     {
-                        _logger.Trace($"{nameof(SetClientPropertyUpdateCallbackHandlerAsync)}: DeviceClient {_testDevice.Id} callback property: WritableProperty: {patch}, {context}");
+                        _logger.Trace($"{nameof(SetClientPropertyUpdateCallbackHandlerAsync)}: DeviceClient {_testDevice.Id} callback property: WritableProperty: {patch}.");
 
                         try
                         {
@@ -193,7 +191,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
                             isPropertyPresent.Should().BeTrue();
                             propertyFromCollection.Should().BeEquivalentTo((T)ExpectedClientPropertyValue);
-                            context.Should().Be(userContext);
                         }
                         catch (Exception ex)
                         {
@@ -206,8 +203,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                         }
 
                         return Task.FromResult(true);
-                    },
-                    userContext)
+                    })
                 .ConfigureAwait(false);
         }
 

--- a/e2e/test/iothub/command/CommandE2ETests.cs
+++ b/e2e/test/iothub/command/CommandE2ETests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -120,8 +121,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Commands
             digitalTwinClient.Dispose();
 #endif
             logger.Trace($"{nameof(DigitalTwinsSendCommandAndVerifyResponseAsync)}: Command status: {statusCode}.");
-            Assert.AreEqual(200, statusCode, $"The expected response status should be 200 but was {statusCode}");
-            Assert.AreEqual(responseExpected, payloadReceived, $"The expected response payload should be {responseExpected} but was {payloadReceived}");
+            statusCode.Should().Be(200, "The expected response status should be 200.");
+            payloadReceived.Should().Be(responseExpected);
         }
 
         public static async Task<Task> SetDeviceReceiveCommandAsync(DeviceClient deviceClient, string componentName, string commandName, MsTestLogger logger)
@@ -139,16 +140,16 @@ namespace Microsoft.Azure.Devices.E2ETests.Commands
                             var valueToTest = request.GetPayload<ServiceCommandRequestObject>();
                             if (string.IsNullOrEmpty(componentName))
                             {
-                                Assert.AreEqual(null, request.ComponentName, $"The expected component name should be null but was {request.ComponentName}");
+                                request.ComponentName.Should().BeNull();
                             }
                             else
                             {
-                                Assert.AreEqual(componentName, request.ComponentName, $"The expected component name should be {componentName} but was {request.ComponentName}");
+                                request.ComponentName.Should().Be(componentName);
                             }
                             var assertionObject = new ServiceCommandRequestAssertion();
                             string responseExpected = JsonConvert.SerializeObject(assertionObject);
-                            Assert.AreEqual(responseExpected, request.GetPayloadAsString(), $"The expected response payload should be {responseExpected} but was {request.GetPayloadAsString()}");
-                            Assert.AreEqual(assertionObject.A, valueToTest.A, $"The expected response object did not decode properly. Value a should be {assertionObject.A} but was {valueToTest?.A ?? int.MinValue}");
+                            request.GetPayloadAsString().Should().Be(responseExpected);
+                            valueToTest.A.Should().Be(assertionObject.A, "The expected response object should decode properly.");
                             commandCallReceived.SetResult(true);
                         }
                         catch (Exception ex)

--- a/e2e/test/iothub/properties/PropertiesE2ETests.cs
+++ b/e2e/test/iothub/properties/PropertiesE2ETests.cs
@@ -206,19 +206,18 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
             // Set a callback
             await deviceClient.
                 SubscribeToWritablePropertyUpdateRequestsAsync(
-                    (patch, context) =>
+                    patch =>
                     {
                         Assert.Fail("After having unsubscribed from receiving client property update notifications " +
                             "this callback should not have been invoked.");
 
                         return Task.FromResult(true);
-                    },
-                    null)
+                    })
                 .ConfigureAwait(false);
 
             // Unsubscribe
             await deviceClient
-                .SubscribeToWritablePropertyUpdateRequestsAsync(null, null)
+                .SubscribeToWritablePropertyUpdateRequestsAsync(null)
                 .ConfigureAwait(false);
 
             await RegistryManagerUpdateWritablePropertyAsync(testDevice.Id, propName, propValue)
@@ -261,7 +260,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
             string serializedActualPropertyValue = JsonConvert.SerializeObject(actualProp);
             serializedActualPropertyValue.Should().Be(JsonConvert.SerializeObject(propValue));
 
-            await deviceClient.SubscribeToWritablePropertyUpdateRequestsAsync(null, null).ConfigureAwait(false);
+            await deviceClient.SubscribeToWritablePropertyUpdateRequestsAsync(null).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);
         }
 
@@ -278,7 +277,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
             using var writablePropertyCallbackSemaphore = new SemaphoreSlim(0, 1);
             await deviceClient
                 .SubscribeToWritablePropertyUpdateRequestsAsync(
-                    async (writableProperties, userContext) =>
+                    async (writableProperties) =>
                     {
                         try
                         {
@@ -286,7 +285,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
 
                             isPropertyPresent.Should().BeTrue();
                             propertyFromCollection.Should().BeEquivalentTo(propValue);
-                            userContext.Should().BeNull();
 
                             var writablePropertyAcks = new ClientPropertyCollection();
                             foreach (KeyValuePair<string, object> writableProperty in writableProperties)
@@ -304,7 +302,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
                             writablePropertyCallbackSemaphore.Release();
                         }
                     },
-                    null,
                     cts.Token)
                 .ConfigureAwait(false);
 

--- a/e2e/test/iothub/properties/PropertiesWithComponentsE2ETests.cs
+++ b/e2e/test/iothub/properties/PropertiesWithComponentsE2ETests.cs
@@ -215,19 +215,18 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
             // Set a callback
             await deviceClient.
                 SubscribeToWritablePropertyUpdateRequestsAsync(
-                    (patch, context) =>
+                    patch =>
                     {
                         Assert.Fail("After having unsubscribed from receiving client property update notifications " +
                             "this callback should not have been invoked.");
 
                         return Task.FromResult(true);
-                    },
-                    null)
+                    })
                 .ConfigureAwait(false);
 
             // Unsubscribe
             await deviceClient
-                .SubscribeToWritablePropertyUpdateRequestsAsync(null, null)
+                .SubscribeToWritablePropertyUpdateRequestsAsync(null)
                 .ConfigureAwait(false);
 
             await RegistryManagerUpdateWritablePropertyAsync(testDevice.Id, ComponentName, propName, propValue)
@@ -270,7 +269,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
             string serializedActualPropertyValue = JsonConvert.SerializeObject(actualProp);
             serializedActualPropertyValue.Should().Be(JsonConvert.SerializeObject(propValue));
 
-            await deviceClient.SubscribeToWritablePropertyUpdateRequestsAsync(null, null).ConfigureAwait(false);
+            await deviceClient.SubscribeToWritablePropertyUpdateRequestsAsync(null).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);
         }
 
@@ -287,7 +286,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
             using var writablePropertyCallbackSemaphore = new SemaphoreSlim(0, 1);
             await deviceClient
                 .SubscribeToWritablePropertyUpdateRequestsAsync(
-                    async (writableProperties, userContext) =>
+                    async (writableProperties) =>
                     {
                         try
                         {
@@ -295,7 +294,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
 
                             isPropertyPresent.Should().BeTrue();
                             propertyFromCollection.Should().BeEquivalentTo(propValue);
-                            userContext.Should().BeNull();
 
                             var writablePropertyAcks = new ClientPropertyCollection();
                             foreach (KeyValuePair<string, object> writableProperty in writableProperties)
@@ -319,7 +317,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
                             writablePropertyCallbackSemaphore.Release();
                         }
                     },
-                    null,
                     cts.Token)
                 .ConfigureAwait(false);
 

--- a/e2e/test/iothub/telemetry/TelemetrySendE2ETests.cs
+++ b/e2e/test/iothub/telemetry/TelemetrySendE2ETests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.E2ETests.Helpers;

--- a/iothub/device/devdoc/Convention-based operations.md
+++ b/iothub/device/devdoc/Convention-based operations.md
@@ -121,12 +121,11 @@ public Task<ClientProperties> GetClientPropertiesAsync(CancellationToken cancell
 public Task<ClientPropertiesUpdateResponse> UpdateClientPropertiesAsync(ClientPropertyCollection propertyCollection, CancellationToken cancellationToken = default);
 
 /// <summary>
-/// Sets the global listener for Writable properties
+/// Sets the listener for writable property update events.
 /// </summary>
-/// <param name="callback">The global call back to handle all writable property updates.</param>
-/// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
+/// <param name="callback">The callback to handle all writable property updates for the client.</param>
 /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-public Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, object, Task> callback, object userContext, CancellationToken cancellationToken = default);
+public Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, object, Task> callback, CancellationToken cancellationToken = default);
 ```
 
 #### All related types

--- a/iothub/device/devdoc/Convention-based operations.md
+++ b/iothub/device/devdoc/Convention-based operations.md
@@ -69,7 +69,7 @@ public class NewtonsoftJsonPayloadSerializer : PayloadSerializer {
 
 public abstract class PayloadCollection : IEnumerable, IEnumerable<KeyValuePair<string, object>> {
     protected PayloadCollection();
-    public IDictionary<string, object> Collection { get; private set; }
+    public IDictionary<string, object> Collection { get; }
     public PayloadConvention Convention { get; internal set; }
     public virtual object this[string key] { get; set; }
     public virtual void Add(string key, object value);
@@ -125,7 +125,7 @@ public Task<ClientPropertiesUpdateResponse> UpdateClientPropertiesAsync(ClientPr
 /// </summary>
 /// <param name="callback">The callback to handle all writable property updates for the client.</param>
 /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-public Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, object, Task> callback, CancellationToken cancellationToken = default);
+public Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, Task> callback, CancellationToken cancellationToken = default);
 ```
 
 #### All related types
@@ -133,8 +133,8 @@ public Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCo
 ```csharp
 public class ClientProperties {
     public ClientProperties();
-    public ClientPropertyCollection ReportedFromClient { get; private set; }
-    public ClientPropertyCollection WritablePropertyRequests { get; private set; }
+    public ClientPropertyCollection ReportedFromClient { get; }
+    public ClientPropertyCollection WritablePropertyRequests { get; }
 }
 
 public class ClientPropertyCollection : PayloadCollection {
@@ -213,28 +213,29 @@ public sealed class TelemetryMessage : MessageBase {
 
 ```csharp
 /// <summary>
-/// Set the global command callback handler.
+/// Sets the listener for command invocation requests.
 /// </summary>
-/// <param name="callback">A method implementation that will handle the incoming command.</param>
-/// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
+/// <param name="callback">The callback to handle all incoming commands for the client.</param>
 /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-public Task SubscribeToCommandsAsync(Func<CommandRequest, object, Task<CommandResponse>> callback, object userContext, CancellationToken cancellationToken = default);
+public Task SubscribeToCommandsAsync(Func<CommandRequest, Task<CommandResponse>> callback, CancellationToken cancellationToken = default);
 ```
 #### All related types
 
 ```csharp
 public sealed class CommandRequest {
-    public string CommandName { get; private set; }
-    public string ComponentName { get; private set; }
-    public string DataAsJson { get; }
-    public T GetData<T>();
-    public byte[] GetDataAsBytes();
+    public CommandRequest();
+    public string CommandName { get; }
+    public string ComponentName { get; }
+    public T GetPayload<T>();
+    public ReadOnlyCollection<byte> GetPayloadAsBytes();
+    public string GetPayloadAsString();
 }
 
 public sealed class CommandResponse {
+    public CommandResponse();
     public CommandResponse(int status);
-    public CommandResponse(object result, int status);
-    public string ResultAsJson { get; }
-    public int Status { get; private set; }
+    public CommandResponse(object payload, int status);
+    public int Status { get; }
+    public object Payload { get; }
 }
 ```

--- a/iothub/device/devdoc/Convention-based operations.md
+++ b/iothub/device/devdoc/Convention-based operations.md
@@ -43,23 +43,23 @@ public abstract class PayloadSerializer {
 }
 
 public sealed class DefaultPayloadConvention : PayloadConvention {
-    public static readonly DefaultPayloadConvention Instance;
     public DefaultPayloadConvention();
+    public static DefaultPayloadConvention Instance { get; }
     public override PayloadEncoder PayloadEncoder { get; }
     public override PayloadSerializer PayloadSerializer { get; }
 }
 
 public class Utf8PayloadEncoder : PayloadEncoder {
-    public static readonly Utf8PayloadEncoder Instance;
     public Utf8PayloadEncoder();
     public override Encoding ContentEncoding { get; }
+    public static Utf8PayloadEncoder Instance { get; }
     public override byte[] EncodeStringToByteArray(string contentPayload);
 }
 
 public class NewtonsoftJsonPayloadSerializer : PayloadSerializer {
-    public static readonly NewtonsoftJsonPayloadSerializer Instance;
     public NewtonsoftJsonPayloadSerializer();
     public override string ContentType { get; }
+    public static NewtonsoftJsonPayloadSerializer Instance { get; }
     public override T ConvertFromObject<T>(object objectToConvert);
     public override IWritablePropertyResponse CreateWritablePropertyResponse(object value, int statusCode, long version, string description = null);
     public override T DeserializeToType<T>(string stringToDeserialize);
@@ -69,7 +69,6 @@ public class NewtonsoftJsonPayloadSerializer : PayloadSerializer {
 
 public abstract class PayloadCollection : IEnumerable, IEnumerable<KeyValuePair<string, object>> {
     protected PayloadCollection();
-    public IDictionary<string, object> Collection { get; }
     public PayloadConvention Convention { get; internal set; }
     public virtual object this[string key] { get; set; }
     public virtual void Add(string key, object value);
@@ -198,7 +197,9 @@ public Task SendTelemetryAsync(TelemetryMessage telemetryMessage, CancellationTo
 ```csharp
 public class TelemetryCollection : PayloadCollection {
     public TelemetryCollection();
+    public void Add(IDictionary<string, object> telemetryValues);
     public override void Add(string telemetryName, object telemetryValue);
+    public void AddOrUpdate(IDictionary<string, object> telemetryValues);
     public override void AddOrUpdate(string telemetryName, object telemetryValue);
 }
 
@@ -235,7 +236,7 @@ public sealed class CommandResponse {
     public CommandResponse();
     public CommandResponse(int status);
     public CommandResponse(object payload, int status);
-    public int Status { get; }
     public object Payload { get; }
+    public int Status { get; }
 }
 ```

--- a/iothub/device/src/ClientProperties.cs
+++ b/iothub/device/src/ClientProperties.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// See the <see href="https://docs.microsoft.com/azure/iot-pnp/concepts-convention#writable-properties">Writable properties</see> documentation for more information.
         /// </remarks>
-        public ClientPropertyCollection WritablePropertyRequests { get; private set; }
+        public ClientPropertyCollection WritablePropertyRequests { get; }
 
         /// <summary>
         /// The collection of properties reported by the client.
@@ -49,6 +49,6 @@ namespace Microsoft.Azure.Devices.Client
         /// Client reported properties can either be <see href="https://docs.microsoft.com/azure/iot-develop/concepts-convention#read-only-properties">Read-only properties</see>
         /// or they can be <see href="https://docs.microsoft.com/azure/iot-pnp/concepts-convention#writable-properties">Writable properties</see>.
         /// </remarks>
-        public ClientPropertyCollection ReportedFromClient { get; private set; }
+        public ClientPropertyCollection ReportedFromClient { get; }
     }
 }

--- a/iothub/device/src/CommandRequest.cs
+++ b/iothub/device/src/CommandRequest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// The command data in Json format.
+        /// The command data as a string.
         /// </summary>
         public string GetPayloadAsString()
         {

--- a/iothub/device/src/CommandRequest.cs
+++ b/iothub/device/src/CommandRequest.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text;
+using System.Collections.ObjectModel;
+using System.Linq;
 using Microsoft.Azure.Devices.Shared;
 
 namespace Microsoft.Azure.Devices.Client
@@ -11,35 +12,42 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     public sealed class CommandRequest
     {
-        private readonly byte[] _data;
+        private readonly ReadOnlyCollection<byte> _payload;
         private readonly PayloadConvention _payloadConvention;
+
+        /// <summary>
+        /// Public constructor provided only for mocking purposes.
+        /// </summary>
+        public CommandRequest()
+        {
+        }
 
         internal CommandRequest(PayloadConvention payloadConvention, string commandName, string componentName = default, byte[] data = default)
         {
             CommandName = commandName;
             ComponentName = componentName;
-            _data = data;
+            _payload = new ReadOnlyCollection<byte>(data);
             _payloadConvention = payloadConvention;
         }
 
         /// <summary>
         /// The name of the component that is command is invoked on.
         /// </summary>
-        public string ComponentName { get; private set; }
+        public string ComponentName { get; }
 
         /// <summary>
         /// The command name.
         /// </summary>
-        public string CommandName { get; private set; }
+        public string CommandName { get; }
 
         /// <summary>
         /// The command request data.
         /// </summary>
         /// <typeparam name="T">The type to cast the command request data to.</typeparam>
         /// <returns>The command request data.</returns>
-        public T GetData<T>()
+        public T GetPayload<T>()
         {
-            string dataAsJson = DataAsJson;
+            string dataAsJson = GetPayloadAsString();
 
             return dataAsJson == null
                 ? default
@@ -52,16 +60,21 @@ namespace Microsoft.Azure.Devices.Client
         /// <returns>
         /// The command request data bytes.
         /// </returns>
-        public byte[] GetDataAsBytes()
+        public ReadOnlyCollection<byte> GetPayloadAsBytes()
         {
             // Need to return a clone of the array so that consumers
             // of this library cannot change its contents.
-            return (byte[])_data.Clone();
+            return _payload;
         }
 
         /// <summary>
         /// The command data in Json format.
         /// </summary>
-        public string DataAsJson => (_data == null || _data.Length == 0) ? null : Encoding.UTF8.GetString(_data);
+        public string GetPayloadAsString()
+        {
+            return _payload.Count == 0
+                ? null
+                : _payloadConvention.PayloadEncoder.ContentEncoding.GetString(GetPayloadAsBytes().ToArray());
+        }
     }
 }

--- a/iothub/device/src/CommandResponse.cs
+++ b/iothub/device/src/CommandResponse.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text;
 using Microsoft.Azure.Devices.Shared;
 
 namespace Microsoft.Azure.Devices.Client
@@ -11,18 +10,25 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     public sealed class CommandResponse
     {
-        private readonly object _result;
+        private readonly object _payload;
 
         internal PayloadConvention PayloadConvention { get; set; }
 
         /// <summary>
+        /// Public constructor provided only for mocking purposes.
+        /// </summary>
+        public CommandResponse()
+        {
+        }
+
+        /// <summary>
         /// Creates a new instance of the class with the associated command response data and a status code.
         /// </summary>
-        /// <param name="result">The command response data.</param>
+        /// <param name="payload">The command response payload.</param>
         /// <param name="status">A status code indicating success or failure.</param>
-        public CommandResponse(object result, int status)
+        public CommandResponse(object payload, int status)
         {
-            _result = result;
+            _payload = payload;
             Status = status;
         }
 
@@ -38,13 +44,28 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// The command response status code indicating success or failure.
         /// </summary>
-        public int Status { get; private set; }
+        public int Status { get; }
+
+        /// <summary>
+        /// The command response payload.
+        /// </summary>
+        public object Payload { get; }
 
         /// <summary>
         /// The serialized command response data.
         /// </summary>
-        public string ResultAsJson => _result == null ? null : PayloadConvention.PayloadSerializer.SerializeToString(_result);
+        internal string GetPayloadAsString()
+        {
+            return _payload == null
+                ? null
+                : PayloadConvention.PayloadSerializer.SerializeToString(_payload);
+        }
 
-        internal byte[] ResultAsBytes => _result == null ? null : Encoding.UTF8.GetBytes(ResultAsJson);
+        internal byte[] GetPayloadAsBytes()
+        {
+            return _payload == null
+                ? null
+                : PayloadConvention.PayloadEncoder.ContentEncoding.GetBytes(GetPayloadAsString());
+        }
     }
 }

--- a/iothub/device/src/DeviceClient.ConventionBasedOperations.cs
+++ b/iothub/device/src/DeviceClient.ConventionBasedOperations.cs
@@ -69,13 +69,9 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Sets the listener for writable property update events.
         /// </summary>
-        /// <param name="callback">The callback to handle all writable property updates.</param>
-        /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
+        /// <param name="callback">The callback to handle all writable property updates for the client.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        public Task SubscribeToWritablePropertyUpdateRequestsAsync(
-            Func<ClientPropertyCollection, object, Task> callback,
-            object userContext,
-            CancellationToken cancellationToken = default)
-            => InternalClient.SubscribeToWritablePropertyUpdateRequestsAsync(callback, userContext, cancellationToken);
+        public Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, Task> callback, CancellationToken cancellationToken = default)
+            => InternalClient.SubscribeToWritablePropertyUpdateRequestsAsync(callback, cancellationToken);
     }
 }

--- a/iothub/device/src/DeviceClient.ConventionBasedOperations.cs
+++ b/iothub/device/src/DeviceClient.ConventionBasedOperations.cs
@@ -36,15 +36,12 @@ namespace Microsoft.Azure.Devices.Client
             => InternalClient.SendTelemetryAsync(telemetryMessage, cancellationToken);
 
         /// <summary>
-        /// Set the command callback handler.
+        /// Sets the listener for command invocation requests.
         /// </summary>
-        /// <param name="callback">A method implementation that will handle the incoming command.</param>
-        /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
+        /// <param name="callback">The callback to handle all incoming commands for the client.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        public Task SubscribeToCommandsAsync(
-            Func<CommandRequest, object, Task<CommandResponse>> callback, object userContext,
-            CancellationToken cancellationToken = default)
-            => InternalClient.SubscribeToCommandsAsync(callback, userContext, cancellationToken);
+        public Task SubscribeToCommandsAsync(Func<CommandRequest, Task<CommandResponse>> callback, CancellationToken cancellationToken = default)
+            => InternalClient.SubscribeToCommandsAsync(callback, cancellationToken);
 
         /// <summary>
         /// Retrieve the client properties.

--- a/iothub/device/src/InternalClient.ConventionBasedOperations.cs
+++ b/iothub/device/src/InternalClient.ConventionBasedOperations.cs
@@ -113,13 +113,11 @@ namespace Microsoft.Azure.Devices.Client
         internal Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, Task> callback, CancellationToken cancellationToken)
         {
             // Subscribe to DesiredPropertyUpdateCallback internally and use the callback received internally to invoke the user supplied Property callback.
-            var desiredPropertyUpdateCallback = new DesiredPropertyUpdateCallback((twinCollection, userContext) =>
+            var desiredPropertyUpdateCallback = new DesiredPropertyUpdateCallback(async (twinCollection, userContext) =>
             {
                 // convert a TwinCollection to PropertyCollection
                 var propertyCollection = ClientPropertyCollection.WritablePropertyUpdateRequestsFromTwinCollection(twinCollection, PayloadConvention);
-                callback.Invoke(propertyCollection);
-
-                return TaskHelpers.CompletedTask;
+                await callback.Invoke(propertyCollection).ConfigureAwait(false);
             });
 
             // We pass in a null context to the internal API because the updated SubscribeToWritablePropertyUpdateRequestsAsync API

--- a/iothub/device/src/InternalClient.ConventionBasedOperations.cs
+++ b/iothub/device/src/InternalClient.ConventionBasedOperations.cs
@@ -105,19 +105,24 @@ namespace Microsoft.Azure.Devices.Client
             }
         }
 
-        internal Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, object, Task> callback, object userContext, CancellationToken cancellationToken)
+        internal Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, Task> callback, CancellationToken cancellationToken)
         {
             // Subscribe to DesiredPropertyUpdateCallback internally and use the callback received internally to invoke the user supplied Property callback.
             var desiredPropertyUpdateCallback = new DesiredPropertyUpdateCallback((twinCollection, userContext) =>
             {
                 // convert a TwinCollection to PropertyCollection
                 var propertyCollection = ClientPropertyCollection.WritablePropertyUpdateRequestsFromTwinCollection(twinCollection, PayloadConvention);
-                callback.Invoke(propertyCollection, userContext);
+                callback.Invoke(propertyCollection);
 
                 return TaskHelpers.CompletedTask;
             });
 
-            return SetDesiredPropertyUpdateCallbackAsync(desiredPropertyUpdateCallback, userContext, cancellationToken);
+            // We pass in a null context to the internal API because the updated SubscribeToWritablePropertyUpdateRequestsAsync API
+            // no longer requires you to pass in a user context.
+            // Since SubscribeToWritablePropertyUpdateRequestsAsync callback is invoked for all property update events,
+            // the user context passed in would be the same for all scenarios.
+            // This user context can be set at a class level instead.
+            return SetDesiredPropertyUpdateCallbackAsync(desiredPropertyUpdateCallback, null, cancellationToken);
         }
     }
 }

--- a/iothub/device/src/ModuleClient.ConventionBasedOperations.cs
+++ b/iothub/device/src/ModuleClient.ConventionBasedOperations.cs
@@ -36,15 +36,12 @@ namespace Microsoft.Azure.Devices.Client
             => InternalClient.SendTelemetryAsync(telemetryMessage, cancellationToken);
 
         /// <summary>
-        /// Set the global command callback handler.
+        /// Sets the listener for command invocation requests.
         /// </summary>
-        /// <param name="callback">A method implementation that will handle the incoming command.</param>
-        /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
+        /// <param name="callback">The callback to handle all incoming commands for the client.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        public Task SubscribeToCommandsAsync(
-            Func<CommandRequest, object, Task<CommandResponse>> callback, object userContext,
-            CancellationToken cancellationToken = default)
-            => InternalClient.SubscribeToCommandsAsync(callback, userContext, cancellationToken);
+        public Task SubscribeToCommandsAsync(Func<CommandRequest, Task<CommandResponse>> callback, CancellationToken cancellationToken = default)
+            => InternalClient.SubscribeToCommandsAsync(callback, cancellationToken);
 
         /// <summary>
         /// Retrieve the client properties.

--- a/iothub/device/src/ModuleClient.ConventionBasedOperations.cs
+++ b/iothub/device/src/ModuleClient.ConventionBasedOperations.cs
@@ -65,12 +65,11 @@ namespace Microsoft.Azure.Devices.Client
             => InternalClient.UpdateClientPropertiesAsync(propertyCollection, cancellationToken);
 
         /// <summary>
-        /// Sets the global listener for writable property update events.
+        /// Sets the listener for writable property update events.
         /// </summary>
-        /// <param name="callback">The global call back to handle all writable property updates.</param>
-        /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
+        /// <param name="callback">The callback to handle all writable property updates for the client.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        public Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, object, Task> callback, object userContext, CancellationToken cancellationToken = default)
-            => InternalClient.SubscribeToWritablePropertyUpdateRequestsAsync(callback, userContext, cancellationToken);
+        public Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, Task> callback, CancellationToken cancellationToken = default)
+            => InternalClient.SubscribeToWritablePropertyUpdateRequestsAsync(callback, cancellationToken);
     }
 }

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// The underlying collection for the payload.
         /// </summary>
-        public IDictionary<string, object> Collection { get; } = new Dictionary<string, object>();
+        internal IDictionary<string, object> Collection { get; } = new Dictionary<string, object>();
 
         /// <summary>
         /// The convention to use with this payload.

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// The underlying collection for the payload.
         /// </summary>
-        public IDictionary<string, object> Collection { get; private set; } = new Dictionary<string, object>();
+        public IDictionary<string, object> Collection { get; } = new Dictionary<string, object>();
 
         /// <summary>
         /// The convention to use with this payload.


### PR DESCRIPTION
Changes:
- Remove `userContext` from property update callback API.
- Remove `userContext` from command invocation callback API.

Reasoning:
Since the same callback APIs are invoked for all property/command invocation requests, the user context passed in would be the same for all scenarios. This user context can be set at a class level instead, if required.