### PR TITLE
fix(vsts): Add CA name to keyvault entry during test infrastructure setup

### DIFF
--- a/e2e/test/prerequisites/E2ETestsSetup/e2eTestsSetup.ps1
+++ b/e2e/test/prerequisites/E2ETestsSetup/e2eTestsSetup.ps1
@@ -718,6 +718,7 @@ $keyvaultKvps = @{
     "IOTHUB-X509-CHAIN-DEVICE-NAME" = $iotHubCertChainDeviceCommonName;
     "IOTHUB-USER-ASSIGNED-MSI-RESOURCE-ID" = $msiResourceId;
     "E2E-IKEY" = $instrumentationKey;
+    "CA-NAME" = "dps_test_ca";
 
     <#[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="fake shared access token")]#>
     "IOTHUB-DEVICE-CONN-STRING-INVALIDCERT" = "HostName=invalidcertiothub1.westus.cloudapp.azure.com;DeviceId=DoNotDelete1;SharedAccessKey=zWmeTGWmjcgDG1dpuSCVjc5ZY4TqVnKso5+g1wt/K3E=";


### PR DESCRIPTION
In the absence of Azure CLI support, the following items of our E2E infrastructure setup process are currently performed offline:
(this note has been added to the PBI as well)

- Link DPS instance to your CA
`curl -k -L -i -X PUT -H 'Content-Type: application/json' -H 'Content-Encoding: utf-8' -H 'Authorization: <dps_service_api_sas_key> ' https://<dps_instance_hostname>/certificateAuthorities/<ca_name>?api-version=2021-11-01-preview  -d"{'certificateAuthorityType':'DigiCertCertificateAuthority','profileName':<profile_id>','apiKey':'<api_key>'}"`

- Link individual enrollment using x509 onboarding certificates to CA
`curl -k -L -i -X PUT -H "Content-Type: application/json" -H "Content-Encoding:  utf-8" -H "Authorization: <dps_service_api_sas_key>" https://<dps_instance_hostname>/enrollments/<registration_id>?api-version=2021-11-01-preview -H "If-Match: <etag>" -d "{'registrationId':'<registration_id>','deviceId':'<device_id>','attestation':{'type':'x509','x509':{'clientCertificates':{'primary':{'info':{'subjectName':'<subject_name>','sha1Thumbprint':'<thumbprint>','sha256Thumbprint':'<thumbprint>','issuerName':'<issuer>','notBeforeUtc':'<utc_time>','notAfterUtc':'<utc_time>','serialNumber':'<serial_number>','version':'<version>'}}}}},'etag':'<etag>','clientCertificateIssuancePolicy':{'certificateAuthorityName': '<ca_name>'}}"`

- Link enrollment group using x509 onboarding certificates to CA
`curl -k -L -i -X PUT -H "Content-Type: application/json" -H "Content-Encoding:  utf-8" -H "Authorization: <dps_service_api_sas_key>" https://<dps_instance_hostname>/enrollmentGroups/<group_id>?api-version=2021-11-01-preview -H "If-Match: *" -d "{'enrollmentGroupId':'<group_id>','attestation':{'type':'x509','x509':{'caReferences':{'primary':'<ca_certificate_name>'}}},'clientCertificateIssuancePolicy':{'certificateAuthorityName':'<ca_name>'}}"`

E2E test enrollments using TPM and Symmetric Keys are created on-the-fly. They have the "linking" code included as a part of test.