### PR TITLE
Move the common file from Shared to Client namespace

### DIFF
--- a/iothub/device/src/Convention/CommonClientResponseCodes.cs
+++ b/iothub/device/src/Convention/CommonClientResponseCodes.cs
@@ -3,7 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.Azure.Devices.Shared
+namespace Microsoft.Azure.Devices.Client
 {
     /// <summary>
     /// A list of common status codes to represent the response from the client.


### PR DESCRIPTION
One file left over from the `Shared` to `Client` namespace move.