### PR TITLE
refactor(prov-device): Rename variables for accepting client certificate signing requests

### DIFF
--- a/common/src/device/provisioning/transport/DeviceRegistrationResult.cs
+++ b/common/src/device/provisioning/transport/DeviceRegistrationResult.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport.Models
         /// <summary>
         /// The PEM encoded operational client certificate that was signed by the certificate authority.
         /// This client certificate was used by the device provisioning service to register the enrollment with IoT Hub.
-        /// The IoT device can then use this returned operational certificate along with the private key information to authenticate with IoT Hub.
+        /// The IoT device can then use this returned client certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>
         [JsonProperty(PropertyName = "issuedClientCertificate")]
         public string IssuedClientCertificate { get; set; }

--- a/common/src/device/provisioning/transport/DeviceRegistrationResult.cs
+++ b/common/src/device/provisioning/transport/DeviceRegistrationResult.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport.Models
         public JRaw Payload { get; set; }
 
         /// <summary>
-        /// The PEM encoded operational client certificate that was signed by the certificate authority.
+        /// The client certificate that was signed by the certificate authority.
         /// This client certificate was used by the device provisioning service to register the enrollment with IoT Hub.
         /// The IoT device can then use this returned client certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>

--- a/common/src/device/provisioning/transport/DeviceRegistrationResult.cs
+++ b/common/src/device/provisioning/transport/DeviceRegistrationResult.cs
@@ -68,9 +68,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport.Models
         public JRaw Payload { get; set; }
 
         /// <summary>
-        /// The PEM encoded operational client certificate that was returned by the certificate authority.
+        /// The PEM encoded operational client certificate that was signed by the certificate authority.
         /// This operational certificate was used by the device provisioning service to register the enrollment with IoT Hub.
-        /// The IoT device can use this operational certificate to authenticate with IoT Hub.
+        /// The IoT device can then use this returned operational certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>
         [JsonProperty(PropertyName = "issuedClientCertificate")]
         public string IssuedClientCertificate { get; set; }

--- a/common/src/device/provisioning/transport/DeviceRegistrationResult.cs
+++ b/common/src/device/provisioning/transport/DeviceRegistrationResult.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport.Models
 
         /// <summary>
         /// The PEM encoded operational client certificate that was signed by the certificate authority.
-        /// This operational certificate was used by the device provisioning service to register the enrollment with IoT Hub.
+        /// This client certificate was used by the device provisioning service to register the enrollment with IoT Hub.
         /// The IoT device can then use this returned operational certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>
         [JsonProperty(PropertyName = "issuedClientCertificate")]

--- a/common/src/device/provisioning/transport/DeviceRegistrationResult.cs
+++ b/common/src/device/provisioning/transport/DeviceRegistrationResult.cs
@@ -69,8 +69,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport.Models
 
         /// <summary>
         /// The client certificate that was signed by the certificate authority.
-        /// This client certificate was used by the device provisioning service to register the enrollment with IoT Hub.
-        /// The IoT device can then use this returned client certificate along with the private key information to authenticate with IoT Hub.
+        /// This client certificate was used by the device provisioning service to register the enrollment with IoT hub.
+        /// The IoT device can then use this returned client certificate along with the private key information to authenticate with IoT hub.
         /// </summary>
         [JsonProperty(PropertyName = "issuedClientCertificate")]
         public string IssuedClientCertificate { get; set; }

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -1131,10 +1131,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
                             result = timeout != TimeSpan.MaxValue
                                 ? await provClient.RegisterAsync(
-                                    new ProvisioningRegistrationAdditionalData { OperationalCertificateRequest = certificateRequest },
+                                    new ProvisioningRegistrationAdditionalData { ClientCertificateSigningRequest = certificateRequest },
                                     timeout).ConfigureAwait(false)
                                 : await provClient.RegisterAsync(
-                                    new ProvisioningRegistrationAdditionalData { OperationalCertificateRequest = certificateRequest },
+                                    new ProvisioningRegistrationAdditionalData { ClientCertificateSigningRequest = certificateRequest },
                                     cts.Token).ConfigureAwait(false);
                             break;
                         }

