### PR TITLE
Rename C2D methods, misc code cleanup

### DIFF
--- a/e2e/test/helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/helpers/TestDeviceCallbackHandler.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
         private async Task CompleteMessageAsync(Client.Message message)
         {
-            await _deviceClient.CompleteAsync(message).ConfigureAwait(false);
+            await _deviceClient.CompleteMessageAsync(message).ConfigureAwait(false);
         }
 
         public async Task WaitForReceiveMessageCallbackAsync(CancellationToken ct)

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageReceiveFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageReceiveFaultInjectionPoolAmqpTests.cs
@@ -970,7 +970,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 await serviceClient.SendAsync(testDevice.Id, msg).ConfigureAwait(false);
                 Logger.Trace($"{nameof(FaultInjectionPoolAmqpTests)}: Sent message to device {testDevice.Id}: payload='{payload}' p1Value='{p1Value}'");
 
-                Client.Message receivedMessage = await deviceClient.ReceiveAsync(timeout).ConfigureAwait(false);
+                Client.Message receivedMessage = await deviceClient.ReceiveMessageAsync(timeout).ConfigureAwait(false);
                 await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts.Token).ConfigureAwait(false);
                 receivedMessage.Should().BeNull();
             }

--- a/e2e/test/iothub/messaging/MessageFeedbackE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageFeedbackE2ETests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     transport == Client.TransportType.Mqtt_WebSocket_Only)
                 {
                     // Dummy ReceiveAsync to ensure mqtt subscription registration before SendAsync() is called on service client.
-                    await deviceClient.ReceiveAsync(TIMESPAN_FIVE_SECONDS).ConfigureAwait(false);
+                    await deviceClient.ReceiveMessageAsync(TIMESPAN_FIVE_SECONDS).ConfigureAwait(false);
                 }
 
                 await serviceClient.OpenAsync().ConfigureAwait(false);
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 {
                     (Message msg, string payload, string p1Value) = MessageReceiveE2ETests.ComposeC2dTestMessage(logger);
                     await serviceClient.SendAsync(testDevice.Id, msg).ConfigureAwait(false);
-                    Client.Message message = await deviceClient.ReceiveAsync(TIMESPAN_ONE_MINUTE).ConfigureAwait(false);
+                    Client.Message message = await deviceClient.ReceiveMessageAsync(TIMESPAN_ONE_MINUTE).ConfigureAwait(false);
                     if (message == null)
                     {
                         Assert.Fail("No message received.");
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 {
                     var stopwatch = new Stopwatch();
                     stopwatch.Start();
-                    await deviceClient.CompleteAsync(messages[MESSAGE_COUNT - 1 - i]).ConfigureAwait(false);
+                    await deviceClient.CompleteMessageAsync(messages[MESSAGE_COUNT - 1 - i]).ConfigureAwait(false);
                     stopwatch.Stop();
                     Assert.IsFalse(stopwatch.ElapsedMilliseconds > deviceClient.OperationTimeoutInMilliseconds, $"CompleteAsync is over {deviceClient.OperationTimeoutInMilliseconds}");
                 }

--- a/e2e/test/iothub/messaging/MessageReceiveE2EPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2EPoolAmqpTests.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Logger.Trace($"Sent 1st C2D message from service - to be received on callback: deviceId={testDevice.Id}, messageId={firstMessage.MessageId}");
 
                 // The message should be received on the callback, while a call to ReceiveAsync() should return null.
-                Client.Message receivedMessage = await deviceClient.ReceiveAsync(timeout).ConfigureAwait(false);
+                Client.Message receivedMessage = await deviceClient.ReceiveMessageAsync(timeout).ConfigureAwait(false);
                 await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts.Token).ConfigureAwait(false);
                 receivedMessage.Should().BeNull();
 
@@ -337,7 +337,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 {
                     await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts.Token).ConfigureAwait(false);
                 };
-                Client.Message message = await deviceClient.ReceiveAsync(timeout).ConfigureAwait(false);
+                Client.Message message = await deviceClient.ReceiveMessageAsync(timeout).ConfigureAwait(false);
                 message.MessageId.Should().Be(secondMessage.MessageId);
                 receiveMessageOverCallback.Should().Throw<OperationCanceledException>();
             }

--- a/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
@@ -498,11 +498,11 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     if (transport == Client.TransportType.Http1)
                     {
                         // timeout on HTTP is not supported
-                        receivedMessage = await dc.ReceiveAsync().ConfigureAwait(false);
+                        receivedMessage = await dc.ReceiveMessageAsync().ConfigureAwait(false);
                     }
                     else
                     {
-                        receivedMessage = await dc.ReceiveAsync(s_oneMinute).ConfigureAwait(false);
+                        receivedMessage = await dc.ReceiveMessageAsync(s_oneMinute).ConfigureAwait(false);
                     }
 
                     if (receivedMessage == null)
@@ -513,7 +513,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     try
                     {
                         // always complete message
-                        await dc.CompleteAsync(receivedMessage).ConfigureAwait(false);
+                        await dc.CompleteMessageAsync(receivedMessage).ConfigureAwait(false);
                     }
                     catch (Exception)
                     {
@@ -551,7 +551,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             try
             {
                 using var cts = new CancellationTokenSource(s_fiveSeconds);
-                await dc.ReceiveAsync(cts.Token).ConfigureAwait(false);
+                await dc.ReceiveMessageAsync(cts.Token).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex)
                 when (ex.IsTransient && ex.InnerException is OperationCanceledException)
@@ -574,7 +574,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 logger.Trace($"Receiving messages for device {deviceId}.");
 
                 using var cts = new CancellationTokenSource(s_oneMinute);
-                using Client.Message receivedMessage = await dc.ReceiveAsync(cts.Token).ConfigureAwait(false);
+                using Client.Message receivedMessage = await dc.ReceiveMessageAsync(cts.Token).ConfigureAwait(false);
 
                 if (receivedMessage == null)
                 {
@@ -584,7 +584,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 try
                 {
                     // always complete message
-                    await dc.CompleteAsync(receivedMessage).ConfigureAwait(false);
+                    await dc.CompleteMessageAsync(receivedMessage).ConfigureAwait(false);
                 }
                 catch (Exception)
                 {
@@ -660,7 +660,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             if (transport == Client.TransportType.Mqtt_Tcp_Only
                 || transport == Client.TransportType.Mqtt_WebSocket_Only)
             {
-                await deviceClient.ReceiveAsync(s_fiveSeconds).ConfigureAwait(false);
+                await deviceClient.ReceiveMessageAsync(s_fiveSeconds).ConfigureAwait(false);
             }
 
             (Message msg, string payload, string p1Value) = ComposeC2dTestMessage(Logger);
@@ -704,7 +704,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             if (transport == Client.TransportType.Mqtt_Tcp_Only
                 || transport == Client.TransportType.Mqtt_WebSocket_Only)
             {
-                await deviceClient.ReceiveAsync(s_fiveSeconds).ConfigureAwait(false);
+                await deviceClient.ReceiveMessageAsync(s_fiveSeconds).ConfigureAwait(false);
             }
 
             (Message msg, string payload, string p1Value) = ComposeC2dTestMessage(Logger);
@@ -728,7 +728,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     logger.Trace($"{nameof(ReceiveMessageWithoutTimeoutCheckAsync)} - Calling ReceiveAsync()");
 
                     sw.Restart();
-                    using Client.Message message = await dc.ReceiveAsync().ConfigureAwait(false);
+                    using Client.Message message = await dc.ReceiveMessageAsync().ConfigureAwait(false);
                     sw.Stop();
 
                     logger.Trace($"{nameof(ReceiveMessageWithoutTimeoutCheckAsync)} - Received message={message}; time taken={sw.ElapsedMilliseconds} ms");
@@ -738,7 +738,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                         break;
                     }
 
-                    await dc.CompleteAsync(message).ConfigureAwait(false);
+                    await dc.CompleteMessageAsync(message).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -791,7 +791,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             if (transport == Client.TransportType.Mqtt_Tcp_Only
                 || transport == Client.TransportType.Mqtt_WebSocket_Only)
             {
-                Client.Message leftoverMessage = await deviceClient.ReceiveAsync(s_fiveSeconds).ConfigureAwait(false);
+                Client.Message leftoverMessage = await deviceClient.ReceiveMessageAsync(s_fiveSeconds).ConfigureAwait(false);
                 Logger.Trace($"Leftover message on Mqtt was: {leftoverMessage} with Id={leftoverMessage?.MessageId}");
             }
 
@@ -800,9 +800,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await serviceClient.SendAsync(testDevice.Id, firstMessage).ConfigureAwait(false);
             Logger.Trace($"Sent C2D message from service, messageId={firstMessage.MessageId} - to be received on polling ReceiveAsync");
 
-            using Client.Message receivedFirstMessage = await deviceClient.ReceiveAsync(s_tenSeconds).ConfigureAwait(false);
+            using Client.Message receivedFirstMessage = await deviceClient.ReceiveMessageAsync(s_tenSeconds).ConfigureAwait(false);
             receivedFirstMessage.MessageId.Should().Be(firstMessage.MessageId);
-            await deviceClient.CompleteAsync(receivedFirstMessage).ConfigureAwait(false);
+            await deviceClient.CompleteMessageAsync(receivedFirstMessage).ConfigureAwait(false);
 
             // Now, set a callback on the device client to receive C2D messages.
             await testDeviceCallbackHandler.SetMessageReceiveCallbackHandlerAsync().ConfigureAwait(false);
@@ -815,7 +815,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             // The message should be received on the callback, while a call to ReceiveAsync() should return null.
             using var cts = new CancellationTokenSource(s_tenSeconds);
-            using Client.Message receivedSecondMessage = await deviceClient.ReceiveAsync(s_tenSeconds).ConfigureAwait(false);
+            using Client.Message receivedSecondMessage = await deviceClient.ReceiveMessageAsync(s_tenSeconds).ConfigureAwait(false);
             await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts.Token).ConfigureAwait(false);
             receivedSecondMessage.Should().BeNull();
 
@@ -827,7 +827,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             if (transport == Client.TransportType.Mqtt_Tcp_Only
                 || transport == Client.TransportType.Mqtt_WebSocket_Only)
             {
-                Client.Message leftoverMessage = await deviceClient.ReceiveAsync(s_fiveSeconds).ConfigureAwait(false);
+                Client.Message leftoverMessage = await deviceClient.ReceiveMessageAsync(s_fiveSeconds).ConfigureAwait(false);
                 Logger.Trace($"Leftover message on Mqtt was: {leftoverMessage} with Id={leftoverMessage?.MessageId}");
             }
 
@@ -841,10 +841,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             {
                 await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts.Token).ConfigureAwait(false);
             };
