### PR TITLE
fix(DeviceClient): Avoid NRE after client dispose

### DIFF
--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -691,7 +691,6 @@ namespace Microsoft.Azure.Devices.Client
             if (disposing)
             {
                 InternalClient?.Dispose();
-                InternalClient = null;
             }
         }
 

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1902,7 +1902,6 @@ namespace Microsoft.Azure.Devices.Client
         public void Dispose()
         {
             InnerHandler?.Dispose();
-            InnerHandler = null;
             _methodsSemaphore?.Dispose();
             _moduleReceiveMessageSemaphore?.Dispose();
             _fileUploadHttpTransportHandler?.Dispose();


### PR DESCRIPTION
Recently we had a customer issue regarding the SDK behavior suggesting that the SDK started to behave differently (in this case throwing a different type of exception) when the DeviceClient has been disposed and subsequent calls are made to it.

Starting from version 1.36.0, a regression happened in which the scenario above would throw a NullReferenceException instead of the ObjectDisposedException that was thrown in the previous versions.

This PR reverts that behavior to start throwing ObjectDisposedException after the client gets disposed.