### PR TITLE
DPS client certificate issuance over Amqp and Http (individual enrollments)

### DIFF
--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -762,10 +762,142 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
         // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
         [LoggedTestMethod]
+        public async Task DPS_Registration_Mqtt_X509_IndividualEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Mqtt_Tcp_Only,
+                AttestationMechanismType.X509,
+                EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_MqttWs_X509_IndividualEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Mqtt_WebSocket_Only,
+                AttestationMechanismType.X509,
+                EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
         public async Task DPS_Registration_Mqtt_SymmetricKey_IndividualEnrollment_ConnectToHubWithOperationalCertificate()
         {
             await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
                 Client.TransportType.Mqtt_Tcp_Only,
+                AttestationMechanismType.SymmetricKey,
+                EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_MqttWs_SymmetricKey_IndividualEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Mqtt_WebSocket_Only,
+                AttestationMechanismType.SymmetricKey,
+                EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_Amqp_Tpm_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Amqp_Tcp_Only,
+                AttestationMechanismType.Tpm,
+                EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_AmqpWs_Tpm_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Amqp_WebSocket_Only,
+                AttestationMechanismType.Tpm,
+                EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_Amqp_X509_IndividualEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Amqp_Tcp_Only,
+                AttestationMechanismType.X509,
+                EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_AmqpWs_X509_IndividualEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Amqp_WebSocket_Only,
+                AttestationMechanismType.X509,
+                EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_Amqp_SymmetricKey_IndividualEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Amqp_Tcp_Only,
+                AttestationMechanismType.SymmetricKey,
+                EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_AmqpWs_SymmetricKey_IndividualEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Amqp_WebSocket_Only,
+                AttestationMechanismType.SymmetricKey,
+                EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_Http_Tpm_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Http1,
+                AttestationMechanismType.Tpm,
+                EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_Http_X509_IndividualEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Http1,
+                AttestationMechanismType.X509,
+                EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_Http_SymmetricKey_IndividualEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Http1,
                 AttestationMechanismType.SymmetricKey,
                 EnrollmentType.Individual,
                 connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
@@ -1452,6 +1584,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         {
             s_individualEnrollmentCertificate?.Dispose();
             s_groupEnrollmentCertificate?.Dispose();
+
             // Delete all the test client certificates created
             try
             {

--- a/provisioning/transport/http/src/ProvisioningTransportHandlerHttp.cs
+++ b/provisioning/transport/http/src/ProvisioningTransportHandlerHttp.cs
@@ -125,11 +125,16 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 Logging.Info(this, $"Uri: {builder.Uri}; User-Agent: {message.ProductInfo}");
 
                 DeviceRegistration deviceRegistration = authStrategy.CreateDeviceRegistration();
-                if (message.Payload != null
-                    && message.Payload.Length > 0)
+                if (!string.IsNullOrWhiteSpace(message.Payload))
                 {
                     deviceRegistration.Payload = new JRaw(message.Payload);
                 }
+
+                if (!string.IsNullOrWhiteSpace(message.OperationalCertificateRequest))
+                {
+                    deviceRegistration.OperationalCertificateRequest = message.OperationalCertificateRequest;
+                }
+
                 string registrationId = message.Security.GetRegistrationID();
 
                 RegistrationOperationStatus operation = await client.RuntimeRegistration
@@ -281,22 +286,23 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 
         private static DeviceRegistrationResult ConvertToProvisioningRegistrationResult(Models.DeviceRegistrationResult result)
         {
-            Enum.TryParse(result.Status, true, out ProvisioningRegistrationStatusType status);
-            Enum.TryParse(result.Substatus, true, out ProvisioningRegistrationSubstatusType substatus);
+            Enum.TryParse(result?.Status, true, out ProvisioningRegistrationStatusType status);
+            Enum.TryParse(result?.Substatus, true, out ProvisioningRegistrationSubstatusType substatus);
 
             return new DeviceRegistrationResult(
-                result.RegistrationId,
-                result.CreatedDateTimeUtc,
-                result.AssignedHub,
-                result.DeviceId,
+                result?.RegistrationId,
+                result?.CreatedDateTimeUtc,
+                result?.AssignedHub,
+                result?.DeviceId,
                 status,
                 substatus,
-                result.GenerationId,
-                result.LastUpdatedDateTimeUtc,
+                result?.GenerationId,
+                result?.LastUpdatedDateTimeUtc,
                 result.ErrorCode == null ? 0 : (int)result.ErrorCode,
-                result.ErrorMessage,
-                result.Etag,
-                result?.Payload?.ToString(CultureInfo.InvariantCulture));
+                result?.ErrorMessage,
+                result?.Etag,
+                result?.Payload?.ToString(CultureInfo.InvariantCulture),
+                result?.IssuedClientCertificate);
         }
     }
 }


### PR DESCRIPTION
From #2328 :

This PR covers the implementation idea for DPS client certificate issuance over MQTT protocol for individual enrollments.

The DPS client certificate feature is built on the following idea:	
- you have a CA that can accept certificate signing requests from you and issue you with a signed public certificate.
    - test CA provided by DPS team for now. We might need to create a separate test account for our test pipeline
- you link your DPS instance to your CA
   - service API (not implemented here). The tests are written based on this link already being in place.
- you link your DPS enrollments to your CA 
    - service API (implemented via service API).
- generate your public-private key pair and corresponding certificate signing request 
    - implemented va `openssl` commands for the tests
- register your enrollment passing in the certificate request. This certificate request contains your public key and "your" identifying information (subject name, etc). DPS receives this request, forwards it to your linked CA, receives a signed public certificate in return. DPS will provision your enrollment to IoT hub with this signed public certificate and also return it to you.
    - implemented over MQTT for nowby the SDK. Service support is available over all three protocols.
- use the issued certificate and previously generate key pair and generate your pfx file. This pfx file contains your device's identifying information and the private key necessary to negotiate the TLS handshake 
    - implemented va `openssl` commands for the tests
- use the pfx file to create an `X509Certificate2` which can be used to authenticate with IoT Hub using `DeviceAuthenticationWithX509Certificate` authentication method.
    - support already available on the SDK

API diff

```diff
{
     namespace Microsoft.Azure.Devices.Provisioning.Client {
         public class DeviceRegistrationResult {
+           public string IssuedClientCertificate { get; set; }
         }
         public class ProvisioningRegistrationAdditionalData {
+          public string OperationalCertificateRequest { get; set; }
         }
     }
     namespace Microsoft.Azure.Devices.Provisioning.Client.Transport {
         public class ProvisioningTransportRegisterMessage {
+          public string OperationalCertificateRequest { get; private set; }
         }
     }
 }
```

```diff
 {
     namespace Microsoft.Azure.Devices.Provisioning.Service {
+       public class ClientCertificateIssuancePolicy {
+          public ClientCertificateIssuancePolicy();
+          public string CertificateAuthorityName { get; set; }
+       }
         public class IndividualEnrollment : IETagHolder {
+          public ClientCertificateIssuancePolicy ClientCertificateIssuancePolicy { get; set; }
         }
     }
 }
```