### PR TITLE
Add logging for module client c2d response

### DIFF
--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1774,18 +1774,26 @@ namespace Microsoft.Azure.Devices.Client
                 if (Logging.IsEnabled)
                     Logging.Info(this, $"{nameof(MessageResponse)} = {response}", nameof(OnModuleEventMessageReceivedAsync));
 
-                switch (response)
+                try
                 {
-                    case MessageResponse.Completed:
-                        await CompleteAsync(message).ConfigureAwait(false);
-                        break;
+                    switch (response)
+                    {
+                        case MessageResponse.Completed:
+                            await CompleteAsync(message).ConfigureAwait(false);
+                            break;
 
-                    case MessageResponse.Abandoned:
-                        await AbandonAsync(message).ConfigureAwait(false);
-                        break;
+                        case MessageResponse.Abandoned:
+                            await AbandonAsync(message).ConfigureAwait(false);
+                            break;
 
-                    default:
-                        break;
+                        default:
+                            break;
+                    }
+                }
+                catch (Exception ex) when (Logging.IsEnabled)
+                {
+                    Logging.Error(this, ex, nameof(OnModuleEventMessageReceivedAsync));
+                    throw;
                 }
             }
             finally


### PR DESCRIPTION
If our calls to complete or reject a message fails, we don't log it - we should!