### PR TITLE
Updates from usability study

### DIFF
--- a/e2e/test/iothub/command/CommandE2ETests.cs
+++ b/e2e/test/iothub/command/CommandE2ETests.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Commands
                             commandCallReceived.SetException(ex);
                         }
 
-                        return Task.FromResult(new CommandResponse(new DeviceCommandResponse(), 200));
+                        return Task.FromResult(new CommandResponse(200, new DeviceCommandResponse()));
                     })
                 .ConfigureAwait(false);
 

--- a/e2e/test/iothub/properties/PropertiesWithComponentsE2ETests.cs
+++ b/e2e/test/iothub/properties/PropertiesWithComponentsE2ETests.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Properties
 
             // For the property patch sent here will result in the component being removed.
             var propertyPatch4 = new ClientPropertyCollection();
-            propertyPatch4.AddComponentProperties(ComponentName, null);
+            propertyPatch4.AddRootProperty(ComponentName, null);
             await deviceClient.UpdateClientPropertiesAsync(propertyPatch4).ConfigureAwait(false);
 
             serviceTwin = await registryManager.GetTwinAsync(testDevice.Id).ConfigureAwait(false);

--- a/iothub/device/devdoc/Convention-based operations.md
+++ b/iothub/device/devdoc/Convention-based operations.md
@@ -1,6 +1,6 @@
-## Plug and Play convention compatible APIs
+# Plug and Play convention compatible APIs
 
-#### Common
+## Common
 
 ```diff
 public class ClientOptions {
@@ -18,7 +18,6 @@ public class ModuleClient : IDisposable {
 ```
 
 ```csharp
-
 public abstract class PayloadConvention {
     protected PayloadConvention();
     public abstract PayloadEncoder PayloadEncoder { get; }
@@ -72,7 +71,6 @@ public abstract class PayloadCollection : IEnumerable, IEnumerable<KeyValuePair<
     public PayloadConvention Convention { get; internal set; }
     public virtual object this[string key] { get; set; }
     public virtual void Add(string key, object value);
-    public virtual void AddOrUpdate(string key, object value);
     public void ClearCollection();
     public bool Contains(string key);
     public IEnumerator<KeyValuePair<string, object>> GetEnumerator();
@@ -101,7 +99,7 @@ public class CommonClientResponseCodes {
 }
 ```
 
-### Properties
+## Properties
 
 ```csharp
 /// <summary>
@@ -127,7 +125,7 @@ public Task<ClientPropertiesUpdateResponse> UpdateClientPropertiesAsync(ClientPr
 public Task SubscribeToWritablePropertyUpdateRequestsAsync(Func<ClientPropertyCollection, Task> callback, CancellationToken cancellationToken = default);
 ```
 
-#### All related types
+### All related types
 
 ```csharp
 public class ClientProperties {
@@ -139,14 +137,8 @@ public class ClientProperties {
 public class ClientPropertyCollection : PayloadCollection {
     public ClientPropertyCollection();
     public long Version { get; protected set; }
-    public void AddComponentProperties(string componentName, IDictionary<string, object> properties);
-    public void AddComponentProperty(string componentName, string propertyName, object propertyValue);
-    public void AddOrUpdateComponentProperties(string componentName, IDictionary<string, object> properties);
-    public void AddOrUpdateComponentProperty(string componentName, string propertyName, object propertyValue);
-    public void AddOrUpdateRootProperties(IDictionary<string, object> properties);
-    public void AddOrUpdateRootProperty(string propertyName, object propertyValue);
-    public void AddRootProperties(IDictionary<string, object> properties);
     public void AddRootProperty(string propertyName, object propertyValue);
+    public void AddComponentProperty(string componentName, string propertyName, object propertyValue);
     public bool Contains(string componentName, string propertyName);
     public virtual bool TryGetValue<T>(string componentName, string propertyName, out T propertyValue);
 }
@@ -178,7 +170,7 @@ public class ClientPropertiesUpdateResponse {
 }
 ```
 
-### Telemetry
+## Telemetry
 
 ```csharp
 /// <summary>
@@ -192,15 +184,14 @@ public class ClientPropertiesUpdateResponse {
 /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
 public Task SendTelemetryAsync(TelemetryMessage telemetryMessage, CancellationToken cancellationToken = default);
 ```
-#### All related types
+
+### All related types
 
 ```csharp
 public class TelemetryCollection : PayloadCollection {
     public TelemetryCollection();
     public void Add(IDictionary<string, object> telemetryValues);
     public override void Add(string telemetryName, object telemetryValue);
-    public void AddOrUpdate(IDictionary<string, object> telemetryValues);
-    public override void AddOrUpdate(string telemetryName, object telemetryValue);
 }
 
 public sealed class TelemetryMessage : MessageBase {
@@ -210,7 +201,7 @@ public sealed class TelemetryMessage : MessageBase {
 }
 ```
 
-### Commands
+## Commands
 
 ```csharp
 /// <summary>
@@ -220,7 +211,8 @@ public sealed class TelemetryMessage : MessageBase {
 /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
 public Task SubscribeToCommandsAsync(Func<CommandRequest, Task<CommandResponse>> callback, CancellationToken cancellationToken = default);
 ```
-#### All related types
+
+### All related types
 
 ```csharp
 public sealed class CommandRequest {
@@ -235,8 +227,8 @@ public sealed class CommandRequest {
 public sealed class CommandResponse {
     public CommandResponse();
     public CommandResponse(int status);
-    public CommandResponse(object payload, int status);
-    public object Payload { get; }
-    public int Status { get; }
+    public CommandResponse(int status, object payload);
+    public object Payload { get; set; }
+    public int Status { get; set; }
 }
 ```

