### PR TITLE
Cleanup and trim out waste in c2d tests

### DIFF
--- a/e2e/test/helpers/templates/PoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/PoolingOverAmqp.cs
@@ -58,14 +58,15 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                 totalRuns++;
 
                 // Arrange
-                // Initialize the test device client instances
-                // Set the device client connection status change handler
+
                 logger.Trace($">>> {nameof(PoolingOverAmqp)} Initializing device clients for multiplexing test - Test run {totalRuns}");
                 for (int i = 0; i < devicesCount; i++)
                 {
+                    // Initialize the test device client instances
                     TestDevice testDevice = await TestDevice.GetTestDeviceAsync(logger, $"{devicePrefix}_{i}_").ConfigureAwait(false);
                     DeviceClient deviceClient = testDevice.CreateDeviceClient(transportSettings, authScope);
 
+                    // Set the device client connection status change handler
                     var amqpConnectionStatusChange = new AmqpConnectionStatusChange(logger);
                     deviceClient.SetConnectionStatusChangesHandler(amqpConnectionStatusChange.ConnectionStatusChangesHandler);
 
@@ -78,12 +79,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
 
                     if (initOperation != null)
                     {
-                        operations.Add(initOperation(deviceClient, testDevice, testDeviceCallbackHandler));
+                        await initOperation(deviceClient, testDevice, testDeviceCallbackHandler).ConfigureAwait(false);
                     }
                 }