-            using Client.Message receivedThirdMessage = await deviceClient.ReceiveAsync(s_tenSeconds).ConfigureAwait(false);
+            using Client.Message receivedThirdMessage = await deviceClient.ReceiveMessageAsync(s_tenSeconds).ConfigureAwait(false);
             receivedThirdMessage.MessageId.Should().Be(thirdMessage.MessageId);
             receiveMessageOverCallback.Should().Throw<OperationCanceledException>();
-            await deviceClient.CompleteAsync(receivedThirdMessage).ConfigureAwait(false);
+            await deviceClient.CompleteMessageAsync(receivedThirdMessage).ConfigureAwait(false);
 
             firstMessage.Dispose();
             secondMessage.Dispose();
@@ -868,7 +868,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 async (message, context) =>
                 {
                     Logger.Trace($"Received message over the first message handler: MessageId={message.MessageId}");
-                    await deviceClient.CompleteAsync(message).ConfigureAwait(false);
+                    await deviceClient.CompleteMessageAsync(message).ConfigureAwait(false);
                     firstHandlerSemaphore.Release();
                 },
                 deviceClient);
@@ -888,7 +888,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 async (message, context) =>
                 {
                     Logger.Trace($"Received message over the second message handler: MessageId={message.MessageId}");
-                    await deviceClient.CompleteAsync(message).ConfigureAwait(false);
+                    await deviceClient.CompleteMessageAsync(message).ConfigureAwait(false);
                     secondHandlerSemaphore.Release();
                 },
                 deviceClient);

--- a/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveFaultInjectionTests.cs
@@ -376,7 +376,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 if (transport == Client.TransportType.Mqtt_Tcp_Only ||
                     transport == Client.TransportType.Mqtt_WebSocket_Only)
                 {
-                    await deviceClient.ReceiveAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                    await deviceClient.ReceiveMessageAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
                 }
             }
 
@@ -436,7 +436,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 testDeviceCallbackHandler.ExpectedMessageSentByService = message;
                 await serviceClient.SendAsync(testDevice.Id, message).ConfigureAwait(false);
 
-                Client.Message receivedMessage = await deviceClient.ReceiveAsync(timeout).ConfigureAwait(false);
+                Client.Message receivedMessage = await deviceClient.ReceiveMessageAsync(timeout).ConfigureAwait(false);
                 await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts.Token).ConfigureAwait(false);
                 receivedMessage.Should().BeNull();
             }

--- a/iothub/device/src/ClientCallbackDefinitions.cs
+++ b/iothub/device/src/ClientCallbackDefinitions.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices.Client
+{
+    /// <summary>
+    /// Delegate for connection status changed.
+    /// </summary>
+    /// <remarks>
+    /// This can be set for both <see cref="DeviceClient"/> and <see cref="ModuleClient"/>.
+    /// </remarks>
+    /// <param name="status">The updated connection status</param>
+    /// <param name="reason">The reason for the connection status change</param>
+    public delegate void ConnectionStatusChangesHandler(ConnectionStatus status, ConnectionStatusChangeReason reason);
+
+    /// <summary>
+    /// Delegate for method call. This will be called every time we receive a method call that was registered.
+    /// </summary>
+    /// <remarks>
+    /// This can be set for both <see cref="DeviceClient"/> and <see cref="ModuleClient"/>.
+    /// </remarks>
+    /// <param name="methodRequest">Class with details about method.</param>
+    /// <param name="userContext">Context object passed in when the callback was registered.</param>
+    /// <returns>MethodResponse</returns>
+    public delegate Task<MethodResponse> MethodCallback(MethodRequest methodRequest, object userContext);
+
+    /// <summary>
+    /// Delegate for desired property update callbacks. This will be called every time we receive a patch from the service.
+    /// </summary>
+    /// <remarks>
+    /// This can be set for both <see cref="DeviceClient"/> and <see cref="ModuleClient"/>.
+    /// </remarks>
+    /// <param name="desiredProperties">Properties that were contained in the update that was received from the service</param>
+    /// <param name="userContext">Context object passed in when the callback was registered</param>
+    public delegate Task DesiredPropertyUpdateCallback(TwinCollection desiredProperties, object userContext);
+
+    /// <summary>
+    /// Delegate that gets called when a message is received on a <see cref="DeviceClient"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is set using <see cref="DeviceClient.SetReceiveMessageHandlerAsync(ReceiveMessageCallback, object, CancellationToken)"/>.
+    /// </remarks>
+    /// <param name="message">The received message.</param>
+    /// <param name="userContext">Context object passed in when the callback was registered.</param>
+    public delegate Task ReceiveMessageCallback(Message message, object userContext);
+
+    /// <summary>
+    /// Delegate that gets called when a message is received on a <see cref="ModuleClient"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is set using <see cref="ModuleClient.SetInputMessageHandlerAsync(string, MessageHandler, object, CancellationToken)"/>
+    /// and <see cref="ModuleClient.SetMessageHandlerAsync(MessageHandler, object, CancellationToken)"/>.
+    /// </remarks>
+    /// <param name="message">The received message.</param>
+    /// <param name="userContext">Context object passed in when the callback was registered.</param>
+    /// <returns>MessageResponse</returns>
+    public delegate Task<MessageResponse> MessageHandler(Message message, object userContext);
+}

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -306,19 +306,19 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <summary>
         /// Receive a message from the device queue using the default timeout.
-        /// After handling a received message, a client should call <see cref="CompleteAsync(Message)"/>,
-        /// <see cref="AbandonAsync(Message)"/>, or <see cref="RejectAsync(Message)"/>, and then dispose the message.
+        /// After handling a received message, a client should call <see cref="CompleteMessageAsync(Message)"/>,
+        /// <see cref="AbandonMessageAsync(Message)"/>, or <see cref="RejectMessageAsync(Message)"/>, and then dispose the message.
         /// </summary>
         /// <remarks>
         /// <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
         /// </remarks>
         /// <returns>The receive message or null if there was no message until the default timeout</returns>
-        public Task<Message> ReceiveAsync() => InternalClient.ReceiveAsync();
+        public Task<Message> ReceiveMessageAsync() => InternalClient.ReceiveAsync();
 
         /// <summary>
         /// Receive a message from the device queue using the cancellation token.
-        /// After handling a received message, a client should call <see cref="CompleteAsync(Message, CancellationToken)"/>,
-        /// <see cref="AbandonAsync(Message, CancellationToken)"/>, or <see cref="RejectAsync(Message, CancellationToken)"/>,
+        /// After handling a received message, a client should call <see cref="CompleteMessageAsync(Message, CancellationToken)"/>,
+        /// <see cref="AbandonMessageAsync(Message, CancellationToken)"/>, or <see cref="RejectMessageAsync(Message, CancellationToken)"/>,
         /// and then dispose the message.
         /// </summary>
         /// <remarks>
@@ -329,12 +329,12 @@ namespace Microsoft.Azure.Devices.Client
         /// <exception cref="IotHubCommunicationException">Thrown when the operation has been canceled. The inner exception will be
         /// <see cref="OperationCanceledException"/>.</exception>
         /// <returns>The received message or null if there was no message until cancellation token has expired</returns>
-        public Task<Message> ReceiveAsync(CancellationToken cancellationToken) => InternalClient.ReceiveAsync(cancellationToken);
+        public Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken) => InternalClient.ReceiveAsync(cancellationToken);
 
         /// <summary>
         /// Receive a message from the device queue using a timeout.