--- a/iothub/device/src/ClientPropertyCollection.cs
+++ b/iothub/device/src/ClientPropertyCollection.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Azure.Devices.Shared;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -17,33 +16,26 @@ namespace Microsoft.Azure.Devices.Client
     {
         private const string VersionName = "$version";
 
-        /// <summary>
-        /// Adds the value to the collection.
-        /// </summary>
+        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string)" />
         /// <remarks>
-        /// If the collection already has a key matching a property name supplied this method will throw an <see cref="ArgumentException"/>.
-        /// <para>
-        /// When using this as part of the writable property flow to respond to a writable property update you should pass in the value
-        /// as an instance of <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>
+        /// When using this as part of the writable property flow to respond to a writable property update, pass in
+        /// <paramref name="propertyValue"/> as an instance of
+        /// <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>
+        /// from <see cref="DeviceClient.PayloadConvention"/> (or <see cref="ModuleClient.PayloadConvention"/>)
         /// to ensure the correct formatting is applied when the object is serialized.
-        /// </para>
         /// </remarks>
-        /// <param name="propertyName">The name of the property to add.</param>
-        /// <param name="propertyValue">The value of the property to add.</param>
+        /// <param name="propertyName">The name of the property to add or update.</param>
+        /// <param name="propertyValue">The value of the property to add or update.</param>
+        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string)" />
         /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="propertyName"/> already exists in the collection.</exception>
         public void AddRootProperty(string propertyName, object propertyValue)
-            => AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, null, false);
+            => AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, null);
 
-        /// <inheritdoc path="/remarks" cref="AddRootProperty(string, object)" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception" cref="AddRootProperty(string, object)" />
-        /// <summary>
-        /// Adds the value to the collection.
-        /// </summary>
-        /// <param name="componentName">The component with the property to add.</param>
-        /// <param name="propertyName">The name of the property to add.</param>
-        /// <param name="propertyValue">The value of the property to add.</param>
+        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string)" />
+        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string)" />
+        /// <param name="componentName">The component with the property to add or update.</param>
+        /// <param name="propertyName">The name of the property to add or update.</param>
+        /// <param name="propertyValue">The value of the property to add or update.</param>
         /// <exception cref="ArgumentNullException"><paramref name="componentName"/> or <paramref name="propertyName"/> is <c>null</c>.</exception>
         public void AddComponentProperty(string componentName, string propertyName, object propertyValue)
         {
@@ -52,127 +44,7 @@ namespace Microsoft.Azure.Devices.Client
                 throw new ArgumentNullException(nameof(componentName));
             }
 
-            AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName, false);
-        }
-
-        /// <inheritdoc path="/remarks" cref="AddRootProperty(string, object)" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <summary>
-        /// Adds the value to the collection.
-        /// </summary>
-        /// <param name="componentName">The component with the properties to add.</param>
-        /// <param name="properties">A collection of properties to add.</param>
-        /// <exception cref="ArgumentException">A property name in <paramref name="properties"/> already exists in the collection.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="componentName"/> or a property name in <paramref name="properties"/> is <c>null</c>.</exception>
-        public void AddComponentProperties(string componentName, IDictionary<string, object> properties)
-        {
-            if (componentName == null)
-            {
-                throw new ArgumentNullException(nameof(componentName));
-            }
-
-            AddInternal(properties, componentName, false);
-        }
-
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception" cref="AddRootProperty(string, object)" />
-        /// <summary>
-        /// Adds the collection of root-level property values to the collection.
-        /// </summary>
-        /// <remarks>
-        /// If the collection already has a key matching a property name supplied this method will throw an <see cref="ArgumentException"/>.
-        /// <para>
-        /// When using this as part of the writable property flow to respond to a writable property update you should pass in the value
-        /// as an instance of <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>
-        /// to ensure the correct formatting is applied when the object is serialized.
-        /// </para>
-        /// </remarks>
-        /// <param name="properties">A collection of properties to add.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="properties"/> is <c>null</c>.</exception>
-        public void AddRootProperties(IDictionary<string, object> properties)
-        {
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
-            }
-
-            properties
-                .ToList()
-                .ForEach(entry => Collection.Add(entry.Key, entry.Value));
-        }
-
-        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/remarks" cref="AddOrUpdateComponentProperties(string, IDictionary{string, object})" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <param name="propertyName">The name of the property to add or update.</param>
-        /// <param name="propertyValue">The value of the property to add or update.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <c>null</c>.</exception>
-        public void AddOrUpdateRootProperty(string propertyName, object propertyValue)
-            => AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, null, true);
-
-        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/remarks" cref="AddOrUpdateComponentProperties(string, IDictionary{string, object})" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <param name="componentName">The component with the property to add or update.</param>
-        /// <param name="propertyName">The name of the property to add or update.</param>
-        /// <param name="propertyValue">The value of the property to add or update.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="componentName"/> or <paramref name="propertyName"/> is <c>null</c>.</exception>
-        public void AddOrUpdateComponentProperty(string componentName, string propertyName, object propertyValue)
-        {
-            if (componentName == null)
-            {
-                throw new ArgumentNullException(nameof(componentName));
-            }
-
-            AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName, true);
-        }
-
-        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <remarks>
-        /// If the collection has a key that matches this will overwrite the current value. Otherwise it will attempt to add this to the collection.
-        /// <para>
-        /// When using this as part of the writable property flow to respond to a writable property update
-        /// you should pass in the value as an instance of <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>
-        /// to ensure the correct formatting is applied when the object is serialized.
-        /// </para>
-        /// </remarks>
-        /// <param name="componentName">The component with the properties to add or update.</param>
-        /// <param name="properties">A collection of properties to add or update.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="componentName"/> or a property name in <paramref name="properties"/> is <c>null</c>.</exception>
-        public void AddOrUpdateComponentProperties(string componentName, IDictionary<string, object> properties)
-        {
-            if (componentName == null)
-            {
-                throw new ArgumentNullException(nameof(componentName));
-            }
-
-            AddInternal(properties, componentName, true);
-        }
-
-        /// <inheritdoc path="/summary" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/seealso" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <inheritdoc path="/exception" cref="AddInternal(IDictionary{string, object}, string, bool)" />
-        /// <remarks>
-        /// If the collection has a key that matches this will overwrite the current value. Otherwise it will attempt to add this to the collection.
-        /// <para>
-        /// When using this as part of the writable property flow to respond to a writable property update you should pass in the value
-        /// as an instance of <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>
-        /// to ensure the correct formatting is applied when the object is serialized.
-        /// </para>
-        /// </remarks>
-        /// <param name="properties">A collection of properties to add or update.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="properties"/> is <c>null</c>.</exception>
-        public void AddOrUpdateRootProperties(IDictionary<string, object> properties)
-        {
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
-            }
-
-            properties
-                .ToList()
-                .ForEach(entry => Collection[entry.Key] = entry.Value);
+            AddInternal(new Dictionary<string, object> { { propertyName, propertyValue } }, componentName);
         }
 
         /// <summary>
