### PR TITLE
fix(iot-device): Fix twin operations with Mqtt to retry on throttling

### DIFF
--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -1154,7 +1154,15 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                         {
                             if (status >= 300)
                             {
-                                throw new IotHubException($"Request {rid} returned status {status}", isTransient: false);
+                                // Retry for Http status code 429 (too many requests)
+                                if (status == 429)
+                                {
+                                    throw new IotHubThrottledException($"Request {rid} was throttled by the server");
+                                }
+                                else
+                                {
+                                    throw new IotHubException($"Request {rid} returned status {status}", isTransient: false);
+                                }
                             }
                             else
                             {

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -1154,6 +1154,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                         {
                             if (status >= 300)
                             {
+                                // The Hub team is refactoring the retriable status codes without breaking changes to the existing ones.
+                                // It can be expected that we may bring more retriable codes here in the future.
                                 // Retry for Http status code 429 (too many requests)
                                 if (status == 429)
                                 {


### PR DESCRIPTION
#2257

As a reference, SDK logs before and after this fix:

**Previously:**
```
ThreadID="32,692" 
thisOrContextObject="ErrorDelegatingHandler#59778040" 
memberName="ExecuteWithErrorHandlingAsync" 
message="Exception caught: Microsoft.Azure.Devices.Client.Exceptions.IotHubException: Request e0bb8dfa-5087-4252-9221-7c7b42b875eb returned status 429 
at Microsoft.Azure.Devices.Client.Transport.Mqtt.MqttTransportHandler.<>c__DisplayClass102_0.<SendTwinRequestAsync>b__0(Message possibleResponse) in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Transport\Mqtt\MqttTransportHandler.cs:line 1157 
--- End of stack trace from previous location --- 
at Microsoft.Azure.Devices.Client.Transport.Mqtt.MqttTransportHandler.SendTwinRequestAsync(Message request, String rid, CancellationToken cancellationToken) in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Transport\Mqtt\MqttTransportHandler.cs:line 1184 
at Microsoft.Azure.Devices.Client.Transport.Mqtt.MqttTransportHandler.SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken) in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Transport\Mqtt\MqttTransportHandler.cs:line 995 
at Microsoft.Azure.Devices.Client.Transport.ErrorDelegatingHandler.<>c__DisplayClass27_0.<<ExecuteWithErrorHandlingAsync>b__0>d.MoveNext() in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Pipeline\ErrorDelegatingHandler.cs:line 183 
--- End of stack trace from previous location --- 
at Microsoft.Azure.Devices.Client.Transport.ErrorDelegatingHandler.ExecuteWithErrorHandlingAsync[T](Func`1 asyncOperation) in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Pipeline\ErrorDelegatingHandler.cs:line 197" 
ActivityID="00001385-0001-0000-f83d-0000ffdcd7b5" 
```

**Currently:**
```
ThreadID="8,208" 
thisOrContextObject="ErrorDelegatingHandler#19762970" 
memberName="ExecuteWithErrorHandlingAsync" 
message="Exception caught: Microsoft.Azure.Devices.Client.Exceptions.IotHubThrottledException: Request a502fc7f-b602-48dc-8045-76e24cbfb33b was throttled by the server 
at Microsoft.Azure.Devices.Client.Transport.Mqtt.MqttTransportHandler.<>c__DisplayClass102_0.<SendTwinRequestAsync>b__0(Message possibleResponse) in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Transport\Mqtt\MqttTransportHandler.cs:line 1160 
--- End of stack trace from previous location --- 
at Microsoft.Azure.Devices.Client.Transport.Mqtt.MqttTransportHandler.SendTwinRequestAsync(Message request, String rid, CancellationToken cancellationToken) in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Transport\Mqtt\MqttTransportHandler.cs:line 1192 
at Microsoft.Azure.Devices.Client.Transport.Mqtt.MqttTransportHandler.SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken) in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Transport\Mqtt\MqttTransportHandler.cs:line 995 
at Microsoft.Azure.Devices.Client.Transport.ErrorDelegatingHandler.<>c__DisplayClass27_0.<<ExecuteWithErrorHandlingAsync>b__0>d.MoveNext() in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Pipeline\ErrorDelegatingHandler.cs:line 183 
--- End of stack trace from previous location --- 
at Microsoft.Azure.Devices.Client.Transport.ErrorDelegatingHandler.ExecuteWithErrorHandlingAsync[T](Func`1 asyncOperation) in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Pipeline\ErrorDelegatingHandler.cs:line 197" 
ActivityID="00001d89-0001-0000-f045-0000ffdcd7b5"  

ThreadID="8,208" 
thisOrContextObject="RetryStrategyAdapter#66483072" 
memberName="RetryStrategyAdapter.ShouldRetry" 
parameters="(0, Microsoft.Azure.Devices.Client.Exceptions.IotHubThrottledException: Request a502fc7f-b602-48dc-8045-76e24cbfb33b was throttled by the server 
at Microsoft.Azure.Devices.Client.Transport.Mqtt.MqttTransportHandler.<>c__DisplayClass102_0.<SendTwinRequestAsync>b__0(Message possibleResponse) in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Transport\Mqtt\MqttTransportHandler.cs:line 1160 
--- End of stack trace from previous location --- 
at Microsoft.Azure.Devices.Client.Transport.Mqtt.MqttTransportHandler.SendTwinRequestAsync(Message request, String rid, CancellationToken cancellationToken) in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Transport\Mqtt\MqttTransportHandler.cs:line 1192 
at Microsoft.Azure.Devices.Client.Transport.Mqtt.MqttTransportHandler.SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken) in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Transport\Mqtt\MqttTransportHandler.cs:line 995 
at Microsoft.Azure.Devices.Client.Transport.ErrorDelegatingHandler.<>c__DisplayClass27_0.<<ExecuteWithErrorHandlingAsync>b__0>d.MoveNext() in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Pipeline\ErrorDelegatingHandler.cs:line 183 
--- End of stack trace from previous location --- 
at Microsoft.Azure.Devices.Client.Transport.ErrorDelegatingHandler.ExecuteWithErrorHandlingAsync[T](Func`1 asyncOperation) in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Pipeline\ErrorDelegatingHandler.cs:line 197 
at Microsoft.Azure.Devices.Client.Transport.RetryDelegatingHandler.<>c__DisplayClass31_0.<<SendTwinPatchAsync>b__0>d.MoveNext() in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\Pipeline\RetryDelegatingHandler.cs:line 567 
--- End of stack trace from previous location --- 
at Microsoft.Azure.Devices.Client.TransientFaultHandling.RetryPolicy.<>c__DisplayClass34_0.<<RunWithRetryAsync>b__0>d.MoveNext() in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\TransientFaultHandling\RetryPolicy.cs:line 267 
--- End of stack trace from previous location --- 
at Microsoft.Azure.Devices.Client.TransientFaultHandling.RetryPolicy.RunWithRetryAsync[T](Func`1 taskFunc, ShouldRetry shouldRetry, Func`2 isTransient, Action`3 onRetrying, Boolean fastFirstRetry, CancellationToken cancellationToken) in C:\XXX\azure-iot-sdk-csharp\iothub\device\src\TransientFaultHandling\RetryPolicy.cs:line 308)" 
ActivityID="00001da7-0001-0000-f045-0000ffdcd7b5" 
```