### PR TITLE
feat(prov-device): Add new device registration substatus

### DIFF
--- a/e2e/test/provisioning/ReprovisioningE2ETests.cs
+++ b/e2e/test/provisioning/ReprovisioningE2ETests.cs
@@ -569,7 +569,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     else
                     {
                         Assert.AreNotEqual(twin.Properties.Desired.Count, 1);
-                        Assert.AreEqual(ProvisioningRegistrationSubstatusType.InitialAssignment, result.Substatus);
+                        Assert.AreEqual(ProvisioningRegistrationSubstatusType.ReprovisionedToInitialAssignment, result.Substatus);
                     }
                 }
 

--- a/provisioning/device/src/ProvisioningRegistrationSubstatus.cs
+++ b/provisioning/device/src/ProvisioningRegistrationSubstatus.cs
@@ -23,6 +23,15 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// Device has been assigned to a different IoT hub and its device data was populated from the initial state stored in the enrollment.
         /// Device data was removed from the previously assigned IoT hub.
         /// </summary>
-        DeviceDataReset = 3
+        DeviceDataReset = 3,
+
+        /// <summary>
+        /// Device has been re-provisioned to a previously assigned IoT hub.
+        /// </summary>
+        /// <remarks>
+        /// For API versions prior to "2019-04-15" a substatus of <see cref="InitialAssignment"/> was returned if the device previously existed in hub.
+        /// Starting API version "2019-04-15" a substatus of ReprovisionedToInitialAssignment is returned if the device previously existed in hub.
+        /// </remarks>
+        ReprovisionedToInitialAssignment = 4,
     }
 }


### PR DESCRIPTION
This change was introduced in API version "2019-04-15".

The ‘ReprovisionedToInitialAssignment’ value is simply an extension to the original “InitialAssignment” value.

The ‘InitialAssigment’ value was being returned only when a device was being provisioned into Hub for the first time (from a DPS standpoint).

Starting with API version "2019-04-15”, the substatus returned would be “ReprovisionedtoInitialAssignment” if the device previously existed in Hub, but DPS was unaware and assumed that it was provisioning it for the first time.

Reprovisioning a device (which means that DPS is aware that it previously provisioned this device) would return different substatus values like ‘deviceDataMigrated’ or ‘ deviceDataReset’.