@@ -204,7 +76,11 @@ namespace Microsoft.Azure.Devices.Client
         /// Gets the value of a component-level property.
         /// </summary>
         /// <remarks>
+        /// If this instance is in an update request for a writable property, <paramref name="propertyValue"/> should be of type
+        /// <see cref="WritableClientProperty"/>.
+        /// <para>
         /// To get the value of a top-level property use <see cref="PayloadCollection.TryGetValue{T}(string, out T)"/>.
+        /// </para>
         /// </remarks>
         /// <typeparam name="T">The type to cast the object to.</typeparam>
         /// <param name="componentName">The component which holds the required property.</param>
@@ -462,10 +338,9 @@ namespace Microsoft.Azure.Devices.Client
         /// <seealso cref="PayloadEncoder"/>
         /// <param name="properties">A collection of properties to add or update.</param>
         /// <param name="componentName">The component with the properties to add or update.</param>
-        /// <param name="forceUpdate">Forces the collection to use the Add or Update behavior.
-        /// Setting to true will simply overwrite the value. Setting to false will use <see cref="IDictionary{TKey, TValue}.Add(TKey, TValue)"/></param>
+        /// 
         /// <exception cref="ArgumentNullException"><paramref name="properties"/> is <c>null</c>.</exception>
-        private void AddInternal(IDictionary<string, object> properties, string componentName = default, bool forceUpdate = false)
+        private void AddInternal(IDictionary<string, object> properties, string componentName = default)
         {
             // If the componentName is null then simply add the key-value pair to Collection dictionary.
             // This will either insert a property or overwrite it if it already exists.
@@ -486,14 +361,7 @@ namespace Microsoft.Azure.Devices.Client
                         throw new ArgumentNullException(nameof(entry.Key));
                     }
 
-                    if (forceUpdate)
-                    {
-                        Collection[entry.Key] = entry.Value;
-                    }
-                    else
-                    {
-                        Collection.Add(entry.Key, entry.Value);
-                    }
+                    Collection[entry.Key] = entry.Value;
                 }
             }
             else
@@ -521,14 +389,7 @@ namespace Microsoft.Azure.Devices.Client
                             throw new ArgumentNullException(nameof(entry.Key));
                         }
 
-                        if (forceUpdate)
-                        {
-                            componentProperties[entry.Key] = entry.Value;
-                        }
-                        else
-                        {
-                            componentProperties.Add(entry.Key, entry.Value);
-                        }
+                        componentProperties[entry.Key] = entry.Value;
                     }
 
                     // For a component level property, the property patch needs to contain the {"__t": "c"} component identifier.