-        /// After handling a received message, a client should call <see cref="CompleteAsync(Message, CancellationToken)"/>,
-        /// <see cref="AbandonAsync(Message, CancellationToken)"/>, or <see cref="RejectAsync(Message, CancellationToken)"/>,
+        /// After handling a received message, a client should call <see cref="CompleteMessageAsync(Message, CancellationToken)"/>,
+        /// <see cref="AbandonMessageAsync(Message, CancellationToken)"/>, or <see cref="RejectMessageAsync(Message, CancellationToken)"/>,
         /// and then dispose the message.
         /// </summary>
         /// <remarks>
@@ -342,12 +342,12 @@ namespace Microsoft.Azure.Devices.Client
         /// <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
         /// </remarks>
         /// <returns>The received message or null if there was no message until the specified time has elapsed.</returns>
-        public Task<Message> ReceiveAsync(TimeSpan timeout) => InternalClient.ReceiveAsync(timeout);
+        public Task<Message> ReceiveMessageAsync(TimeSpan timeout) => InternalClient.ReceiveAsync(timeout);
 
         /// <summary>
         /// Sets a new delegate for receiving a message from the device queue using a cancellation token.
-        /// After handling a received message, a client should call <see cref="CompleteAsync(Message, CancellationToken)"/>,
-        /// <see cref="AbandonAsync(Message, CancellationToken)"/>, or <see cref="RejectAsync(Message, CancellationToken)"/>,
+        /// After handling a received message, a client should call <see cref="CompleteMessageAsync(Message, CancellationToken)"/>,
+        /// <see cref="AbandonMessageAsync(Message, CancellationToken)"/>, or <see cref="RejectMessageAsync(Message, CancellationToken)"/>,
         /// and then dispose the message.
         /// If a null delegate is passed, it will disable the callback triggered on receiving messages from the service.
         /// <param name="messageHandler">The delegate to be used when a could to device message is received by the client.</param>
@@ -364,7 +364,7 @@ namespace Microsoft.Azure.Devices.Client
         /// Deletes a received message from the device queue.
         /// </summary>
         /// <param name="lockToken">The message lockToken.</param>
-        public Task CompleteAsync(string lockToken) => InternalClient.CompleteAsync(lockToken);
+        public Task CompleteMessageAsync(string lockToken) => InternalClient.CompleteMessageAsync(lockToken);
 
         /// <summary>
         /// Deletes a received message from the device queue.
@@ -373,14 +373,14 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="IotHubCommunicationException">Thrown when the operation has been canceled.
         /// The inner exception will be <see cref="OperationCanceledException"/>.</exception>
-        public Task CompleteAsync(string lockToken, CancellationToken cancellationToken) =>
-            InternalClient.CompleteAsync(lockToken, cancellationToken);
+        public Task CompleteMessageAsync(string lockToken, CancellationToken cancellationToken) =>
+            InternalClient.CompleteMessageAsync(lockToken, cancellationToken);
 
         /// <summary>
         /// Deletes a received message from the device queue.
         /// </summary>
         /// <param name="message">The message.</param>
-        public Task CompleteAsync(Message message) => InternalClient.CompleteAsync(message);
+        public Task CompleteMessageAsync(Message message) => InternalClient.CompleteMessageAsync(message);
 
         /// <summary>
         /// Deletes a received message from the device queue.
@@ -389,8 +389,8 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="IotHubCommunicationException">Thrown when the operation has been canceled.
         /// The inner exception will be <see cref="OperationCanceledException"/>.</exception>
-        public Task CompleteAsync(Message message, CancellationToken cancellationToken) =>
-            InternalClient.CompleteAsync(message, cancellationToken);
+        public Task CompleteMessageAsync(Message message, CancellationToken cancellationToken) =>
+            InternalClient.CompleteMessageAsync(message, cancellationToken);
 
         /// <summary>
         /// Puts a received message back onto the device queue.
@@ -400,7 +400,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
         /// </remarks>
         /// <param name="lockToken">The message lockToken.</param>
-        public Task AbandonAsync(string lockToken) => InternalClient.AbandonAsync(lockToken);
+        public Task AbandonMessageAsync(string lockToken) => InternalClient.AbandonMessageAsync(lockToken);
 
         /// <summary>
         /// Puts a received message back onto the device queue.
@@ -413,8 +413,8 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="IotHubCommunicationException">Thrown when the operation has been canceled.
         /// The inner exception will be <see cref="OperationCanceledException"/>.</exception>
-        public Task AbandonAsync(string lockToken, CancellationToken cancellationToken) =>
-            InternalClient.AbandonAsync(lockToken, cancellationToken);
+        public Task AbandonMessageAsync(string lockToken, CancellationToken cancellationToken) =>
+            InternalClient.AbandonMessageAsync(lockToken, cancellationToken);
 
         /// <summary>
         /// Puts a received message back onto the device queue.
@@ -424,7 +424,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
         /// </remarks>
         /// <param name="message">The message to abandon.</param>
-        public Task AbandonAsync(Message message) => InternalClient.AbandonAsync(message);
+        public Task AbandonMessageAsync(Message message) => InternalClient.AbandonMessageAsync(message);
 
         /// <summary>
         /// Puts a received message back onto the device queue.
@@ -437,8 +437,8 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="IotHubCommunicationException">Thrown when the operation has been canceled.
         /// The inner exception will be <see cref="OperationCanceledException"/>.</exception>
-        public Task AbandonAsync(Message message, CancellationToken cancellationToken) =>
-            InternalClient.AbandonAsync(message, cancellationToken);
+        public Task AbandonMessageAsync(Message message, CancellationToken cancellationToken) =>
+            InternalClient.AbandonMessageAsync(message, cancellationToken);
 
         /// <summary>
         /// Deletes a received message from the device queue and indicates to the server that the message could not be processed.
@@ -448,7 +448,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
         /// </remarks>
         /// <param name="lockToken">The message lockToken.</param>
-        public Task RejectAsync(string lockToken) => InternalClient.RejectAsync(lockToken);
+        public Task RejectMessageAsync(string lockToken) => InternalClient.RejectMessageAsync(lockToken);
 
         /// <summary>
         /// Deletes a received message from the device queue and indicates to the server that the message could not be processed.
@@ -461,8 +461,8 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="lockToken">The message lockToken.</param>
         /// <exception cref="IotHubCommunicationException">Thrown when the operation has been canceled.
         /// The inner exception will be <see cref="OperationCanceledException"/>.</exception>
-        public Task RejectAsync(string lockToken, CancellationToken cancellationToken) =>
-            InternalClient.RejectAsync(lockToken, cancellationToken);
+        public Task RejectMessageAsync(string lockToken, CancellationToken cancellationToken) =>
+            InternalClient.RejectMessageAsync(lockToken, cancellationToken);
 
         /// <summary>
         /// Deletes a received message from the device queue and indicates to the server that the message could not be processed.
@@ -472,7 +472,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
         /// </remarks>
         /// <param name="message">The message.</param>
-        public Task RejectAsync(Message message) => InternalClient.RejectAsync(message);
+        public Task RejectMessageAsync(Message message) => InternalClient.RejectMessageAsync(message);
 
         /// <summary>
         /// Deletes a received message from the device queue and indicates to the server that the message could not be processed.
@@ -485,8 +485,8 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="IotHubCommunicationException">Thrown when the operation has been canceled.
         /// The inner exception will be <see cref="OperationCanceledException"/>.</exception>
