### PR TITLE
Cleanup remaining netcoreapp targets

### DIFF
--- a/common/src/service/HttpClientHelper.cs
+++ b/common/src/service/HttpClientHelper.cs
@@ -870,8 +870,7 @@ namespace Microsoft.Azure.Devices
 
         internal static HttpMessageHandler CreateDefaultHttpMessageHandler(IWebProxy webProxy, Uri baseUri, int connectionLeaseTimeoutMilliseconds)
         {
-#if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_0 && !NETCOREAPP1_1
-            // SocketsHttpHandler is only available in netcoreapp2.1 and onwards
+#if NET5_0_OR_GREATER
             var httpMessageHandler = new SocketsHttpHandler();
             httpMessageHandler.SslOptions.EnabledSslProtocols = TlsVersions.Instance.Preferred;
 #else

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!--netcoreapp2.1 target framework here is solely so that this library can use the SocketsHttpHandler class to handle connection lease timeout issues.-->
-    <!--See #1874 for additional details-->
     <TargetFrameworks>net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/iothub/service/src/ServicePointHelpers.cs
+++ b/iothub/service/src/ServicePointHelpers.cs
@@ -33,8 +33,7 @@ namespace Microsoft.Azure.Devices
                     ServicePoint servicePoint = ServicePointManager.FindServicePoint(baseUri);
                     servicePoint.ConnectionLeaseTimeout = connectionLeaseTimeoutMilliseconds;
                     break;
-#if NETCOREAPP2_1_OR_GREATER || NET5_0_OR_GREATER
-                // SocketsHttpHandler is only available in netcore2.1 and onwards
+#if NET5_0_OR_GREATER
                 case SocketsHttpHandler socketsHttpHandler:
                     socketsHttpHandler.MaxConnectionsPerServer = DefaultMaxConnectionsPerServer;
                     socketsHttpHandler.PooledConnectionLifetime = TimeSpan.FromMilliseconds(connectionLeaseTimeoutMilliseconds);

--- a/supported_platforms.md
+++ b/supported_platforms.md
@@ -8,8 +8,6 @@ The NuGet packages provide support for the following .NET versions:
 - .NET 5.0
 - .NET Standard 2.1
 - .NET Standard 2.0
-- .NET Framework 4.7.2 (IoT Hub SDKs only)
-- .NET Framework 4.5.1 (IoT Hub SDKs only)
 
 This SDK _may_ work with newer versions of .NET, but there are no guarantees that they will _always_ work for those until we officially add support for them nor are there guarantees that we will fix bugs that are only present on those versions.
 
@@ -26,7 +24,6 @@ Nightly test platform details:
 - .NET Core 3.1
 - .NET Core 2.1.18
 - .NET Framework 4.7.2 (only IoT Hub SDKs tested)
-- .NET Framework 4.5.1 (only IoT Hub SDKs tested)
 
 
 Default locale: en_US, platform encoding: Cp1252
@@ -35,7 +32,7 @@ OS name: "windows server 2022", version: "10.0", arch: "amd64", family: "windows
 
 ## Ubuntu 20.04
 
-Note that, while we only directly test on Ubuntu 20.04, we do generally support other [Linux distributions supported by .NET core](https://docs.microsoft.com/dotnet/core/install/linux). 
+Note that, while we only directly test on Ubuntu 20.04, we do generally support other [Linux distributions supported by .NET core](https://docs.microsoft.com/dotnet/core/install/linux).
 
 Nightly test platform details:
 


### PR DESCRIPTION
I need to talk to Tim about this as he added this support originally, I'd guess before we added net5.0 support.

That said, I don't think libraries should target netcoreapp. Maybe we have a good reason for an exception here, but I'll post this PR to start the discussion.