### PR TITLE
Remove "ProvisioningDeviceClient.RegisterAsync()" methods which takes "timeout" as parameter

### DIFF
--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -384,51 +384,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         #endregion CustomAllocationDefinition tests
 
         [LoggedTestMethod]
-        public async Task DPS_Registration_Mqtt_SymmetricKey_IndividualEnrollment_TimeSpanTimeoutRespected()
-        {
-            try
-            {
-                await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Mqtt_Tcp_Only, AttestationMechanismType.SymmetricKey, EnrollmentType.Individual, TimeSpan.Zero).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                return; // expected exception was thrown, so exit the test
-            }
-
-            throw new AssertFailedException("Expected an OperationCanceledException to be thrown since the timeout was set to TimeSpan.Zero");
-        }
-
-        [LoggedTestMethod]
-        public async Task DPS_Registration_Http_SymmetricKey_IndividualEnrollment_TimeSpanTimeoutRespected()
-        {
-            try
-            {
-                await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Http1, AttestationMechanismType.SymmetricKey, EnrollmentType.Individual, TimeSpan.Zero).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                return; // expected exception was thrown, so exit the test
-            }
-
-            throw new AssertFailedException("Expected an OperationCanceledException to be thrown since the timeout was set to TimeSpan.Zero");
-        }
-
-        [LoggedTestMethod]
-        public async Task DPS_Registration_Amqp_SymmetricKey_IndividualEnrollment_TimeSpanTimeoutRespected()
-        {
-            try
-            {
-                await ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(Client.TransportType.Amqp_Tcp_Only, AttestationMechanismType.SymmetricKey, EnrollmentType.Individual, TimeSpan.Zero).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                return; // expected exception was thrown, so exit the test
-            }
-
-            throw new AssertFailedException("Expected an OperationCanceledException to be thrown since the timeout was set to TimeSpan.Zero");
-        }
-
-        [LoggedTestMethod]
         [DoNotParallelize] //TPM tests need to execute in serial as tpm only accepts one connection at a time
         public async Task DPS_Registration_Http_Tpm_InvalidRegistrationId_RegisterFail()
         {
@@ -582,16 +537,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             Client.TransportType transportType,
             AttestationMechanismType attestationType,
             EnrollmentType? enrollmentType,
-            TimeSpan timeout)
-        {
-            //Default reprovisioning settings: Hashed allocation, no reprovision policy, hub names, or custom allocation policy
-            await ProvisioningDeviceClientValidRegistrationIdRegisterOkAsync(transportType, attestationType, enrollmentType, false, null, AllocationPolicy.Hashed, null, null, null, timeout, s_proxyServerAddress).ConfigureAwait(false);
-        }
-
-        public async Task ProvisioningDeviceClient_ValidRegistrationId_Register_Ok(
-            Client.TransportType transportType,
-            AttestationMechanismType attestationType,
-            EnrollmentType? enrollmentType,
             bool setCustomProxy,
             string proxyServerAddress = null)
         {
@@ -606,7 +551,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     null,
                     null,
                     null,
-                    TimeSpan.MaxValue,
                     proxyServerAddress)
                 .ConfigureAwait(false);
         }
@@ -631,7 +575,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     null,
                     iothubs,
                     capabilities,
-                    TimeSpan.MaxValue,
                     proxyServerAddress)
                 .ConfigureAwait(false);
         }
@@ -646,7 +589,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             CustomAllocationDefinition customAllocationDefinition,
             ICollection<string> iothubs,
             Devices.Provisioning.Service.DeviceCapabilities deviceCapabilities,
