### PR TITLE
Version bump for 2022-05-06 release

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net5.0;netstandard2.1;netstandard2.0;net472;net451</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.40.0</Version>
+    <Version>1.41.0</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!--netcoreapp2.1 target framework here is solely so that this library can use the SocketsHttpHandler class to handle connection lease timeout issues.-->
     <!--See #1874 for additional details-->
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.37.0</Version>
+    <Version>1.37.1</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.16.1</Version>
+    <Version>1.16.2</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client AMQP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,10 +1,10 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.40.0
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.37.0
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.41.0
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.37.1
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.30.1
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.19.1
 provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.18.1
-provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.16.1
+provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.16.2
 provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.15.1
 provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.17.1
 security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.14.1


### PR DESCRIPTION
## Microsoft.Azure.Devices.Client 1.41.0

- Update QoS settings to AtLeastOnce for mqtt layer subscriptions (#2302)
- Use await instead of TaskCompletionSource in AsyncExecution (#2320)
- Fix: file upload SAS URI operation requires certificate to be copied (#2350)
- Allow users to configure websocket keep-alive (#2352)
- Update to latest Microsoft.Azure.Amqp library version (#2367)

## Microsoft.Azure.Devices 1.37.1

- Update to Azure.Core 1.22.0 to update dependency on System.Text.Encodings.Web (#2309)
- Add missing param validation to service client (#2324)
- Update to latest Microsoft.Azure.Amqp library version (#2367)

## Microsoft.Azure.Devices.Provisioning.Transport.Amqp 1.16.2

- Update to latest Microsoft.Azure.Amqp library version (#2367)