--- a/provisioning/device/src/DeviceRegistrationResult.cs
+++ b/provisioning/device/src/DeviceRegistrationResult.cs
@@ -201,8 +201,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
         /// <summary>
         /// The client certificate that was signed by the certificate authority.
-        /// This client certificate was used by the device provisioning service to register the enrollment with IoT Hub.
-        /// The IoT device can then use this returned client certificate along with the private key information to authenticate with IoT Hub.
+        /// This client certificate was used by the device provisioning service to register the enrollment with IoT hub.
+        /// The IoT device can then use this returned client certificate along with the private key information to authenticate with IoT hub.
         /// </summary>
         public string IssuedClientCertificate { get; set; }
     }

--- a/provisioning/device/src/DeviceRegistrationResult.cs
+++ b/provisioning/device/src/DeviceRegistrationResult.cs
@@ -200,9 +200,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         public string JsonPayload { get; private set; }
 
         /// <summary>
-        /// The PEM encoded operational client certificate that was returned by the certificate authority.
+        /// The PEM encoded operational client certificate that was signed by the certificate authority.
         /// This operational certificate was used by the device provisioning service to register the enrollment with IoT Hub.
-        /// The IoT device can use this operational certificate to authenticate with IoT Hub.
+        /// The IoT device can then use this returned operational certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>
         public string IssuedClientCertificate { get; set; }
     }

--- a/provisioning/device/src/DeviceRegistrationResult.cs
+++ b/provisioning/device/src/DeviceRegistrationResult.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
         /// <summary>
         /// The PEM encoded operational client certificate that was signed by the certificate authority.
-        /// This operational certificate was used by the device provisioning service to register the enrollment with IoT Hub.
+        /// This client certificate was used by the device provisioning service to register the enrollment with IoT Hub.
         /// The IoT device can then use this returned client certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>
         public string IssuedClientCertificate { get; set; }

--- a/provisioning/device/src/DeviceRegistrationResult.cs
+++ b/provisioning/device/src/DeviceRegistrationResult.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// <summary>
         /// The PEM encoded operational client certificate that was signed by the certificate authority.
         /// This operational certificate was used by the device provisioning service to register the enrollment with IoT Hub.
-        /// The IoT device can then use this returned operational certificate along with the private key information to authenticate with IoT Hub.
+        /// The IoT device can then use this returned client certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>
         public string IssuedClientCertificate { get; set; }
     }

--- a/provisioning/device/src/DeviceRegistrationResult.cs
+++ b/provisioning/device/src/DeviceRegistrationResult.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         public string JsonPayload { get; private set; }
 
         /// <summary>
-        /// The PEM encoded operational client certificate that was signed by the certificate authority.
+        /// The client certificate that was signed by the certificate authority.
         /// This client certificate was used by the device provisioning service to register the enrollment with IoT Hub.
         /// The IoT device can then use this returned client certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>

