### PR TITLE
Specify windows 2022 for pri1 windows images, and use windows 2019 for pri2 targets

### DIFF
--- a/azureiot.sln
+++ b/azureiot.sln
@@ -78,6 +78,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		readme.md = readme.md
 		supported_platforms.md = supported_platforms.md
 		test.runsettings = test.runsettings
+		vsts\vsts.yaml = vsts\vsts.yaml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Devices.Shared.Tests", "shared\tests\Microsoft.Azure.Devices.Shared.Tests.csproj", "{CEEE435F-32FC-4DE5-8735-90F6AC950A01}"

--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1.18;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
+    <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
@@ -45,7 +47,6 @@
     <!-- .NET 4.5.1 requires the System.ValueTuple NuGet package to be referenced explicitly. -->
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
-  <!-- NetCore and .NET 4.7.2 -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.3" />
     <PackageReference Include="Azure.Identity" Version="1.3.0" />

--- a/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
+++ b/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net5.0;netcoreapp3.1;netcoreapp2.1.18;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
 
+    <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>

--- a/iothub/service/tests/Microsoft.Azure.Devices.Tests.csproj
+++ b/iothub/service/tests/Microsoft.Azure.Devices.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net5.0;netcoreapp3.1;netcoreapp2.1.18;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>

--- a/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.Tests.csproj
+++ b/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
+    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
+    <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <!-- Suppress framework end of life warnings as we have to keep supporting these frameworks for our customers -->

