### PR TITLE
sdk source .net framework dependency change to NS2.0

### DIFF
--- a/authentication/src/Microsoft.Azure.Devices.Authentication.csproj
+++ b/authentication/src/Microsoft.Azure.Devices.Authentication.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.1;netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/common/src/HttpContentExtensions.cs
+++ b/common/src/HttpContentExtensions.cs
@@ -15,50 +15,34 @@ namespace Microsoft.Azure.Devices
     {
         internal static async Task CopyToStreamAsync(this HttpContent content, Stream stream, CancellationToken cancellationToken)
         {
-#if NET5_0_OR_GREATER
-            await content.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
-#else
             // .NET implementations < .NET 5.0 do not support CancellationTokens for HttpContent APIs, so we will discard it.
             _ = cancellationToken;
 
             await content.CopyToAsync(stream).ConfigureAwait(false);
-#endif
         }
 
         internal static Task<Stream> ReadHttpContentAsStream(this HttpContent httpContent, CancellationToken cancellationToken)
         {
-#if NET5_0_OR_GREATER
-            return httpContent.ReadAsStreamAsync(cancellationToken);
-#else
             // .NET implementations < .NET 5.0 do not support CancellationTokens for HttpContent APIs, so we will discard it.
             _ = cancellationToken;
 
             return httpContent.ReadAsStreamAsync();
-#endif
         }
 
         internal static Task<byte[]> ReadHttpContentAsByteArrayAsync(this HttpContent content, CancellationToken cancellationToken)
         {
-#if NET5_0_OR_GREATER
-            return content.ReadAsByteArrayAsync(cancellationToken);
-#else
             // .NET implementations < .NET 5.0 do not support CancellationTokens for HttpContent APIs, so we will discard it.
             _ = cancellationToken;
 
             return content.ReadAsByteArrayAsync();
-#endif
         }
 
         internal static Task<string> ReadHttpContentAsStringAsync(this HttpContent content, CancellationToken cancellationToken)
         {
-#if NET5_0_OR_GREATER
-            return content.ReadAsStringAsync(cancellationToken);
-#else
             // .NET implementations < .NET 5.0 do not support CancellationTokens for HttpContent APIs, so we will discard it.
             _ = cancellationToken;
 
             return content.ReadAsStringAsync();
-#endif
         }
 
     }

--- a/common/src/StreamExtensions.cs
+++ b/common/src/StreamExtensions.cs
@@ -14,11 +14,7 @@ namespace Microsoft.Azure.Devices
     {
         internal static async Task WriteToStreamAsync(this Stream stream, byte[] requestBytes, CancellationToken cancellationToken)
         {
-#if NETSTANDARD2_0
             await stream.WriteAsync(requestBytes, 0, requestBytes.Length, cancellationToken).ConfigureAwait(false);
-#else
-            await stream.WriteAsync(requestBytes, cancellationToken).ConfigureAwait(false);
-#endif
         }
     }
 }