-        public Task RejectAsync(Message message, CancellationToken cancellationToken) =>
-            InternalClient.RejectAsync(message, cancellationToken);
+        public Task RejectMessageAsync(Message message, CancellationToken cancellationToken) =>
+            InternalClient.RejectMessageAsync(message, cancellationToken);
 
         /// <summary>
         /// Sends an event to a hub

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -17,90 +15,16 @@ using Microsoft.Azure.Devices.Client.Utilities;
 namespace Microsoft.Azure.Devices.Client
 {
     /// <summary>
-    /// Delegate for connection status changed.
-    /// </summary>
-    /// <remarks>
-    /// This can be set for both <see cref="DeviceClient"/> and <see cref="ModuleClient"/>.
-    /// </remarks>
-    /// <param name="status">The updated connection status</param>
-    /// <param name="reason">The reason for the connection status change</param>
-    public delegate void ConnectionStatusChangesHandler(ConnectionStatus status, ConnectionStatusChangeReason reason);
-
-    /// <summary>
-    /// Delegate for method call. This will be called every time we receive a method call that was registered.
-    /// </summary>
-    /// <remarks>
-    /// This can be set for both <see cref="DeviceClient"/> and <see cref="ModuleClient"/>.
-    /// </remarks>
-    /// <param name="methodRequest">Class with details about method.</param>
-    /// <param name="userContext">Context object passed in when the callback was registered.</param>
-    /// <returns>MethodResponse</returns>
-    public delegate Task<MethodResponse> MethodCallback(MethodRequest methodRequest, object userContext);
-
-    /// <summary>
-    /// Delegate for desired property update callbacks. This will be called every time we receive a patch from the service.
-    /// </summary>
-    /// <remarks>
-    /// This can be set for both <see cref="DeviceClient"/> and <see cref="ModuleClient"/>.
-    /// </remarks>
-    /// <param name="desiredProperties">Properties that were contained in the update that was received from the service</param>
-    /// <param name="userContext">Context object passed in when the callback was registered</param>
-    public delegate Task DesiredPropertyUpdateCallback(TwinCollection desiredProperties, object userContext);
-
-    /// <summary>
-    /// Delegate that gets called when a message is received on a <see cref="DeviceClient"/>.
-    /// </summary>
-    /// <remarks>
-    /// This is set using <see cref="DeviceClient.SetReceiveMessageHandlerAsync(ReceiveMessageCallback, object, CancellationToken)"/>.
-    /// </remarks>
-    /// <param name="message">The received message.</param>
-    /// <param name="userContext">Context object passed in when the callback was registered.</param>
-    public delegate Task ReceiveMessageCallback(Message message, object userContext);
-
-    /// <summary>
-    /// Delegate that gets called when a message is received on a <see cref="ModuleClient"/>.
-    /// </summary>
-    /// <remarks>
-    /// This is set using <see cref="ModuleClient.SetInputMessageHandlerAsync(string, MessageHandler, object, CancellationToken)"/>
-    /// and <see cref="ModuleClient.SetMessageHandlerAsync(MessageHandler, object, CancellationToken)"/>.
-    /// </remarks>
-    /// <param name="message">The received message.</param>
-    /// <param name="userContext">Context object passed in when the callback was registered.</param>
-    /// <returns>MessageResponse</returns>
-    public delegate Task<MessageResponse> MessageHandler(Message message, object userContext);
-
-    /// <summary>
-    /// Status of handling a message.
-    /// </summary>
-    public enum MessageResponse
-    {
-        /// <summary>
-        /// No acknowledgment of receipt will be sent.
-        /// </summary>
-        None,
-
-        /// <summary>
-        /// Event will be completed, removing it from the queue.
-        /// </summary>
-        Completed,
-
-        /// <summary>
-        /// Event will be abandoned.
-        /// </summary>
-        Abandoned,
-    };
-
-    /// <summary>
     /// Contains methods that a device can use to send messages to and receive messages from the service,
     /// respond to direct method invocations from the service, and send and receive twin property updates.
     /// </summary>
     internal class InternalClient : IDisposable
     {
-        private readonly SemaphoreSlim _methodsSemaphore = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _deviceReceiveMessageSemaphore = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _moduleReceiveMessageSemaphore = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _twinDesiredPropertySemaphore = new SemaphoreSlim(1, 1);
-        private readonly ProductInfo _productInfo = new ProductInfo();
+        private readonly SemaphoreSlim _methodsSemaphore = new(1, 1);
+        private readonly SemaphoreSlim _deviceReceiveMessageSemaphore = new(1, 1);
+        private readonly SemaphoreSlim _moduleReceiveMessageSemaphore = new(1, 1);
+        private readonly SemaphoreSlim _twinDesiredPropertySemaphore = new(1, 1);
+        private readonly ProductInfo _productInfo = new();
         private readonly HttpTransportHandler _fileUploadHttpTransportHandler;
         private readonly ITransportSettings[] _transportSettings;
         private readonly ClientOptions _clientOptions;
@@ -113,8 +37,7 @@ namespace Microsoft.Azure.Devices.Client
         // Stores methods supported by the client device and their associated delegate.
 
         private bool _isDeviceMethodEnabled;
-        private readonly Dictionary<string, Tuple<MethodCallback, object>> _deviceMethods =
-            new Dictionary<string, Tuple<MethodCallback, object>>();
+        private readonly Dictionary<string, Tuple<MethodCallback, object>> _deviceMethods = new();
 
         private volatile Tuple<MethodCallback, object> _deviceDefaultMethodCallback;
 
@@ -155,7 +78,7 @@ namespace Microsoft.Azure.Devices.Client
             _clientOptions = options;
             IotHubConnectionString = iotHubConnectionString;
 
-            var pipelineContext = new PipelineContext()
+            var pipelineContext = new PipelineContext
             {
                 TransportSettingsArray = transportSettings,
                 IotHubConnectionString = iotHubConnectionString,
@@ -267,7 +190,7 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Explicitly open the InternalClient instance.
+        /// Explicitly open the client instance.
         /// </summary>
         public async Task OpenAsync()
         {
@@ -284,14 +207,14 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Explicitly open the InternalClient instance.
+        /// Explicitly open the client instance.
         /// </summary>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
-        public Task OpenAsync(CancellationToken cancellationToken)
+        public async Task OpenAsync(CancellationToken cancellationToken)
         {
             try
             {
-                return InnerHandler.OpenAsync(cancellationToken);
+                await InnerHandler.OpenAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -301,7 +224,7 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Close the InternalClient instance
+        /// Close the client instance
         /// </summary>
         /// <returns>A task to await</returns>
         public async Task CloseAsync()
@@ -319,14 +242,14 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Close the InternalClient instance
+        /// Close the client instance
         /// </summary>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
-        public Task CloseAsync(CancellationToken cancellationToken)
+        public async Task CloseAsync(CancellationToken cancellationToken)
         {
             try
             {
-                return InnerHandler.CloseAsync(cancellationToken);
+                await InnerHandler.CloseAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -378,12 +301,12 @@ namespace Microsoft.Azure.Devices.Client
         /// Deletes a received message from the device queue
         /// </summary>
         /// <returns>The lock identifier for the previously received message</returns>
-        public async Task CompleteAsync(string lockToken)
+        public async Task CompleteMessageAsync(string lockToken)
         {
             try
             {
                 using CancellationTokenSource cts = CancellationTokenSourceFactory();
-                await CompleteAsync(lockToken, cts.Token).ConfigureAwait(false);
+                await CompleteMessageAsync(lockToken, cts.Token).ConfigureAwait(false);
             }
             catch (Exception ex) when (IsCausedByTimeoutOrCancellation(ex))
             {
@@ -398,16 +321,13 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="lockToken"></param>
         /// <param name="cancellationToken">A token to cancel the operation. </param>
         /// <returns>The lock identifier for the previously received message</returns>
-        public Task CompleteAsync(string lockToken, CancellationToken cancellationToken)
+        public async Task CompleteMessageAsync(string lockToken, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(lockToken))
-            {
-                throw new ArgumentNullException(nameof(lockToken));
-            }
+            Argument.AssertNotNullOrWhiteSpace(lockToken, nameof(lockToken));
 
             try
             {
-                return InnerHandler.CompleteAsync(lockToken, cancellationToken);
+                await InnerHandler.CompleteAsync(lockToken, cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -420,14 +340,11 @@ namespace Microsoft.Azure.Devices.Client
         /// Deletes a received message from the device queue
         /// </summary>
         /// <returns>The previously received message</returns>
-        public Task CompleteAsync(Message message)
+        public async Task CompleteMessageAsync(Message message)
         {
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
+            Argument.AssertNotNull(message, nameof(message));
 
-            return CompleteAsync(message.LockToken);
+            await CompleteMessageAsync(message.LockToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -436,18 +353,15 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="message">The message to complete</param>
         /// <param name="cancellationToken">A token to cancel the operation. </param>
         /// <returns>The previously received message</returns>
-        public Task CompleteAsync(Message message, CancellationToken cancellationToken)
+        public async Task CompleteMessageAsync(Message message, CancellationToken cancellationToken)
         {
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
+            Argument.AssertNotNull(message, nameof(message));
 
             // The asynchronous operation shall retry until time specified in OperationTimeoutInMilliseconds
             // property expire or unrecoverable error(authentication, quota exceed) occurs.
             try
             {
-                return CompleteAsync(message.LockToken, cancellationToken);
+                await CompleteMessageAsync(message.LockToken, cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -460,12 +374,12 @@ namespace Microsoft.Azure.Devices.Client
         /// Puts a received message back onto the device queue
         /// </summary>
         /// <returns>The previously received message</returns>
-        public async Task AbandonAsync(string lockToken)
+        public async Task AbandonMessageAsync(string lockToken)
         {
             try
             {
                 using CancellationTokenSource cts = CancellationTokenSourceFactory();
-                await AbandonAsync(lockToken, cts.Token).ConfigureAwait(false);
+                await AbandonMessageAsync(lockToken, cts.Token).ConfigureAwait(false);
             }
             catch (Exception ex) when (IsCausedByTimeoutOrCancellation(ex))
             {
@@ -478,18 +392,15 @@ namespace Microsoft.Azure.Devices.Client
         /// Puts a received message back onto the device queue
         /// </summary>
         /// <returns>The previously received message</returns>
-        public Task AbandonAsync(string lockToken, CancellationToken cancellationToken)
+        public async Task AbandonMessageAsync(string lockToken, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(lockToken))
-            {
-                throw new ArgumentNullException(nameof(lockToken));
-            }
+            Argument.AssertNotNullOrWhiteSpace(lockToken, nameof(lockToken));
 
             // The asynchronous operation shall retry until time specified in OperationTimeoutInMilliseconds property
             // expire or unrecoverable error(authentication, quota exceed) occurs.
             try
             {
-                return InnerHandler.AbandonAsync(lockToken, cancellationToken);
+                await InnerHandler.AbandonAsync(lockToken, cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -502,27 +413,24 @@ namespace Microsoft.Azure.Devices.Client
         /// Puts a received message back onto the device queue
         /// </summary>
         /// <returns>The lock identifier for the previously received message</returns>
-        public Task AbandonAsync(Message message)
+        public async Task AbandonMessageAsync(Message message)
         {
-            return message == null
-                ? throw new ArgumentNullException(nameof(message))
-                : AbandonAsync(message.LockToken);
+            Argument.AssertNotNull(message, nameof(message));
+
+            await AbandonMessageAsync(message.LockToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Puts a received message back onto the device queue
         /// </summary>
         /// <returns>The lock identifier for the previously received message</returns>
-        public Task AbandonAsync(Message message, CancellationToken cancellationToken)
+        public async Task AbandonMessageAsync(Message message, CancellationToken cancellationToken)
         {
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
+            Argument.AssertNotNull(message, nameof(message));
 
             try
             {
-                return AbandonAsync(message.LockToken, cancellationToken);
+                await AbandonMessageAsync(message.LockToken, cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -535,12 +443,12 @@ namespace Microsoft.Azure.Devices.Client
         /// Deletes a received message from the device queue and indicates to the server that the message could not be processed.
         /// </summary>
         /// <returns>The previously received message</returns>
-        public async Task RejectAsync(string lockToken)
+        public async Task RejectMessageAsync(string lockToken)
         {
             try
             {
                 using CancellationTokenSource cts = CancellationTokenSourceFactory();
-                await RejectAsync(lockToken, cts.Token).ConfigureAwait(false);
+                await RejectMessageAsync(lockToken, cts.Token).ConfigureAwait(false);
             }
             catch (Exception ex) when (IsCausedByTimeoutOrCancellation(ex))
             {
@@ -553,16 +461,13 @@ namespace Microsoft.Azure.Devices.Client
         /// Deletes a received message from the device queue and indicates to the server that the message could not be processed.
         /// </summary>
         /// <returns>The previously received message</returns>
-        public Task RejectAsync(string lockToken, CancellationToken cancellationToken)
+        public async Task RejectMessageAsync(string lockToken, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(lockToken))
-            {
-                throw new ArgumentNullException(nameof(lockToken));
-            }
+            Argument.AssertNotNullOrWhiteSpace(lockToken, nameof(lockToken));
 
             try
             {
-                return InnerHandler.RejectAsync(lockToken, cancellationToken);
+                await InnerHandler.RejectAsync(lockToken, cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -575,27 +480,24 @@ namespace Microsoft.Azure.Devices.Client
         /// Deletes a received message from the device queue and indicates to the server that the message could not be processed.
         /// </summary>
         /// <returns>The lock identifier for the previously received message</returns>
-        public Task RejectAsync(Message message)
+        public async Task RejectMessageAsync(Message message)
         {
-            return message == null
-                ? throw new ArgumentNullException(nameof(message))
-                : RejectAsync(message.LockToken);
+            Argument.AssertNotNull(message, nameof(message));
+
+            await RejectMessageAsync(message.LockToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Deletes a received message from the device queue and indicates to the server that the message could not be processed.
         /// </summary>
         /// <returns>The lock identifier for the previously received message</returns>
-        public Task RejectAsync(Message message, CancellationToken cancellationToken)
+        public async Task RejectMessageAsync(Message message, CancellationToken cancellationToken)
         {
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
+            Argument.AssertNotNull(message, nameof(message));
 
             try
             {
-                return RejectAsync(message.LockToken, cancellationToken);
+                await RejectMessageAsync(message.LockToken, cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -626,12 +528,9 @@ namespace Microsoft.Azure.Devices.Client
         /// Sends an event to device hub
         /// </summary>
         /// <returns>The message containing the event</returns>
-        public Task SendEventAsync(Message message, CancellationToken cancellationToken)
+        public async Task SendEventAsync(Message message, CancellationToken cancellationToken)
         {
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
+            Argument.AssertNotNull(message, nameof(message));
 
             if (_clientOptions?.SdkAssignsMessageId == SdkAssignsMessageId.WhenUnset && message.MessageId == null)
             {
@@ -643,7 +542,7 @@ namespace Microsoft.Azure.Devices.Client
             // expire or unrecoverable error(authentication or quota exceed) occurs.
             try
             {
-                return InnerHandler.SendEventAsync(message, cancellationToken);
+                await InnerHandler.SendEventAsync(message, cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -674,12 +573,9 @@ namespace Microsoft.Azure.Devices.Client
         /// Sends a batch of events to device hub
         /// </summary>
         /// <returns>The task containing the event</returns>
-        public Task SendEventBatchAsync(IEnumerable<Message> messages, CancellationToken cancellationToken)
+        public async Task SendEventBatchAsync(IEnumerable<Message> messages, CancellationToken cancellationToken)
         {
-            if (messages == null)
-            {
-                throw new ArgumentNullException(nameof(messages));
-            }
+            Argument.AssertNotNullOrEmpty(messages, nameof(messages));
 
             if (_clientOptions?.SdkAssignsMessageId == SdkAssignsMessageId.WhenUnset)
             {
@@ -693,10 +589,10 @@ namespace Microsoft.Azure.Devices.Client
             }
 
             // The asynchronous operation shall retry until time specified in OperationTimeoutInMilliseconds property
-            // expire or unrecoverable error(authentication or quota exceed) occurs.
+            // expire or unrecoverable error (authentication or quota exceed) occurs.
             try
             {
-                return InnerHandler.SendEventAsync(messages, cancellationToken);
+                await InnerHandler.SendEventAsync(messages, cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -743,6 +639,8 @@ namespace Microsoft.Azure.Devices.Client
                 Logging.Enter(this, methodName, methodHandler, userContext, nameof(SetMethodHandlerAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
+            Argument.AssertNotNullOrWhiteSpace(methodName, nameof(methodName));
+
             await _methodsSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             try
@@ -810,6 +708,7 @@ namespace Microsoft.Azure.Devices.Client
                 Logging.Enter(this, methodHandler, userContext, nameof(SetMethodDefaultHandlerAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
+
             await _methodsSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             try
@@ -846,8 +745,6 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         internal async Task OnMethodCalledAsync(MethodRequestInternal methodRequestInternal)
         {
-            Tuple<MethodCallback, object> callbackContextPair = null;
-
             if (Logging.IsEnabled)
                 Logging.Enter(this, methodRequestInternal?.Name, methodRequestInternal, nameof(OnMethodCalledAsync));
 
@@ -856,6 +753,7 @@ namespace Microsoft.Azure.Devices.Client
                 return;
             }
 
+            Tuple<MethodCallback, object> callbackContextPair = null;
             MethodResponseInternal methodResponseInternal = null;
             byte[] requestData = methodRequestInternal.GetBytes();
 
@@ -935,11 +833,11 @@ namespace Microsoft.Azure.Devices.Client
                 Logging.Exit(this, methodRequestInternal.Name, methodRequestInternal, nameof(OnMethodCalledAsync));
         }
 
-        internal Task SendMethodResponseAsync(MethodResponseInternal methodResponse, CancellationToken cancellationToken)
+        internal async Task SendMethodResponseAsync(MethodResponseInternal methodResponse, CancellationToken cancellationToken)
         {
             try
             {
-                return InnerHandler.SendMethodResponseAsync(methodResponse, cancellationToken);
+                await InnerHandler.SendMethodResponseAsync(methodResponse, cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -1056,12 +954,12 @@ namespace Microsoft.Azure.Devices.Client
         /// For the complete device twin object, use Microsoft.Azure.Devices.RegistryManager.GetTwinAsync(string deviceId).
         /// </summary>
         /// <returns>The device twin object for the current device</returns>
-        public Task<Twin> GetTwinAsync(CancellationToken cancellationToken)
+        public async Task<Twin> GetTwinAsync(CancellationToken cancellationToken)
         {
             // `GetTwinAsync` shall call `SendTwinGetAsync` on the transport to get the twin state.
             try
             {
-                return InnerHandler.SendTwinGetAsync(cancellationToken);
+                return await InnerHandler.SendTwinGetAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -1093,18 +991,14 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="reportedProperties">Reported properties to push</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        public Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
+        public async Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
-            // `UpdateReportedPropertiesAsync` shall throw an `ArgumentNull` exception if `reportedProperties` is null.
-            if (reportedProperties == null)
-            {
-                throw new ArgumentNullException(nameof(reportedProperties));
-            }
+            Argument.AssertNotNull(reportedProperties, nameof(reportedProperties));
 
             // `UpdateReportedPropertiesAsync` shall call `SendTwinPatchAsync` on the transport to update the reported properties.
             try
             {
-                return InnerHandler.SendTwinPatchAsync(reportedProperties, cancellationToken);
+                await InnerHandler.SendTwinPatchAsync(reportedProperties, cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -1168,13 +1062,13 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive
         /// notice of cancellation.</param>
         /// <returns>The receive message or null if there was no message until the default timeout</returns>
-        public Task<Message> ReceiveAsync(CancellationToken cancellationToken)
+        public async Task<Message> ReceiveAsync(CancellationToken cancellationToken)
         {
             // The asynchronous operation shall retry until time specified in OperationTimeoutInMilliseconds property expire or
             // unrecoverable (authentication, quota exceed) error occurs.
             try
             {
-                return InnerHandler.ReceiveAsync(cancellationToken);
+                return await InnerHandler.ReceiveAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {
@@ -1358,7 +1252,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="message">The message to send</param>
         /// <param name="cancellationToken">A cancellation token</param>
         /// <returns>The message containing the event</returns>
-        public Task SendEventAsync(string outputName, Message message, CancellationToken cancellationToken)
+        public async Task SendEventAsync(string outputName, Message message, CancellationToken cancellationToken)
         {
             try
             {
@@ -1367,19 +1261,12 @@ namespace Microsoft.Azure.Devices.Client
 
                 ValidateModuleTransportHandler("SendEventAsync for a named output");
 
-                if (string.IsNullOrWhiteSpace(outputName))
-                {
-                    throw new ArgumentNullException(nameof(outputName));
-                }
-
-                if (message == null)
-                {
-                    throw new ArgumentNullException(nameof(message));
-                }
+                Argument.AssertNotNullOrWhiteSpace(outputName, nameof(outputName));
+                Argument.AssertNotNull(message, nameof(message));
 
                 message.SystemProperties.Add(MessageSystemPropertyNames.OutputName, outputName);
 
-                return InnerHandler.SendEventAsync(message, cancellationToken);
+                await InnerHandler.SendEventAsync(message, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -1415,7 +1302,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="messages">A list of one or more messages to send</param>
         /// <param name="cancellationToken"></param>
         /// <returns>The task containing the event</returns>
-        public Task SendEventBatchAsync(string outputName, IEnumerable<Message> messages, CancellationToken cancellationToken)
+        public async Task SendEventBatchAsync(string outputName, IEnumerable<Message> messages, CancellationToken cancellationToken)
         {
             try
             {
@@ -1424,20 +1311,13 @@ namespace Microsoft.Azure.Devices.Client
 
                 ValidateModuleTransportHandler("SendEventBatchAsync for a named output");
 
-                if (string.IsNullOrWhiteSpace(outputName))
-                {
-                    throw new ArgumentNullException(nameof(outputName));
-                }
-
+                Argument.AssertNotNullOrWhiteSpace(outputName, nameof(outputName));
                 var messagesList = messages?.ToList();
-                if (messagesList == null || messagesList.Count == 0)
-                {
-                    throw new ArgumentNullException(nameof(messages));
-                }
+                Argument.AssertNotNullOrEmpty(messagesList, nameof(messages));
 
                 messagesList.ForEach(m => m.SystemProperties.Add(MessageSystemPropertyNames.OutputName, outputName));
 
-                return InnerHandler.SendEventAsync(messagesList, cancellationToken);
+                await InnerHandler.SendEventAsync(messagesList, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -1656,11 +1536,11 @@ namespace Microsoft.Azure.Devices.Client
                 switch (response)
                 {
                     case MessageResponse.Completed:
-                        await CompleteAsync(message).ConfigureAwait(false);
+                        await CompleteMessageAsync(message).ConfigureAwait(false);
                         break;
 
                     case MessageResponse.Abandoned:
-                        await AbandonAsync(message).ConfigureAwait(false);
+                        await AbandonMessageAsync(message).ConfigureAwait(false);
                         break;
 
                     default:
@@ -1732,7 +1612,7 @@ namespace Microsoft.Azure.Devices.Client
         {
             return ex is OperationCanceledException
                 || ex is IotHubCommunicationException
-                && (ex.InnerException is OperationCanceledException
+                    && (ex.InnerException is OperationCanceledException
                 || ex.InnerException is TimeoutException);
         }
 

--- a/iothub/device/src/MessageResponse.cs
+++ b/iothub/device/src/MessageResponse.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Client
+{
+    /// <summary>
+    /// Status of handling a message.
+    /// </summary>
+    public enum MessageResponse
+    {
+        /// <summary>
+        /// No acknowledgment of receipt will be sent.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Event will be completed, removing it from the queue.
+        /// </summary>
+        Completed,
+
+        /// <summary>
+        /// Event will be abandoned.
+        /// </summary>
+        Abandoned,
+    };
+}

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="lockToken">The message lockToken.</param>
         /// <returns>The lock identifier for the previously received message</returns>
-        public Task CompleteAsync(string lockToken) => InternalClient.CompleteAsync(lockToken);
+        public Task CompleteMessageAsync(string lockToken) => InternalClient.CompleteMessageAsync(lockToken);
 
         /// <summary>
         /// Deletes a received message from the module queue.
@@ -313,14 +313,14 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
         /// <returns>The lock identifier for the previously received message</returns>
-        public Task CompleteAsync(string lockToken, CancellationToken cancellationToken) => InternalClient.CompleteAsync(lockToken, cancellationToken);
+        public Task CompleteMessageAsync(string lockToken, CancellationToken cancellationToken) => InternalClient.CompleteMessageAsync(lockToken, cancellationToken);
 
         /// <summary>
         /// Deletes a received message from the module queue.
         /// </summary>
         /// <param name="message">The message.</param>
         /// <returns>The previously received message</returns>
-        public Task CompleteAsync(Message message) => InternalClient.CompleteAsync(message);
+        public Task CompleteMessageAsync(Message message) => InternalClient.CompleteMessageAsync(message);
 
         /// <summary>
         /// Deletes a received message from the module queue.
@@ -329,14 +329,14 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="message">The message.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
         /// <returns>The previously received message</returns>
-        public Task CompleteAsync(Message message, CancellationToken cancellationToken) => InternalClient.CompleteAsync(message, cancellationToken);
+        public Task CompleteMessageAsync(Message message, CancellationToken cancellationToken) => InternalClient.CompleteMessageAsync(message, cancellationToken);
 
         /// <summary>
         /// Puts a received message back onto the module queue.
         /// </summary>
         /// <param name="lockToken">The message lockToken.</param>
         /// <returns>The previously received message</returns>
-        public Task AbandonAsync(string lockToken) => InternalClient.AbandonAsync(lockToken);
+        public Task AbandonMessageAsync(string lockToken) => InternalClient.AbandonMessageAsync(lockToken);
 
         /// <summary>
         /// Puts a received message back onto the module queue.
@@ -345,13 +345,13 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
         /// <returns>The previously received message</returns>
-        public Task AbandonAsync(string lockToken, CancellationToken cancellationToken) => InternalClient.AbandonAsync(lockToken, cancellationToken);
+        public Task AbandonMessageAsync(string lockToken, CancellationToken cancellationToken) => InternalClient.AbandonMessageAsync(lockToken, cancellationToken);
 
         /// <summary>
         /// Puts a received message back onto the module queue.
         /// </summary>
         /// <returns>The lock identifier for the previously received message</returns>
-        public Task AbandonAsync(Message message) => InternalClient.AbandonAsync(message);
+        public Task AbandonMessageAsync(Message message) => InternalClient.AbandonMessageAsync(message);
 
         /// <summary>
         /// Puts a received message back onto the module queue.
@@ -360,7 +360,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
         /// <returns>The lock identifier for the previously received message</returns>
-        public Task AbandonAsync(Message message, CancellationToken cancellationToken) => InternalClient.AbandonAsync(message, cancellationToken);
+        public Task AbandonMessageAsync(Message message, CancellationToken cancellationToken) => InternalClient.AbandonMessageAsync(message, cancellationToken);
 
         /// <summary>
         /// Sends an event to IoT hub.

--- a/iothub/device/src/Utilities/Argument.cs
+++ b/iothub/device/src/Utilities/Argument.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.Devices.Client
+{
+    /// <summary>
+    /// Argument validation.
+    /// </summary>
+    /// <remarks>
+    /// This class should contain only common argument validation.
+    /// Be sure to document exceptions thrown by these methods on your public methods.
+    /// </remarks>
+    internal static class Argument
+    {
+        /// <summary>
+        /// Throws if <paramref name="value"/> is null.
+        /// </summary>
+        /// <param name="value">The value to validate.</param>
+        /// <param name="name">The name of the parameter.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        public static void AssertNotNull<T>(T value, string name)
+        {
+            if (value is null)
+            {
+                throw new ArgumentNullException(name);
+            }
+        }
+
+        /// <summary>
+        /// Throws if <paramref name="value"/> is null, an empty string, or consists only of white-space characters.
+        /// </summary>
+        /// <param name="value">The value to validate.</param>
+        /// <param name="name">The name of the parameter.</param>
+        /// <exception cref="ArgumentException"><paramref name="value"/> is an empty string or consists only of white-space characters.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        public static void AssertNotNullOrWhiteSpace(string value, string name)
+        {
+            if (value is null)
+            {
+                throw new ArgumentNullException(name);
+            }
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("Value cannot be empty or contain only white-space characters.", name);
+            }
+        }
+
+        /// <summary>
+        /// Throws if <paramref name="value"/> is null or an empty collection.
+        /// </summary>
+        /// <param name="value">The value to validate.</param>
+        /// <param name="name">The name of the parameter.</param>
+        /// <exception cref="ArgumentException"><paramref name="value"/> is an empty collection.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        internal static void AssertNotNullOrEmpty<T>(IEnumerable<T> value, string name)
+        {
+            if (value is null)
+            {
+                throw new ArgumentNullException(name);
+            }
+
+            // .NET Framework's Enumerable.Any() always allocates an enumerator, so we optimize for collections here.
+            if (value is ICollection<T> collectionOfT
+                && collectionOfT.Count == 0)
+            {
+                throw new ArgumentException("Value cannot be an empty collection.", name);
+            }
+
+            if (value is ICollection collection
+                && collection.Count == 0)
+            {
+                throw new ArgumentException("Value cannot be an empty collection.", name);
+            }
+
+            using IEnumerator<T> e = value.GetEnumerator();
+            if (!e.MoveNext())
+            {
+                throw new ArgumentException("Value cannot be an empty collection.", name);
+            }
+        }
+    }
+}

--- a/iothub/device/tests/DeviceClientTests.cs
+++ b/iothub/device/tests/DeviceClientTests.cs
@@ -153,8 +153,6 @@ namespace Microsoft.Azure.Devices.Client.Test
             act.Should().Throw<ArgumentException>();
         }
 
-        /* Tests_SRS_DEVICECLIENT_28_002: [This property shall be defaulted to 240000 (4 minutes).] */
-
         [TestMethod]
         public void DeviceClient_OperationTimeoutInMilliseconds_Property_DefaultValue()
         {
@@ -279,7 +277,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             innerHandler.ReceiveAsync(Arg.Any<TimeoutHelper>()).Returns(new Task<Message>(() => new Message()));
             deviceClient.InnerHandler = innerHandler;
 
-            Task<Message> t = deviceClient.ReceiveAsync(TimeSpan.Zero);
+            Task<Message> t = deviceClient.ReceiveMessageAsync(TimeSpan.Zero);
 
             await innerHandler.Received().ReceiveAsync(Arg.Any<TimeoutHelper>()).ConfigureAwait(false);
         }
@@ -311,7 +309,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_10_012: [** If the given methodRequestInternal argument is null, fail silently **]**
         public async Task DeviceClient_OnMethodCalled_NullMethodRequest()
         {
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -352,7 +349,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_28_020: [** If the given methodRequestInternal data is not valid json, respond with status code 400 (BAD REQUEST) **]**
         public async Task DeviceClient_OnMethodCalled_MethodRequestHasInvalidJson()
         {
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -373,7 +369,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_10_011: [ The OnMethodCalled shall invoke the specified delegate. ]
         public async Task DeviceClient_OnMethodCalled_MethodRequestHasValidJson()
         {
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -394,7 +389,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_28_021: [** If the MethodResponse from the MethodHandler is not valid json, respond with status code 500 (USER CODE EXCEPTION) **]**
         public async Task DeviceClient_OnMethodCalled_MethodResponseHasInvalidJson()
         {
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -415,8 +409,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_24_002: [ The OnMethodCalled shall invoke the default delegate if there is no specified delegate for that method. ]
-        // Tests_SRS_DEVICECLIENT_03_013: [Otherwise, the MethodResponseInternal constructor shall be invoked with the result supplied.]
         public async Task DeviceClient_OnMethodCalled_MethodRequestHasValidJson_With_SetMethodDefaultHandler()
         {
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -437,8 +429,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_24_002: [ The OnMethodCalled shall invoke the default delegate if there is no specified delegate for that method. ]
-        // Tests_SRS_DEVICECLIENT_03_013: [Otherwise, the MethodResponseInternal constructor shall be invoked with the result supplied.]
         public async Task DeviceClient_OnMethodCalled_MethodRequestHasValidJson_With_SetMethodHandlerNotMatchedAndDefaultHandler()
         {
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -466,8 +456,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_10_011: [ The OnMethodCalled shall invoke the specified delegate. ]
-        // Tests_SRS_DEVICECLIENT_03_013: [Otherwise, the MethodResponseInternal constructor shall be invoked with the result supplied.]
         public async Task DeviceClient_OnMethodCalled_MethodRequestHasValidJson_With_SetMethodHandlerAndDefaultHandler()
         {
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -495,8 +483,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_10_011: [ The OnMethodCalled shall invoke the specified delegate. ]
-        // Tests_SRS_DEVICECLIENT_03_012: [If the MethodResponse does not contain result, the MethodResponseInternal constructor shall be invoked with no results.]
         public async Task DeviceClient_OnMethodCalled_MethodRequestHasValidJson_With_No_Result()
         {
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -517,7 +503,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_10_013: [** If the given method does not have an associated delegate and no default delegate was registered, respond with status code 501 (METHOD NOT IMPLEMENTED) **]**
         public async Task DeviceClientOnMethodCalledNoMethodHandler()
         {
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -532,8 +517,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_10_001: [ It shall lazy-initialize the deviceMethods property. ]
-        // Tests_SRS_DEVICECLIENT_10_003: [ The given delegate will only be added if it is not null. ]
         public async Task DeviceClientSetMethodHandlerSetFirstMethodHandler()
         {
             string connectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;SharedAccessKey=dGVzdFN0cmluZzE=";
@@ -580,8 +563,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_10_001: [ It shall lazy-initialize the deviceMethods property. ]
-        // Tests_SRS_DEVICECLIENT_10_003: [ The given delegate will only be added if it is not null. ]
         public async Task DeviceClientSetMethodHandlerSetFirstMethodDefaultHandler()
         {
             string connectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;SharedAccessKey=dGVzdFN0cmluZzE=";
@@ -628,7 +609,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_10_002: [ If the given methodName already has an associated delegate, the existing delegate shall be removed. ]
         public async Task DeviceClientSetMethodHandlerOverwriteExistingDelegate()
         {
             string connectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;SharedAccessKey=dGVzdFN0cmluZzE=";
@@ -688,7 +668,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_24_001: [ If the default callback has already been set, it is replaced with the new callback. ]
         public async Task DeviceClientSetMethodHandlerOverwriteExistingDefaultDelegate()
         {
             string connectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;SharedAccessKey=dGVzdFN0cmluZzE=";
@@ -748,8 +727,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_10_004: [ The deviceMethods property shall be deleted if the last delegate has been removed. ]
-        // Tests_SRS_DEVICECLIENT_10_006: [ It shall DisableMethodsAsync when the last delegate has been removed. ]
         public async Task DeviceClientSetMethodHandlerUnsetLastMethodHandler()
         {
             string connectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;SharedAccessKey=dGVzdFN0cmluZzE=";
@@ -792,8 +769,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_10_004: [ The deviceMethods property shall be deleted if the last delegate has been removed. ]
-        // Tests_SRS_DEVICECLIENT_10_006: [ It shall DisableMethodsAsync when the last delegate has been removed. ]
         public async Task DeviceClientSetMethodHandlerUnsetLastMethodHandlerWithDefaultHandlerSet()
         {
             string connectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;SharedAccessKey=dGVzdFN0cmluZzE=";
@@ -853,8 +828,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_10_004: [ The deviceMethods property shall be deleted if the last delegate has been removed. ]
-        // Tests_SRS_DEVICECLIENT_10_006: [ It shall DisableMethodsAsync when the last delegate has been removed. ]
         public async Task DeviceClientSetMethodHandlerUnsetDefaultHandlerSet()
         {
             string connectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;SharedAccessKey=dGVzdFN0cmluZzE=";
@@ -927,9 +900,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_28_024: [** `OnConnectionOpened` shall invoke the connectionStatusChangesHandler if ConnectionStatus is changed **]**
-        // Tests_SRS_DEVICECLIENT_28_025: [** `SetConnectionStatusChangesHandler` shall set connectionStatusChangesHandler **]**
-        // Tests_SRS_DEVICECLIENT_28_026: [** `SetConnectionStatusChangesHandler` shall unset connectionStatusChangesHandler if `statusChangesHandler` is null **]**
         public void DeviceClientOnConnectionOpenedInvokeHandlerForStatusChange()
         {
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -953,7 +923,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_28_026: [** `SetConnectionStatusChangesHandler` shall unset connectionStatusChangesHandler if `statusChangesHandler` is null **]**
         public void DeviceClientOnConnectionOpenedWithNullHandler()
         {
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -976,7 +945,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_28_024: [** `OnConnectionOpened` shall invoke the connectionStatusChangesHandler if ConnectionStatus is changed **]**
         public void DeviceClientOnConnectionOpenedNotInvokeHandlerWithoutStatusChange()
         {
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -1006,8 +974,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        // Tests_SRS_DEVICECLIENT_28_022: [** `OnConnectionClosed` shall invoke the RecoverConnections process. **]**
-        // Tests_SRS_DEVICECLIENT_28_023: [** `OnConnectionClosed` shall invoke the connectionStatusChangesHandler if ConnectionStatus is changed. **]**
         public void DeviceClientOnConnectionClosedInvokeHandlerAndRecoveryForStatusChange()
         {
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -1055,7 +1021,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             DeviceClient client = DeviceClient.CreateFromConnectionString(FakeConnectionString);
 
-            Func<Task> act = async () => await client.CompleteAsync((Message)null);
+            Func<Task> act = async () => await client.CompleteMessageAsync((Message)null);
 
             act.Should().Throw<ArgumentNullException>();
         }
@@ -1065,7 +1031,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             DeviceClient client = DeviceClient.CreateFromConnectionString(FakeConnectionString);
 
-            Func<Task> act = async () => await client.CompleteAsync((Message)null, CancellationToken.None);
+            Func<Task> act = async () => await client.CompleteMessageAsync((Message)null, CancellationToken.None);
 
             act.Should().Throw<ArgumentNullException>();
         }
@@ -1075,7 +1041,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             DeviceClient client = DeviceClient.CreateFromConnectionString(FakeConnectionString);
 
-            Func<Task> act = async () => await client.CompleteAsync((string)null);
+            Func<Task> act = async () => await client.CompleteMessageAsync((string)null);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -1084,7 +1050,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             DeviceClient client = DeviceClient.CreateFromConnectionString(FakeConnectionString);
 
-            Func<Task> act = async () => await client.CompleteAsync((string)null, CancellationToken.None);
+            Func<Task> act = async () => await client.CompleteMessageAsync((string)null, CancellationToken.None);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -1093,7 +1059,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             DeviceClient client = DeviceClient.CreateFromConnectionString(FakeConnectionString);
 
-            Func<Task> act = async () => await client.RejectAsync((Message)null);
+            Func<Task> act = async () => await client.RejectMessageAsync((Message)null);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -1102,7 +1068,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             DeviceClient client = DeviceClient.CreateFromConnectionString(FakeConnectionString);
 
-            Func<Task> act = async () => await client.RejectAsync((Message)null, CancellationToken.None);
+            Func<Task> act = async () => await client.RejectMessageAsync((Message)null, CancellationToken.None);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -1111,7 +1077,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             DeviceClient client = DeviceClient.CreateFromConnectionString(FakeConnectionString);
 
-            Func<Task> act = async () => await client.RejectAsync((string)null);
+            Func<Task> act = async () => await client.RejectMessageAsync((string)null);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -1120,7 +1086,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             DeviceClient client = DeviceClient.CreateFromConnectionString(FakeConnectionString);
 
-            Func<Task> act = async () => await client.RejectAsync((string)null, CancellationToken.None);
+            Func<Task> act = async () => await client.RejectMessageAsync((string)null, CancellationToken.None);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -1129,7 +1095,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             DeviceClient client = DeviceClient.CreateFromConnectionString(FakeConnectionString);
 
-            Func<Task> act = async () => await client.AbandonAsync((Message)null);
+            Func<Task> act = async () => await client.AbandonMessageAsync((Message)null);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -1138,7 +1104,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             DeviceClient client = DeviceClient.CreateFromConnectionString(FakeConnectionString);
 
-            Func<Task> act = async () => await client.AbandonAsync((Message)null, CancellationToken.None);
+            Func<Task> act = async () => await client.AbandonMessageAsync((Message)null, CancellationToken.None);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -1147,7 +1113,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             DeviceClient client = DeviceClient.CreateFromConnectionString(FakeConnectionString);
 
-            Func<Task> act = async () => await client.AbandonAsync((string)null);
+            Func<Task> act = async () => await client.AbandonMessageAsync((string)null);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -1156,7 +1122,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             DeviceClient client = DeviceClient.CreateFromConnectionString(FakeConnectionString);
 
-            Func<Task> act = async () => await client.AbandonAsync((string)null, CancellationToken.None);
+            Func<Task> act = async () => await client.AbandonMessageAsync((string)null, CancellationToken.None);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -1533,7 +1499,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        public void DeviceClient_ReceiveAsync_Cancelled_MaintainLegacyExecptionBehavior()
+        public void DeviceClient_ReceiveAsync_Cancelled_ThrowsOperationCanceledException()
         {
             //arrange
             using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString);
@@ -1557,15 +1523,15 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // act
 
-            Func<Task> act = async () => await deviceClient.ReceiveAsync(cts.Token);
+            Func<Task> act = async () => await deviceClient.ReceiveMessageAsync(cts.Token);
 
             // assert
 
-            act.Should().Throw<IotHubCommunicationException>();
+            act.Should().Throw<OperationCanceledException>();
         }
 
         [TestMethod]
-        public void DeviceClient_CompleteAsync_Cancelled_MaintainLegacyExecptionBehavior()
+        public void DeviceClient_CompleteAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
 
@@ -1590,15 +1556,15 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // act
 
-            Func<Task> act = async () => await deviceClient.CompleteAsync("SomeToken", cts.Token);
+            Func<Task> act = async () => await deviceClient.CompleteMessageAsync("SomeToken", cts.Token);
 
             // assert
 
-            act.Should().Throw<IotHubCommunicationException>();
+            act.Should().Throw<OperationCanceledException>();
         }
 
         [TestMethod]
-        public void DeviceClient_RejectAsync_Cancelled_MaintainLegacyExecptionBehavior()
+        public void DeviceClient_RejectAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
 
@@ -1623,15 +1589,15 @@ namespace Microsoft.Azure.Devices.Client.Test
             using var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            Func<Task> act = async () => await deviceClient.RejectAsync("SomeToken", cts.Token);
+            Func<Task> act = async () => await deviceClient.RejectMessageAsync("SomeToken", cts.Token);
 
             // assert
 
-            act.Should().Throw<IotHubCommunicationException>();
+            act.Should().Throw<OperationCanceledException>();
         }
 
         [TestMethod]
-        public void DeviceClient_SendEventAsync_Cancelled_MaintainLegacyExecptionBehavior()
+        public void DeviceClient_SendEventAsync_Cancelled_ThrowsOperationCanceledException()
         {
             //arrange
 
@@ -1661,11 +1627,11 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // assert
 
-            act.Should().Throw<IotHubCommunicationException>();
+            act.Should().Throw<OperationCanceledException>();
         }
 
         [TestMethod]
-        public void DeviceClient_OpenAsync_Cancelled_MaintainLegacyExecptionBehavior()
+        public void DeviceClient_OpenAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
 
@@ -1694,11 +1660,11 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // assert
 
-            act.Should().Throw<IotHubCommunicationException>();
+            act.Should().Throw<OperationCanceledException>();
         }
 
         [TestMethod]
-        public void DeviceClient_AbandonAsync_Cancelled_MaintainLegacyExecptionBehavior()
+        public void DeviceClient_AbandonAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
 
@@ -1723,15 +1689,15 @@ namespace Microsoft.Azure.Devices.Client.Test
             using var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            Func<Task> act = async () => await deviceClient.AbandonAsync("SomeLockToken", cts.Token);
+            Func<Task> act = async () => await deviceClient.AbandonMessageAsync("SomeLockToken", cts.Token);
 
             // assert
 
-            act.Should().Throw<IotHubCommunicationException>();
+            act.Should().Throw<OperationCanceledException>();
         }
 
         [TestMethod]
-        public void DeviceClient_UpdateReportedPropertiesAsync_Cancelled_MaintainLegacyExecptionBehavior()
+        public void DeviceClient_UpdateReportedPropertiesAsync_Cancelled_ThrowsOperationCanceledException()
         {
             //arrange
 
@@ -1760,11 +1726,11 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // assert
 
-            act.Should().Throw<IotHubCommunicationException>();
+            act.Should().Throw<OperationCanceledException>();
         }
 
         [TestMethod]
-        public void DeviceClient_GetTwinAsync_Cancelled_MaintainLegacyExecptionBehavior()
+        public void DeviceClient_GetTwinAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
 
@@ -1793,11 +1759,11 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // assert
 
-            act.Should().Throw<IotHubCommunicationException>();
+            act.Should().Throw<OperationCanceledException>();
         }
 
         [TestMethod]
-        public void DeviceClient_CloseAsync_Cancelled_MaintainLegacyExecptionBehavior()
+        public void DeviceClient_CloseAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
 
@@ -1830,7 +1796,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        public void DeviceClient_SetDesiredPropertyCallbackAsync_Cancelled_MaintainLegacyExecptionBehavior()
+        public void DeviceClient_SetDesiredPropertyCallbackAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
 
@@ -1866,7 +1832,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // assert
 
-            act.Should().Throw<TaskCanceledException>();
+            act.Should().Throw<OperationCanceledException>();
         }
 
 


### PR DESCRIPTION
Incremental changes on the way to making DeviceClient and ModuleClient use ctors and be unit testable.

Upcoming changes include removing overrides that don't take cancellation tokens, documenting exceptions, rearranging methods...