--- a/provisioning/device/src/ProvisioningDeviceClient.cs
+++ b/provisioning/device/src/ProvisioningDeviceClient.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         {
             Logging.RegisterAsync(this, _globalDeviceEndpoint, _idScope, _transport, _security);
 
-            var request = new ProvisioningTransportRegisterMessage(_globalDeviceEndpoint, _idScope, _security, data?.JsonData, data?.OperationalCertificateRequest)
+            var request = new ProvisioningTransportRegisterMessage(_globalDeviceEndpoint, _idScope, _security, data?.JsonData, data?.ClientCertificateSigningRequest)
             {
                 ProductInfo = ProductInfo,
             };
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         {
             Logging.RegisterAsync(this, _globalDeviceEndpoint, _idScope, _transport, _security);
 
-            var request = new ProvisioningTransportRegisterMessage(_globalDeviceEndpoint, _idScope, _security, data?.JsonData, data?.OperationalCertificateRequest)
+            var request = new ProvisioningTransportRegisterMessage(_globalDeviceEndpoint, _idScope, _security, data?.JsonData, data?.ClientCertificateSigningRequest)
             {
                 ProductInfo = ProductInfo,
             };

--- a/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
+++ b/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// <summary>
         /// The PEM encoded operational client certificate signing request that the device provisioning service (DPS) will send to its linked certificate authority which will sign
         /// and return an X509 device identity client certificate to the device.
-        /// DPS will register the device and operational client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
+        /// DPS will register the device and client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
         /// The IoT device can then use the returned operational certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>
         public string ClientCertificateSigningRequest { get; set; }

--- a/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
+++ b/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// The PEM encoded operational client certificate signing request that the device provisioning service (DPS) will send to its linked certificate authority which will sign
         /// and return an X509 device identity client certificate to the device.
         /// DPS will register the device and client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
-        /// The IoT device can then use the returned operational certificate along with the private key information to authenticate with IoT Hub.
+        /// The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>
         public string ClientCertificateSigningRequest { get; set; }
     }

--- a/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
+++ b/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         public string JsonData { get; set; }
 
         /// <summary>
-        /// The PEM encoded operational client certificate signing request that the device provisioning service (DPS) will send to its linked certificate authority which will sign
-        /// and return an X509 device identity client certificate to the device.
+        /// The certificate signing request for device client certificate in PKCS 10 format that the device provisioning service (DPS) will send to its linked certificate authority which will sign
+        /// and return an X509 device identity operational client certificate to the device.
         /// DPS will register the device and client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
         /// The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>

--- a/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
+++ b/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
         /// <summary>
         /// The PEM encoded operational client certificate signing request that the device provisioning service (DPS) will send to its linked certificate authority which will sign
-        /// and return an X509 device identity operational client certificate to the device.
+        /// and return an X509 device identity client certificate to the device.
         /// DPS will register the device and operational client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
         /// The IoT device can then use the returned operational certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>

--- a/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
+++ b/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         public string JsonData { get; set; }
 
         /// <summary>
-        /// The PEM encoded operational client certificate request that the device provisioning service (DPS) will send to its linked certificate authority which will sign
+        /// The PEM encoded operational client certificate signing request that the device provisioning service (DPS) will send to its linked certificate authority which will sign
         /// and return an X509 device identity operational client certificate to the device.
-        /// DPS will register the device and operational client certificate thumbprint in IoT Hub and return the certificate to the IoT device.
-        /// The IoT device can then use the operational certificate to authenticate with IoT Hub.
+        /// DPS will register the device and operational client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
+        /// The IoT device can then use the returned operational certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>
-        public string OperationalCertificateRequest { get; set; }
+        public string ClientCertificateSigningRequest { get; set; }
     }
 }

--- a/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
+++ b/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
         /// <summary>
         /// The certificate signing request for device client certificate in PKCS 10 format that the device provisioning service (DPS) will send to its linked certificate authority which will sign
-        /// and return an X509 device identity operational client certificate to the device.
+        /// and return an X509 device identity client certificate to the device.
         /// DPS will register the device and client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
         /// The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>

--- a/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
+++ b/provisioning/device/src/ProvisioningRegistrationAdditionalData.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// <summary>
         /// The certificate signing request for device client certificate in PKCS 10 format that the device provisioning service (DPS) will send to its linked certificate authority which will sign
         /// and return an X509 device identity client certificate to the device.
-        /// DPS will register the device and client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
-        /// The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT Hub.
+        /// DPS will register the device and client certificate thumbprint in IoT hub and return the certificate with the public key to the IoT device.
+        /// The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT hub.
         /// </summary>
         public string ClientCertificateSigningRequest { get; set; }
     }

--- a/provisioning/device/src/ProvisioningTransportRegisterRequest.cs
+++ b/provisioning/device/src/ProvisioningTransportRegisterRequest.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
         /// <summary>
         /// The certificate signing request for device client certificate in PKCS 10 format that the device provisioning service (DPS) will send to its linked certificate authority which will sign
         /// and return an X509 device identity client certificate to the device.
-        /// DPS will register the device and client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
-        /// The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT Hub.
+        /// DPS will register the device and client certificate thumbprint in IoT hub and return the certificate with the public key to the IoT device.
+        /// The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT hub.
         /// </summary>
         public string ClientCertificateSigningRequest { get; private set; }
 