--- a/common/src/service/ExceptionHandlingHelper.cs
+++ b/common/src/service/ExceptionHandlingHelper.cs
@@ -140,19 +140,11 @@ namespace Microsoft.Azure.Devices
                     {
                         foreach (string messageField in messageFields)
                         {
-#if NETSTANDARD2_0
                             if (messageField.IndexOf(CommonConstants.ErrorCode, StringComparison.OrdinalIgnoreCase) >= 0)
-#else
-                            if (messageField.Contains(CommonConstants.ErrorCode, StringComparison.OrdinalIgnoreCase))
-#endif
                             {
                                 const char errorCodeDelimiter = ':';
 
-#if NETSTANDARD2_0
                                 if (messageField.IndexOf(errorCodeDelimiter) >= 0)
-#else
-                                if (messageField.Contains(errorCodeDelimiter))
-#endif
                                 {
                                     string[] errorCodeFields = messageField.Split(errorCodeDelimiter);
                                     if (Enum.TryParse(errorCodeFields[1], out ErrorCode errorCode))

--- a/common/src/service/HttpClientHelper.cs
+++ b/common/src/service/HttpClientHelper.cs
@@ -870,14 +870,9 @@ namespace Microsoft.Azure.Devices
 
         internal static HttpMessageHandler CreateDefaultHttpMessageHandler(IWebProxy webProxy, Uri baseUri, int connectionLeaseTimeoutMilliseconds)
         {
-#if NET5_0_OR_GREATER
-            var httpMessageHandler = new SocketsHttpHandler();
-            httpMessageHandler.SslOptions.EnabledSslProtocols = TlsVersions.Instance.Preferred;
-#else
             var httpMessageHandler = new HttpClientHandler();
             httpMessageHandler.SslProtocols = TlsVersions.Instance.Preferred;
             httpMessageHandler.CheckCertificateRevocationList = TlsVersions.Instance.CertificateRevocationCheck;
-#endif
 
             if (webProxy != DefaultWebProxySettings.Instance)
             {

--- a/common/src/service/StringValidationHelper.cs
+++ b/common/src/service/StringValidationHelper.cs
@@ -58,11 +58,7 @@ namespace Microsoft.Azure.Devices.Common
 
         public static bool IsBase64String(string value)
         {
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-            value = value.Replace("\r", string.Empty, StringComparison.Ordinal).Replace("\n", string.Empty, StringComparison.Ordinal);
-#else
             value = value.Replace("\r", string.Empty).Replace("\n", string.Empty);
-#endif
 
             if (value.Length == 0
                 || value.Length % 4 != 0)

--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -31,10 +31,10 @@ This may not be sufficient to run certain samples that require Visual Studio and
 
 ## Optional Setup required to test Xamarin, Windows IoT
 
-### Installing Visual Studio 2017 for Xamarin applications
+### Installing Visual Studio for Xamarin applications
 
-- Install [Visual Studio 2017][visual-studio]. You can use the **Visual Studio Community** Free download if you meet the licensing requirements.
-- During the installation of Visual Studio 2017, we found that selecting the following workloads and components helps in running and debugging the SDK.
+- Install [Visual Studio][visual-studio]. You can use the **Visual Studio Community** Free download if you meet the licensing requirements.
+- During the installation of Visual Studio, we found that selecting the following workloads and components helps in running and debugging the SDK.
 
 Workloads:
 ![](./workloads.png)
@@ -44,7 +44,7 @@ Components:
 
 ### Installing Windows IoT Core SDK
 
-Install the Microsoft IoT Windows Core Project Templates for Visual Studio 2017 from the Extension Marketplace:
+Install the Microsoft IoT Windows Core Project Templates for Visual Studio 2017+ from the Extension Marketplace:
     https://marketplace.visualstudio.com/items?itemName=MicrosoftIoT.WindowsIoTCoreProjectTemplatesforVS15
 
 ### [Deprecated] Installing .NET Micro Framework

--- a/iothub/device/src/Authentication/HsmAuthentication/Transport/HttpBufferedStream.cs
+++ b/iothub/device/src/Authentication/HsmAuthentication/Transport/HttpBufferedStream.cs
@@ -48,13 +48,9 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication.Transport
             var builder = new StringBuilder();
             while (true)
             {
-#if NETSTANDARD2_0
                 int length = await _innerStream
                     .ReadAsync(buffer, 0, buffer.Length, cancellationToken)
                     .ConfigureAwait(false);
-#else
-                int length = await _innerStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
-#endif
 
                 if (length == 0)
                 {

--- a/iothub/device/src/Authentication/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
+++ b/iothub/device/src/Authentication/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
@@ -50,13 +50,9 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication.Transport
             //
             // Since then the UnixDomainSocketEndpoint has been added to the dotnet framework and there has been considerable work
             // around unix sockets in the BCL. For older versions of the framework we will continue to use the existing class since it works
-            // fine. For netcore 2.1 and greater as well as .NET 5.0 and greater we'll use the native framework version.
+            // fine. For netcore 2.1 and greater as well as .NET 5.0 and greater the native framework version can be an alternatve.
 
-#if NETSTANDARD2_0
             var endpoint = new Microsoft.Azure.Devices.Client.HsmAuthentication.Transport.UnixDomainSocketEndPoint(_providerUri.LocalPath);
-#else
-            var endpoint = new System.Net.Sockets.UnixDomainSocketEndPoint(_providerUri.LocalPath);
-#endif
             await socket.ConnectAsync(endpoint).ConfigureAwait(false);
             return socket;
         }

--- a/iothub/device/src/Common/Data/SharedAccessSignatureAuthorizationRule.cs
+++ b/iothub/device/src/Common/Data/SharedAccessSignatureAuthorizationRule.cs
@@ -62,7 +62,6 @@ namespace Microsoft.Azure.Devices.Client
 
             int hashKeyName, hashPrimaryKey, hashSecondaryKey, hashRights;
 
-#if NETSTANDARD2_0
             hashKeyName = rule.KeyName == null
                 ? 0
                 : rule.KeyName.GetHashCode();
@@ -76,21 +75,6 @@ namespace Microsoft.Azure.Devices.Client
                 : rule.SecondaryKey.GetHashCode();
 
             hashRights = rule.Rights.GetHashCode();
-#else
-            hashKeyName = rule.KeyName == null
-                ? 0
-                : rule.KeyName.GetHashCode(StringComparison.InvariantCultureIgnoreCase);
-
-            hashPrimaryKey = rule.PrimaryKey == null
-                ? 0
-                : rule.PrimaryKey.GetHashCode(StringComparison.InvariantCultureIgnoreCase);
-
-            hashSecondaryKey = rule.SecondaryKey == null
-                ? 0
-                : rule.SecondaryKey.GetHashCode(StringComparison.InvariantCultureIgnoreCase);
-
-            hashRights = rule.Rights.GetHashCode();
-#endif
 
             return hashKeyName ^ hashPrimaryKey ^ hashSecondaryKey ^ hashRights;
         }

--- a/iothub/device/src/Common/Security/StringValidationHelper.cs
+++ b/iothub/device/src/Common/Security/StringValidationHelper.cs
@@ -48,13 +48,8 @@ namespace Microsoft.Azure.Devices.Client
 
         public static bool IsBase64String(string value)
         {
-#if NETSTANDARD2_0
             value = value.Replace("\r", string.Empty)
                 .Replace("\n", string.Empty);
-#else
-            value = value.Replace("\r", string.Empty, StringComparison.InvariantCultureIgnoreCase)
-                .Replace("\n", string.Empty, StringComparison.InvariantCultureIgnoreCase);
-#endif
             if (value.Length == 0 || value.Length % 4 != 0)
             {
                 return false;

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     /// <threadsafety static="true" instance="true" />
     public class DeviceClient : IDisposable
-#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
         , IAsyncDisposable
 #endif
     {
@@ -656,7 +656,7 @@ namespace Microsoft.Azure.Devices.Client
             GC.SuppressFinalize(this);
         }
 
-#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
         // IAsyncDisposable is available in .NET Standard 2.1 and above
 
         /// <summary>

--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RootNamespace>Microsoft.Azure.Devices.Client</RootNamespace>

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Client
     /// Contains methods that a module can use to send messages to and receive from the service and interact with module twins.
     /// </summary>
     public class ModuleClient : IDisposable
-#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
         , IAsyncDisposable
 #endif
     {
@@ -491,7 +491,7 @@ namespace Microsoft.Azure.Devices.Client
             GC.SuppressFinalize(this);
         }
 
-#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
         // IAsyncDisposable is available in .NET Standard 2.1 and above
 
         /// <summary>

--- a/iothub/device/src/ProductInfo.cs
+++ b/iothub/device/src/ProductInfo.cs
@@ -56,19 +56,11 @@ namespace Microsoft.Azure.Devices.Client
 
                 if (!string.IsNullOrWhiteSpace(format))
                 {
-#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-                    infoParts = format
-                        .Replace("{runtime}", runtime, StringComparison.InvariantCultureIgnoreCase)
-                        .Replace("{operatingSystem}", operatingSystem + productType, StringComparison.InvariantCultureIgnoreCase)
-                        .Replace("{architecture}", processorArchitecture, StringComparison.InvariantCultureIgnoreCase)
-                        .Replace("{deviceId}", deviceId, StringComparison.InvariantCultureIgnoreCase);
-#else
                     infoParts = format
                         .Replace("{runtime}", runtime)
                         .Replace("{operatingSystem}", operatingSystem + productType)
                         .Replace("{architecture}", processorArchitecture)
                         .Replace("{deviceId}", deviceId);
-#endif
                 }
                 else
                 {

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotTransport.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotTransport.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
                 }
 
                 // Support for RemoteCertificateValidationCallback for ClientWebSocket is introduced in .NET Standard 2.1
-#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
                 if (_amqpTransportSettings.RemoteCertificateValidationCallback != null)
                 {
                     websocket.Options.RemoteCertificateValidationCallback = _amqpTransportSettings.RemoteCertificateValidationCallback;

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -20,12 +20,7 @@ using DotNetty.Transport.Channels;
 using Microsoft.Azure.Devices.Client.Common;
 using Microsoft.Azure.Devices.Client.Exceptions;
 using Microsoft.Azure.Devices.Client.Extensions;
-
-#if NET5_0_OR_GREATER
-using TaskCompletionSource = System.Threading.Tasks.TaskCompletionSource;
-#else
 using TaskCompletionSource = Microsoft.Azure.Devices.TaskCompletionSource;
-#endif
 
 namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 {

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -30,14 +30,7 @@ using Microsoft.Azure.Devices.Client.Exceptions;
 using Microsoft.Azure.Devices.Client.Extensions;
 using Microsoft.Azure.Devices.Client.TransientFaultHandling;
 using Newtonsoft.Json;
-
-#if NET5_0_OR_GREATER
-
-using TaskCompletionSource = System.Threading.Tasks.TaskCompletionSource;
-
-#else
 using TaskCompletionSource = Microsoft.Azure.Devices.TaskCompletionSource;
-#endif
 
 namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 {
@@ -1313,7 +1306,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 }
 
                 // Support for RemoteCertificateValidationCallback for ClientWebSocket is introduced in .NET Standard 2.1
-#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
                 if (settings.RemoteCertificateValidationCallback != null)
                 {
                     websocket.Options.RemoteCertificateValidationCallback = settings.RemoteCertificateValidationCallback;

--- a/iothub/device/src/Transport/Mqtt/PublishWorkItem.cs
+++ b/iothub/device/src/Transport/Mqtt/PublishWorkItem.cs
@@ -3,12 +3,7 @@
 
 using System;
 using DotNetty.Codecs.Mqtt.Packets;
-
-#if NET5_0_OR_GREATER
-using TaskCompletionSource = System.Threading.Tasks.TaskCompletionSource;
-#else
 using TaskCompletionSource = Microsoft.Azure.Devices.TaskCompletionSource;
-#endif
 
 namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 {

--- a/iothub/device/src/Transport/Mqtt/SimpleWorkQueue.cs
+++ b/iothub/device/src/Transport/Mqtt/SimpleWorkQueue.cs
@@ -7,12 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DotNetty.Common.Utilities;
 using DotNetty.Transport.Channels;
-
-#if NET5_0_OR_GREATER
-using TaskCompletionSource = System.Threading.Tasks.TaskCompletionSource;
-#else
 using TaskCompletionSource = Microsoft.Azure.Devices.TaskCompletionSource;
-#endif
 
 namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 {

--- a/iothub/service/src/Common/Data/SharedAccessSignatureAuthorizationRule.cs
+++ b/iothub/service/src/Common/Data/SharedAccessSignatureAuthorizationRule.cs
@@ -90,15 +90,6 @@ namespace Microsoft.Azure.Devices.Common.Data
             int hashSecondaryKey;
             int hashRights;
 
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-            hashKeyName = rule.KeyName == null ? 0 : rule.KeyName.GetHashCode(StringComparison.InvariantCultureIgnoreCase);
-
-            hashPrimaryKey = rule.PrimaryKey == null ? 0 : rule.PrimaryKey.GetHashCode(StringComparison.InvariantCultureIgnoreCase);
-
-            hashSecondaryKey = rule.SecondaryKey == null ? 0 : rule.SecondaryKey.GetHashCode(StringComparison.InvariantCultureIgnoreCase);
-
-            hashRights = rule.Rights.GetHashCode();
-#else
             hashKeyName = rule.KeyName == null ? 0 : rule.KeyName.GetHashCode();
 
             hashPrimaryKey = rule.PrimaryKey == null ? 0 : rule.PrimaryKey.GetHashCode();
@@ -106,7 +97,6 @@ namespace Microsoft.Azure.Devices.Common.Data
             hashSecondaryKey = rule.SecondaryKey == null ? 0 : rule.SecondaryKey.GetHashCode();
 
             hashRights = rule.Rights.GetHashCode();
-#endif
 
             return hashKeyName ^ hashPrimaryKey ^ hashSecondaryKey ^ hashRights;
         }

--- a/iothub/service/src/IotHubClientWebSocket.cs
+++ b/iothub/service/src/IotHubClientWebSocket.cs
@@ -392,15 +392,9 @@ namespace Microsoft.Azure.Devices
             try
             {
                 byte[] webSocketHeader = PrepareWebSocketHeader(size, webSocketMessageType);
-#if NETSTANDARD2_0
                 await WebSocketStream.WriteAsync(webSocketHeader, 0, webSocketHeader.Length).ConfigureAwait(false);
                 MaskWebSocketData(buffer, offset, size);
                 await WebSocketStream.WriteAsync(buffer, offset, size).ConfigureAwait(false);
-#else
-                await WebSocketStream.WriteAsync(webSocketHeader).ConfigureAwait(false);
-                MaskWebSocketData(buffer, offset, size);
-                await WebSocketStream.WriteAsync(buffer.AsMemory(offset, size)).ConfigureAwait(false);
-#endif
                 succeeded = true;
             }
             finally
@@ -973,11 +967,7 @@ namespace Microsoft.Azure.Devices
 
         private static async Task<int> ReadFromStreamAsync(Stream stream, byte[] buffer, int offset, int size)
         {
-#if NETSTANDARD2_0
             return await stream.ReadAsync(buffer, offset, size).ConfigureAwait(false);
-#else
-            return await stream.ReadAsync(buffer.AsMemory(offset, size)).ConfigureAwait(false);
-#endif
         }
 
         private static async Task WriteToStreamAsync(Stream stream, byte[] buffer)
@@ -987,11 +977,7 @@ namespace Microsoft.Azure.Devices
 
         private static async Task WriteToStreamAsync(Stream stream, byte[] buffer, int offset, int size)
         {
-#if NETSTANDARD2_0
             await stream.WriteAsync(buffer, offset, size).ConfigureAwait(false);
-#else
-            await stream.WriteAsync(buffer.AsMemory(offset, size)).ConfigureAwait(false);
-#endif
         }
     }
 }

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RootNamespace>Microsoft.Azure.Devices</RootNamespace>
@@ -51,7 +51,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net5.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|AnyCPU'">
     <NoWarn>1701;1702;1138</NoWarn>
   </PropertyGroup>
 

--- a/iothub/service/src/ServicePointHelpers.cs
+++ b/iothub/service/src/ServicePointHelpers.cs
@@ -33,12 +33,6 @@ namespace Microsoft.Azure.Devices
                     ServicePoint servicePoint = ServicePointManager.FindServicePoint(baseUri);
                     servicePoint.ConnectionLeaseTimeout = connectionLeaseTimeoutMilliseconds;
                     break;
-#if NET5_0_OR_GREATER
-                case SocketsHttpHandler socketsHttpHandler:
-                    socketsHttpHandler.MaxConnectionsPerServer = DefaultMaxConnectionsPerServer;
-                    socketsHttpHandler.PooledConnectionLifetime = TimeSpan.FromMilliseconds(connectionLeaseTimeoutMilliseconds);
-                    break;
-#endif
             }
         }
     }

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/provisioning/device/src/Transports/Amqp/AmqpClientConnection.cs
+++ b/provisioning/device/src/Transports/Amqp/AmqpClientConnection.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
             }
 
             // Support for RemoteCertificateValidationCallback for ClientWebSocket is introduced in .NET Standard 2.1
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
             if (TransportSettings.CertificateValidationCallback != null)
             {
                 websocket.Options.RemoteCertificateValidationCallback = TransportSettings.CertificateValidationCallback;

--- a/provisioning/device/src/Transports/Amqp/SaslTpmHandler.cs
+++ b/provisioning/device/src/Transports/Amqp/SaslTpmHandler.cs
@@ -77,11 +77,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
             {
                 int hashCode = _endorsementKey != null ? _endorsementKey.GetHashCode() : 0;
                 hashCode = (hashCode * 397) ^ (_storageRootKey != null ? _storageRootKey.GetHashCode() : 0);
-#if NETSTANDARD2_1
-                hashCode = (hashCode * 397) ^ (_idScope != null ? _idScope.GetHashCode(StringComparison.Ordinal) : 0);
-#else
                 hashCode = (hashCode * 397) ^ (_idScope != null ? _idScope.GetHashCode() : 0);
-#endif
                 hashCode = (hashCode * 397) ^ (_authentication != null ? _authentication.GetHashCode() : 0);
 
                 return hashCode;

--- a/provisioning/device/src/Transports/Http/Generated/RuntimeRegistration.cs
+++ b/provisioning/device/src/Transports/Http/Generated/RuntimeRegistration.cs
@@ -113,15 +113,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                 new Uri(_baseUrl + (_baseUrl.EndsWith("/", StringComparison.Ordinal) ? "" : "/")),
                 "{idScope}/registrations/{registrationId}/operations/{operationId}").ToString();
 
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-            _url = _url.Replace("{registrationId}", Uri.EscapeDataString(registrationId), StringComparison.Ordinal);
-            _url = _url.Replace("{operationId}", Uri.EscapeDataString(operationId), StringComparison.Ordinal);
-            _url = _url.Replace("{idScope}", Uri.EscapeDataString(idScope), StringComparison.Ordinal);
-#else
             _url = _url.Replace("{registrationId}", Uri.EscapeDataString(registrationId));
             _url = _url.Replace("{operationId}", Uri.EscapeDataString(operationId));
             _url = _url.Replace("{idScope}", Uri.EscapeDataString(idScope));
-#endif
 
             // Create HTTP transport objects
             var _httpRequest = new HttpRequestMessage();
@@ -306,14 +300,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                     "{idScope}/registrations/{registrationId}")
                 .ToString();
 
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-            url = url.Replace("{registrationId}", Uri.EscapeDataString(registrationId), StringComparison.Ordinal);
-            url = url.Replace("{idScope}", Uri.EscapeDataString(idScope), StringComparison.Ordinal);
-#else
             url = url.Replace("{registrationId}", Uri.EscapeDataString(registrationId));
             url = url.Replace("{idScope}", Uri.EscapeDataString(idScope));
-#endif
-
+            
             // Create HTTP transport objects
             var _httpRequest = new HttpRequestMessage();
             HttpResponseMessage _httpResponse = null;
@@ -491,13 +480,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                     "{idScope}/registrations/{registrationId}/register")
                 .ToString();
 
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-            url = url.Replace("{registrationId}", Uri.EscapeDataString(registrationId), StringComparison.Ordinal);
-            url = url.Replace("{idScope}", Uri.EscapeDataString(idScope), StringComparison.Ordinal);
-#else
             url = url.Replace("{registrationId}", Uri.EscapeDataString(registrationId));
             url = url.Replace("{idScope}", Uri.EscapeDataString(idScope));
-#endif
 
             var _queryParameters = new List<string>();
             if (forceRegistration != null)

--- a/provisioning/device/src/Transports/Http/HttpContentExtensions.cs
+++ b/provisioning/device/src/Transports/Http/HttpContentExtensions.cs
@@ -15,50 +15,34 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
     {
         internal static async Task CopyToStreamAsync(this HttpContent content, Stream stream, CancellationToken cancellationToken)
         {
-#if NET5_0_OR_GREATER
-            await content.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
-#else
             // .NET implementations < .NET 5.0 do not support CancellationTokens for HttpContent APIs, so we will discard it.
             _ = cancellationToken;
 
             await content.CopyToAsync(stream).ConfigureAwait(false);
-#endif
         }
 
         internal static Task<Stream> ReadHttpContentAsStream(this HttpContent httpContent, CancellationToken cancellationToken)
         {
-#if NET5_0_OR_GREATER
-            return httpContent.ReadAsStreamAsync(cancellationToken);
-#else
             // .NET implementations < .NET 5.0 do not support CancellationTokens for HttpContent APIs, so we will discard it.
             _ = cancellationToken;
 
             return httpContent.ReadAsStreamAsync();
-#endif
         }
 
         internal static Task<byte[]> ReadHttpContentAsByteArrayAsync(this HttpContent content, CancellationToken cancellationToken)
         {
-#if NET5_0_OR_GREATER
-            return content.ReadAsByteArrayAsync(cancellationToken);
-#else
             // .NET implementations < .NET 5.0 do not support CancellationTokens for HttpContent APIs, so we will discard it.
             _ = cancellationToken;
 
             return content.ReadAsByteArrayAsync();
-#endif
         }
 
         internal static Task<string> ReadHttpContentAsStringAsync(this HttpContent content, CancellationToken cancellationToken)
         {
-#if NET5_0_OR_GREATER
-            return content.ReadAsStringAsync(cancellationToken);
-#else
             // .NET implementations < .NET 5.0 do not support CancellationTokens for HttpContent APIs, so we will discard it.
             _ = cancellationToken;
 
             return content.ReadAsStringAsync();
-#endif
         }
 
     }

--- a/provisioning/device/src/Transports/Http/TPM/TpmCredentials.cs
+++ b/provisioning/device/src/Transports/Http/TPM/TpmCredentials.cs
@@ -25,21 +25,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
             {
                 Action<string> action = (value) =>
                 {
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-                    _sasToken = value.Replace(SASHeaderName + " ", "", StringComparison.Ordinal);
-#else
                     _sasToken = value.Replace(SASHeaderName + " ", "");
-#endif
                     SetAuthorizationHeader(request, _sasToken);
                 };
 
-#if NET5_0_OR_GREATER
-                HttpRequestOptions requestOptions = request.Options;
-                var requestOptionsKey = new HttpRequestOptionsKey<Action<string>>(TpmDelegatingHandler.ProvisioningHeaderName);
-                requestOptions.Set(requestOptionsKey, action);
-#else
                 request.Properties.Add(TpmDelegatingHandler.ProvisioningHeaderName, action);
-#endif
             }
             else
             {

--- a/provisioning/device/src/Transports/Http/TPM/TpmDelegatingHandler.cs
+++ b/provisioning/device/src/Transports/Http/TPM/TpmDelegatingHandler.cs
@@ -32,11 +32,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
             if(response.StatusCode == HttpStatusCode.Unauthorized)
             {
-#if NET5_0_OR_GREATER
-                if (request.Options.TryGetValue(new HttpRequestOptionsKey<object>(ProvisioningHeaderName), out object result))
-#else
                 if (request.Properties.TryGetValue(ProvisioningHeaderName, out object result))
-#endif
                 {
                     if (result is Action<string> setSasToken)
                     {

--- a/provisioning/device/src/Transports/Mqtt/ProvisioningTransportHandlerMqtt.cs
+++ b/provisioning/device/src/Transports/Mqtt/ProvisioningTransportHandlerMqtt.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
             }
 
             // Support for RemoteCertificateValidationCallback for ClientWebSocket is introduced in .NET Standard 2.1
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
             if (RemoteCertificateValidationCallback != null)
             {
                 websocket.Options.RemoteCertificateValidationCallback = RemoteCertificateValidationCallback;

--- a/provisioning/service/src/Authentication/SharedAccessSignatureAuthorizationRule.cs
+++ b/provisioning/service/src/Authentication/SharedAccessSignatureAuthorizationRule.cs
@@ -57,11 +57,7 @@ namespace Microsoft.Azure.Devices.Common.Service.Auth
 
         public override int GetHashCode()
         {
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-            return (_primaryKey + _secondaryKey).GetHashCode(StringComparison.Ordinal);
-#else
             return (_primaryKey + _secondaryKey).GetHashCode();
-#endif
         }
     }
 }

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
+++ b/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
sdk source .net framework dependency change to NS2.0 and NS2.1 (remove net5.0)

<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
<!-- include test results -->
Completed local E2E test with zero error
- [ ] This pull-request is submitted against the `main` branch.
<!-- If not against main, please add the reason. -->
Part of the SDK clean up, for previews/v2 branch

## Description of the changes
removed net5.0 framework dependency
default to netstandard2.0 feature set whenever possible

## Reference/Link to the issue solved with this PR (if any)
Part of the SDK clean-up, for previews/v2