### PR TITLE
ado: make component governance run even if build fails

### DIFF
--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -122,6 +122,14 @@ jobs:
           testResultsFiles: "**/*.trx"
 
         condition: always()
+        
+      - task: ComponentGovernanceComponentDetection@0
+        displayName: Component Governance Detection
+        inputs:
+          scanType: 'Register'
+          verbosity: 'Verbose'
+          alertWarningLevel: 'Low' # The task will present a warning, but will not cause the build to fail
+        condition: always()
 
   ### Linux build 2 ###
   - job: LINUX2
@@ -250,6 +258,14 @@ jobs:
           testResultsFiles: "**/*.trx"
 
         condition: always()
+        
+      - task: ComponentGovernanceComponentDetection@0
+        displayName: Component Governance Detection
+        inputs:
+          scanType: 'Register'
+          verbosity: 'Verbose'
+          alertWarningLevel: 'Low' # The task will present a warning, but will not cause the build to fail
+        condition: always()
 
   ### Windows build 1 ###
   - job: WINDOWS1
@@ -358,6 +374,14 @@ jobs:
           platform: Windows
           configuration: "Debug UT + Release E2E ($(FRAMEWORK))"
 
+        condition: always()
+        
+      - task: ComponentGovernanceComponentDetection@0
+        displayName: Component Governance Detection
+        inputs:
+          scanType: 'Register'
+          verbosity: 'Verbose'
+          alertWarningLevel: 'Low' # The task will present a warning, but will not cause the build to fail
         condition: always()
 
   ### Windows build 2 ###
@@ -489,6 +513,14 @@ jobs:
           platform: Windows
           configuration: "Debug UT + Release E2E ($(FRAMEWORK))"
 
+        condition: always()
+
+      - task: ComponentGovernanceComponentDetection@0
+        displayName: Component Governance Detection
+        inputs:
+          scanType: 'Register'
+          verbosity: 'Verbose'
+          alertWarningLevel: 'Low' # The task will present a warning, but will not cause the build to fail
         condition: always()
 
   ### .Net SDL Analyzers ###

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -605,6 +605,14 @@ jobs:
         displayName: "Create Security Analysis Report"
         inputs:
           AllTools: true
+          
+      - task: ComponentGovernanceComponentDetection@0
+        displayName: Component Governance Detection
+        inputs:
+          scanType: 'Register'
+          verbosity: 'Verbose'
+          alertWarningLevel: 'Low' # The task will present a warning, but will not cause the build to fail
+        condition: always()
 
       - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
         displayName: "TSA upload"


### PR DESCRIPTION
We're getting stale component governance alerts since our canary builds haven't passed in a while