### PR TITLE
Implement DPS client certificate issuance for group enrollments

### DIFF
--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -784,6 +784,28 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
         // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
         [LoggedTestMethod]
+        public async Task DPS_Registration_Mqtt_X509_GroupEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Mqtt_Tcp_Only,
+                AttestationMechanismType.X509,
+                EnrollmentType.Group,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_MqttWs_X509_GroupEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Mqtt_WebSocket_Only,
+                AttestationMechanismType.X509,
+                EnrollmentType.Group,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
         public async Task DPS_Registration_Mqtt_SymmetricKey_IndividualEnrollment_ConnectToHubWithOperationalCertificate()
         {
             await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
@@ -801,6 +823,28 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                 Client.TransportType.Mqtt_WebSocket_Only,
                 AttestationMechanismType.SymmetricKey,
                 EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_Mqtt_SymmetricKey_GroupEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Mqtt_Tcp_Only,
+                AttestationMechanismType.SymmetricKey,
+                EnrollmentType.Group,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_MqttWs_SymmetricKey_GroupEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Mqtt_WebSocket_Only,
+                AttestationMechanismType.SymmetricKey,
+                EnrollmentType.Group,
                 connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
         }
 
@@ -850,6 +894,28 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
         // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
         [LoggedTestMethod]
+        public async Task DPS_Registration_Amqp_X509_GroupEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Amqp_Tcp_Only,
+                AttestationMechanismType.X509,
+                EnrollmentType.Group,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_AmqpWs_X509_GroupEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Amqp_WebSocket_Only,
+                AttestationMechanismType.X509,
+                EnrollmentType.Group,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
         public async Task DPS_Registration_Amqp_SymmetricKey_IndividualEnrollment_ConnectToHubWithOperationalCertificate()
         {
             await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
@@ -867,6 +933,28 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                 Client.TransportType.Amqp_WebSocket_Only,
                 AttestationMechanismType.SymmetricKey,
                 EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_Amqp_SymmetricKey_GroupEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Amqp_Tcp_Only,
+                AttestationMechanismType.SymmetricKey,
+                EnrollmentType.Group,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_AmqpWs_SymmetricKey_GroupEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Amqp_WebSocket_Only,
+                AttestationMechanismType.SymmetricKey,
+                EnrollmentType.Group,
                 connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
         }
 
@@ -894,12 +982,34 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
         // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
         [LoggedTestMethod]
+        public async Task DPS_Registration_Http_X509_GroupEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Http1,
+                AttestationMechanismType.X509,
+                EnrollmentType.Group,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
         public async Task DPS_Registration_Http_SymmetricKey_IndividualEnrollment_ConnectToHubWithOperationalCertificate()
         {
             await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
                 Client.TransportType.Http1,
                 AttestationMechanismType.SymmetricKey,
                 EnrollmentType.Individual,
+                connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
+        }
+
+        // For the purpose of this E2E test the DPS instance has already been linked to the CA: https://github.com/Azure/CertsForIoT-B#getting-started
+        [LoggedTestMethod]
+        public async Task DPS_Registration_Http_SymmetricKey_GroupEnrollment_ConnectToHubWithOperationalCertificate()
+        {
+            await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
+                Client.TransportType.Http1,
+                AttestationMechanismType.SymmetricKey,
+                EnrollmentType.Group,
                 connectToHubUsingOperationalCertificate: true).ConfigureAwait(false);
         }
 
@@ -1425,7 +1535,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                                 allocationPolicy,
                                 customAllocationDefinition,
                                 iothubs,
-                                capabilities).ConfigureAwait(false);
+                                capabilities,
+                                connectToHubUsingOperationalCertificate).ConfigureAwait(false);
 
                             Assert.IsTrue(symmetricKeyEnrollmentGroup.Attestation is SymmetricKeyAttestation);
                             var symmetricKeyAttestation = (SymmetricKeyAttestation)symmetricKeyEnrollmentGroup.Attestation;

--- a/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
@@ -313,7 +313,15 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             }
         }
 