-
-                await Task.WhenAll(operations).ConfigureAwait(false);
-                operations.Clear();
 
                 try
                 {

--- a/e2e/test/iothub/messaging/MessageReceiveE2EPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2EPoolAmqpTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
 using Microsoft.Azure.Devices.E2ETests.Helpers.Templates;
@@ -20,56 +19,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
     {
         private readonly string DevicePrefix = $"E2E_{nameof(MessageReceiveE2EPoolAmqpTests)}_";
 
-        [Ignore]
-        [LoggedTestMethod]
-        public async Task Message_DeviceSak_DeviceReceiveSingleMessage_SingleConnection_Amqp()
-        {
-            await ReceiveMessagePoolOverAmqpAsync(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount)
-                .ConfigureAwait(false);
-        }
-
-        [Ignore]
-        [LoggedTestMethod]
-        public async Task Message_DeviceSak_DeviceReceiveSingleMessage_SingleConnection_AmqpWs()
-        {
-            await ReceiveMessagePoolOverAmqpAsync(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount)
-                .ConfigureAwait(false);
-        }
-
-        [Ignore]
-        [LoggedTestMethod]
-        public async Task Message_IoTHubSak_DeviceReceiveSingleMessage_SingleConnection_Amqp()
-        {
-            await ReceiveMessagePoolOverAmqpAsync(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        [Ignore]
-        [LoggedTestMethod]
-        public async Task Message_IoTHubSak_DeviceReceiveSingleMessage_SingleConnection_AmqpWs()
-        {
-            await ReceiveMessagePoolOverAmqpAsync(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.SingleConnection_PoolSize,
-                    PoolingOverAmqp.SingleConnection_DevicesCount,
-                    ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
         [LoggedTestMethod]
         public async Task Message_DeviceSak_DeviceReceiveSingleMessage_MultipleConnections_Amqp()
         {
-            await ReceiveMessagePoolOverAmqpAsync(
+            await ReceiveMessage_PoolOverAmqpAsync(
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
                     PoolingOverAmqp.MultipleConnections_DevicesCount)
@@ -79,7 +32,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [LoggedTestMethod]
         public async Task Message_DeviceSak_DeviceReceiveSingleMessage_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessagePoolOverAmqpAsync(
+            await ReceiveMessage_PoolOverAmqpAsync(
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
                     PoolingOverAmqp.MultipleConnections_DevicesCount)
@@ -89,7 +42,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_DeviceReceiveSingleMessage_MultipleConnections_Amqp()
         {
-            await ReceiveMessagePoolOverAmqpAsync(
+            await ReceiveMessage_PoolOverAmqpAsync(
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
                     PoolingOverAmqp.MultipleConnections_DevicesCount,
@@ -100,7 +53,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_DeviceReceiveSingleMessage_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessagePoolOverAmqpAsync(
+            await ReceiveMessage_PoolOverAmqpAsync(
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
                     PoolingOverAmqp.MultipleConnections_DevicesCount,
@@ -111,7 +64,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [LoggedTestMethod]
         public async Task Message_DeviceSak_DeviceReceiveSingleMessageUsingCallback_MultipleConnections_Amqp()
         {
-            await ReceiveMessageUsingCallbackPoolOverAmqpAsync(
+            await ReceiveMessageUsingCallback_PoolOverAmqpAsync(
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
                     PoolingOverAmqp.MultipleConnections_DevicesCount)
@@ -121,7 +74,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [LoggedTestMethod]
         public async Task Message_DeviceSak_DeviceReceiveSingleMessageUsingCallback_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessageUsingCallbackPoolOverAmqpAsync(
+            await ReceiveMessageUsingCallback_PoolOverAmqpAsync(
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
                     PoolingOverAmqp.MultipleConnections_DevicesCount)
@@ -131,7 +84,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_DeviceReceiveSingleMessageUsingCallback_MultipleConnections_Amqp()
         {
-            await ReceiveMessageUsingCallbackPoolOverAmqpAsync(
+            await ReceiveMessageUsingCallback_PoolOverAmqpAsync(
                     Client.TransportType.Amqp_Tcp_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
                     PoolingOverAmqp.MultipleConnections_DevicesCount,
@@ -142,7 +95,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [LoggedTestMethod]
         public async Task Message_IoTHubSak_DeviceReceiveSingleMessageUsingCallback_MultipleConnections_AmqpWs()
         {
-            await ReceiveMessageUsingCallbackPoolOverAmqpAsync(
+            await ReceiveMessageUsingCallback_PoolOverAmqpAsync(
                     Client.TransportType.Amqp_WebSocket_Only,
                     PoolingOverAmqp.MultipleConnections_PoolSize,
                     PoolingOverAmqp.MultipleConnections_DevicesCount,
@@ -150,49 +103,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 .ConfigureAwait(false);
         }
 
-        [LoggedTestMethod]
-        public async Task Message_DeviceSak_DeviceReceiveSingleMessageUsingCallbackAndUnsubscribe_MultipleConnections_Amqp()
-        {
-            await ReceiveMessageUsingCallbackAndUnsubscribePoolOverAmqpAsync(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount)
-                .ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceSak_DeviceReceiveSingleMessageUsingCallbackAndUnsubscribe_MultipleConnections_AmqpWs()
-        {
-            await ReceiveMessageUsingCallbackAndUnsubscribePoolOverAmqpAsync(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount)
-                .ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_IoTHubSak_DeviceReceiveSingleMessageUsingCallbackAndUnsubscribe_MultipleConnections_Amqp()
-        {
-            await ReceiveMessageUsingCallbackAndUnsubscribePoolOverAmqpAsync(
-                    Client.TransportType.Amqp_Tcp_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_IoTHubSak_DeviceReceiveSingleMessageUsingCallbackAndUnsubscribe_MultipleConnections_AmqpWs()
-        {
-            await ReceiveMessageUsingCallbackAndUnsubscribePoolOverAmqpAsync(
-                    Client.TransportType.Amqp_WebSocket_Only,
-                    PoolingOverAmqp.MultipleConnections_PoolSize,
-                    PoolingOverAmqp.MultipleConnections_DevicesCount,
-                    ConnectionStringAuthScope.IoTHub)
-                .ConfigureAwait(false);
-        }
-
-        private async Task ReceiveMessagePoolOverAmqpAsync(
+        private async Task ReceiveMessage_PoolOverAmqpAsync(
             Client.TransportType transport,
             int poolSize,
             int devicesCount,
@@ -242,7 +153,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 .ConfigureAwait(false);
         }
 
-        private async Task ReceiveMessageUsingCallbackPoolOverAmqpAsync(
+        private async Task ReceiveMessageUsingCallback_PoolOverAmqpAsync(
             Client.TransportType transport,
             int poolSize,
             int devicesCount,
@@ -267,89 +178,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
                 await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts.Token).ConfigureAwait(false);
-            }
-
-            async Task CleanupOperationAsync()
-            {
-                await serviceClient.CloseAsync().ConfigureAwait(false);
-                serviceClient.Dispose();
-            }
-
-            await PoolingOverAmqp
-                .TestPoolAmqpAsync(
-                    DevicePrefix,
-                    transport,
-                    poolSize,
-                    devicesCount,
-                    InitOperationAsync,
-                    TestOperationAsync,
-                    CleanupOperationAsync,
-                    authScope,
-                    true,
-                    Logger)
-                .ConfigureAwait(false);
-        }
-
-        private async Task ReceiveMessageUsingCallbackAndUnsubscribePoolOverAmqpAsync(
-            Client.TransportType transport,
-            int poolSize,
-            int devicesCount,
-            ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device)
-        {
-            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
-
-            async Task InitOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler testDeviceCallbackHandler)
-            {
-                await testDeviceCallbackHandler.SetMessageReceiveCallbackHandlerAsync().ConfigureAwait(false);
-            }
-
-            async Task TestOperationAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler testDeviceCallbackHandler)
-            {
-                var generalTimeout = TimeSpan.FromSeconds(20);
-
-                // Send a message to the device from the service.
-                (Message firstMessage, string payload, _) = MessageReceiveE2ETests.ComposeC2dTestMessage(Logger);
-                testDeviceCallbackHandler.ExpectedMessageSentByService = firstMessage;
-                await serviceClient.SendAsync(testDevice.Id, firstMessage).ConfigureAwait(false);
-                Logger.Trace($"Sent 1st C2D message from service - to be received on callback: deviceId={testDevice.Id}, messageId={firstMessage.MessageId}");
-
-                // The message should be received on the callback, while a call to ReceiveMessageAsync() should return null.
-                using var ctsReceive1 = new CancellationTokenSource(generalTimeout);
-                Client.Message receivedMessage = null;
-                try
-                {
-                    receivedMessage = await deviceClient.ReceiveMessageAsync(ctsReceive1.Token).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException) { }
-                receivedMessage.Should().BeNull();
-
-                using var ctsCallback1 = new CancellationTokenSource(generalTimeout);
-                await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(ctsCallback1.Token).ConfigureAwait(false);
-
-                // Now unsubscribe from receiving c2d messages over the callback.
-                using var ctsUnsub = new CancellationTokenSource(generalTimeout);
-                await deviceClient.SetReceiveMessageHandlerAsync(null, deviceClient, ctsUnsub.Token).ConfigureAwait(false);
-
-                // Send a message to the device from the service.
-                (Message secondMessage, _, _) = MessageReceiveE2ETests.ComposeC2dTestMessage(Logger);
-                await serviceClient.SendAsync(testDevice.Id, secondMessage).ConfigureAwait(false);
-                Logger.Trace($"Sent 2nd C2D message from service - to be received on polling ReceiveMessageAsync(): deviceId={testDevice.Id}, messageId={secondMessage.MessageId}");
-
-                // This time, the message should not be received on the callback, rather it should be received on a call to ReceiveMessageAsync().
-                using var ctsCallback2 = new CancellationTokenSource();
-                Task callbackTask = testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(ctsCallback2.Token);
-
-                using var ctsReceive2 = new CancellationTokenSource(generalTimeout);
-                using Client.Message polledMessage2 = await deviceClient.ReceiveMessageAsync(ctsReceive2.Token).ConfigureAwait(false);
-                polledMessage2.MessageId.Should().Be(secondMessage.MessageId);
-                ctsCallback2.Cancel();
-
-                try
-                {
-                    await callbackTask.ConfigureAwait(false);
-                    Assert.Fail("Callback task should have thrown.");
-                }
-                catch (OperationCanceledException) { }
             }
 
             async Task CleanupOperationAsync()

--- a/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
@@ -9,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
-using Microsoft.Azure.Devices.Client.Exceptions;
 using Microsoft.Azure.Devices.Client.Transport.Mqtt;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
 using Microsoft.Azure.Devices.E2ETests.Helpers.Templates;
@@ -32,93 +32,15 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         private static readonly TimeSpan s_oneMinute = TimeSpan.FromMinutes(1);
 
         [LoggedTestMethod]
-        public async Task Message_DeviceReceiveSingleMessage_Amqp()
-        {
-            await ReceiveSingleMessageAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveSingleMessage_AmqpWs()
-        {
-            await ReceiveSingleMessageAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveSingleMessage_Mqtt()
-        {
-            await ReceiveSingleMessageAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveSingleMessage_MqttWs()
-        {
-            await ReceiveSingleMessageAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveSingleMessage_Http()
-        {
-            await ReceiveSingleMessageAsync(TestDeviceType.Sasl, Client.TransportType.Http1).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveSingleMessage_Amqp()
-        {
-            await ReceiveSingleMessageAsync(TestDeviceType.X509, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveSingleMessage_AmqpWs()
-        {
-            await ReceiveSingleMessageAsync(TestDeviceType.X509, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveSingleMessage_Mqtt()
-        {
-            await ReceiveSingleMessageAsync(TestDeviceType.X509, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveSingleMessage_MqttWs()
-        {
-            await ReceiveSingleMessageAsync(TestDeviceType.X509, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveSingleMessage_Http()
-        {
-            await ReceiveSingleMessageAsync(TestDeviceType.X509, Client.TransportType.Http1).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
         public async Task Message_DeviceReceiveSingleMessageWithCancellationToken_Amqp()
         {
-            await ReceiveSingleMessageWithCancellationTokenAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveSingleMessageWithCancellationToken_AmqpWs()
-        {
-            await ReceiveSingleMessageWithCancellationTokenAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
+            await ReceiveSingleMessageWithCancellationTokenAsync(TestDeviceType.Sasl, Client.TransportType.Amqp).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
         public async Task Message_DeviceReceiveSingleMessageWithCancellationToken_Mqtt()
         {
-            await ReceiveSingleMessageWithCancellationTokenAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveSingleMessageCancelled_Mqtt()
-        {
-            await Mqtt_ReceiveSingleMessageWithCancelledAsync(TestDeviceType.Sasl).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveSingleMessageWithCancellationToken_MqttWs()
-        {
-            await ReceiveSingleMessageWithCancellationTokenAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
+            await ReceiveSingleMessageWithCancellationTokenAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -128,269 +50,69 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         }
 
         [LoggedTestMethod]
-        public async Task X509_DeviceReceiveSingleMessageWithCancellationToken_Amqp()
+        public async Task Message_DeviceReceiveMessageCancelsAfterSpecifiedDelay_Amqp()
         {
-            await ReceiveSingleMessageWithCancellationTokenAsync(TestDeviceType.X509, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
+            await DeviceClientGivesUpWaitingForC2dMessageAsync(Client.TransportType.Amqp).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
-        public async Task X509_DeviceReceiveSingleMessageWithCancellationToken_AmqpWs()
+        public async Task Message_DeviceReceiveMessageCancelsAfterSpecifiedDelay_Mqtt()
         {
-            await ReceiveSingleMessageWithCancellationTokenAsync(TestDeviceType.X509, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveSingleMessageWithCancellationToken_Mqtt()
-        {
-            await ReceiveSingleMessageWithCancellationTokenAsync(TestDeviceType.X509, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveSingleMessageWithCancellationToken_MqttWs()
-        {
-            await ReceiveSingleMessageWithCancellationTokenAsync(TestDeviceType.X509, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveSingleMessageWithCancellationToken_Http()
-        {
-            await ReceiveSingleMessageWithCancellationTokenAsync(TestDeviceType.X509, Client.TransportType.Http1).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveMessageOperationTimeout_Amqp()
-        {
-            await ReceiveMessageWithTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveMessageOperationTimeout_AmqpWs()
-        {
-            await ReceiveMessageWithTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveMessageOperationTimeout_Mqtt()
-        {
-            await ReceiveMessageWithTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceReceiveMessageOperationTimeout_MqttWs()
-        {
-            await ReceiveMessageWithTimeoutAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        [ExpectedException(typeof(NotSupportedException))]
-        public async Task DeviceReceiveMessageUsingCallback_Http()
-        {
-            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.Sasl, Client.TransportType.Http1).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task DeviceReceiveMessageUsingCallback_Mqtt()
-        {
-            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task DeviceReceiveMessageUsingCallback_MqttWs()
-        {
-            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveMessageUsingCallback_Mqtt()
-        {
-            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.X509, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveMessageUsingCallback_MqttWs()
-        {
-            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.X509, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task DeviceReceiveMessageUsingCallbackAndUnsubscribe_Mqtt()
-        {
-            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task DeviceReceiveMessageUsingCallbackAndUnsubscribe_MqttWs()
-        {
-            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveMessageUsingCallbackAndUnsubscribe_Mqtt()
-        {
-            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.X509, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveMessageUsingCallbackAndUnsubscribe_MqttWs()
-        {
-            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.X509, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
+            await DeviceClientGivesUpWaitingForC2dMessageAsync(Client.TransportType.Mqtt).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
         public async Task DeviceReceiveMessageUsingCallback_Amqp()
         {
-            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
+            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.Sasl, Client.TransportType.Amqp).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
-        public async Task DeviceReceiveMessageUsingCallback_AmqpWs()
+        public async Task DeviceReceiveMessageUsingCallback_Mqtt()
         {
-            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveMessageUsingCallback_Amqp()
-        {
-            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.X509, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveMessageUsingCallback_AmqpWs()
-        {
-            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.X509, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
+            await ReceiveSingleMessageUsingCallbackAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
         public async Task DeviceReceiveMessageUsingCallbackAndUnsubscribe_Amqp()
         {
-            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
+            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, Client.TransportType.Amqp).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
-        public async Task DeviceReceiveMessageUsingCallbackAndUnsubscribe_AmqpWs()
+        public async Task DeviceReceiveMessageUsingCallbackAndUnsubscribe_Mqtt()
         {
-            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveMessageUsingCallbackAndUnsubscribe_Amqp()
-        {
-            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.X509, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveMessageUsingCallbackAndUnsubscribe_AmqpWs()
-        {
-            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.X509, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
+            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
         public async Task DeviceReceiveMessageUsingCallbackUpdateHandler_Mqtt()
         {
-            await ReceiveMessageUsingCallbackUpdateHandlerAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task DeviceReceiveMessageUsingCallbackUpdateHandler_MqttWs()
-        {
-            await ReceiveMessageUsingCallbackUpdateHandlerAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveMessageUsingCallbackUpdateHandler_Mqtt()
-        {
-            await ReceiveMessageUsingCallbackUpdateHandlerAsync(TestDeviceType.X509, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveMessageUsingCallbackUpdateHandler_MqttWs()
-        {
-            await ReceiveMessageUsingCallbackUpdateHandlerAsync(TestDeviceType.X509, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
+            await ReceiveMessageUsingCallbackUpdateHandlerAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
         public async Task DeviceReceiveMessageUsingCallbackUpdateHandler_Amqp()
         {
-            await ReceiveMessageUsingCallbackUpdateHandlerAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task DeviceReceiveMessageUsingCallbackUpdateHandler_AmqpWs()
-        {
-            await ReceiveMessageUsingCallbackUpdateHandlerAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveMessageUsingCallbackUpdateHandler_Amqp()
-        {
-            await ReceiveMessageUsingCallbackUpdateHandlerAsync(TestDeviceType.X509, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceiveMessageUsingCallbackUpdateHandler_AmqpWs()
-        {
-            await ReceiveMessageUsingCallbackUpdateHandlerAsync(TestDeviceType.X509, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
+            await ReceiveMessageUsingCallbackUpdateHandlerAsync(TestDeviceType.Sasl, Client.TransportType.Amqp).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
         public async Task DeviceReceivePendingMessageUsingCallback_Mqtt()
         {
-            await ReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task DeviceReceivePendingMessageUsingCallback_MqttWs()
-        {
-            await ReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
+            await ReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
         public async Task DeviceReceivePendingMessageUsingCallback_Amqp()
         {
-            await ReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task DeviceReceivePendingMessageUsingCallback_AmqpWs()
-        {
-            await ReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceivePendingMessageUsingCallback_Mqtt()
-        {
-            await ReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.X509, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceivePendingMessageUsingCallback_MqttWs()
-        {
-            await ReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.X509, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceivePendingMessageUsingCallback_Amqp()
-        {
-            await ReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.X509, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceReceivePendingMessageUsingCallback_AmqpWs()
-        {
-            await ReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.X509, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
+            await ReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, Client.TransportType.Amqp).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
         public async Task DeviceDoesNotReceivePendingMessageUsingCallback_Mqtt()
         {
             var settings = new ITransportSettings[] { new MqttTransportSettings(Client.TransportType.Mqtt_Tcp_Only) { CleanSession = true } };
-            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task DeviceDoesNotReceivePendingMessageUsingCallback_MqttWs()
-        {
-            var settings = new ITransportSettings[] { new MqttTransportSettings(Client.TransportType.Mqtt_WebSocket_Only) { CleanSession = true } };
             await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
         }
 
@@ -402,62 +124,15 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         }
 
         [LoggedTestMethod]
-        public async Task DeviceDoesNotReceivePendingMessageUsingCallback_AmqpWs()
-        {
-            var settings = new ITransportSettings[] { new AmqpTransportSettings(Client.TransportType.Amqp_WebSocket_Only) };
-            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceDoesNotReceivePendingMessageUsingCallback_Mqtt()
-        {
-            var settings = new ITransportSettings[] { new MqttTransportSettings(Client.TransportType.Mqtt_Tcp_Only) { CleanSession = true } };
-            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.X509, settings).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceDoesNotReceivePendingMessageUsingCallback_MqttWs()
-        {
-            var settings = new ITransportSettings[] { new MqttTransportSettings(Client.TransportType.Mqtt_WebSocket_Only) { CleanSession = true } };
-            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.X509, settings).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceDoesNotReceivePendingMessageUsingCallback_Amqp()
-        {
-            var settings = new ITransportSettings[] { new AmqpTransportSettings(Client.TransportType.Amqp_Tcp_Only) };
-            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.X509, settings).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task X509_DeviceDoesNotReceivePendingMessageUsingCallback_AmqpWs()
-        {
-            var settings = new ITransportSettings[] { new AmqpTransportSettings(Client.TransportType.Amqp_WebSocket_Only) };
-            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.X509, settings).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
         public async Task Message_DeviceMaintainsConnectionAfterUnsubscribing_Amqp()
         {
-            await UnsubscribeDoesNotCauseConnectionStatusEventAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceMaintainsConnectionAfterUnsubscribing_AmqpWs()
-        {
-            await UnsubscribeDoesNotCauseConnectionStatusEventAsync(TestDeviceType.Sasl, Client.TransportType.Amqp_WebSocket_Only).ConfigureAwait(false);
+            await UnsubscribeDoesNotCauseConnectionStatusEventAsync(TestDeviceType.Sasl, Client.TransportType.Amqp).ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
         public async Task Message_DeviceMaintainsConnectionAfterUnsubscribing_Mqtt()
         {
-            await UnsubscribeDoesNotCauseConnectionStatusEventAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_Tcp_Only).ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod]
-        public async Task Message_DeviceMaintainsConnectionAfterUnsubscribing_MqttWs()
-        {
-            await UnsubscribeDoesNotCauseConnectionStatusEventAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt_WebSocket_Only).ConfigureAwait(false);
+            await UnsubscribeDoesNotCauseConnectionStatusEventAsync(TestDeviceType.Sasl, Client.TransportType.Mqtt).ConfigureAwait(false);
         }
 
         public static (Message message, string payload, string p1Value) ComposeC2dTestMessage(MsTestLogger logger)
@@ -487,80 +162,45 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             sw.Start();
 
-            while (!received && sw.Elapsed < FaultInjection.RecoveryTime)
+            while (!received
+                && sw.Elapsed < FaultInjection.RecoveryTime)
             {
-                Client.Message receivedMessage = null;
+                logger.Trace($"Receiving messages for device {deviceId}.");
+
+                using var cts = new CancellationTokenSource(s_oneMinute);
+                using Client.Message receivedMessage = await dc.ReceiveMessageAsync(cts.Token).ConfigureAwait(false);
+
+                receivedMessage.Should().NotBeNull($"No message is received for device {deviceId} in {s_oneMinute}.");
 
                 try
                 {
-                    logger.Trace($"Receiving messages for device {deviceId}.");
-
-                    if (transport == Client.TransportType.Http1)
-                    {
-                        // timeout on HTTP is not supported
-                        receivedMessage = await dc.ReceiveMessageAsync().ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        using var cts = new CancellationTokenSource(s_oneMinute);
-                        receivedMessage = await dc.ReceiveMessageAsync(cts.Token).ConfigureAwait(false);
-                    }
-
-                    if (receivedMessage == null)
-                    {
-                        Assert.Fail($"No message is received for device {deviceId} in {s_oneMinute}.");
-                    }
-
-                    try
-                    {
-                        // always complete message
-                        await dc.CompleteMessageAsync(receivedMessage).ConfigureAwait(false);
-                    }
-                    catch (Exception)
-                    {
-                        // ignore exception from CompleteAsync
-                    }
-
-                    Assert.AreEqual(receivedMessage.MessageId, message.MessageId, "Received message Id is not what was sent by service");
-                    Assert.AreEqual(receivedMessage.UserId, message.UserId, "Received user Id is not what was sent by service");
-                    Assert.AreEqual(receivedMessage.To, receivedMessageDestination, "Received message destination is not what was sent by service");
-
-                    string messageData = Encoding.ASCII.GetString(receivedMessage.GetBytes());
-                    logger.Trace($"{nameof(VerifyReceivedC2dMessageAsync)}: Received message: for {deviceId}: {messageData}");
-                    if (Equals(payload, messageData))
-                    {
-                        Assert.AreEqual(1, receivedMessage.Properties.Count, $"The count of received properties did not match for device {deviceId}");
-                        System.Collections.Generic.KeyValuePair<string, string> prop = receivedMessage.Properties.Single();
-                        string propertyKey = "property1";
-                        Assert.AreEqual(propertyKey, prop.Key, $"The key \"property1\" did not match for device {deviceId}");
-                        Assert.AreEqual(message.Properties[propertyKey], prop.Value, $"The value of \"property1\" did not match for device {deviceId}");
-                        received = true;
-                    }
+                    // always complete message
+                    await dc.CompleteMessageAsync(receivedMessage).ConfigureAwait(false);
                 }
-                finally
+                catch (Exception)
                 {
-                    receivedMessage?.Dispose();
+                    // ignore exception from CompleteAsync
+                }
+
+                receivedMessage.MessageId.Should().Be(message.MessageId, "Received message Id is not what was sent by service");
+                receivedMessage.UserId.Should().Be(message.UserId, "Received user Id is not what was sent by service");
+                receivedMessage.To.Should().Be(receivedMessageDestination, "Received message destination is not what was sent by service");
+
+                string messageData = Encoding.ASCII.GetString(receivedMessage.GetBytes());
+                logger.Trace($"{nameof(VerifyReceivedC2dMessageAsync)}: Received message: for {deviceId}: {messageData}");
+                if (Equals(payload, messageData))
+                {
+                    receivedMessage.Properties.Count.Should().Be(1, $"The count of received properties did not match for device {deviceId}");
+                    KeyValuePair<string, string> prop = receivedMessage.Properties.Single();
+                    string propertyKey = "property1";
+                    prop.Key.Should().Be(propertyKey, $"The key \"property1\" did not match for device {deviceId}");
+                    prop.Value.Should().Be(message.Properties[propertyKey], $"The value of \"property1\" did not match for device {deviceId}");
+                    received = true;
                 }
             }
 
             sw.Stop();
-            Assert.IsTrue(received, $"No message received for device {deviceId} with payload={payload} in {FaultInjection.RecoveryTime}.");
-        }
-
-        public static async Task Mqtt_VerifyReceivedC2dMessageCancelledAsync(DeviceClient dc)
-        {
-            try
-            {
-                using var cts = new CancellationTokenSource(s_fiveSeconds);
-                await dc.ReceiveMessageAsync(cts.Token).ConfigureAwait(false);
-            }
-            catch (IotHubCommunicationException ex)
-                when (ex.IsTransient && ex.InnerException is OperationCanceledException)
-            {
-                return;
-            }
-
-            Assert.Fail();
+            received.Should().BeTrue($"No message received for device {deviceId} with payload={payload} in {FaultInjection.RecoveryTime}.");
         }
 
         public static async Task VerifyReceivedC2dMessageWithCancellationTokenAsync(Client.TransportType transport, DeviceClient dc, string deviceId, string payload, string p1Value, MsTestLogger logger)
@@ -570,7 +210,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             sw.Start();
 
-            while (!received && sw.Elapsed < FaultInjection.RecoveryTime)
+            while (!received
+                && sw.Elapsed < FaultInjection.RecoveryTime)
             {
                 logger.Trace($"Receiving messages for device {deviceId}.");
 
@@ -594,18 +235,46 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
                 string messageData = Encoding.ASCII.GetString(receivedMessage.GetBytes());
                 logger.Trace($"{nameof(VerifyReceivedC2dMessageWithCancellationTokenAsync)}: Received message: for {deviceId}: {messageData}");
-                if (Equals(payload, messageData))
+                if (payload == messageData)
                 {
-                    Assert.AreEqual(1, receivedMessage.Properties.Count, $"The count of received properties did not match for device {deviceId}");
-                    System.Collections.Generic.KeyValuePair<string, string> prop = receivedMessage.Properties.Single();
-                    Assert.AreEqual("property1", prop.Key, $"The key \"property1\" did not match for device {deviceId}");
-                    Assert.AreEqual(p1Value, prop.Value, $"The value of \"property1\" did not match for device {deviceId}");
+                    receivedMessage.Properties.Count.Should().Be(1, $"The count of received properties did not match for device {deviceId}");
+                    KeyValuePair<string, string> prop = receivedMessage.Properties.Single();
+                    prop.Key.Should().Be("property1", $"The key \"property1\" did not match for device {deviceId}");
+                    prop.Value.Should().Be(p1Value, $"The value of \"property1\" did not match for device {deviceId}");
                     received = true;
                 }
             }
 
             sw.Stop();
             Assert.IsTrue(received, $"No message received for device {deviceId} with payload={payload} in {FaultInjection.RecoveryTime}.");
+        }
+
+        private async Task DeviceClientGivesUpWaitingForC2dMessageAsync(Client.TransportType transportType)
+        {
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, TestDeviceType.Sasl).ConfigureAwait(false);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transportType);
+
+            await deviceClient.OpenAsync().ConfigureAwait(false);
+
+            // There is no message being sent so the device client should timeout waiting for the message.
+
+            var delay = TimeSpan.FromSeconds(3);
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                using var cts = new CancellationTokenSource(delay);
+                await deviceClient.ReceiveMessageAsync(cts.Token).ConfigureAwait(false);
+                Assert.Fail();
+            }
+            catch (OperationCanceledException)
+            {
+                sw.Stop();
+                sw.Elapsed.Should().BeCloseTo(delay, 1000, $"Cancellation didn't occur near the {delay} specified in the cancellation token.");
+            }
+            finally
+            {
+                await deviceClient.CloseAsync().ConfigureAwait(false);
+            }
         }
 
         private async Task ReceiveMessageWithTimeoutAsync(TestDeviceType type, Client.TransportType transport)
@@ -618,7 +287,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             try
             {
-                Logger.Trace($"{nameof(ReceiveMessageWithTimeoutAsync)} - using device client timeout={s_oneMinute}");
+                Logger.Trace($"{nameof(ReceiveMessageWithTimeoutAsync)} - using device client timeout={s_fiveSeconds}");
 
                 await ReceiveMessageWithoutTimeoutCheckAsync(deviceClient, s_oneMinute, s_fiveSeconds, Logger).ConfigureAwait(false);
             }
@@ -627,51 +296,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 Logger.Trace($"{nameof(ReceiveMessageWithTimeoutAsync)} - calling CloseAsync() for transport={transport}");
                 await deviceClient.CloseAsync().ConfigureAwait(false);
             }
-        }
-
-        private async Task ReceiveSingleMessageAsync(TestDeviceType type, Client.TransportType transport)
-        {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
-            using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
-
-            await deviceClient.OpenAsync().ConfigureAwait(false);
-            await serviceClient.OpenAsync().ConfigureAwait(false);
-
-            // For Mqtt - the device needs to have subscribed to the devicebound topic, in order for IoT hub to deliver messages to the device.
-            // For this reason we will make a "fake" ReceiveAsync() call, which will result in the device subscribing to the c2d topic.
-            // Note: We need this "fake" ReceiveAsync() call even though we (SDK default) CONNECT with a CleanSession flag set to 0.
-            // This is because this test device is newly created, and it has never subscribed to IoT hub c2d topic.
-            // Hence, IoT hub doesn't know about its CleanSession preference yet.
-            if (transport == Client.TransportType.Mqtt_Tcp_Only
-                || transport == Client.TransportType.Mqtt_WebSocket_Only)
-            {
-                using var cts = new CancellationTokenSource(s_fiveSeconds);
-                await deviceClient.ReceiveMessageAsync(cts.Token).ConfigureAwait(false);
-            }
-
-            (Message msg, string payload, string p1Value) = ComposeC2dTestMessage(Logger);
-            using (msg)
-            {
-                await serviceClient.SendAsync(testDevice.Id, msg).ConfigureAwait(false);
-                await VerifyReceivedC2dMessageAsync(transport, deviceClient, testDevice.Id, msg, payload, Logger).ConfigureAwait(false);
-            }
-
-            await deviceClient.CloseAsync().ConfigureAwait(false);
-            await serviceClient.CloseAsync().ConfigureAwait(false);
-        }
-
-        private async Task Mqtt_ReceiveSingleMessageWithCancelledAsync(TestDeviceType type)
-        {
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt_Tcp_Only);
-
-            await deviceClient.OpenAsync().ConfigureAwait(false);
-
-            // There is no message being sent so the device client should timeout waiting for the message.
-            await Mqtt_VerifyReceivedC2dMessageCancelledAsync(deviceClient).ConfigureAwait(false);
-
-            await deviceClient.CloseAsync().ConfigureAwait(false);
         }
 
         private async Task ReceiveSingleMessageWithCancellationTokenAsync(TestDeviceType type, Client.TransportType transport)
@@ -692,8 +316,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 || transport == Client.TransportType.Mqtt_Tcp_Only
                 || transport == Client.TransportType.Mqtt_WebSocket_Only)
             {
-                using var cts = new CancellationTokenSource(s_fiveSeconds);
-                await deviceClient.ReceiveMessageAsync(cts.Token).ConfigureAwait(false);
+                using var cts = new CancellationTokenSource(s_oneSecond);
+                try
+                {
+                    using Client.Message discardMessage = await deviceClient.ReceiveMessageAsync(cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) { }
             }
 
             (Message msg, string payload, string p1Value) = ComposeC2dTestMessage(Logger);
@@ -710,34 +338,23 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         private static async Task ReceiveMessageWithoutTimeoutCheckAsync(DeviceClient dc, TimeSpan maxTimeToWait, TimeSpan bufferTime, MsTestLogger logger)
         {
             var sw = new Stopwatch();
-            while (true)
+            logger.Trace($"{nameof(ReceiveMessageWithoutTimeoutCheckAsync)} - Calling ReceiveAsync()");
+
+            using var cts = new CancellationTokenSource(maxTimeToWait);
+            sw.Restart();
+            try
             {
-                try
-                {
-                    logger.Trace($"{nameof(ReceiveMessageWithoutTimeoutCheckAsync)} - Calling ReceiveAsync()");
-
-                    using var cts = new CancellationTokenSource(maxTimeToWait);
-                    sw.Restart();
-                    using Client.Message message = await dc.ReceiveMessageAsync(cts.Token).ConfigureAwait(false);
-                    sw.Stop();
-
-                    logger.Trace($"{nameof(ReceiveMessageWithoutTimeoutCheckAsync)} - Received message={message}; time taken={sw.ElapsedMilliseconds} ms");
-
-                    if (message == null)
-                    {
-                        break;
-                    }
-
-                    await dc.CompleteMessageAsync(message).ConfigureAwait(false);
-                }
-                finally
-                {
-                    TimeSpan maxLatency = maxTimeToWait + bufferTime;
-                    if (sw.Elapsed > maxLatency)
-                    {
-                        Assert.Fail($"ReceiveAsync did not return in {maxLatency}, instead it took {sw.Elapsed}.");
-                    }
-                }
+                using Client.Message message = await dc.ReceiveMessageAsync(cts.Token).ConfigureAwait(false);
+                sw.Stop();
+                logger.Trace($"{nameof(ReceiveMessageWithoutTimeoutCheckAsync)} - Received message={message}; time taken={sw.Elapsed}.");
+                await dc.CompleteMessageAsync(message).ConfigureAwait(false);
+                TimeSpan maxLatency = maxTimeToWait + bufferTime;
+                sw.Elapsed.Should().BeGreaterThan(maxLatency, $"ReceiveAsync did not return in {maxLatency}; instead it took {sw.Elapsed}.");
+            }
+            catch (OperationCanceledException)
+            {
+                sw.Stop();
+                Assert.Fail($"Message not received after {sw.Elapsed}");
             }
         }
 
@@ -776,14 +393,18 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
-            // For Mqtt - we will need to subscribe to the Mqtt receive telemetry topic
+            // For MQTT - we will need to subscribe to the MQTT receive telemetry topic
             // before the device can begin receiving c2d messages.
             if (transport == Client.TransportType.Mqtt_Tcp_Only
                 || transport == Client.TransportType.Mqtt_WebSocket_Only)
             {
-                using var cts1 = new CancellationTokenSource(s_fiveSeconds);
-                Client.Message leftoverMessage = await deviceClient.ReceiveMessageAsync(cts1.Token).ConfigureAwait(false);
-                Logger.Trace($"Leftover message on Mqtt was: {leftoverMessage} with Id={leftoverMessage?.MessageId}");
+                try
+                {
+                    using var cts1 = new CancellationTokenSource(s_oneSecond);
+                    using Client.Message discardMessage = await deviceClient.ReceiveMessageAsync(cts1.Token).ConfigureAwait(false);
+                    Logger.Trace($"Leftover message on Mqtt was: {discardMessage} with Id={discardMessage?.MessageId}");
+                }
+                catch (OperationCanceledException) { }
             }
 
             // First receive message using the polling ReceiveAsync() API.
@@ -805,11 +426,18 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await serviceClient.SendAsync(testDevice.Id, secondMessage).ConfigureAwait(false);
             Logger.Trace($"Sent C2D message from service, messageId={secondMessage.MessageId} - to be received on callback");
 
-            // The message should be received on the callback, while a call to ReceiveAsync() should return null.
-            using var cts3 = new CancellationTokenSource(s_tenSeconds);
-            using Client.Message receivedSecondMessage = await deviceClient.ReceiveMessageAsync(cts3.Token).ConfigureAwait(false);
-            await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts3.Token).ConfigureAwait(false);
-            receivedSecondMessage.Should().BeNull();
+            // A call to ReceiveAsync() should return null.
+            try
+            {
+                using var cts3 = new CancellationTokenSource(s_fiveSeconds);
+                using Client.Message receivedSecondMessage = await deviceClient.ReceiveMessageAsync(cts3.Token).ConfigureAwait(false);
+                receivedSecondMessage.Should().BeNull();
+            }
+            catch (OperationCanceledException) { }
+
+            // The message should be received on the callback
+            using var cts4 = new CancellationTokenSource(s_fiveSeconds);
+            await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts4.Token).ConfigureAwait(false);
 
             // Now unsubscribe from receiving c2d messages over the callback.
             await deviceClient.SetReceiveMessageHandlerAsync(null, deviceClient).ConfigureAwait(false);
@@ -819,9 +447,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             if (transport == Client.TransportType.Mqtt_Tcp_Only
                 || transport == Client.TransportType.Mqtt_WebSocket_Only)
             {
-                using var cts4 = new CancellationTokenSource(s_tenSeconds);
-                Client.Message leftoverMessage = await deviceClient.ReceiveMessageAsync(cts4.Token).ConfigureAwait(false);
-                Logger.Trace($"Leftover message on Mqtt was: {leftoverMessage} with Id={leftoverMessage?.MessageId}");
+                try
+                {
+                    using var cts5 = new CancellationTokenSource(s_tenSeconds);
+                    using Client.Message leftoverMessage = await deviceClient.ReceiveMessageAsync(cts5.Token).ConfigureAwait(false);
+                    Logger.Trace($"Leftover message on Mqtt was: {leftoverMessage} with Id={leftoverMessage?.MessageId}");
+                }
+                catch (OperationCanceledException) { }
             }
 
             // Send a message to the device from the service.
@@ -830,19 +462,15 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             Logger.Trace($"Sent C2D message from service, messageId={thirdMessage.MessageId} - to be received on polling ReceiveAsync");
 
             // This time, the message should not be received on the callback, rather it should be received on a call to ReceiveAsync().
-            using var cts5 = new CancellationTokenSource(s_tenSeconds);
+            using var cts6 = new CancellationTokenSource(s_fiveSeconds);
             Func<Task> receiveMessageOverCallback = async () =>
             {
-                await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts5.Token).ConfigureAwait(false);
+                await testDeviceCallbackHandler.WaitForReceiveMessageCallbackAsync(cts6.Token).ConfigureAwait(false);
             };
-            using Client.Message receivedThirdMessage = await deviceClient.ReceiveMessageAsync(cts5.Token).ConfigureAwait(false);
+            using Client.Message receivedThirdMessage = await deviceClient.ReceiveMessageAsync(cts6.Token).ConfigureAwait(false);
             receivedThirdMessage.MessageId.Should().Be(thirdMessage.MessageId);
-            receiveMessageOverCallback.Should().Throw<OperationCanceledException>();
             await deviceClient.CompleteMessageAsync(receivedThirdMessage).ConfigureAwait(false);
-
-            firstMessage.Dispose();
-            secondMessage.Dispose();
-            thirdMessage.Dispose();
+            receiveMessageOverCallback.Should().Throw<OperationCanceledException>();
 
             await deviceClient.CloseAsync().ConfigureAwait(false);
             await serviceClient.CloseAsync().ConfigureAwait(false);
@@ -898,10 +526,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             (Message secondMessage, _, _) = ComposeC2dTestMessage(Logger);
             Logger.Trace($"Sending C2D message from service, messageId={secondMessage.MessageId}");
             await Task
-                    .WhenAll(
-                        serviceClient.SendAsync(testDevice.Id, secondMessage),
-                        secondHandlerSemaphore.WaitAsync(secondCts.Token))
-                    .ConfigureAwait(false);
+                .WhenAll(
+                    serviceClient.SendAsync(testDevice.Id, secondMessage),
+                    secondHandlerSemaphore.WaitAsync(secondCts.Token))
+                .ConfigureAwait(false);
             secondCallbackHandler.Should().Throw<OperationCanceledException>();
 
             await deviceClient.CloseAsync().ConfigureAwait(false);
@@ -951,10 +579,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             testDeviceCallbackHandler.Dispose();
         }
 
-        private async Task DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType type, ITransportSettings[] settings)
+        private async Task DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType type, ITransportSettings[] transportSettings)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
-            DeviceClient deviceClient = testDevice.CreateDeviceClient(settings);
+            DeviceClient deviceClient = testDevice.CreateDeviceClient(transportSettings);
             var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
 
             using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
@@ -964,14 +592,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             // Subscribe to receive C2D messages over the callback.
             await testDeviceCallbackHandler.SetMessageReceiveCallbackHandlerAsync().ConfigureAwait(false);
 
-            // Now dispose and reinitialize the client instance.
+            // Now dispose and then reinitialize the client instance.
+            await deviceClient.CloseAsync().ConfigureAwait(false);
             deviceClient.Dispose();
-            deviceClient = null;
 
             testDeviceCallbackHandler.Dispose();
             testDeviceCallbackHandler = null;
 
-            deviceClient = testDevice.CreateDeviceClient(settings);
+            deviceClient = testDevice.CreateDeviceClient(transportSettings);
             testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
 
             // Open the device client - for MQTT, this will connect the device with CleanSession flag set to true.
@@ -995,6 +623,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             receiveMessageOverCallback.Should().Throw<OperationCanceledException>();
 
             await serviceClient.CloseAsync().ConfigureAwait(false);
+            await deviceClient.CloseAsync().ConfigureAwait(false);
             deviceClient.Dispose();
             testDeviceCallbackHandler.Dispose();
         }

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -720,7 +720,7 @@ namespace Microsoft.Azure.Devices.Client
             // unrecoverable (authentication, quota exceed) error occurs.
             try
             {
-                return await InnerHandler.ReceiveAsync(cancellationToken).ConfigureAwait(false);
+                return await InnerHandler.ReceiveMessageAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (IotHubCommunicationException ex) when (ex.InnerException is OperationCanceledException)
             {

--- a/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
@@ -80,10 +80,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return InnerHandler.WaitForTransportClosedAsync();
         }
 
-        public virtual Task<Message> ReceiveAsync(CancellationToken cancellationToken)
+        public virtual Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
-            return InnerHandler.ReceiveAsync(cancellationToken);
+            return InnerHandler.ReceiveMessageAsync(cancellationToken);
         }
 
         public virtual Task<Message> ReceiveAsync(TimeoutHelper timeoutHelper)

--- a/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
@@ -48,9 +48,9 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return ExecuteWithErrorHandlingAsync(() => base.OpenAsync(timeoutHelper));
         }
 
-        public override Task<Message> ReceiveAsync(CancellationToken cancellationToken)
+        public override Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken)
         {
-            return ExecuteWithErrorHandlingAsync(() => base.ReceiveAsync(cancellationToken));
+            return ExecuteWithErrorHandlingAsync(() => base.ReceiveMessageAsync(cancellationToken));
         }
 
         public override Task<Message> ReceiveAsync(TimeoutHelper timeoutHelper)

--- a/iothub/device/src/Pipeline/IDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/IDelegatingHandler.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Client
         Task SendEventAsync(IEnumerable<Message> messages, CancellationToken cancellationToken);
 
         // Telemetry downlink for devices.
-        Task<Message> ReceiveAsync(CancellationToken cancellationToken);
+        Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken);
 
         Task<Message> ReceiveAsync(TimeoutHelper timeoutHelper);
 

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
-        public override async Task<Message> ReceiveAsync(CancellationToken cancellationToken)
+        public override async Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken)
         {
             try
             {
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         async () =>
                         {
                             await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
-                            return await base.ReceiveAsync(cancellationToken).ConfigureAwait(false);
+                            return await base.ReceiveMessageAsync(cancellationToken).ConfigureAwait(false);
                         },
                         cancellationToken)
                     .ConfigureAwait(false);

--- a/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             return message;
         }
 
-        public override async Task<Message> ReceiveAsync(CancellationToken cancellationToken)
+        public override async Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, cancellationToken, nameof(ReceiveAsync));

--- a/iothub/device/src/Transport/Http/HttpTransportHandler.cs
+++ b/iothub/device/src/Transport/Http/HttpTransportHandler.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 "Device twins are not supported over HTTP; they are only supported over the MQTT and AMQP protocols.");
         }
 
-        public override async Task<Message> ReceiveAsync(CancellationToken cancellationToken)
+        public override async Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -287,7 +287,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             else
             {
                 using var cts = new CancellationTokenSource(s_defaultOperationTimeout);
-                return await ReceiveAsync(cts.Token).ConfigureAwait(false);
+                return await ReceiveMessageAsync(cts.Token).ConfigureAwait(false);
             }
         }
 

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
         }
 
-        public override async Task<Message> ReceiveAsync(CancellationToken cancellationToken)
+        public override async Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken)
         {
             if (_isDeviceReceiveMessageCallbackSet)
             {

--- a/iothub/device/tests/DeviceClientTests.cs
+++ b/iothub/device/tests/DeviceClientTests.cs
@@ -1463,7 +1463,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             // We will setup the main handler which can be either MQTT or AMQP or HTTP handler to throw
             // a cancellation token expiry exception (OperationCancelledException) To ensure that we mimic when a token expires.
             mainProtocolHandler
-                .When(x => x.ReceiveAsync(Arg.Any<CancellationToken>()))
+                .When(x => x.ReceiveMessageAsync(Arg.Any<CancellationToken>()))
                 .Do(x => { throw new OperationCanceledException(); });
 
             ErrorDelegatingHandler errorHandler = new ErrorDelegatingHandler(null, mainProtocolHandler);

--- a/iothub/device/tests/Pipeline/ErrorDelegatingHandlerTests.cs
+++ b/iothub/device/tests/Pipeline/ErrorDelegatingHandlerTests.cs
@@ -191,9 +191,9 @@ namespace Microsoft.Azure.Devices.Client.Test
                 thrownExceptionType, expectedExceptionType).ConfigureAwait(false);
 
             await OperationAsync_ExceptionThrownAndThenSucceed_OperationSuccessfullyCompleted(
-                di => di.ReceiveAsync(Arg.Any<CancellationToken>()),
-                di => di.ReceiveAsync(cancellationToken),
-                di => di.Received(2).ReceiveAsync(Arg.Any<CancellationToken>()),
+                di => di.ReceiveMessageAsync(Arg.Any<CancellationToken>()),
+                di => di.ReceiveMessageAsync(cancellationToken),
+                di => di.Received(2).ReceiveMessageAsync(Arg.Any<CancellationToken>()),
                 thrownExceptionType, expectedExceptionType).ConfigureAwait(false);
         }
 

--- a/iothub/device/tests/Pipeline/RetryDelegatingHandlerImplicitOpenTests.cs
+++ b/iothub/device/tests/Pipeline/RetryDelegatingHandlerImplicitOpenTests.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Azure.Devices.Client.Test
             innerHandlerMock.OpenAsync(Arg.Any<CancellationToken>()).Returns(t => TaskHelpers.CompletedTask);
             innerHandlerMock.SendEventAsync(Arg.Any<Message>(), Arg.Any<CancellationToken>()).Returns(t => TaskHelpers.CompletedTask);
             innerHandlerMock.SendEventAsync(Arg.Any<IEnumerable<Message>>(), Arg.Any<CancellationToken>()).Returns(t => TaskHelpers.CompletedTask);
-            innerHandlerMock.ReceiveAsync(Arg.Any<CancellationToken>()).Returns(t => Task.FromResult(new Message()));
-            innerHandlerMock.ReceiveAsync(Arg.Any<CancellationToken>()).Returns(t => Task.FromResult(new Message()));
+            innerHandlerMock.ReceiveMessageAsync(Arg.Any<CancellationToken>()).Returns(t => Task.FromResult(new Message()));
+            innerHandlerMock.ReceiveMessageAsync(Arg.Any<CancellationToken>()).Returns(t => Task.FromResult(new Message()));
             innerHandlerMock.AbandonAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(t => TaskHelpers.CompletedTask);
             innerHandlerMock.CompleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(t => TaskHelpers.CompletedTask);
             innerHandlerMock.RejectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(t => TaskHelpers.CompletedTask);
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             {
                 sut => sut.SendEventAsync(new Message(), cancellationToken),
                 sut => sut.SendEventAsync(new[] { new Message() }, cancellationToken),
-                sut => sut.ReceiveAsync(cancellationToken),
+                sut => sut.ReceiveMessageAsync(cancellationToken),
                 sut => sut.AbandonAsync(string.Empty, cancellationToken),
                 sut => sut.CompleteAsync(string.Empty, cancellationToken),
                 sut => sut.RejectAsync(string.Empty, cancellationToken),

--- a/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
+++ b/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
@@ -334,12 +334,12 @@ namespace Microsoft.Azure.Devices.Client.Test
             using var cts = new CancellationTokenSource();
 
             cts.Cancel();
-            innerHandlerMock.ReceiveAsync(cts.Token).Returns(new Task<Message>(() => new Message(new byte[0])));
+            innerHandlerMock.ReceiveMessageAsync(cts.Token).Returns(new Task<Message>(() => new Message(new byte[0])));
             var contextMock = Substitute.For<PipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             // act and assert
-            await sut.ReceiveAsync(cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+            await sut.ReceiveMessageAsync(cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
         }
 
         [TestMethod]

--- a/iothub/device/tests/Transport/Amqp/AmqpTransportHandlerTests.cs
+++ b/iothub/device/tests/Transport/Amqp/AmqpTransportHandlerTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
         [TestMethod]
         public async Task AmqpTransportHandlerReceiveAsyncTokenCancellationRequested()
         {
-            await TestOperationCanceledByToken(token => CreateFromConnectionString().ReceiveAsync(token)).ConfigureAwait(false);
+            await TestOperationCanceledByToken(token => CreateFromConnectionString().ReceiveMessageAsync(token)).ConfigureAwait(false);
         }
 
         [TestMethod]

--- a/iothub/device/tests/Transport/Http/HttpTransportHandlerTests.cs
+++ b/iothub/device/tests/Transport/Http/HttpTransportHandlerTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
         [TestMethod]
         public async Task HttpTransportHandler_ReceiveAsync_TokenCancellationRequested()
         {
-            await TestOperationCanceledByToken(token => CreateFromConnectionString().ReceiveAsync(token)).ConfigureAwait(false);
+            await TestOperationCanceledByToken(token => CreateFromConnectionString().ReceiveMessageAsync(token)).ConfigureAwait(false);
         }
 
         [TestMethod]

--- a/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
+++ b/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
         [TestMethod]
         public async Task MqttTransportHandlerReceiveAsyncTokenCancellationRequested()
         {
-            await TestOperationCanceledByToken(token => CreateFromConnectionString().ReceiveAsync(token)).ConfigureAwait(false);
+            await TestOperationCanceledByToken(token => CreateFromConnectionString().ReceiveMessageAsync(token)).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -522,7 +522,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
 
             transport.OnConnected();
             await transport.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-            Task receivingTask = transport.ReceiveAsync(CancellationToken.None);
+            Task receivingTask = transport.ReceiveMessageAsync(CancellationToken.None);
             Task task = transport.WaitForTransportClosedAsync();
 
             // act


### PR DESCRIPTION
Rename an internal method to indicate it is receiving a message.

Remove test overloads for X509 and web sockets.

Remove tests for AMQP pooling already covered in single device tests.