--- a/iothub/device/src/CommandResponse.cs
+++ b/iothub/device/src/CommandResponse.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     public sealed class CommandResponse
     {
-        private readonly object _payload;
-
         internal PayloadConvention PayloadConvention { get; set; }
 
         /// <summary>
@@ -24,12 +22,12 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Creates a new instance of the class with the associated command response data and a status code.
         /// </summary>
-        /// <param name="payload">The command response payload.</param>
         /// <param name="status">A status code indicating success or failure.</param>
-        public CommandResponse(object payload, int status)
+        /// <param name="payload">The command response payload that will be serialized using <see cref="DeviceClient.PayloadConvention"/>.</param>
+        public CommandResponse(int status, object payload)
         {
-            _payload = payload;
             Status = status;
+            Payload = payload;
         }
 
         /// <summary>
@@ -44,26 +42,26 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// The command response status code indicating success or failure.
         /// </summary>
-        public int Status { get; }
+        public int Status { get; set; }
 
         /// <summary>
-        /// The command response payload.
+        /// The command response payload that will be serialized using <see cref="ClientOptions.PayloadConvention"/>.
         /// </summary>
-        public object Payload { get; }
+        public object Payload { get; set; }
 
         /// <summary>
         /// The serialized command response data.
         /// </summary>
         internal string GetPayloadAsString()
         {
-            return _payload == null
+            return Payload == null
                 ? null
-                : PayloadConvention.PayloadSerializer.SerializeToString(_payload);
+                : PayloadConvention.PayloadSerializer.SerializeToString(Payload);
         }
 
         internal byte[] GetPayloadAsBytes()
         {
-            return _payload == null
+            return Payload == null
                 ? null
                 : PayloadConvention.PayloadEncoder.ContentEncoding.GetBytes(GetPayloadAsString());
         }

--- a/iothub/device/src/DeviceClient.ConventionBasedOperations.cs
+++ b/iothub/device/src/DeviceClient.ConventionBasedOperations.cs
@@ -21,6 +21,9 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// The payload convention implementation that the client uses for convention-based operations.
         /// </summary>
+        /// <remarks>
+        /// You can override the default value in <see cref="ClientOptions.PayloadConvention"/>.
+        /// </remarks>
         public PayloadConvention PayloadConvention => InternalClient.PayloadConvention;
 
         /// <summary>

--- a/iothub/device/src/PayloadCollection.cs
+++ b/iothub/device/src/PayloadCollection.cs
@@ -35,8 +35,7 @@ namespace Microsoft.Azure.Devices.Client
         /// It is recommended to use <see cref="TryGetValue"/> to deserialize to a complex type.
         /// <para>
         /// For setting component-level property values see <see cref="ClientPropertyCollection.AddComponentProperty(string, string, object)"/>
-        /// and <see cref="ClientPropertyCollection.AddComponentProperties(string, IDictionary{string, object})"/> instead
-        /// as these convenience methods ensure that component-level properties include the component identifier markers: { "__t": "c" }.
+        /// instead as these convenience methods ensure that component-level properties include the component identifier markers: { "__t": "c" }.
         /// For more information see <see href="https://docs.microsoft.com/azure/iot-pnp/concepts-convention#sample-multiple-components-read-only-property"/>.
         /// </para>
         /// </remarks>
@@ -45,36 +44,26 @@ namespace Microsoft.Azure.Devices.Client
         public virtual object this[string key]
         {
             get => Collection[key];
-            set => AddOrUpdate(key, value);
-        }
-
-        /// <summary>
-        /// Adds the key-value pair to the collection.
-        /// </summary>
-        /// <remarks>
-        /// For property operations see <see cref="ClientPropertyCollection.AddRootProperty(string, object)"/>
-        /// and <see cref="ClientPropertyCollection.AddComponentProperties(string, IDictionary{string, object})"/> instead.
-        /// </remarks>
-        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['key']"/>
-        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['value']"/>
-        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/exception"/>
-        /// <exception cref="ArgumentException">An element with the same key already exists in the collection.</exception>
-        public virtual void Add(string key, object value)
-        {
-            Collection.Add(key, value);
+            set => Add(key, value);
         }
 
         /// <summary>
         /// Adds or updates the key-value pair to the collection.
         /// </summary>
         /// <remarks>
-        /// For property operations see <see cref="ClientPropertyCollection.AddOrUpdateRootProperty(string, object)"/>
-        /// and <see cref="ClientPropertyCollection.AddOrUpdateComponentProperties(string, IDictionary{string, object})"/> instead.
+        /// When using this as part of the writable property flow to respond to a writable property update, pass in
+        /// <paramref name="value"/> as an instance of
+        /// <see cref="PayloadSerializer.CreateWritablePropertyResponse(object, int, long, string)"/>
+        /// from <see cref="DeviceClient.PayloadConvention"/> (or <see cref="ModuleClient.PayloadConvention"/>)
+        /// to ensure the correct formatting is applied when the object is serialized.
+        /// <para>
+        /// For property operations see <see cref="ClientPropertyCollection.AddRootProperty(string, object)"/> instead.
+        /// </para>
         /// </remarks>
         /// <param name="key">The name of the key to be added to the collection.</param>
         /// <param name="value">The value to be added to the collection.</param>
         /// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c>.</exception>
-        public virtual void AddOrUpdate(string key, object value)
+        public virtual void Add(string key, object value)
         {
             Collection[key] = value;
         }
@@ -105,6 +94,10 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Gets the value of the object from the collection.
         /// </summary>
+        /// <remarks>
+        /// If this instance is in an update request for a writable property, <paramref name="value"/> should be of type
+        /// <see cref="WritableClientProperty"/>.
+        /// </remarks>
         /// <typeparam name="T">The type to cast the object to.</typeparam>
         /// <param name="key">The key of the property to get.</param>
         /// <param name="value">When this method returns true, this contains the value of the object from the collection.

--- a/iothub/device/src/TelemetryCollection.cs
+++ b/iothub/device/src/TelemetryCollection.cs
@@ -13,12 +13,11 @@ namespace Microsoft.Azure.Devices.Client
     public class TelemetryCollection : PayloadCollection
     {
         /// <summary>
-        /// Adds the telemetry to the telemetry collection.
+        /// Adds or updates the telemetry collection.
         /// </summary>
-        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['telemetryName']"/>
-        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['telemetryValue']"/>
-        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/exception"/>
-        /// <exception cref="ArgumentException">An element with the same key already exists in the collection.</exception>
+        /// <param name="telemetryName">The name of the telemetry.</param>
+        /// <param name="telemetryValue">The value of the telemetry.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="telemetryName"/> is <c>null</c> </exception>
         public override void Add(string telemetryName, object telemetryValue)
         {
             base.Add(telemetryName, telemetryValue);
@@ -27,20 +26,8 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Adds or updates the telemetry collection.
         /// </summary>
-        /// <param name="telemetryName">The name of the telemetry.</param>
-        /// <param name="telemetryValue">The value of the telemetry.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="telemetryName"/> is <c>null</c> </exception>
-        public override void AddOrUpdate(string telemetryName, object telemetryValue)
-        {
-            base.AddOrUpdate(telemetryName, telemetryValue);
-        }
-
-        /// <summary>
-        /// Adds the telemetry values to the telemetry collection.
-        /// </summary>
-        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['telemetryName']"/>
-        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['telemetryValue']"/>
-        /// <exception cref="ArgumentException">An element with the same key already exists in the collection.</exception>
+        /// <inheritdoc cref="Add(string, object)" path="/param['telemetryName']"/>
+        /// <inheritdoc cref="Add(string, object)" path="/param['telemetryValue']"/>
         /// <exception cref="ArgumentNullException"><paramref name="telemetryValues"/> is <c>null</c>.</exception>
         public void Add(IDictionary<string, object> telemetryValues)
         {
@@ -52,24 +39,6 @@ namespace Microsoft.Azure.Devices.Client
             telemetryValues
                 .ToList()
                 .ForEach(entry => base.Add(entry.Key, entry.Value));
-        }
-
-        /// <summary>
-        /// Adds or updates the telemetry values in the telemetry collection.
-        /// </summary>
-        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['telemetryName']"/>
-        /// <inheritdoc cref="AddOrUpdate(string, object)" path="/param['telemetryValue']"/>
-        /// <exception cref="ArgumentNullException"><paramref name="telemetryValues"/> is <c>null</c>.</exception>
-        public void AddOrUpdate(IDictionary<string, object> telemetryValues)
-        {
-            if (telemetryValues == null)
-            {
-                throw new ArgumentNullException(nameof(telemetryValues));
-            }
-
-            telemetryValues
-                .ToList()
-                .ForEach(entry => base.AddOrUpdate(entry.Key, entry.Value));
         }
     }
 }

--- a/iothub/device/tests/Convention/ClientPropertyCollectionTests.cs
+++ b/iothub/device/tests/Convention/ClientPropertyCollectionTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
         }
 
         [TestMethod]