-            TimeSpan timeout,
             string proxyServerAddress = null)
         {
             string groupId = _idPrefix + AttestationTypeToString(attestationType) + "-" + Guid.NewGuid();
@@ -691,9 +633,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                 {
                     try
                     {
-                        result = timeout != TimeSpan.MaxValue
-                            ? await provClient.RegisterAsync(timeout).ConfigureAwait(false)
-                            : await provClient.RegisterAsync(cts.Token).ConfigureAwait(false);
+                        result = await provClient.RegisterAsync(cts.Token).ConfigureAwait(false);
                         break;
                     }
                     // Catching all ProvisioningTransportException as the status code is not the same for Mqtt, Amqp and Http.

--- a/provisioning/device/src/ProvisioningDeviceClient.cs
+++ b/provisioning/device/src/ProvisioningDeviceClient.cs
@@ -64,54 +64,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// <summary>
         /// Registers the current device using the Device Provisioning Service and assigns it to an IoT hub.
         /// </summary>
-        /// <param name="timeout">The maximum amount of time to allow this operation to run for before timing out.</param>
-        /// <remarks>
-        /// Due to the AMQP library used by this library uses not accepting cancellation tokens, this overload and <see cref="RegisterAsync(ProvisioningRegistrationAdditionalData, TimeSpan)"/>
-        /// are the only overloads for this method that allow for a specified timeout to be respected in the middle of an AMQP operation such as opening
-        /// the AMQP connection. MQTT and HTTPS connections do not share that same limitation, though.
-        /// </remarks>
-        /// <returns>The registration result.</returns>
-        public Task<DeviceRegistrationResult> RegisterAsync(TimeSpan timeout)
-        {
-            return RegisterAsync(null, timeout);
-        }
-
-        /// <summary>
-        /// Registers the current device using the Device Provisioning Service and assigns it to an IoT hub.
-        /// </summary>
-        /// <param name="data">
-        /// The optional additional data that is passed through to the custom allocation policy webhook if 
-        /// a custom allocation policy webhook is setup for this enrollment.
-        /// </param>
-        /// <param name="timeout">The maximum amount of time to allow this operation to run for before timing out.</param>
-        /// <remarks>
-        /// Due to the AMQP library used by this library uses not accepting cancellation tokens, this overload and <see cref="RegisterAsync(TimeSpan)"/>
-        /// are the only overloads for this method that allow for a specified timeout to be respected in the middle of an AMQP operation such as opening
-        /// the AMQP connection. MQTT and HTTPS connections do not share that same limitation, though.
-        /// </remarks>
-        /// <returns>The registration result.</returns>
-        public Task<DeviceRegistrationResult> RegisterAsync(ProvisioningRegistrationAdditionalData data, TimeSpan timeout)
-        {
-            Logging.RegisterAsync(this, _globalDeviceEndpoint, _idScope, _transport, _security);
-
-            var request = new ProvisioningTransportRegisterMessage(_globalDeviceEndpoint, _idScope, _security, data?.JsonData)
-            {
-                ProductInfo = ProductInfo,
-            };
-
-            return _transport.RegisterAsync(request, timeout);
-        }
-
-        /// <summary>
-        /// Registers the current device using the Device Provisioning Service and assigns it to an IoT hub.
-        /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <remarks>
-        /// Due to the AMQP library used by this library uses not accepting cancellation tokens, the provided cancellation token will only be checked 
-        /// for cancellation in between AMQP operations, and not during. In order to have a timeout for this operation that is checked during AMQP operations
-        /// (such as opening the connection), you must use <see cref="RegisterAsync(TimeSpan)"/> instead. MQTT and HTTPS connections do not have the same 
-        /// behavior as AMQP connections in this regard. MQTT and HTTPS connections will check this cancellation token for cancellation during their protocol level operations.
-        /// </remarks>
         /// <returns>The registration result.</returns>
         public Task<DeviceRegistrationResult> RegisterAsync(CancellationToken cancellationToken = default)
         {
@@ -128,13 +81,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// a custom allocation policy webhook is setup for this enrollment.
         /// </param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <remarks>
-        /// Due to the AMQP library used by this library uses not accepting cancellation tokens, the provided cancellation token will only be checked 
-        /// for cancellation in between AMQP operations, and not during. In order to have a timeout for this operation that is checked during AMQP operations
-        /// (such as opening the connection), you must use <see cref="RegisterAsync(ProvisioningRegistrationAdditionalData, TimeSpan)">this overload</see> instead. 
-        /// MQTT and HTTPS connections do not have the same behavior as AMQP connections in this regard. MQTT and HTTPS connections will check this cancellation 
-        /// token for cancellation during their protocol level operations.
-        /// </remarks>
         /// <returns>The registration result.</returns>
         public Task<DeviceRegistrationResult> RegisterAsync(ProvisioningRegistrationAdditionalData data, CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
This removes TimeSpan methods in DPS client which should have been marked as obsolete when we updated the Amqp library.