--- a/provisioning/service/tests/Config/X509CertificateWithInfoTests.cs
+++ b/provisioning/service/tests/Config/X509CertificateWithInfoTests.cs
@@ -76,7 +76,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         {
             // arrange
             X509Certificate2 certificateNull = null;
+#pragma warning disable SYSLIB0026 // Type or member is obsolete
             using var certificateEmpty = new X509Certificate2();
+#pragma warning restore SYSLIB0026 // Type or member is obsolete
             string certificateString = null;
             string certificateStringEmpty = "";
             string certificateStringInvalid =

--- a/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.Tests.csproj
+++ b/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
+    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/provisioning/transport/amqp/tests/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.Tests.csproj
+++ b/provisioning/transport/amqp/tests/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
+    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/provisioning/transport/http/tests/Microsoft.Azure.Devices.Provisioning.Transport.Http.Tests.csproj
+++ b/provisioning/transport/http/tests/Microsoft.Azure.Devices.Provisioning.Transport.Http.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
+    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/provisioning/transport/mqtt/tests/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.Tests.csproj
+++ b/provisioning/transport/mqtt/tests/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
+    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/security/tpm/tests/Microsoft.Azure.Devices.Provisioning.Security.Tpm.Tests.csproj
+++ b/security/tpm/tests/Microsoft.Azure.Devices.Provisioning.Security.Tpm.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
+    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/shared/tests/Microsoft.Azure.Devices.Shared.Tests.csproj
+++ b/shared/tests/Microsoft.Azure.Devices.Shared.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Microsoft.Azure.Devices.Shared.Tests</RootNamespace>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net5.0;netcoreapp3.1;netcoreapp2.1.18;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.18</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.18'">False</IsTestProject>
 
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>

--- a/supported_platforms.md
+++ b/supported_platforms.md
@@ -31,7 +31,7 @@ Nightly test platform details:
 
 Default locale: en_US, platform encoding: Cp1252
 
-OS name: "windows server 2019", version: "10.0", arch: "amd64", family: "windows"
+OS name: "windows server 2022", version: "10.0", arch: "amd64", family: "windows"
 
 ## Ubuntu 20.04
 

--- a/vsts/test-release-nuget.yaml
+++ b/vsts/test-release-nuget.yaml
@@ -166,7 +166,7 @@ jobs:
 
     condition: succeeded()
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
     steps:
       - task: UseDotNet@2
         displayName: 'Use .NET Core SDK 2.1'
@@ -209,13 +209,13 @@ jobs:
           TargetFolder: '$(Build.SourcesDirectory)/bin/pkg'
           OverWrite: true
 
-      - script: |  
-          call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\Common7\\Tools\\VsDevCmd.bat"
+      - script: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
           sn -Vr *,31bf3856ad364e35
             
         displayName: 'Disable strong name validation'
 
-      - script: |  
+      - script: |
           choco install -y squid
             
         displayName: 'Install Squid'

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -25,16 +25,33 @@ jobs:
       # Change maxParallel to 1 make builds run in serial rather than in parallel
       maxParallel: 100
       matrix:
+        .Net 6.0:
+          FRAMEWORK: net6.0
         .Net 5.0:
           FRAMEWORK: net5.0
-        .Net Core 3.1:
-          FRAMEWORK: netcoreapp3.1
 
     condition: succeeded()
     pool:
       # If this is changed, don't forget to update supported_platforms.md in the root directory. That document outlines what OS we test on and should stay up to date.
       vmImage: ubuntu-20.04
     steps:
+
+      - task: UseDotNet@2
+        displayName: 'Use .NET SDK 6.0'
+        inputs:
+          packageType: sdk
+          version: 6.x
+          performMultiLevelLookup: true
+          installationPath: $(Agent.ToolsDirectory)/dotnet
+
+      - task: UseDotNet@2
+        displayName: 'Use .NET SDK 5.0'
+        inputs:
+          packageType: sdk
+          version: 5.x
+          performMultiLevelLookup: true
+          installationPath: $(Agent.ToolsDirectory)/dotnet
+
       - task: Docker@1
         displayName: "Start TPM Simulator"
         inputs:
@@ -139,6 +156,8 @@ jobs:
       # Change maxParallel to 1 make builds run in serial rather than in parallel
       maxParallel: 100
       matrix:
+        .Net Core 3.1:
+          FRAMEWORK: netcoreapp3.1
         .Net Core 2.1.18:
           FRAMEWORK: netcoreapp2.1.18
 
@@ -147,13 +166,6 @@ jobs:
       # If this is changed, don't forget to update supported_platforms.md in the root directory. That document outlines what OS we test on and should stay up to date.
       vmImage: ubuntu-20.04
     steps:
-      - task: UseDotNet@2
-        displayName: 'Use .NET Core SDK 2.1'
-        inputs:
-          packageType: sdk
-          version: 2.1.x
-          performMultiLevelLookup: true
-          installationPath: $(Agent.ToolsDirectory)/dotnet
 
       - task: UseDotNet@2
         displayName: 'Use .NET Core SDK 3.1'
@@ -164,10 +176,10 @@ jobs:
           installationPath: $(Agent.ToolsDirectory)/dotnet
 
       - task: UseDotNet@2
-        displayName: 'Use .NET SDK 5.0'
+        displayName: 'Use .NET Core SDK 2.1'
         inputs:
           packageType: sdk
-          version: 5.x
+          version: 2.1.x
           performMultiLevelLookup: true
           installationPath: $(Agent.ToolsDirectory)/dotnet
 
@@ -275,21 +287,36 @@ jobs:
       # Change maxParallel to 1 make builds run in serial rather than in parallel
       maxParallel: 100
       matrix:
+        .Net 6.0:
+          FRAMEWORK: net6.0
         .Net 5.0:
           FRAMEWORK: net5.0
-        .Net Core 3.1:
-          FRAMEWORK: netcoreapp3.1
-        .Net Framework 4.5.1:
-          FRAMEWORK: net451
 
     condition: succeeded()
     pool:
       # If this is changed, don't forget to update supported_platforms.md in the root directory. That document outlines what OS we test on and should stay up to date.
-      vmImage: windows-2019
+      vmImage: windows-2022
     steps:
+
+      - task: UseDotNet@2
+        displayName: 'Use .NET SDK 6.0'
+        inputs:
+          packageType: sdk
+          version: 6.x
+          performMultiLevelLookup: true
+          installationPath: $(Agent.ToolsDirectory)/dotnet
+
+      - task: UseDotNet@2
+        displayName: 'Use .NET SDK 5.0'
+        inputs:
+          packageType: sdk
+          version: 5.x
+          performMultiLevelLookup: true
+          installationPath: $(Agent.ToolsDirectory)/dotnet
+
       - script: |
-          call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\Common7\\Tools\\VsDevCmd.bat"
-          sn -Vr *,31bf3856ad364e35
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+          sn.exe -Vr *,31bf3856ad364e35
 
         displayName: "Disable strong name validation"
 
@@ -392,23 +419,31 @@ jobs:
       # Change maxParallel to 1 make builds run in serial rather than in parallel
       maxParallel: 100
       matrix:
+        .Net Core 3.1:
+          FRAMEWORK: netcoreapp3.1
         .Net Core 2.1.18:
           FRAMEWORK: netcoreapp2.1.18
         .Net Framework 4.7.2:
           FRAMEWORK: net472
+        .Net Framework 4.5.1:
+          FRAMEWORK: net451
 
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     pool:
       # If this is changed, don't forget to update supported_platforms.md in the root directory. That document outlines what OS we test on and should stay up to date.
-      vmImage: windows-2019
+      vmImage: windows-2022
     steps:
-      - task: UseDotNet@2
-        displayName: 'Use .NET Core SDK 2.1'
-        inputs:
-          packageType: sdk
-          version: 2.1.x
-          performMultiLevelLookup: true
-          installationPath: $(Agent.ToolsDirectory)/dotnet
+
+      #- run: choco install dotnetcore-2.1-sdk
+      #- run: choco install netfx-4.7.2-devpack
+      #- run: choco install dotnet4.5.1
+
+      - task: actions/setup-dotnet@v2
+        with:
+          dotnet-version: |
+            '2.1.x'
+            '4.7.2'
+            '4.5.1'
 
       - task: UseDotNet@2
         displayName: 'Use .NET Core SDK 3.1'
@@ -419,16 +454,32 @@ jobs:
           installationPath: $(Agent.ToolsDirectory)/dotnet
 
       - task: UseDotNet@2
-        displayName: 'Use .NET SDK 5.0'
+        displayName: 'Use .NET Core SDK 2.1'
         inputs:
           packageType: sdk
-          version: 5.x
+          version: 2.1.x
+          performMultiLevelLookup: true
+          installationPath: $(Agent.ToolsDirectory)/dotnet
+
+      - task: UseDotNet@2
+        displayName: 'Use .NET SDK 4.7.2'
+        inputs:
+          packageType: sdk
+          version: 4.7.2
+          performMultiLevelLookup: true
+          installationPath: $(Agent.ToolsDirectory)/dotnet
+
+      - task: UseDotNet@2
+        displayName: 'Use .NET SDK 4.5.1'
+        inputs:
+          packageType: sdk
+          version: 4.5.1
           performMultiLevelLookup: true
           installationPath: $(Agent.ToolsDirectory)/dotnet
 
       - script: |
-          call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\Common7\\Tools\\VsDevCmd.bat"
-          sn -Vr *,31bf3856ad364e35
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+          sn.exe -Vr *,31bf3856ad364e35
 
         displayName: "Disable strong name validation"
 
@@ -530,7 +581,7 @@ jobs:
 
     condition: succeeded()
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
     steps:
       - script: |
           rem Run dotnet first experience.
@@ -570,7 +621,7 @@ jobs:
           UsesHSM: true
 
       - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
-        displayName: "Run BinSkim "
+        displayName: "Run BinSkim"
         inputs:
           arguments: 'analyze  $(Build.SourcesDirectory)\Microsoft.Azure.Devices.*.dll --recurse --verbose'
 
@@ -578,7 +629,7 @@ jobs:
         enabled: false
 
       - task: securedevelopmentteam.vss-secure-development-tools.build-task-codemetrics.CodeMetrics@1
-        displayName: "Run CodeMetrics "
+        displayName: "Run CodeMetrics"
         inputs:
           Files: '$(Build.SourcesDirectory)\**\Microsoft.Azure.Devices.*.dll'
 


### PR DESCRIPTION
Test pipeline with windows 2022

https://github.com/actions/virtual-environments/issues/4856

The new image doesn't have old .NET targets, and the old image doesn't support net6.0. So we can split windows image by new/old .net targets and avoid having to install .net versions on either image.