-        public void ClientPropertyCollection_AddSimpleObjectAgainThrowsException()
+        public void ClientPropertyCollection_AddSimpleObjectAgainSuccess()
         {
             // arrange
             var clientProperties = new ClientPropertyCollection
@@ -118,10 +118,10 @@ namespace Microsoft.Azure.Devices.Client.Tests
             };
 
             // act
-            Action act = () => clientProperties.AddRootProperty(StringPropertyName, StringPropertyValue);
+            clientProperties.AddRootProperty(StringPropertyName, StringPropertyValue);
 
             // assert
-            act.Should().Throw<ArgumentException>("\"Add\" method does not support adding a key that already exists in the collection.");
+            clientProperties[StringPropertyName].Should().Be(StringPropertyValue);
         }
 
         [TestMethod]
@@ -138,10 +138,10 @@ namespace Microsoft.Azure.Devices.Client.Tests
             clientProperties.TryGetValue(StringPropertyName, out string outValue);
             outValue.Should().Be(StringPropertyValue);
 
-            clientProperties.AddOrUpdateRootProperty(StringPropertyName, UpdatedPropertyValue);
+            clientProperties.AddRootProperty(StringPropertyName, UpdatedPropertyValue);
 
             clientProperties.TryGetValue(StringPropertyName, out string outValueChanged);
-            outValueChanged.Should().Be(UpdatedPropertyValue, "\"AddOrUpdate\" should overwrite the value if the key already exists in the collection.");
+            outValueChanged.Should().Be(UpdatedPropertyValue, "\"Add\" should overwrite the value if the key already exists in the collection.");
         }
 
         [TestMethod]
@@ -226,7 +226,10 @@ namespace Microsoft.Azure.Devices.Client.Tests
                 { DateTimePropertyName, s_dateTimePropertyValue }
             };
             var clientProperties = new ClientPropertyCollection();
-            clientProperties.AddComponentProperties(ComponentName, componentLevelProperties);
+            foreach (var propKvp in componentLevelProperties)
+            {
+                clientProperties.AddComponentProperty(ComponentName, propKvp.Key, propKvp.Value);
+            }
 
             // act, assert
 
@@ -265,17 +268,18 @@ namespace Microsoft.Azure.Devices.Client.Tests
         }
 
         [TestMethod]
-        public void ClientPropertyCollection_AddSimpleObjectWithComponentAgainThrowsException()
+        public void ClientPropertyCollection_AddSimpleObjectWithComponentAgainSuccess()
         {
             // arrange
             var clientProperties = new ClientPropertyCollection();
             clientProperties.AddComponentProperty(ComponentName, StringPropertyName, StringPropertyValue);
 
             // act
-            Action act = () => clientProperties.AddComponentProperty(ComponentName, StringPropertyName, StringPropertyValue);
+            clientProperties.AddComponentProperty(ComponentName, StringPropertyName, StringPropertyValue);
 
             // assert
-            act.Should().Throw<ArgumentException>("\"Add\" method does not support adding a key that already exists in the collection.");
+            clientProperties.TryGetValue<string>(ComponentName, StringPropertyName, out string stringPropertyValue);
+            stringPropertyValue.Should().Be(StringPropertyValue);
         }
 
         [TestMethod]
@@ -290,9 +294,9 @@ namespace Microsoft.Azure.Devices.Client.Tests
             clientProperties.TryGetValue(ComponentName, StringPropertyName, out string outValue);
             outValue.Should().Be(StringPropertyValue);
 
-            clientProperties.AddOrUpdateComponentProperty(ComponentName, StringPropertyName, UpdatedPropertyValue);
+            clientProperties.AddComponentProperty(ComponentName, StringPropertyName, UpdatedPropertyValue);
             clientProperties.TryGetValue(ComponentName, StringPropertyName, out string outValueChanged);
-            outValueChanged.Should().Be(UpdatedPropertyValue, "\"AddOrUpdate\" should overwrite the value if the key already exists in the collection.");
+            outValueChanged.Should().Be(UpdatedPropertyValue, "\"Add\" should overwrite the value if the key already exists in the collection.");
         }
 
         [TestMethod]
@@ -443,19 +447,6 @@ namespace Microsoft.Azure.Devices.Client.Tests
         }
 
         [TestMethod]
-        public void ClientPropertyCollection_AddOrUpdateNullPropertyNameThrows()
-        {
-            // arrange
-            var testPropertyCollection = new ClientPropertyCollection();
-
-            // act
-            Action testAction = () => testPropertyCollection.AddOrUpdateRootProperty(null, 123);
-
-            // assert
-            testAction.Should().Throw<ArgumentNullException>();
-        }
-
-        [TestMethod]
         public void ClientPropertyCollection_AddNullPropertyValueSuccess()
         {
             // arrange
@@ -473,45 +464,14 @@ namespace Microsoft.Azure.Devices.Client.Tests
         }
 
         [TestMethod]
