### PR TITLE
Bump versions for 02/17/2022 preview release

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.38.1-preview-001</Version>
+    <Version>1.41.0-preview-001</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.35.0-preview-002</Version>
+    <Version>1.38.0-preview-001</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.18.0-preview-002</Version>
+    <Version>1.20.0-preview-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.18.0-preview-002</Version>
+    <Version>1.19.0-preview-001</Version>
     <Title>Microsoft Azure IoT Provisioning Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.15.0-preview-002</Version>
+    <Version>1.17.0-preview-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client AMQP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
+++ b/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.14.0-preview-002</Version>
+    <Version>1.16.0-preview-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client HTTP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
+++ b/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.16.0-preview-002</Version>
+    <Version>1.18.0-preview-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client MQTT Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
+++ b/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>1.14.0-preview-002</Version>
+    <Version>1.15.0-preview-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Security TPM Client</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/shared/src/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/src/Microsoft.Azure.Devices.Shared.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.29.0-preview-002</Version>
+    <Version>1.31.0-preview-001</Version>
     <Title>Microsoft Azure IoT Devices Shared</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,10 +1,10 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj,1.38.1-preview-001
-iothub\service\src\Microsoft.Azure.Devices.csproj,1.35.0-preview-002
-shared\src\Microsoft.Azure.Devices.Shared.csproj,1.29.0-preview-002
-provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj,1.18.0-preview-002
-provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj,1.15.0-preview-002
-provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj,1.14.0-preview-002
-provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj,1.16.0-preview-002
-security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj,1.14.0-preview-002
-provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj,1.18.0-preview-002
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj,1.41.0-preview-001
+iothub\service\src\Microsoft.Azure.Devices.csproj,1.38.0-preview-001
+shared\src\Microsoft.Azure.Devices.Shared.csproj,1.31.0-preview-001
+provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj,1.20.0-preview-001
+provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj,1.17.0-preview-001
+provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj,1.16.0-preview-001
+provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj,1.18.0-preview-001
+security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj,1.15.0-preview-001
+provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj,1.19.0-preview-001


### PR DESCRIPTION
Release notes:
-----------------------

## SDK updates from `main` branch.

This release is bringing changes from the main release [2022-01-26](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2022_01_26).
The previous preview release was based on the main release  [2021-08-11](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2021-8-11).

## Microsoft.Azure.Devices.Client 1.41.0-preview-001

- Updates from `GA release` [2022-01-26](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2022_01_26).
- Update native Azure IoT Plug and Play (PnP) APIs:
    - Update the command and property callback APIs to no longer require users to pass a context object in the callback implementation.
        - Command callback function is updated from `Func<CommandRequest, object, Task<CommandResponse>> callback` to `Func<CommandRequest, Task<CommandResponse>> callback`. Since `SubscribeToCommandsAsync` callback is invoked for all command invocation requests,
the user context passed in would be the same for all scenarios. This user context can be set at a class level instead.
        - Property callback function is updated from `Func<ClientPropertyCollection, object, Task> callback` to `Func<ClientPropertyCollection, Task> callback`. Since `SubscribeToWritablePropertyUpdateRequestsAsync` callback is invoked for all property update events, the user context passed in would be the same for all scenarios. This user context can be set at a class level instead.
    - .NET property private setters have been removed and the property has been made readonly instead.
    - Payload getters in `CommandRequest` have been simplified
        - `public string DataAsJson { get; }` has been updated to `public string GetPayloadAsString()`.
        - `public T GetData<T>()` has been updated to `public T GetPayload<T>()`.
        - `public byte[] GetDataAsBytes()` has been updated to `public ReadOnlyCollection<byte> GetPayloadAsBytes()`.
    - Payload getter in `CommandResponse` has been simplified
        - `public string ResultAsJson { get; }` has been updated to `public object Payload { get; }`.

## Microsoft.Azure.Devices 1.38.0-preview-001

- Updates from `GA release` [2022-01-26](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2022_01_26).

## Microsoft.Azure.Devices.Shared 1.31.0-preview-001

- Updates from `GA release` [2022-01-26](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2022_01_26).

## Microsoft.Azure.Devices.Provisioning.Client 1.20.0-preview-001

- Updates from `GA release` [2022-01-26](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2022_01_26).

## Microsoft.Azure.Devices.Provisioning.Transport.Mqtt 1.18.0-preview-001

- Updates from `GA release` [2022-01-26](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2022_01_26).

## Microsoft.Azure.Devices.Provisioning.Transport.Amqp 1.17.0-preview-001

- Updates from `GA release` [2022-01-26](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2022_01_26).

## Microsoft.Azure.Devices.Provisioning.Client.Transport.Http 1.16.0-preview-001

- Updates from `GA release` [2022-01-26](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2022_01_26).

## Microsoft.Azure.Devices.Provisioning.Security.Tpm 1.15.0-preview-001

- Updates from `GA release` [2022-01-26](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2022_01_26).

## Microsoft.Azure.Devices.Provisioning.Service 1.19.0-preview-001

- Updates from `GA release` [2022-01-26](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/2022_01_26).

===========================

Versions (main):
iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.40.0
iothub\service\src\Microsoft.Azure.Devices.csproj, 1.37.0
shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.30.1
provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.19.1
provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.18.1
provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.16.1
provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.15.1
provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.17.1
security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.14.1

Versions (proposed in preview):
iothub\device\src\Microsoft.Azure.Devices.Client.csproj,1.41.0-preview-001
iothub\service\src\Microsoft.Azure.Devices.csproj,1.38.0-preview-001
shared\src\Microsoft.Azure.Devices.Shared.csproj,1.31.0-preview-001
provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj,1.20.0-preview-001
provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj,1.17.0-preview-001
provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj,1.16.0-preview-001
provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj,1.18.0-preview-001
security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj,1.15.0-preview-001
provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj,1.19.0-preview-001