### PR TITLE
Fix private nuget versioning

### DIFF
--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -75,12 +75,12 @@
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.*" />
   </ItemGroup>
   <ItemGroup Condition=" ('$(AZURE_IOT_LOCALPACKAGES.ToUpper())' != '') And ( '$(TargetFramework)' != 'net451' ) ">
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.20.0-private-001" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Amqp" Version="1.17.0-private-001" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Http" Version="1.16.0-private-001" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.18.0-private-001" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.21.0-private-001" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Amqp" Version="1.18.0-private-001" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Http" Version="1.17.0-private-001" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.19.0-private-001" />
     <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Security.Tpm" Version="1.*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Service" Version="1.19.0-private-001" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Service" Version="1.20.0-private-001" />
     <ProjectReference Include="$(RootDir)\security\tpm\samples\SecurityProviderTpmSimulator\SecurityProviderTpmSimulator.csproj" />
   </ItemGroup>
 </Project>

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -1351,23 +1351,16 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             using var cts = new CancellationTokenSource(FailingTimeoutMiliseconds);
 
             Logger.Trace("ProvisioningDeviceClient RegisterAsync . . . ");
-            try
-            {
-                DeviceRegistrationResult result = await provClient.RegisterAsync(cts.Token).ConfigureAwait(false);
 
-                Logger.Trace($"{result.Status}");
+            DeviceRegistrationResult result = await provClient.RegisterAsync(cts.Token).ConfigureAwait(false);
 
-                Assert.AreEqual(ProvisioningRegistrationStatusType.Failed, result.Status);
-                Assert.IsNull(result.AssignedHub);
-                Assert.IsNull(result.DeviceId);
-                // Exception message must contain the errorCode value as below
-                Assert.AreEqual(404201, result.ErrorCode);
-            }
-            finally
-            {
-                Logger.Trace($"Deleting test enrollment type {AttestationMechanismType.Tpm}-{EnrollmentType.Individual} with registration Id {security.GetRegistrationID()}.");
-                await DeleteCreatedEnrollmentAsync(EnrollmentType.Individual, security).ConfigureAwait(false);
-            }
+            Logger.Trace($"{result.Status}");
+
+            Assert.AreEqual(ProvisioningRegistrationStatusType.Failed, result.Status);
+            Assert.IsNull(result.AssignedHub);
+            Assert.IsNull(result.DeviceId);
+            // Exception message must contain the errorCode value as below
+            Assert.AreEqual(404201, result.ErrorCode);
         }
 
         private async Task ProvisioningDeviceClientInvalidIdScopeRegisterFailAsync(
@@ -1731,7 +1724,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                 {
                     await dpsClient.DeleteIndividualEnrollmentAsync(security.GetRegistrationID()).ConfigureAwait(false);
                 }
-                else
+                else if (enrollmentType == EnrollmentType.Group)
                 {
                     await dpsClient.DeleteEnrollmentGroupAsync(groupId).ConfigureAwait(false);
                 }

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.20.0-private-001</Version>
+    <Version>1.21.0-private-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.19.0-private-001</Version>
+    <Version>1.20.0-private-001</Version>
     <Title>Microsoft Azure IoT Provisioning Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.17.0-private-001</Version>
+    <Version>1.18.0-private-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client AMQP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
+++ b/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.16.0-private-001</Version>
+    <Version>1.17.0-private-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client HTTP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
+++ b/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.18.0-private-001</Version>
+    <Version>1.19.0-private-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client MQTT Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -2,9 +2,9 @@ AssemblyPath, Version
 iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.41.0
 iothub\service\src\Microsoft.Azure.Devices.csproj, 1.37.1
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.30.1
-provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.20.0-private-001
-provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.19.0-private-001
-provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.17.0-private-001
-provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.16.0-private-001
-provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.18.0-private-001
+provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.21.0-private-001
+provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.20.0-private-001
+provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.18.0-private-001
+provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.17.0-private-001
+provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.19.0-private-001
 security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.14.1


### PR DESCRIPTION
There was already a `preview` nuget with a version higher than our latest master, so these `private` nugets should have been bumped by 2 versions.

This PR also fixes the cleanup logic for an E2E test.