-        public void ClientPropertyCollection_AddOrUpdateNullPropertyValueSuccess()
-        {
-            // arrange
-            var testPropertyCollection = new ClientPropertyCollection();
-
-            // act
-            // This should add an entry in the dictionary with a null value.
-            // This patch would be interpreted by the service as the client wanting to remove property "abc" from its properties.
-            testPropertyCollection.AddOrUpdateRootProperty("abc", null);
-
-            // assert
-            bool isValueRetrieved = testPropertyCollection.TryGetValue<object>("abc", out object propertyValue);
-            isValueRetrieved.Should().BeTrue();
-            propertyValue.Should().BeNull();
-        }
-
-        [TestMethod]
-        public void ClientPropertyCollection_AddPropertyValueAlreadyExistsThrows()
+        public void ClientPropertyCollection_AddPropertyValueAlreadyExistsSuccess()
         {
             // arrange
             var testPropertyCollection = new ClientPropertyCollection();
             testPropertyCollection.AddRootProperty("abc", 123);
 
             // act
-            Action testAction = () => testPropertyCollection.AddRootProperty("abc", 1);
-
-            // assert
-            testAction.Should().Throw<ArgumentException>();
-        }
-
-        [TestMethod]
-        public void ClientPropertyCollection_AddOrUpdatePropertyValueAlreadyExistsSuccess()
-        {
-            // arrange
-            var testPropertyCollection = new ClientPropertyCollection();
-            testPropertyCollection.AddRootProperty("abc", 123);
-
-            // act
-            testPropertyCollection.AddOrUpdateRootProperty("abc", 1);
+            testPropertyCollection.AddRootProperty("abc", 1);
 
             // assert
             bool isValueRetrieved = testPropertyCollection.TryGetValue<int>("abc", out int propertyValue);
@@ -520,33 +480,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
         }
 
         [TestMethod]
-        public void ClientPropertyCollection_AddNullClientPropertyCollectionThrows()
-        {
-            // arrange
-            var testPropertyCollection = new ClientPropertyCollection();
-
-            // act
-            Action testAction = () => testPropertyCollection.AddRootProperties(null);
-
-            // assert
-            testAction.Should().Throw<ArgumentNullException>();
-        }
-
-        [TestMethod]
-        public void ClientPropertyCollection_AddOrUpdateNullClientPropertyCollectionThrows()
-        {
-            // arrange
-            var testPropertyCollection = new ClientPropertyCollection();
-
-            // act
-            Action testAction = () => testPropertyCollection.AddOrUpdateRootProperties(null);
-
-            // assert
-            testAction.Should().Throw<ArgumentNullException>();
-        }
-
-        [TestMethod]
-        public void ClientPropertyCollection_AddClientPropertyCollectionAlreadyExistsThrows()
+        public void ClientPropertyCollection_AddClientPropertyCollectionAlreadyExistsSuccess()
         {
             // arrange
             var testPropertyCollection = new ClientPropertyCollection();
@@ -558,26 +492,10 @@ namespace Microsoft.Azure.Devices.Client.Tests
             };
 
             // act
-            Action testAction = () => testPropertyCollection.AddRootProperties(propertyValues);
-
-            // assert
-            testAction.Should().Throw<ArgumentException>();
-        }
-
-        [TestMethod]
-        public void ClientPropertyCollection_AddOrUpdateClientPropertyCollectionAlreadyExistsSuccess()
-        {
-            // arrange
-            var testPropertyCollection = new ClientPropertyCollection();
-            testPropertyCollection.AddRootProperty("abc", 123);
-            var propertyValues = new Dictionary<string, object>
+            foreach (var propKvp in propertyValues)
             {
-                { "qwe", 98 },
-                { "abc", 2 },
-            };
-
-            // act
-            testPropertyCollection.AddOrUpdateRootProperties(propertyValues);
+                testPropertyCollection.AddRootProperty(propKvp.Key, propKvp.Value);
+            }
 
             // assert
             bool isValue1Retrieved = testPropertyCollection.TryGetValue<int>("qwe", out int value1Retrieved);
@@ -603,19 +521,6 @@ namespace Microsoft.Azure.Devices.Client.Tests
         }
 
         [TestMethod]
-        public void ClientPropertyCollection_AddOrUpdateNullPropertyNameWithComponentThrows()
-        {
-            // arrange
-            var testPropertyCollection = new ClientPropertyCollection();
-
-            // act
-            Action testAction = () => testPropertyCollection.AddOrUpdateComponentProperty("testComponent", null, 123);
-
-            // assert
-            testAction.Should().Throw<ArgumentNullException>();
-        }
-
-        [TestMethod]
         public void ClientPropertyCollection_AddNullComponentNameThrows()
         {
             // arrange
@@ -623,19 +528,6 @@ namespace Microsoft.Azure.Devices.Client.Tests
 
             // act
             Action testAction = () => testPropertyCollection.AddComponentProperty(null, "abc", 123);
-
-            // assert
-            testAction.Should().Throw<ArgumentNullException>();
-        }
-
-        [TestMethod]
-        public void ClientPropertyCollection_AddOrUpdateNullComponentNameThrows()
-        {
-            // arrange
-            var testPropertyCollection = new ClientPropertyCollection();
-
-            // act
-            Action testAction = () => testPropertyCollection.AddOrUpdateComponentProperty(null, "abc", 123);
 
             // assert
             testAction.Should().Throw<ArgumentNullException>();
@@ -664,28 +556,6 @@ namespace Microsoft.Azure.Devices.Client.Tests
         }
 
         [TestMethod]
