### PR TITLE
Bump version number for LTS release

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.36.5</Version>
+    <Version>1.36.6</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.31.2</Version>
+    <Version>1.31.3</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.13.6</Version>
+    <Version>1.13.7</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client AMQP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,9 +1,9 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.36.5
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.31.2
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.36.6
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.31.3
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.27.1
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.4
-provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.6
+provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.7
 provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.12.4
 provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.14.2
 security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.12.4


### PR DESCRIPTION
## Microsoft.Azure.Devices.Client 1.36.6

- Update Microsoft.Azure.Amqp version to 2.5.12

## Microsoft.Azure.Devices 1.31.3

- Update Microsoft.Azure.Amqp version to 2.5.12

## Microsoft.Azure.Devices.Provisioning.Transport.Amqp 1.13.7

- Update Microsoft.Azure.Amqp version to 2.5.12