### PR TITLE
Bump version for private release

### DIFF
--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -76,12 +76,12 @@
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.*" />
   </ItemGroup>
   <ItemGroup Condition=" ('$(AZURE_IOT_LOCALPACKAGES.ToUpper())' != '') And ( '$(TargetFramework)' != 'net451' ) ">
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.21.0-private-001" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Amqp" Version="1.18.0-private-001" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Http" Version="1.17.0-private-001" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.19.0-private-001" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.21.1-private-001" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Amqp" Version="1.18.0-private-002" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Http" Version="1.17.0-private-002" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.19.0-private-002" />
     <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Security.Tpm" Version="1.*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Service" Version="1.20.0-private-001" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Service" Version="1.20.1-private-001" />
     <ProjectReference Include="$(RootDir)\security\tpm\samples\SecurityProviderTpmSimulator\SecurityProviderTpmSimulator.csproj" />
   </ItemGroup>
 </Project>

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.21.0-private-001</Version>
+    <Version>1.21.1-private-001</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.20.0-private-001</Version>
+    <Version>1.20.1-private-001</Version>
     <Title>Microsoft Azure IoT Provisioning Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.18.0-private-001</Version>
+    <Version>1.18.0-private-002</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client AMQP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
+++ b/provisioning/transport/http/src/Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.17.0-private-001</Version>
+    <Version>1.17.0-private-002</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client HTTP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
+++ b/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.19.0-private-001</Version>
+    <Version>1.19.0-private-002</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client MQTT Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -2,9 +2,9 @@ AssemblyPath, Version
 iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.41.0
 iothub\service\src\Microsoft.Azure.Devices.csproj, 1.37.1
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.30.1
-provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.21.0-private-001
-provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.20.0-private-001
-provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.18.0-private-001
-provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.17.0-private-001
-provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.19.0-private-001
+provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.21.1-private-001
+provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.20.1-private-001
+provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.18.0-private-002
+provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.17.0-private-002
+provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.19.0-private-002
 security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.14.1


### PR DESCRIPTION
Files changed: https://github.com/Azure/azure-iot-sdk-csharp/pull/2458

APIs surface diff:

```diff
namespace Microsoft.Azure.Devices.Provisioning.Client {
	public class DeviceRegistrationResult {
+		public TrustBundle TrustBundle { get; set; }
	}
	
+	public class TrustBundle {
+		public TrustBundle();
+		public List<X509CertificateWithMetadata> Certificates { get; internal set; }
+		public DateTime CreatedDateTime { get; internal set; }
+		public string Etag { get; internal set; }
+		public string Id { get; internal set; }
+		public DateTime LastModifiedDateTime { get; internal set; }
+	}

+	public class X509CertificateMetadata {
+		public X509CertificateMetadata();
+		public string IssuerName { get; internal set; }
+		public DateTime NotAfterUtc { get; internal set; }
+		public DateTime NotBeforeUtc { get; internal set; }
+		public int SerialNumber { get; internal set; }
+		public string Sha1Thumbprint { get; internal set; }
+		public string Sha256Thumbprint { get; internal set; }
+		public string SubjectName { get; internal set; }
+	}

+	public class X509CertificateWithMetadata {
+		public X509CertificateWithMetadata();
+		public string Certificate { get; internal set; }
+		public X509CertificateMetadata Metadata { get; internal set; }
+	}
}

namespace Microsoft.Azure.Devices.Provisioning.Service {
	public class IndividualEnrollment : IETagHolder {
+		public string TrustBundleId { get; set; }
	}
	
	public class EnrollmentGroup : IETagHolder {
+		public string TrustBundleId { get; set; }
	}
}
```