-        public void ClientPropertyCollection_AddOrUpdateNullPropertyValueWithComponentSuccess()
-        {
-            // arrange
-            var testPropertyCollection = new ClientPropertyCollection();
-            testPropertyCollection.AddComponentProperty("testComponent", "qwe", 123);
-
-            // act
-            // This should add an entry in the dictionary with a null value.
-            // This patch would be interpreted by the service as the client wanting to remove property "abc" from its properties.
-            testPropertyCollection.AddOrUpdateComponentProperty("testComponent", "abc", null);
-
-            // assert
-            bool isValue1Retrieved = testPropertyCollection.TryGetValue<int>("testComponent", "qwe", out int property1Value);
-            isValue1Retrieved.Should().BeTrue();
-            property1Value.Should().Be(123);
-
-            bool isValue2Retrieved = testPropertyCollection.TryGetValue<object>("testComponent", "abc", out object property2Value);
-            isValue2Retrieved.Should().BeTrue();
-            property2Value.Should().BeNull();
-        }
-
-        [TestMethod]
         public void ClientPropertyCollection_AddNullClientPropertyCollectionWithComponentSuccess()
         {
             // arrange
@@ -696,7 +566,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
             // act
             // This should add an entry in the dictionary with a null value.
             // This patch would be interpreted by the service as the client wanting to remove component "testComponent" from its properties.
-            testPropertyCollection.AddComponentProperties("testComponent", null);
+            testPropertyCollection.AddRootProperty("testComponent", null);
 
             // assert
             bool iscomponentValueRetrieved = testPropertyCollection.TryGetValue<int>("testComponent", "qwe", out int _);
@@ -708,7 +578,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
         }
 
         [TestMethod]
-        public void ClientPropertyCollection_AddOrUpdateNullClientPropertyCollectionWithComponentThrows()
+        public void ClientPropertyCollection_AddNullClientPropertyCollectionWithComponentThrows()
         {
             // arrange
             var testPropertyCollection = new ClientPropertyCollection();
@@ -718,7 +588,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
             // act
             // This should add an entry in the dictionary with a null value.
             // This patch would be interpreted by the service as the client wanting to remove component "testComponent" from its properties.
-            testPropertyCollection.AddOrUpdateComponentProperties("testComponent", null);
+            testPropertyCollection.AddRootProperty("testComponent", null);
 
             // assert
             bool iscomponentValueRetrieved = testPropertyCollection.TryGetValue<int>("testComponent", "qwe", out int property2Value);
@@ -730,28 +600,14 @@ namespace Microsoft.Azure.Devices.Client.Tests
         }
 
         [TestMethod]
-        public void ClientPropertyCollection_AddPropertyValueAlreadyExistsWithComponentThrows()
+        public void ClientPropertyCollection_AddPropertyValueAlreadyExistsWithComponentSuccess()
         {
             // arrange
             var testPropertyCollection = new ClientPropertyCollection();
             testPropertyCollection.AddComponentProperty("testComponent", "abc", 123);
 
             // act
-            Action testAction = () => testPropertyCollection.AddComponentProperty("testComponent", "abc", 1);
-
-            // assert
-            testAction.Should().Throw<ArgumentException>();
-        }
-
-        [TestMethod]
-        public void ClientPropertyCollection_AddOrUpdatePropertyValueAlreadyExistsWithComponentSuccess()
-        {
-            // arrange
-            var testPropertyCollection = new ClientPropertyCollection();
-            testPropertyCollection.AddComponentProperty("testComponent", "abc", 123);
-
-            // act
-            testPropertyCollection.AddOrUpdateComponentProperty("testComponent", "abc", 1);
+            testPropertyCollection.AddComponentProperty("testComponent", "abc", 1);
 
             // assert
             bool isValueRetrieved = testPropertyCollection.TryGetValue<int>("testComponent", "abc", out int propertyValue);
@@ -760,7 +616,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
         }
 
         [TestMethod]
-        public void ClientPropertyCollection_AddClientPropertyCollectionAlreadyExistsWithComponentThrows()
+        public void ClientPropertyCollection_AddClientPropertyCollectionAlreadyExistsWithComponentSuccess()
         {
             // arrange
             var testPropertyCollection = new ClientPropertyCollection();
@@ -772,26 +628,10 @@ namespace Microsoft.Azure.Devices.Client.Tests
             };
 
             // act
-            Action testAction = () => testPropertyCollection.AddComponentProperties("testComponent", propertyValues);
-
-            // assert
-            testAction.Should().Throw<ArgumentException>();
-        }
-
-        [TestMethod]
-        public void ClientPropertyCollection_AddOrUpdateClientPropertyCollectionAlreadyExistsWithComponentSuccess()
-        {
-            // arrange
-            var testPropertyCollection = new ClientPropertyCollection();
-            testPropertyCollection.AddComponentProperty("testComponent", "abc", 123);
-            var propertyValues = new Dictionary<string, object>
+            foreach (var propKvp in propertyValues)
             {
-                { "qwe", 98 },
-                { "abc", 2 },
-            };
-
-            // act
-            testPropertyCollection.AddOrUpdateComponentProperties("testComponent", propertyValues);
+                testPropertyCollection.AddComponentProperty("testComponent", propKvp.Key, propKvp.Value);
+            }
 
             // assert
             bool isValue1Retrieved = testPropertyCollection.TryGetValue<int>("testComponent", "qwe", out int value1Retrieved);
@@ -816,7 +656,10 @@ namespace Microsoft.Azure.Devices.Client.Tests
             var propertyValuesAsDictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(propertyValues));
 
             // act
-            testPropertyCollection.AddRootProperties(propertyValuesAsDictionary);
+            foreach (var propKvp in propertyValuesAsDictionary)
+            {
+                testPropertyCollection.AddRootProperty(propKvp.Key, propKvp.Value);
+            }
 
             // assert
             bool isIdPresent = testPropertyCollection.TryGetValue<int>("Id", out int id);