--- a/provisioning/device/src/ProvisioningTransportRegisterRequest.cs
+++ b/provisioning/device/src/ProvisioningTransportRegisterRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 
         /// <summary>
         /// The certificate signing request for device client certificate in PKCS 10 format that the device provisioning service (DPS) will send to its linked certificate authority which will sign
-        /// and return an X509 device identity operational client certificate to the device.
+        /// and return an X509 device identity client certificate to the device.
         /// DPS will register the device and client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
         /// The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>

--- a/provisioning/device/src/ProvisioningTransportRegisterRequest.cs
+++ b/provisioning/device/src/ProvisioningTransportRegisterRequest.cs
@@ -33,12 +33,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
         public string Payload { get; private set; }
 
         /// <summary>
-        /// The PEM encoded operational client certificate request that the device provisioning service (DPS) will send to its linked certificate authority which will sign
+        /// The certificate signing request for device client certificate in PKCS 10 format that the device provisioning service (DPS) will send to its linked certificate authority which will sign
         /// and return an X509 device identity operational client certificate to the device.
-        /// DPS will register the device and operational client certificate thumbprint in IoT Hub and return the certificate to the IoT device.
-        /// The IoT device can then use the operational certificate to authenticate with IoT Hub.
+        /// DPS will register the device and client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
+        /// The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>
-        public string OperationalCertificateRequest { get; private set; }
+        public string ClientCertificateSigningRequest { get; private set; }
 
         /// <summary>
         /// The Product Information sent to the Provisioning Service. The application can specify extra information.
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             string idScope,
             SecurityProvider security,
             string payload = null,
-            string operationalCertificateRequest = null)
+            string clientCertificateSigningRequest = null)
         {
             GlobalDeviceEndpoint = globalDeviceEndpoint;
             IdScope = idScope;
@@ -103,9 +103,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 Payload = payload;
             }
 
-            if (!string.IsNullOrWhiteSpace(operationalCertificateRequest))
+            if (!string.IsNullOrWhiteSpace(clientCertificateSigningRequest))
             {
-                OperationalCertificateRequest = operationalCertificateRequest;
+                ClientCertificateSigningRequest = clientCertificateSigningRequest;
             }
         }
     }