-        public static async Task<EnrollmentGroup> CreateEnrollmentGroup(ProvisioningServiceClient provisioningServiceClient, AttestationMechanismType attestationType, string groupId, ReprovisionPolicy reprovisionPolicy, AllocationPolicy allocationPolicy, CustomAllocationDefinition customAllocationDefinition, ICollection<string> iothubs, DeviceCapabilities capabilities)
+        public static async Task<EnrollmentGroup> CreateEnrollmentGroup(
+            ProvisioningServiceClient provisioningServiceClient,
+            AttestationMechanismType attestationType,
+            string groupId,
+            ReprovisionPolicy reprovisionPolicy,
+            AllocationPolicy allocationPolicy,
+            CustomAllocationDefinition customAllocationDefinition,
+            ICollection<string> iothubs, DeviceCapabilities capabilities,
+            bool connectToHubUsingOperationalCertificate = false)
         {
             Attestation attestation;
             switch (attestationType)
@@ -338,6 +346,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                 AllocationPolicy = allocationPolicy,
                 CustomAllocationDefinition = customAllocationDefinition,
                 IotHubs = iothubs,
+                ClientCertificateIssuancePolicy = connectToHubUsingOperationalCertificate ? new ClientCertificateIssuancePolicy { CertificateAuthorityName = s_clientCertificatesCAName } : null,
             };
 
             return await provisioningServiceClient.CreateOrUpdateEnrollmentGroupAsync(enrollmentGroup).ConfigureAwait(false);

--- a/provisioning/service/src/Config/EnrollmentGroup.cs
+++ b/provisioning/service/src/Config/EnrollmentGroup.cs
@@ -337,5 +337,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </summary>
         [JsonProperty(PropertyName = "customAllocationDefinition", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public CustomAllocationDefinition CustomAllocationDefinition { get; set; }
+
+        /// <summary>
+        /// The issuance policy for client certificates.
+        /// </summary>
+        [JsonProperty(PropertyName = "clientCertificateIssuancePolicy", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public ClientCertificateIssuancePolicy ClientCertificateIssuancePolicy { get; set; }
     }
 }


### PR DESCRIPTION
From #2328 :

This PR covers the implementation idea for DPS client certificate issuance over MQTT protocol for individual enrollments.

The DPS client certificate feature is built on the following idea:	
- you have a CA that can accept certificate signing requests from you and issue you with a signed public certificate.
    - test CA provided by DPS team for now. We might need to create a separate test account for our test pipeline
- you link your DPS instance to your CA
   - service API (not implemented here). The tests are written based on this link already being in place.
- you link your DPS enrollments to your CA 
    - service API (implemented via service API).
- generate your public-private key pair and corresponding certificate signing request 
    - implemented va `openssl` commands for the tests
- register your enrollment passing in the certificate request. This certificate request contains your public key and "your" identifying information (subject name, etc). DPS receives this request, forwards it to your linked CA, receives a signed public certificate in return. DPS will provision your enrollment to IoT hub with this signed public certificate and also return it to you.
    - implemented over MQTT for nowby the SDK. Service support is available over all three protocols.
- use the issued certificate and previously generate key pair and generate your pfx file. This pfx file contains your device's identifying information and the private key necessary to negotiate the TLS handshake 
    - implemented va `openssl` commands for the tests
- use the pfx file to create an `X509Certificate2` which can be used to authenticate with IoT Hub using `DeviceAuthenticationWithX509Certificate` authentication method.
    - support already available on the SDK

API diff

```diff
{
     namespace Microsoft.Azure.Devices.Provisioning.Client {
         public class DeviceRegistrationResult {
+           public string IssuedClientCertificate { get; set; }
         }
         public class ProvisioningRegistrationAdditionalData {
+          public string OperationalCertificateRequest { get; set; }
         }
     }
     namespace Microsoft.Azure.Devices.Provisioning.Client.Transport {
         public class ProvisioningTransportRegisterMessage {
+          public string OperationalCertificateRequest { get; private set; }
         }
     }
 }
```

```diff
 {
     namespace Microsoft.Azure.Devices.Provisioning.Service {
+       public class ClientCertificateIssuancePolicy {
+          public ClientCertificateIssuancePolicy();
+          public string CertificateAuthorityName { get; set; }
+       }
         public class IndividualEnrollment : IETagHolder {
+          public ClientCertificateIssuancePolicy ClientCertificateIssuancePolicy { get; set; }
         }
        public class EnrollmentGroup : IETagHolder {
+          public ClientCertificateIssuancePolicy ClientCertificateIssuancePolicy { get; set; }
         }
     }
 }
```