--- a/iothub/device/tests/Convention/TelemetryCollectionTests.cs
+++ b/iothub/device/tests/Convention/TelemetryCollectionTests.cs
@@ -13,21 +13,9 @@ namespace Microsoft.Azure.Devices.Client.Tests
     [TestCategory("Unit")]
     public class TelemetryCollectionTests
     {
+
         [TestMethod]
         public void TelemetryCollection_Add_NullTelemetryNameThrows()
-        {
-            // arrange
-            var testTelemetryCollection = new TelemetryCollection();
-
-            // act
-            Action testAction = () => testTelemetryCollection.Add(null, 123);
-
-            // assert
-            testAction.Should().Throw<ArgumentNullException>();
-        }
-
-        [TestMethod]
-        public void TelemetryCollection_AddOrUpdate_NullTelemetryNameThrows()
         {
             // arrange
             var testTelemetryCollection = new TelemetryCollection();
@@ -53,34 +41,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
         }
 
         [TestMethod]
-        public void TelemetryCollection_AddOrUpdate_NullTelemetryValueSuccess()
-        {
-            // arrange
-            var testTelemetryCollection = new TelemetryCollection();
-
-            // act
-            testTelemetryCollection.Add("abc", null);
-
-            // assert
-            testTelemetryCollection["abc"].Should().BeNull();
-        }
-
-        [TestMethod]
-        public void TelemetryCollection_Add_TelemetryValueAlreadyExistsThrows()
-        {
-            // arrange
-            var testTelemetryCollection = new TelemetryCollection();
-            testTelemetryCollection.Add("abc", 123);
-
-            // act
-            Action testAction = () => testTelemetryCollection.Add("abc", 1);
-
-            // assert
-            testAction.Should().Throw<ArgumentException>();
-        }
-
-        [TestMethod]
-        public void TelemetryCollection_AddOrUpdate_TelemetryValueAlreadyExistsSuccess()
+        public void TelemetryCollection_Add_TelemetryValueAlreadyExistsSuccess()
         {
             // arrange
             var testTelemetryCollection = new TelemetryCollection();
@@ -107,39 +68,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
         }
 
         [TestMethod]
-        public void TelemetryCollection_AddOrUpdate_NullTelemetryCollectionThrows()
-        {
-            // arrange
-            var testTelemetryCollection = new TelemetryCollection();
-
-            // act
-            Action testAction = () => testTelemetryCollection.Add(null);
-
-            // assert
-            testAction.Should().Throw<ArgumentNullException>();
-        }
-
-        [TestMethod]
-        public void TelemetryCollection_Add_TelemetryCollectionAlreadyExistsThrows()
-        {
-            // arrange
-            var testTelemetryCollection = new TelemetryCollection();
-            testTelemetryCollection.Add("abc", 123);
-            var telemetryValues = new Dictionary<string, object>
-            {
-                { "qwe", 98 },
-                { "abc", 2 },
-            };
-
-            // act
-            Action testAction = () => testTelemetryCollection.Add(telemetryValues);
-
-            // assert
-            testAction.Should().Throw<ArgumentException>();
-        }
-
-        [TestMethod]
-        public void TelemetryCollection_AddOrUpdate_TelemetryCollectionAlreadyExistsSuccess()
+        public void TelemetryCollection_Add_TelemetryCollectionAlreadyExistsSuccess()
         {
             // arrange
             var testTelemetryCollection = new TelemetryCollection();

--- a/iothub/device/tests/Convention/TelemetryCollectionTests.cs
+++ b/iothub/device/tests/Convention/TelemetryCollectionTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
             var testTelemetryCollection = new TelemetryCollection();
 
             // act
-            Action testAction = () => testTelemetryCollection.AddOrUpdate(null, 123);
+            Action testAction = () => testTelemetryCollection.Add(null, 123);
 
             // assert
             testAction.Should().Throw<ArgumentNullException>();
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
             var testTelemetryCollection = new TelemetryCollection();
 
             // act
-            testTelemetryCollection.AddOrUpdate("abc", null);
+            testTelemetryCollection.Add("abc", null);
 
             // assert
             testTelemetryCollection["abc"].Should().BeNull();
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
             testTelemetryCollection.Add("abc", 123);
 
             // act
-            testTelemetryCollection.AddOrUpdate("abc", 1);
+            testTelemetryCollection.Add("abc", 1);
 
             // assert
             testTelemetryCollection["abc"].Should().Be(1);
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
             var testTelemetryCollection = new TelemetryCollection();
 
             // act
-            Action testAction = () => testTelemetryCollection.AddOrUpdate(null);
+            Action testAction = () => testTelemetryCollection.Add(null);
 
             // assert
             testAction.Should().Throw<ArgumentNullException>();
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
         {
             // arrange
             var testTelemetryCollection = new TelemetryCollection();
-            testTelemetryCollection.AddOrUpdate("abc", 123);
+            testTelemetryCollection.Add("abc", 123);
             var telemetryValues = new Dictionary<string, object>
             {
                 { "qwe", 98 },
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
         {
             // arrange
             var testTelemetryCollection = new TelemetryCollection();
-            testTelemetryCollection.AddOrUpdate("abc", 123);
+            testTelemetryCollection.Add("abc", 123);
             var telemetryValues = new Dictionary<string, object>
             {
                 { "qwe", 98 },
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
             };
 
             // act
-            testTelemetryCollection.AddOrUpdate(telemetryValues);
+            testTelemetryCollection.Add(telemetryValues);
 
             // assert
             testTelemetryCollection["qwe"].Should().Be(98);


### PR DESCRIPTION
- Simplify ClientPropertiesCollection interface by removing plural methods and `Add` methods that throw if duplicate.
- Improve doc comments
- Make `CommandResponse` easier to initialize/use.