--- a/provisioning/service/src/Config/ClientCertificateIssuancePolicy.cs
+++ b/provisioning/service/src/Config/ClientCertificateIssuancePolicy.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     public class ClientCertificateIssuancePolicy
     {
         /// <summary>
-        /// The CA name that can receice certificate signing requests from DPS on behalf of a device and issue it with an operational certificate.
+        /// The CA name that can receice certificate signing requests from DPS on behalf of a device and issue it with an operational client certificate.
         /// </summary>
         [JsonProperty(PropertyName = "certificateAuthorityName", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string CertificateAuthorityName { get; set; }

--- a/provisioning/service/src/Config/ClientCertificateIssuancePolicy.cs
+++ b/provisioning/service/src/Config/ClientCertificateIssuancePolicy.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     public class ClientCertificateIssuancePolicy
     {
         /// <summary>
-        /// The CA name that can receice certificate signing requests from DPS on behalf of a device and issue it with an operational client certificate.
+        /// The CA name that can receice certificate signing requests from DPS on behalf of a device and issue it with a client certificate.
         /// </summary>
         [JsonProperty(PropertyName = "certificateAuthorityName", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string CertificateAuthorityName { get; set; }

--- a/provisioning/transport/amqp/src/ProvisioningTransportHandlerAmqp.cs
+++ b/provisioning/transport/amqp/src/ProvisioningTransportHandlerAmqp.cs
@@ -159,9 +159,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                     deviceRegistration.Payload = new JRaw(message.Payload);
                 }
 
-                if (!string.IsNullOrWhiteSpace(message.OperationalCertificateRequest))
+                if (!string.IsNullOrWhiteSpace(message.ClientCertificateSigningRequest))
                 {
-                    deviceRegistration.OperationalCertificateRequest = message.OperationalCertificateRequest;
+                    deviceRegistration.ClientCertificateSigningRequest = message.ClientCertificateSigningRequest;
                 }
 
                 RegistrationOperationStatus operation = await RegisterDeviceAsync(connection, correlationId, deviceRegistration, bundleCancellationToken).ConfigureAwait(false);

--- a/provisioning/transport/generated/src/Models/DeviceRegistration.cs
+++ b/provisioning/transport/generated/src/Models/DeviceRegistration.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport.Models
         /// <summary>
         /// The certificate signing request for device client certificate in PKCS 10 format that the device provisioning service (DPS) will send to its linked certificate authority which will sign
         /// and return an X509 device identity client certificate to the device.
-        /// DPS will register the device and client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
-        /// The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT Hub.
+        /// DPS will register the device and client certificate thumbprint in IoT hub and return the certificate with the public key to the IoT device.
+        /// The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT hub.
         /// </summary>
         [JsonProperty(PropertyName = "clientCertificateCsr", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string ClientCertificateSigningRequest { get; set; }

--- a/provisioning/transport/generated/src/Models/DeviceRegistration.cs
+++ b/provisioning/transport/generated/src/Models/DeviceRegistration.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport.Models
 
         /// <summary>
         /// The certificate signing request for device client certificate in PKCS 10 format that the device provisioning service (DPS) will send to its linked certificate authority which will sign
-        /// and return an X509 device identity operational client certificate to the device.
+        /// and return an X509 device identity client certificate to the device.
         /// DPS will register the device and client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
         /// The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>

--- a/provisioning/transport/generated/src/Models/DeviceRegistration.cs
+++ b/provisioning/transport/generated/src/Models/DeviceRegistration.cs
@@ -27,13 +27,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport.Models
         public JRaw Payload { get; set; }
 
         /// <summary>
-        /// The PEM encoded operational client certificate request that the device provisioning service (DPS) will send to its linked certificate authority which will sign
+        /// The certificate signing request for device client certificate in PKCS 10 format that the device provisioning service (DPS) will send to its linked certificate authority which will sign
         /// and return an X509 device identity operational client certificate to the device.
-        /// DPS will register the device and operational client certificate thumbprint in IoT Hub and return the certificate to the IoT device.
-        /// The IoT device can then use the operational certificate to authenticate with IoT Hub.
+        /// DPS will register the device and client certificate thumbprint in IoT Hub and return the certificate with the public key to the IoT device.
+        /// The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT Hub.
         /// </summary>
         [JsonProperty(PropertyName = "clientCertificateCsr", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public string OperationalCertificateRequest { get; set; }
+        public string ClientCertificateSigningRequest { get; set; }
     }
 }
 

--- a/provisioning/transport/http/src/ProvisioningTransportHandlerHttp.cs
+++ b/provisioning/transport/http/src/ProvisioningTransportHandlerHttp.cs
@@ -130,9 +130,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                     deviceRegistration.Payload = new JRaw(message.Payload);
                 }
 
-                if (!string.IsNullOrWhiteSpace(message.OperationalCertificateRequest))
+                if (!string.IsNullOrWhiteSpace(message.ClientCertificateSigningRequest))
                 {
-                    deviceRegistration.OperationalCertificateRequest = message.OperationalCertificateRequest;
+                    deviceRegistration.ClientCertificateSigningRequest = message.ClientCertificateSigningRequest;
                 }
 
                 string registrationId = message.Security.GetRegistrationID();

--- a/provisioning/transport/mqtt/src/ProvisioningChannelHandlerAdapter.cs
+++ b/provisioning/transport/mqtt/src/ProvisioningChannelHandlerAdapter.cs
@@ -352,9 +352,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 deviceRegistration.Payload = new JRaw(_message.Payload);
             }
 
-            if (!string.IsNullOrWhiteSpace(_message.OperationalCertificateRequest))
+            if (!string.IsNullOrWhiteSpace(_message.ClientCertificateSigningRequest))
             {
-                deviceRegistration.OperationalCertificateRequest = _message.OperationalCertificateRequest;
+                deviceRegistration.ClientCertificateSigningRequest = _message.ClientCertificateSigningRequest;
             }
 
             string deviceRegistrationJsonString = JsonConvert.SerializeObject(deviceRegistration);


### PR DESCRIPTION
Renamed `OperationalCertificateRequest` to `ClientCertificateSigningRequest`.
Also updated some doc comments to highlight that the signed certificate only contains the public key information.