### PR TITLE
Move TransportType to ClientOptions

### DIFF
--- a/e2e/test/helpers/TestDevice.cs
+++ b/e2e/test/helpers/TestDevice.cs
@@ -167,19 +167,19 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
         public Client.IAuthenticationMethod AuthenticationMethod { get; private set; }
 
-        public DeviceClient CreateDeviceClient(Client.TransportType transport, ClientOptions options = default)
+        public DeviceClient CreateDeviceClient(ClientOptions options = default)
         {
             DeviceClient deviceClient = null;
 
             if (AuthenticationMethod == null)
             {
-                deviceClient = DeviceClient.CreateFromConnectionString(ConnectionString, transport, options);
-                s_logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from connection string: {transport} ID={TestLogger.IdOf(deviceClient)}");
+                deviceClient = DeviceClient.CreateFromConnectionString(ConnectionString, options);
+                s_logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from connection string: {options.TransportType} ID={TestLogger.IdOf(deviceClient)}");
             }
             else
             {
-                deviceClient = DeviceClient.Create(IotHubHostName, AuthenticationMethod, transport, options);
-                s_logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from IAuthenticationMethod: {transport} ID={TestLogger.IdOf(deviceClient)}");
+                deviceClient = DeviceClient.Create(IotHubHostName, AuthenticationMethod, options);
+                s_logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(DeviceClient)} {Device.Id} from IAuthenticationMethod: {options.TransportType} ID={TestLogger.IdOf(deviceClient)}");
             }
 
             return deviceClient;

--- a/e2e/test/helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/helpers/TestDeviceCallbackHandler.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         private readonly TestDevice _testDevice;
         private readonly MsTestLogger _logger;
 
-        private readonly SemaphoreSlim _methodCallbackSemaphore = new SemaphoreSlim(0, 1);
+        private readonly SemaphoreSlim _methodCallbackSemaphore = new(0, 1);
         private ExceptionDispatchInfo _methodExceptionDispatch;
 
-        private readonly SemaphoreSlim _twinCallbackSemaphore = new SemaphoreSlim(0, 1);
+        private readonly SemaphoreSlim _twinCallbackSemaphore = new(0, 1);
         private ExceptionDispatchInfo _twinExceptionDispatch;
         private string _expectedTwinPropertyValue;
 
-        private readonly SemaphoreSlim _receivedMessageCallbackSemaphore = new SemaphoreSlim(0, 1);
+        private readonly SemaphoreSlim _receivedMessageCallbackSemaphore = new(0, 1);
         private ExceptionDispatchInfo _receiveMessageExceptionDispatch;
         private Message _expectedMessageSentByService;
 
@@ -119,31 +119,39 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
         public async Task SetMessageReceiveCallbackHandlerAsync()
         {
-            await _deviceClient.SetReceiveMessageHandlerAsync(
-                async (receivedMessage, context) =>
+            await _deviceClient.SetReceiveMessageHandlerAsync(OnC2dMessageReceivedAsync, null).ConfigureAwait(false);
+        }
+
+        public async Task UnSetMessageReceiveCallbackHandlerAsync()
+        {
+            await _deviceClient.SetReceiveMessageHandlerAsync(null, null).ConfigureAwait(false);
+        }
+
+        private async Task OnC2dMessageReceivedAsync(Client.Message message, object context)
+        {
+            _logger.Trace($"{nameof(SetMessageReceiveCallbackHandlerAsync)}: DeviceClient {_testDevice.Id} received message with Id: {message.MessageId}.");
+
+            try
+            {
+                if (ExpectedMessageSentByService != null)
                 {
-                    _logger.Trace($"{nameof(SetMessageReceiveCallbackHandlerAsync)}: DeviceClient {_testDevice.Id} received message with Id: {receivedMessage.MessageId}.");
+                    message.MessageId.Should().Be(ExpectedMessageSentByService.MessageId, "Received message Id should match what was sent by service");
+                    message.UserId.Should().Be(ExpectedMessageSentByService.UserId, "Received user Id should match what was sent by service");
+                }
 
-                    try
-                    {
-                        receivedMessage.MessageId.Should().Be(ExpectedMessageSentByService.MessageId, "Received message Id should match what was sent by service");
-                        receivedMessage.UserId.Should().Be(ExpectedMessageSentByService.UserId, "Received user Id should match what was sent by service");
-
-                        await CompleteMessageAsync(receivedMessage).ConfigureAwait(false);
-                        _logger.Trace($"{nameof(SetMessageReceiveCallbackHandlerAsync)}: DeviceClient completed message with Id: {receivedMessage.MessageId}.");
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.Trace($"{nameof(SetMessageReceiveCallbackHandlerAsync)}: Error during DeviceClient receive message callback: {ex}.");
-                        _receiveMessageExceptionDispatch = ExceptionDispatchInfo.Capture(ex);
-                    }
-                    finally
-                    {
-                        // Always notify that we got the callback.
-                        _receivedMessageCallbackSemaphore.Release();
-                    }
-                },
-                null).ConfigureAwait(false);
+                await CompleteMessageAsync(message).ConfigureAwait(false);
+                _logger.Trace($"{nameof(SetMessageReceiveCallbackHandlerAsync)}: DeviceClient completed message with Id: {message.MessageId}.");
+            }
+            catch (Exception ex)
+            {
+                _logger.Trace($"{nameof(SetMessageReceiveCallbackHandlerAsync)}: Error during DeviceClient receive message callback: {ex}.");
+                _receiveMessageExceptionDispatch = ExceptionDispatchInfo.Capture(ex);
+            }
+            finally
+            {
+                // Always notify that we got the callback.
+                _receivedMessageCallbackSemaphore.Release();
+            }
         }
 
         private async Task CompleteMessageAsync(Client.Message message)

--- a/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
+++ b/e2e/test/iothub/AuthenticationWithTokenRefreshDisposalTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposeWithClient: true);
 
             // Create an instance of the device client, send a test message and then close and dispose it.
-            var deviceClient = DeviceClient.Create(testDevice.IotHubHostName, authenticationMethod, transport);
+            var deviceClient = DeviceClient.Create(testDevice.IotHubHostName, authenticationMethod, new ClientOptions { TransportType = transport });
             using var message1 = new Client.Message();
             await deviceClient.SendEventAsync(message1).ConfigureAwait(false);
             await deviceClient.CloseAsync();
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             // Perform the same steps again, reusing the previously created authentication method instance.
             // Since the default behavior is to dispose AuthenticationWithTokenRefresh authentication method on DeviceClient disposal,
             // this should now throw an ObjectDisposedException.
-            var deviceClient2 = DeviceClient.Create(testDevice.IotHubHostName, authenticationMethod, transport);
+            var deviceClient2 = DeviceClient.Create(testDevice.IotHubHostName, authenticationMethod, new ClientOptions { TransportType = transport });
             using var message2 = new Client.Message();
 
             Func<Task> act = async () => await deviceClient2.SendEventAsync(message2).ConfigureAwait(false);
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             var authenticationMethod = new DeviceAuthenticationSasToken(testDevice.ConnectionString, disposeWithClient: false);
 
             // Create an instance of the device client, send a test message and then close and dispose it.
-            var deviceClient = DeviceClient.Create(testDevice.IotHubHostName, authenticationMethod, transport);
+            var deviceClient = DeviceClient.Create(testDevice.IotHubHostName, authenticationMethod, new ClientOptions { TransportType = transport });
             using var message1 = new Client.Message();
             await deviceClient.SendEventAsync(message1).ConfigureAwait(false);
             await deviceClient.CloseAsync();
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // Perform the same steps again, reusing the previously created authentication method instance to ensure
             // that the SDK did not dispose the user supplied authentication method instance.
-            var deviceClient2 = DeviceClient.Create(testDevice.IotHubHostName, authenticationMethod, transport);
+            var deviceClient2 = DeviceClient.Create(testDevice.IotHubHostName, authenticationMethod, new ClientOptions { TransportType = transport });
             using var message2 = new Client.Message();
             await deviceClient2.SendEventAsync(message2).ConfigureAwait(false);
             await deviceClient2.CloseAsync();

--- a/e2e/test/iothub/CombinedClientOperationsPoolAmqpTests.cs
+++ b/e2e/test/iothub/CombinedClientOperationsPoolAmqpTests.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                 // D2C Operation
                 Logger.Trace($"{nameof(CombinedClientOperationsPoolAmqpTests)}: Operation 1: Send D2C for device={testDevice.Id}");
-                Task sendD2cMessage = MessageSendE2ETests.SendSingleMessageAsync(deviceClient, testDevice.Id, Logger);
+                Task sendD2cMessage = MessageSendE2ETests.SendSingleMessageAsync(deviceClient, Logger);
                 clientOperations.Add(sendD2cMessage);
 
                 // C2D Operation

--- a/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         private async Task DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base(
-            Client.TransportType protocol, Func<IotHubServiceClient, string, Task> registryManagerOperation)
+            Client.TransportType transportType, Func<IotHubServiceClient, string, Task> registryManagerOperation)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix + $"_{Guid.NewGuid()}").ConfigureAwait(false);
             string deviceConnectionString = testDevice.ConnectionString;
@@ -117,7 +117,8 @@ namespace Microsoft.Azure.Devices.E2ETests
             ConnectionStatusChangeReason? statusChangeReason = null;
             int deviceDisabledReceivedCount = 0;
 
-            using (var deviceClient = DeviceClient.CreateFromConnectionString(deviceConnectionString, protocol))
+            var options = new ClientOptions { TransportType = transportType };
+            using (var deviceClient = DeviceClient.CreateFromConnectionString(deviceConnectionString, options))
             {
                 ConnectionStatusChangesHandler statusChangeHandler = (s, r) =>
                 {

--- a/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
@@ -105,7 +105,8 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         private async Task DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base(
-            Client.TransportType transportType, Func<IotHubServiceClient, string, Task> registryManagerOperation)
+            Client.TransportType transportType,
+            Func<IotHubServiceClient, string, Task> registryManagerOperation)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, DevicePrefix + $"_{Guid.NewGuid()}").ConfigureAwait(false);
             string deviceConnectionString = testDevice.ConnectionString;

--- a/e2e/test/iothub/DeviceClientX509AuthenticationE2ETests.cs
+++ b/e2e/test/iothub/DeviceClientX509AuthenticationE2ETests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             using var deviceClient = DeviceClient.Create(
                 _hostName,
                 auth,
-                DeviceTransportType.Mqtt_Tcp_Only);
+                new ClientOptions { TransportType = DeviceTransportType.Mqtt_Tcp_Only });
 
             // act
             await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             using var deviceClient = DeviceClient.Create(
                 _hostName,
                 auth,
-                DeviceTransportType.Amqp_Tcp_Only);
+                new ClientOptions { TransportType = DeviceTransportType.Amqp_Tcp_Only });
 
             // act
             await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -224,7 +224,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(new[] { transportSetting });
             await deviceClient.OpenAsync().ConfigureAwait(false);
-            await MessageSendE2ETests.SendSingleMessageAsync(deviceClient, testDevice.Id, Logger).ConfigureAwait(false);
+            await MessageSendE2ETests.SendSingleMessageAsync(deviceClient, Logger).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);
         }
 
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             string deviceName = $"DEVICE_NOT_EXIST_{Guid.NewGuid()}";
             using var auth = new DeviceAuthenticationWithX509Certificate(deviceName, s_selfSignedCertificateWithPrivateKey);
-            using var deviceClient = DeviceClient.Create(_hostName, auth, transportType);
+            using var deviceClient = DeviceClient.Create(_hostName, auth, new ClientOptions { TransportType = transportType });
 
             try
             {
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             string deviceName = $"DEVICE_NOT_EXIST_{Guid.NewGuid()}";
             using var auth = new DeviceAuthenticationWithX509Certificate(deviceName, s_selfSignedCertificateWithPrivateKey);
-            using var deviceClient = DeviceClient.Create(_hostName, auth, transportType);
+            using var deviceClient = DeviceClient.Create(_hostName, auth, new ClientOptions { TransportType = transportType });
 
             for (int i = 0; i < 2; i++)
             {

--- a/e2e/test/iothub/FileUploadE2ETests.cs
+++ b/e2e/test/iothub/FileUploadE2ETests.cs
@@ -92,8 +92,9 @@ namespace Microsoft.Azure.Devices.E2ETests
                 useX509auth ? TestDeviceType.X509 : TestDeviceType.Sasl).ConfigureAwait(false);
 
             DeviceClient deviceClient;
-            var clientOptions = new ClientOptions()
+            var clientOptions = new ClientOptions
             {
+                TransportType = Client.TransportType.Http1,
                 FileUploadTransportSettings = fileUploadTransportSettings
             };
 
@@ -104,11 +105,11 @@ namespace Microsoft.Azure.Devices.E2ETests
                 cert = s_selfSignedCertificate;
                 x509Auth = new DeviceAuthenticationWithX509Certificate(testDevice.Id, cert);
                 
-                deviceClient = DeviceClient.Create(testDevice.IotHubHostName, x509Auth, Client.TransportType.Http1);
+                deviceClient = DeviceClient.Create(testDevice.IotHubHostName, x509Auth, new ClientOptions { TransportType = Client.TransportType.Http1 });
             }
             else
             {
-                deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, Client.TransportType.Http1, clientOptions);
+                deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, clientOptions);
             }
 
             var fileUploadSasUriRequest = new FileUploadSasUriRequest()
@@ -147,6 +148,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                         : TestDeviceType.Sasl)
                 .ConfigureAwait(false);
 
+            var options = new ClientOptions { TransportType = transport };
             DeviceClient deviceClient;
             X509Certificate2 cert = null;
             DeviceAuthenticationWithX509Certificate x509Auth = null;
@@ -155,16 +157,18 @@ namespace Microsoft.Azure.Devices.E2ETests
                 cert = s_selfSignedCertificate;
                 x509Auth = new DeviceAuthenticationWithX509Certificate(testDevice.Id, cert);
 
-                deviceClient = DeviceClient.Create(testDevice.IotHubHostName, x509Auth, transport);
+                deviceClient = DeviceClient.Create(testDevice.IotHubHostName, x509Auth, options);
             }
             else
             {
-                deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+                deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, options);
             }
 
             using (deviceClient)
             {
-                FileUploadSasUriResponse sasUriResponse = await deviceClient.GetFileUploadSasUriAsync(new FileUploadSasUriRequest { BlobName = blobName });
+                FileUploadSasUriResponse sasUriResponse = await deviceClient
+                    .GetFileUploadSasUriAsync(new FileUploadSasUriRequest { BlobName = blobName })
+                    .ConfigureAwait(false);
                 await deviceClient.CloseAsync().ConfigureAwait(false);
             }
 

--- a/e2e/test/iothub/NoRetryE2ETests.cs
+++ b/e2e/test/iothub/NoRetryE2ETests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task FaultInjection_NoRetry_NoRecovery_OpenAsync()
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix, TestDeviceType.Sasl).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Amqp_Tcp_Only);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(new ClientOptions { TransportType = Client.TransportType.Amqp_Tcp_Only });
 
             Logger.Trace($"{nameof(FaultInjection_NoRetry_NoRecovery_OpenAsync)}: deviceId={testDevice.Id}");
             deviceClient.SetRetryPolicy(new NoRetry());
@@ -87,8 +87,10 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             Logger.Trace($"{nameof(DuplicateDevice_NoRetry_NoPingpong_OpenAsync)}: 2 device client instances with the same deviceId={testDevice.Id}.");
 
-            using DeviceClient deviceClient1 = testDevice.CreateDeviceClient(Client.TransportType.Amqp_Tcp_Only);
-            using DeviceClient deviceClient2 = testDevice.CreateDeviceClient(Client.TransportType.Amqp_Tcp_Only);
+            var options1 = new ClientOptions { TransportType = Client.TransportType.Amqp_Tcp_Only };
+            using DeviceClient deviceClient1 = testDevice.CreateDeviceClient(options1);
+            var options2 = new ClientOptions { TransportType = Client.TransportType.Amqp_Tcp_Only };
+            using DeviceClient deviceClient2 = testDevice.CreateDeviceClient(options2);
 
             Logger.Trace($"{nameof(DuplicateDevice_NoRetry_NoPingpong_OpenAsync)}: set device client instance 1 to no retry.");
             deviceClient1.SetRetryPolicy(new NoRetry());

--- a/e2e/test/iothub/SasCredentialAuthenticationTests.cs
+++ b/e2e/test/iothub/SasCredentialAuthenticationTests.cs
@@ -124,9 +124,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             // Create a device client instance initializing it with the "Thermostat" model.
             var options = new ClientOptions
             {
+                TransportType = Client.TransportType.Mqtt,
                 ModelId = thermostatModelId,
             };
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt, options);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(options);
 
             // Call openAsync() to open the device's connection, so that the ModelId is sent over Mqtt CONNECT packet.
             await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -154,7 +155,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         {
             // arrange
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(new ClientOptions { TransportType = Client.TransportType.Mqtt });
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
             string signature = TestConfiguration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
@@ -178,7 +179,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         {
             // arrange
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(new ClientOptions { TransportType = Client.TransportType.Mqtt });
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
             string signature = TestConfiguration.IoTHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(-1));

--- a/e2e/test/iothub/TokenCredentialAuthenticationTests.cs
+++ b/e2e/test/iothub/TokenCredentialAuthenticationTests.cs
@@ -86,9 +86,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             // Create a device client instance initializing it with the "Thermostat" model.
             var options = new ClientOptions
             {
+                TransportType = Client.TransportType.Mqtt,
                 ModelId = thermostatModelId,
             };
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt, options);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(options);
 
             // Call openAsync() to open the device's connection, so that the ModelId is sent over Mqtt CONNECT packet.
             await deviceClient.OpenAsync().ConfigureAwait(false);

--- a/e2e/test/iothub/messaging/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
+++ b/e2e/test/iothub/messaging/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         private async Task TestSecurityMessageAsync(Client.TransportType transport)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(new ClientOptions { TransportType = transport });
 
             try
             {
@@ -136,16 +136,15 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         {
             TestModule testModule = await TestModule.GetTestModuleAsync(_devicePrefix, _modulePrefix, Logger).ConfigureAwait(false);
 
-            using (var moduleClient = ModuleClient.CreateFromConnectionString(testModule.ConnectionString, transport))
+            var options = new ClientOptions { TransportType = transport };
+            using var moduleClient = ModuleClient.CreateFromConnectionString(testModule.ConnectionString, options);
+            try
             {
-                try
-                {
-                    await SendSingleSecurityMessageModuleAsync(moduleClient).ConfigureAwait(false);
-                }
-                finally
-                {
-                    await moduleClient.CloseAsync().ConfigureAwait(false);
-                }
+                await SendSingleSecurityMessageModuleAsync(moduleClient).ConfigureAwait(false);
+            }
+            finally
+            {
+                await moduleClient.CloseAsync().ConfigureAwait(false);
             }
         }
 

--- a/e2e/test/iothub/messaging/MessageFeedbackE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageFeedbackE2ETests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         private static async Task CompleteMessageMixOrder(TestDeviceType type, Client.TransportType transport, MsTestLogger logger)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(logger, s_devicePrefix, type).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(new ClientOptions { TransportType = transport });
             using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);

--- a/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         private async Task DeviceClientGivesUpWaitingForC2dMessageAsync(Client.TransportType transportType)
         {
             TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, TestDeviceType.Sasl).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transportType);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(new ClientOptions { TransportType = transportType });
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
@@ -280,7 +280,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         private async Task ReceiveMessageWithTimeoutAsync(TestDeviceType type, Client.TransportType transport)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(new ClientOptions { TransportType = transport });
 
             Logger.Trace($"{nameof(ReceiveMessageWithTimeoutAsync)} - calling OpenAsync() for transport={transport}");
             await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -301,7 +301,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         private async Task ReceiveSingleMessageWithCancellationTokenAsync(TestDeviceType type, Client.TransportType transport)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(new ClientOptions { TransportType = transport });
             using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -361,7 +361,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         private async Task ReceiveSingleMessageUsingCallbackAsync(TestDeviceType type, Client.TransportType transport)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(new ClientOptions { TransportType = transport });
             using var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
 
             using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
@@ -388,7 +388,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         private async Task ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType type, Client.TransportType transport)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(new ClientOptions { TransportType = transport });
             using var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, Logger);
 
             using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
@@ -482,7 +482,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             using var secondHandlerSemaphore = new SemaphoreSlim(0, 1);
 
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(new ClientOptions { TransportType = transport });
             using var serviceClient = ServiceClient.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
 
             // Set the first C2D message handler.
@@ -539,7 +539,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         private async Task ReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType type, Client.TransportType transportType)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
-            using DeviceClient deviceClient1 = testDevice.CreateDeviceClient(transportType);
+            using DeviceClient deviceClient1 = testDevice.CreateDeviceClient(new ClientOptions { TransportType = transportType });
 
             // An MQTT client must have connected at least once to be able to receive C2D messages.
             if (transportType == Client.TransportType.Mqtt
@@ -556,7 +556,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             Logger.Trace($"Sending C2D message from service, messageId={msg.MessageId}");
             await serviceClient.SendAsync(testDevice.Id, msg).ConfigureAwait(false);
 
-            using DeviceClient deviceClient2 = testDevice.CreateDeviceClient(transportType);
+            using DeviceClient deviceClient2 = testDevice.CreateDeviceClient(new ClientOptions { TransportType = transportType });
             // Open the device client - for MQTT, this will connect the device with CleanSession flag set to false.
             // Also, over MQTT it seems the device must be connected (although not necessarily subscribed for C2D messages)
             // in order for C2D messages to get to the device. If they are offline, the messages will never be delivered.
@@ -641,7 +641,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         private async Task UnsubscribeDoesNotCauseConnectionStatusEventAsync(TestDeviceType type, Client.TransportType transportType)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, s_devicePrefix, type).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transportType);
+            var options = new ClientOptions { TransportType = transportType };
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(options);
             bool lostConnection = false;
             deviceClient.SetConnectionStatusChangesHandler((status, statusChangeReason) =>
             {

--- a/e2e/test/iothub/messaging/MessageSendE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageSendE2ETests.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         public async Task Message_ClientThrowsForMqttTopicNameTooLong()
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt);
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(new ClientOptions { TransportType = Client.TransportType.Mqtt });
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
@@ -344,17 +344,19 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         private async Task SendSingleMessage(TestDeviceType type, Client.TransportType transport, int messageSize = 0)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix, type).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
+            var options = new ClientOptions { TransportType = transport };
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(options);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
-            await SendSingleMessageAsync(deviceClient, testDevice.Id, Logger, messageSize).ConfigureAwait(false);
+            await SendSingleMessageAsync(deviceClient, Logger, messageSize).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);
         }
 
         private async Task SendBatchMessages(TestDeviceType type, Client.TransportType transport)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix, type).ConfigureAwait(false);
-            using DeviceClient deviceClient = testDevice.CreateDeviceClient(transport);
+            var options = new ClientOptions { TransportType = transport };
+            using DeviceClient deviceClient = testDevice.CreateDeviceClient(options);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await SendBatchMessagesAsync(deviceClient, testDevice.Id, Logger).ConfigureAwait(false);
@@ -367,7 +369,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             using DeviceClient deviceClient = testDevice.CreateDeviceClient(transportSettings);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
-            await SendSingleMessageAsync(deviceClient, testDevice.Id, Logger, messageSize).ConfigureAwait(false);
+            await SendSingleMessageAsync(deviceClient, Logger, messageSize).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);
         }
 
@@ -381,7 +383,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await moduleClient.CloseAsync().ConfigureAwait(false);
         }
 
-        public static async Task SendSingleMessageAsync(DeviceClient deviceClient, string deviceId, MsTestLogger logger, int messageSize = 0)
+        public static async Task SendSingleMessageAsync(DeviceClient deviceClient, MsTestLogger logger, int messageSize = 0)
         {
             Client.Message testMessage;
 

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                 const string commandName = "Reboot";
                 bool deviceMethodCalledSuccessfully = false;
 
-                deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt);
+                deviceClient = testDevice.CreateDeviceClient(new ClientOptions { TransportType = Client.TransportType.Mqtt });
 
                 await deviceClient.OpenAsync().ConfigureAwait(false);
                 await deviceClient
@@ -520,7 +520,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             ServiceClientTransportSettings serviceClientTransportSettings = default)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+            var options = new ClientOptions { TransportType = transport };
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, options);
 
             await subscribeAndUnsubscribeMethod(deviceClient, MethodName, Logger).ConfigureAwait(false);
 
@@ -536,7 +537,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             ServiceClientTransportSettings serviceClientTransportSettings = default)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+            var options = new ClientOptions { TransportType = transport };
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, options);
 
             Task methodReceivedTask = await setDeviceReceiveMethod(deviceClient, MethodName, Logger).ConfigureAwait(false);
             Task serviceSendTask = ServiceSendMethodAndVerifyResponseAsync(
@@ -556,7 +558,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
         private async Task SendMethodAndRespondAsync(Client.TransportType transport, Func<ModuleClient, string, MsTestLogger, Task<Task>> setDeviceReceiveMethod, TimeSpan responseTimeout = default, ServiceClientTransportSettings serviceClientTransportSettings = default)
         {
             TestModule testModule = await TestModule.GetTestModuleAsync(_devicePrefix, _modulePrefix, Logger).ConfigureAwait(false);
-            using var moduleClient = ModuleClient.CreateFromConnectionString(testModule.ConnectionString, transport);
+            var options = new ClientOptions { TransportType = transport };
+            using var moduleClient = ModuleClient.CreateFromConnectionString(testModule.ConnectionString, options);
 
             Task methodReceivedTask = await setDeviceReceiveMethod(moduleClient, MethodName, Logger).ConfigureAwait(false);
 

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -555,7 +555,11 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await deviceClient.CloseAsync().ConfigureAwait(false);
         }
 
-        private async Task SendMethodAndRespondAsync(Client.TransportType transport, Func<ModuleClient, string, MsTestLogger, Task<Task>> setDeviceReceiveMethod, TimeSpan responseTimeout = default, ServiceClientTransportSettings serviceClientTransportSettings = default)
+        private async Task SendMethodAndRespondAsync(
+            Client.TransportType transport,
+            Func<ModuleClient, string, MsTestLogger, Task<Task>> setDeviceReceiveMethod,
+            TimeSpan responseTimeout = default,
+            ServiceClientTransportSettings serviceClientTransportSettings = default)
         {
             TestModule testModule = await TestModule.GetTestModuleAsync(_devicePrefix, _modulePrefix, Logger).ConfigureAwait(false);
             var options = new ClientOptions { TransportType = transport };
@@ -565,7 +569,15 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
 
             await Task
                 .WhenAll(
-                    ServiceSendMethodAndVerifyResponseAsync(testModule.DeviceId, testModule.Id, MethodName, DeviceResponseJson, ServiceRequestJson, Logger, responseTimeout, serviceClientTransportSettings),
+                    ServiceSendMethodAndVerifyResponseAsync(
+                        testModule.DeviceId,
+                        testModule.Id,
+                        MethodName,
+                        DeviceResponseJson,
+                        ServiceRequestJson,
+                        Logger,
+                        responseTimeout,
+                        serviceClientTransportSettings),
                     methodReceivedTask)
                 .ConfigureAwait(false);
 

--- a/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
+++ b/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
@@ -39,9 +39,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                 // Create a device client instance over Mqtt, initializing it with the "Thermostat" model which has only a root component.
                 var options = new ClientOptions
                 {
+                    TransportType = Client.TransportType.Mqtt,
                     ModelId = ThermostatModelId,
                 };
-                using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt, options);
+                using DeviceClient deviceClient = testDevice.CreateDeviceClient(options);
 
                 // Call openAsync() to open the device's connection, so that the ModelId is sent over Mqtt CONNECT packet.
                 await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -113,7 +114,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
                 {
                     ModelId = TemperatureControllerModelId,
                 };
-                using DeviceClient deviceClient = testDevice.CreateDeviceClient(Client.TransportType.Mqtt, options);
+                using DeviceClient deviceClient = testDevice.CreateDeviceClient(options);
 
                 // Call openAsync() to open the device's connection, so that the ModelId is sent over Mqtt CONNECT packet.
                 await deviceClient.OpenAsync().ConfigureAwait(false);

--- a/e2e/test/iothub/service/IoTHubCertificateValidationE2ETest.cs
+++ b/e2e/test/iothub/service/IoTHubCertificateValidationE2ETest.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             using var deviceClient =
                 DeviceClient.CreateFromConnectionString(
                     TestConfiguration.IoTHub.DeviceConnectionStringInvalidServiceCertificate,
-                    transport);
+                    new ClientOptions { TransportType = transport });
             using var testMessage = new Client.Message();
             await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);

--- a/e2e/test/iothub/service/PnpServiceTests.cs
+++ b/e2e/test/iothub/service/PnpServiceTests.cs
@@ -35,9 +35,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             // Send model ID with MQTT connect packet to make the device plug and play.
             var options = new ClientOptions
             {
+                TransportType = Client.TransportType.Mqtt_Tcp_Only,
                 ModelId = TestModelId,
             };
-            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, Client.TransportType.Mqtt_Tcp_Only, options);
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, options);
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
             // Act
@@ -64,12 +65,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             // Send model ID with MQTT connect packet to make the device plug and play.
             var options = new ClientOptions
             {
+                TransportType = Client.TransportType.Mqtt_Tcp_Only,
                 ModelId = TestModelId,
             };
             string hostName = HostNameHelper.GetHostName(TestConfiguration.IoTHub.ConnectionString);
             X509Certificate2 authCertificate = TestConfiguration.IoTHub.GetCertificateWithPrivateKey();
             using var auth = new DeviceAuthenticationWithX509Certificate(testDevice.Id, authCertificate);
-            using var deviceClient = DeviceClient.Create(hostName, auth, Client.TransportType.Mqtt_Tcp_Only, options);
+            using var deviceClient = DeviceClient.Create(hostName, auth, options);
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
             // Act
@@ -102,9 +104,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             // Send model ID with MQTT connect packet to make the module plug and play.
             var options = new ClientOptions
             {
+                TransportType = Client.TransportType.Mqtt_Tcp_Only,
                 ModelId = TestModelId,
             };
-            using var moduleClient = ModuleClient.CreateFromConnectionString(testModule.ConnectionString, Client.TransportType.Mqtt_Tcp_Only, options);
+            using var moduleClient = ModuleClient.CreateFromConnectionString(testModule.ConnectionString, options);
             await moduleClient.OpenAsync().ConfigureAwait(false);
 
             // Act

--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -351,7 +351,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             // arrange
 
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transportType);
+            var options = new ClientOptions { TransportType = transportType };
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, options);
 
             await Twin_DeviceSetsReportedPropertyAndGetsItBackAsync(deviceClient, testDevice.Id, Guid.NewGuid().ToString(), Logger).ConfigureAwait(false);
 
@@ -377,7 +378,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
         private async Task Twin_DeviceSetsReportedPropertyAndGetsItBackSingleDeviceAsync(Client.TransportType transport)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+            var options = new ClientOptions { TransportType = transport };
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, options);
 
             await Twin_DeviceSetsReportedPropertyAndGetsItBackAsync(deviceClient, testDevice.Id, Guid.NewGuid().ToString(), Logger).ConfigureAwait(false);
         }
@@ -385,7 +387,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
         private async Task Twin_DeviceSetsReportedPropertyArrayAndGetsItBackSingleDeviceAsync(Client.TransportType transport)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+            var options = new ClientOptions { TransportType = transport };
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, options);
 
             await Twin_DeviceSetsReportedPropertyAndGetsItBackAsync(deviceClient, testDevice.Id, s_listOfPropertyValues, Logger).ConfigureAwait(false);
         }
@@ -462,7 +465,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             Logger.Trace($"{nameof(Twin_ServiceSetsDesiredPropertyAndDeviceReceivesEventAsync)}: name={propName}, value={propValue}");
 
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+            var options = new ClientOptions { TransportType = transport };
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, options);
 
             // Set a callback
             await deviceClient.
@@ -497,7 +501,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             Logger.Trace($"{nameof(Twin_ServiceSetsDesiredPropertyAndDeviceReceivesEventAsync)}: name={propName}, value={propValue}");
 
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+            var options = new ClientOptions { TransportType = transport };
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, options);
 
             Task updateReceivedTask = await setTwinPropertyUpdateCallbackAsync(deviceClient, propName, propValue, Logger).ConfigureAwait(false);
 
@@ -526,7 +531,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
             using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
-            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+            var options = new ClientOptions { TransportType = transport };
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, options);
 
             var twinPatch = new Twin();
             twinPatch.Properties.Desired[propName] = propValue;
@@ -546,7 +552,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
             using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
-            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+            var options = new ClientOptions { TransportType = transport };
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, options);
 
             var patch = new Client.TwinCollection();
             patch[propName] = propValue;
@@ -567,7 +574,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
             using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
-            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+            var options = new ClientOptions { TransportType = transport };
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, options);
 
             await deviceClient
                 .UpdateReportedPropertiesAsync(
@@ -618,7 +626,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
             using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IoTHub.ConnectionString);
-            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, transport);
+            var options = new ClientOptions { TransportType = transport };
+            using var deviceClient = DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, options);
 
             bool exceptionThrown = false;
             try

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -957,17 +957,17 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
                 case Client.TransportType.Amqp:
                 case Client.TransportType.Amqp_Tcp_Only:
-                    return new ProvisioningTransportHandlerAmqp(Microsoft.Azure.Devices.Provisioning.Client.TransportFallbackType.TcpOnly);
+                    return new ProvisioningTransportHandlerAmqp(TransportFallbackType.TcpOnly);
 
                 case Client.TransportType.Amqp_WebSocket_Only:
-                    return new ProvisioningTransportHandlerAmqp(Microsoft.Azure.Devices.Provisioning.Client.TransportFallbackType.WebSocketOnly);
+                    return new ProvisioningTransportHandlerAmqp(TransportFallbackType.WebSocketOnly);
 
                 case Client.TransportType.Mqtt:
                 case Client.TransportType.Mqtt_Tcp_Only:
-                    return new ProvisioningTransportHandlerMqtt(Microsoft.Azure.Devices.Provisioning.Client.TransportFallbackType.TcpOnly);
+                    return new ProvisioningTransportHandlerMqtt(TransportFallbackType.TcpOnly);
 
                 case Client.TransportType.Mqtt_WebSocket_Only:
-                    return new ProvisioningTransportHandlerMqtt(Microsoft.Azure.Devices.Provisioning.Client.TransportFallbackType.WebSocketOnly);
+                    return new ProvisioningTransportHandlerMqtt(TransportFallbackType.WebSocketOnly);
             }
 
             throw new NotSupportedException($"Unknown transport: '{transportType}'.");
@@ -980,10 +980,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         private async Task ConfirmRegisteredDeviceWorksAsync(
             DeviceRegistrationResult result,
             Client.IAuthenticationMethod auth,
-            Client.TransportType transportProtocol,
+            Client.TransportType transportType,
             bool sendReportedPropertiesUpdate)
         {
-            using var iotClient = DeviceClient.Create(result.AssignedHub, auth, transportProtocol);
+            using var iotClient = DeviceClient.Create(result.AssignedHub, auth, new ClientOptions { TransportType = transportType });
             Logger.Trace("DeviceClient OpenAsync.");
             await iotClient.OpenAsync().ConfigureAwait(false);
             Logger.Trace("DeviceClient SendEventAsync.");

--- a/e2e/test/provisioning/ReprovisioningE2ETests.cs
+++ b/e2e/test/provisioning/ReprovisioningE2ETests.cs
@@ -551,10 +551,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         private async Task ConfirmRegisteredDeviceWorksAsync(
             DeviceRegistrationResult result,
             Client.IAuthenticationMethod auth,
-            Client.TransportType transportProtocol,
+            Client.TransportType transportType,
             bool transportProtocolSupportsTwinOperations)
         {
-            using var iotClient = DeviceClient.Create(result.AssignedHub, auth, transportProtocol);
+            using var iotClient = DeviceClient.Create(result.AssignedHub, auth, new ClientOptions { TransportType = transportType });
             Logger.Trace("DeviceClient OpenAsync.");
             await iotClient.OpenAsync().ConfigureAwait(false);
             Logger.Trace("DeviceClient SendEventAsync.");
@@ -581,7 +581,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             if (capabilities != null)
             {
                 //hardcoding amqp since http does not support twin, but tests that call into this may use http
-                using var iotClient = DeviceClient.Create(result.AssignedHub, auth, Client.TransportType.Amqp);
+                using var iotClient = DeviceClient.Create(result.AssignedHub, auth, new ClientOptions { TransportType = Client.TransportType.Amqp });
                 //Confirm that the device twin reflects what the enrollment dictated
                 Client.Twin twin = await iotClient.GetTwinAsync().ConfigureAwait(false);
                 twin.Capabilities.IotEdge.Should().Be(capabilities.IotEdge);
@@ -908,11 +908,11 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         private async Task ConfirmDeviceWorksAfterReprovisioningAsync(
             DeviceRegistrationResult result,
             Client.IAuthenticationMethod auth,
-            Client.TransportType transportProtocol,
+            Client.TransportType transportType,
             ReprovisionPolicy reprovisionPolicy,
             bool transportProtocolSupportsTwinOperations)
         {
-            using var iotClient = DeviceClient.Create(result.AssignedHub, auth, transportProtocol);
+            using var iotClient = DeviceClient.Create(result.AssignedHub, auth, new ClientOptions { TransportType = transportType });
             Logger.Trace("DeviceClient OpenAsync.");
             await iotClient.OpenAsync().ConfigureAwait(false);
             Logger.Trace("DeviceClient SendEventAsync.");

--- a/iothub/device/src/ClientFactory.cs
+++ b/iothub/device/src/ClientFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using Microsoft.Azure.Devices.Client.Exceptions;
@@ -31,11 +32,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <returns>InternalClient</returns>
         internal static InternalClient Create(string hostname, IAuthenticationMethod authenticationMethod, ClientOptions options = default)
         {
-            return Create(hostname, authenticationMethod, TransportType.Amqp, options);
+            return Create(hostname, null, authenticationMethod, options);
         }
 
         /// <summary>
-        /// Create an Amqp InternalClient from individual parameters
+        /// Create a InternalClient from individual parameters
         /// </summary>
         /// <param name="hostname">The fully-qualified DNS hostname of IoT hub</param>
         /// <param name="gatewayHostname">The fully-qualified DNS hostname of Gateway</param>
@@ -46,42 +47,6 @@ namespace Microsoft.Azure.Devices.Client
             string hostname,
             string gatewayHostname,
             IAuthenticationMethod authenticationMethod,
-            ClientOptions options = default)
-        {
-            return Create(hostname, gatewayHostname, authenticationMethod, TransportType.Amqp, options);
-        }
-
-        /// <summary>
-        /// Create a InternalClient from individual parameters
-        /// </summary>
-        /// <param name="hostname">The fully-qualified DNS hostname of IoT hub</param>
-        /// <param name="authenticationMethod">The authentication method that is used</param>
-        /// <param name="transportType">The transportType used (Http1, Amqp or Mqtt), <see cref="TransportType"/></param>
-        /// <param name="options">The options that allow configuration of the device client instance during initialization.</param>
-        /// <returns>InternalClient</returns>
-        internal static InternalClient Create(
-            string hostname,
-            IAuthenticationMethod authenticationMethod,
-            TransportType transportType,
-            ClientOptions options = default)
-        {
-            return Create(hostname, null, authenticationMethod, transportType, options);
-        }
-
-        /// <summary>
-        /// Create a InternalClient from individual parameters
-        /// </summary>
-        /// <param name="hostname">The fully-qualified DNS hostname of IoT hub</param>
-        /// <param name="gatewayHostname">The fully-qualified DNS hostname of Gateway</param>
-        /// <param name="authenticationMethod">The authentication method that is used</param>
-        /// <param name="transportType">The transportType used (Http1, Amqp or Mqtt), <see cref="TransportType"/></param>
-        /// <param name="options">The options that allow configuration of the device client instance during initialization.</param>
-        /// <returns>InternalClient</returns>
-        internal static InternalClient Create(
-            string hostname,
-            string gatewayHostname,
-            IAuthenticationMethod authenticationMethod,
-            TransportType transportType,
             ClientOptions options = default)
         {
             if (hostname == null)
@@ -94,8 +59,13 @@ namespace Microsoft.Azure.Devices.Client
                 throw new ArgumentNullException(nameof(authenticationMethod));
             }
 
-            if (transportType != TransportType.Amqp_Tcp_Only
-                && transportType != TransportType.Mqtt_Tcp_Only
+            if (options == default)
+            {
+                options = new();
+            }
+
+            if (options.TransportType != TransportType.Amqp_Tcp_Only
+                && options.TransportType != TransportType.Mqtt_Tcp_Only
                 && authenticationMethod is DeviceAuthenticationWithX509Certificate certificate
                 && certificate.ChainCertificates != null)
             {
@@ -103,7 +73,7 @@ namespace Microsoft.Azure.Devices.Client
             }
 
             if (!string.IsNullOrWhiteSpace(options?.ModelId)
-                && transportType == TransportType.Http1)
+                && options.TransportType == TransportType.Http1)
             {
                 throw new InvalidOperationException("Plug and Play is not supported over the HTTP transport.");
             }
@@ -123,7 +93,7 @@ namespace Microsoft.Azure.Devices.Client
                 InternalClient internalClient = CreateFromConnectionString(
                     connectionStringBuilder.ToString(),
                     authenticationMethod,
-                    PopulateCertificateInTransportSettings(connectionStringBuilder, transportType),
+                    PopulateCertificateInTransportSettings(connectionStringBuilder, options.TransportType),
                     null,
                     options);
 
@@ -148,7 +118,7 @@ namespace Microsoft.Azure.Devices.Client
                 return internalClient;
             }
 
-            return CreateFromConnectionString(connectionStringBuilder.ToString(), authenticationMethod, transportType, null, options);
+            return CreateFromConnectionString(connectionStringBuilder.ToString(), authenticationMethod, null, options);
         }
 
         /// <summary>
@@ -194,16 +164,16 @@ namespace Microsoft.Azure.Devices.Client
                 throw new ArgumentNullException(nameof(authenticationMethod));
             }
 
-            if (!string.IsNullOrWhiteSpace(options?.ModelId)
-                && transportSettings.Any(x => x.GetTransportType() == TransportType.Http1))
-            {
-                throw new InvalidOperationException("Plug and Play is not supported over the HTTP transport.");
-            }
-
             var connectionStringBuilder = IotHubConnectionStringBuilder.Create(hostname, gatewayHostname, authenticationMethod);
 
             // Make sure client options is initialized with the correct transport setting.
             EnsureOptionsIsSetup(connectionStringBuilder.Certificate, ref options);
+
+            if (!string.IsNullOrWhiteSpace(options.ModelId)
+                && transportSettings.Any(x => x.GetTransportType() == TransportType.Http1))
+            {
+                throw new InvalidOperationException("Plug and Play is not supported over the HTTP transport.");
+            }
 
             if (authenticationMethod is DeviceAuthenticationWithX509Certificate)
             {
@@ -231,7 +201,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <returns>InternalClient</returns>
         internal static InternalClient CreateFromConnectionString(string connectionString, ClientOptions options = default)
         {
-            return CreateFromConnectionString(connectionString, TransportType.Amqp, options);
+            return CreateFromConnectionString(connectionString, transportSettings: null, options: options);
         }
 
         /// <summary>
@@ -244,43 +214,6 @@ namespace Microsoft.Azure.Devices.Client
         internal static InternalClient CreateFromConnectionString(
             string connectionString,
             string deviceId,
-            ClientOptions options = default)
-        {
-            return CreateFromConnectionString(connectionString, deviceId, TransportType.Amqp, options);
-        }
-
-        /// <summary>
-        /// Create InternalClient from the specified connection string using the specified transport type
-        /// </summary>
-        /// <param name="connectionString">Connection string for the IoT hub (including DeviceId)</param>
-        /// <param name="transportType">Specifies whether Http1, Amqp or Mqtt transport is used, <see cref="TransportType"/></param>
-        /// <param name="options">The options that allow configuration of the device client instance during initialization.</param>
-        /// <returns>InternalClient</returns>
-        internal static InternalClient CreateFromConnectionString(
-            string connectionString,
-            TransportType transportType,
-            ClientOptions options = default)
-        {
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                throw new ArgumentNullException(nameof(connectionString));
-            }
-
-            return CreateFromConnectionString(connectionString, null, transportType, null, options);
-        }
-
-        /// <summary>
-        /// Create InternalClient from the specified connection string using the specified transport type
-        /// </summary>
-        /// <param name="connectionString">IoT hub-Scope Connection string for the IoT hub (without DeviceId)</param>
-        /// <param name="deviceId">Id of the device</param>
-        /// <param name="transportType">The transportType used (Http1, Amqp or Mqtt), <see cref="TransportType"/></param>
-        /// <param name="options">The options that allow configuration of the device client instance during initialization.</param>
-        /// <returns>InternalClient</returns>
-        internal static InternalClient CreateFromConnectionString(
-            string connectionString,
-            string deviceId,
-            TransportType transportType,
             ClientOptions options = default)
         {
             if (connectionString == null)
@@ -298,7 +231,7 @@ namespace Microsoft.Azure.Devices.Client
                 throw new ArgumentException("Connection string must not contain DeviceId keyvalue parameter", nameof(connectionString));
             }
 
-            return CreateFromConnectionString($"{connectionString};{DeviceId}={deviceId}", transportType, options);
+            return CreateFromConnectionString($"{connectionString};{DeviceId}={deviceId}", options);
         }
 
         /// <summary>
@@ -351,11 +284,15 @@ namespace Microsoft.Azure.Devices.Client
         internal static InternalClient CreateFromConnectionString(
             string connectionString,
             IAuthenticationMethod authenticationMethod,
-            TransportType transportType,
             IDeviceClientPipelineBuilder pipelineBuilder,
             ClientOptions options = default)
         {
-            ITransportSettings[] transportSettings = GetTransportSettings(transportType);
+            if (options == default)
+            {
+                options = new();
+            }
+
+            ITransportSettings[] transportSettings = GetTransportSettings(options.TransportType);
             return CreateFromConnectionString(
                 connectionString,
                 authenticationMethod,
@@ -366,42 +303,29 @@ namespace Microsoft.Azure.Devices.Client
 
         internal static ITransportSettings[] GetTransportSettings(TransportType transportType)
         {
-            switch (transportType)
+            return transportType switch
             {
-                case TransportType.Amqp:
-                    return new ITransportSettings[]
+                TransportType.Amqp => new ITransportSettings[]
                     {
                         new AmqpTransportSettings(TransportType.Amqp_Tcp_Only),
                         new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
-                    };
-
-                case TransportType.Mqtt:
-                    return new ITransportSettings[]
+                    },
+                TransportType.Mqtt => new ITransportSettings[]
                     {
                         new MqttTransportSettings(TransportType.Mqtt_Tcp_Only),
                         new MqttTransportSettings(TransportType.Mqtt_WebSocket_Only)
-                    };
-
-                case TransportType.Amqp_WebSocket_Only:
-                case TransportType.Amqp_Tcp_Only:
-                    return new ITransportSettings[]
+                    },
+                TransportType.Amqp_WebSocket_Only or TransportType.Amqp_Tcp_Only => new ITransportSettings[]
                     {
                         new AmqpTransportSettings(transportType)
-                    };
-
-                case TransportType.Mqtt_WebSocket_Only:
-                case TransportType.Mqtt_Tcp_Only:
-                    return new ITransportSettings[]
+                    },
+                TransportType.Mqtt_WebSocket_Only or TransportType.Mqtt_Tcp_Only => new ITransportSettings[]
                     {
                         new MqttTransportSettings(transportType)
-                    };
-
-                case TransportType.Http1:
-                    return new ITransportSettings[] { new Http1TransportSettings() };
-
-                default:
-                    throw new InvalidOperationException("Unsupported Transport Type {0}".FormatInvariant(transportType));
-            }
+                    },
+                TransportType.Http1 => new ITransportSettings[] { new Http1TransportSettings() },
+                _ => throw new InvalidOperationException($"Unsupported transport type {transportType}"),
+            };
         }
 
         internal static InternalClient CreateFromConnectionString(
@@ -411,6 +335,11 @@ namespace Microsoft.Azure.Devices.Client
             IDeviceClientPipelineBuilder pipelineBuilder,
             ClientOptions options = default)
         {
+            if (options == default)
+            {
+                options = new();
+            }
+
             if (connectionString == null)
             {
                 throw new ArgumentNullException(nameof(connectionString));
@@ -418,15 +347,15 @@ namespace Microsoft.Azure.Devices.Client
 
             if (transportSettings == null)
             {
-                throw new ArgumentNullException(nameof(transportSettings));
+                transportSettings = GetTransportSettings(options.TransportType);
             }
 
             if (transportSettings.Length == 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(connectionString), "Must specify at least one TransportSettings instance");
+                throw new ArgumentOutOfRangeException(nameof(transportSettings), "Must specify at least one TransportSettings instance");
             }
 
-            if (!string.IsNullOrWhiteSpace(options?.ModelId)
+            if (!string.IsNullOrWhiteSpace(options.ModelId)
                 && transportSettings.Any(x => x.GetTransportType() == TransportType.Http1))
             {
                 throw new InvalidOperationException("Plug and Play is not supported over the HTTP transport.");
@@ -439,8 +368,8 @@ namespace Microsoft.Azure.Devices.Client
             // Clients that derive their authentication method from AuthenticationWithTokenRefresh will need to specify
             // the token time to live and renewal buffer values through the corresponding AuthenticationWithTokenRefresh
             // implementation constructors instead, and these values are irrelevant for cert-based auth.
-            if (!(builder.AuthenticationMethod is AuthenticationWithTokenRefresh)
-                && !(builder.AuthenticationMethod is DeviceAuthenticationWithX509Certificate))
+            if (builder.AuthenticationMethod is not AuthenticationWithTokenRefresh
+                && builder.AuthenticationMethod is not DeviceAuthenticationWithX509Certificate)
             {
                 builder.SasTokenTimeToLive = options?.SasTokenTimeToLive ?? default;
                 builder.SasTokenRenewalBuffer = options?.SasTokenRenewalBuffer ?? default;
@@ -454,14 +383,14 @@ namespace Microsoft.Azure.Devices.Client
                 {
                     case TransportType.Amqp_WebSocket_Only:
                     case TransportType.Amqp_Tcp_Only:
-                        if (!(transportSetting is AmqpTransportSettings))
+                        if (transportSetting is not AmqpTransportSettings)
                         {
                             throw new InvalidOperationException("Unknown implementation of ITransportSettings type");
                         }
                         break;
 
                     case TransportType.Http1:
-                        if (!(transportSetting is Http1TransportSettings))
+                        if (transportSetting is not Http1TransportSettings)
                         {
                             throw new InvalidOperationException("Unknown implementation of ITransportSettings type");
                         }
@@ -469,7 +398,7 @@ namespace Microsoft.Azure.Devices.Client
 
                     case TransportType.Mqtt_WebSocket_Only:
                     case TransportType.Mqtt_Tcp_Only:
-                        if (!(transportSetting is MqttTransportSettings))
+                        if (transportSetting is not MqttTransportSettings)
                         {
                             throw new InvalidOperationException("Unknown implementation of ITransportSettings type");
                         }
@@ -513,12 +442,12 @@ namespace Microsoft.Azure.Devices.Client
         {
             if (options == null)
             {
-                options = new ClientOptions();
+                options = new();
             }
 
             if (options.FileUploadTransportSettings == null)
             {
-                options.FileUploadTransportSettings = new Http1TransportSettings();
+                options.FileUploadTransportSettings = new();
             }
 
             if (cert != null
@@ -544,10 +473,9 @@ namespace Microsoft.Azure.Devices.Client
             IotHubConnectionStringBuilder connectionStringBuilder,
             TransportType transportType)
         {
-            switch (transportType)
+            return transportType switch
             {
-                case TransportType.Amqp:
-                    return new ITransportSettings[]
+                TransportType.Amqp => new ITransportSettings[]
                     {
                         new AmqpTransportSettings(TransportType.Amqp_Tcp_Only)
                         {
@@ -557,37 +485,29 @@ namespace Microsoft.Azure.Devices.Client
                         {
                             ClientCertificate = connectionStringBuilder.Certificate
                         }
-                    };
-
-                case TransportType.Amqp_Tcp_Only:
-                    return new ITransportSettings[]
+                    },
+                TransportType.Amqp_Tcp_Only => new ITransportSettings[]
                     {
                         new AmqpTransportSettings(TransportType.Amqp_Tcp_Only)
                         {
                             ClientCertificate = connectionStringBuilder.Certificate
                         }
-                    };
-
-                case TransportType.Amqp_WebSocket_Only:
-                    return new ITransportSettings[]
+                    },
+                TransportType.Amqp_WebSocket_Only => new ITransportSettings[]
                     {
                         new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
                         {
                             ClientCertificate = connectionStringBuilder.Certificate
                         }
-                    };
-
-                case TransportType.Http1:
-                    return new ITransportSettings[]
+                    },
+                TransportType.Http1 => new ITransportSettings[]
                     {
                         new Http1TransportSettings()
                         {
                             ClientCertificate = connectionStringBuilder.Certificate
                         }
-                    };
-
-                case TransportType.Mqtt:
-                    return new ITransportSettings[]
+                    },
+                TransportType.Mqtt => new ITransportSettings[]
                     {
                         new MqttTransportSettings(TransportType.Mqtt_Tcp_Only)
                         {
@@ -597,33 +517,27 @@ namespace Microsoft.Azure.Devices.Client
                         {
                             ClientCertificate = connectionStringBuilder.Certificate
                         }
-                    };
-
-                case TransportType.Mqtt_Tcp_Only:
-                    return new ITransportSettings[]
+                    },
+                TransportType.Mqtt_Tcp_Only => new ITransportSettings[]
                     {
                         new MqttTransportSettings(TransportType.Mqtt_Tcp_Only)
                         {
                             ClientCertificate = connectionStringBuilder.Certificate
                         }
-                    };
-
-                case TransportType.Mqtt_WebSocket_Only:
-                    return new ITransportSettings[]
+                    },
+                TransportType.Mqtt_WebSocket_Only => new ITransportSettings[]
                     {
                         new MqttTransportSettings(TransportType.Mqtt_WebSocket_Only)
                         {
                             ClientCertificate = connectionStringBuilder.Certificate
                         }
-                    };
-
-                default:
-                    throw new InvalidOperationException($"Unsupported Transport {transportType}");
-            }
+                    },
+                _ => throw new InvalidOperationException($"Unsupported Transport {transportType}"),
+            };
         }
 
         private static ITransportSettings[] PopulateCertificateInTransportSettings(
-            IotHubConnectionStringBuilder connectionStringBuilder, 
+            IotHubConnectionStringBuilder connectionStringBuilder,
             ITransportSettings[] transportSettings)
         {
             foreach (ITransportSettings transportSetting in transportSettings)

--- a/iothub/device/src/ClientSettings/ClientOptions.cs
+++ b/iothub/device/src/ClientSettings/ClientOptions.cs
@@ -11,9 +11,15 @@ namespace Microsoft.Azure.Devices.Client
     public class ClientOptions
     {
         /// <summary>
-        /// The DTDL model Id associated with the device or module client instance.
-        /// This feature is currently supported only over MQTT and AMQP.
+        /// The transport type to use (i.e., AMQP, MQTT, HTTP), including whether to use TCP or web sockets where applicable.
         /// </summary>
+        public TransportType TransportType { get; set; } = TransportType.Amqp;
+
+        /// <summary>
+        /// The DTDL model Id associated with the device or module client instance.
+        /// </summary>
+        /// This feature is currently supported only over MQTT and AMQP transports.
+        /// <remarks></remarks>
         public string ModelId { get; set; }
 
         /// <summary>
@@ -26,8 +32,10 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <summary>
         /// The configuration for setting <see cref="Message.MessageId"/> for every message sent by the device or module client instance.
-        /// The default behavior is that <see cref="Message.MessageId"/> is set only by the user.
         /// </summary>
+        /// <remarks>
+        /// The default behavior is that MessageId is set only by the user.
+        /// </remarks>
         public SdkAssignsMessageId SdkAssignsMessageId { get; set; } = SdkAssignsMessageId.Never;
 
         /// <summary>

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -76,42 +76,6 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="hostname">The fully-qualified DNS host name of IoT hub</param>
         /// <param name="authenticationMethod">The authentication method that is used</param>
-        /// <param name="transportType">The transportType used (HTTP1, AMQP or MQTT), <see cref="TransportType"/></param>
-        /// <param name="options">The options that allow configuration of the device client instance during initialization.</param>
-        /// <returns>A disposable DeviceClient instance</returns>
-        public static DeviceClient Create(
-            string hostname,
-            IAuthenticationMethod authenticationMethod,
-            TransportType transportType,
-            ClientOptions options = default)
-        {
-            return Create(() => ClientFactory.Create(hostname, authenticationMethod, transportType, options));
-        }
-
-        /// <summary>
-        /// Create a disposable DeviceClient from the specified parameters
-        /// </summary>
-        /// <param name="hostname">The fully-qualified DNS host name of IoT hub</param>
-        /// <param name="gatewayHostname">The fully-qualified DNS host name of Gateway</param>
-        /// <param name="authenticationMethod">The authentication method that is used</param>
-        /// <param name="transportType">The transportType used (Http1, AMQP or MQTT), <see cref="TransportType"/></param>
-        /// <param name="options">The options that allow configuration of the device client instance during initialization.</param>
-        /// <returns>A disposable DeviceClient instance</returns>
-        public static DeviceClient Create(
-            string hostname,
-            string gatewayHostname,
-            IAuthenticationMethod authenticationMethod,
-            TransportType transportType,
-            ClientOptions options = default)
-        {
-            return Create(() => ClientFactory.Create(hostname, gatewayHostname, authenticationMethod, transportType, options));
-        }
-
-        /// <summary>
-        /// Creates a disposable DeviceClient from the specified parameters
-        /// </summary>
-        /// <param name="hostname">The fully-qualified DNS host name of IoT hub</param>
-        /// <param name="authenticationMethod">The authentication method that is used</param>
         /// <param name="transportSettings">Prioritized list of transportTypes and their settings</param>
         /// <param name="options">The options that allow configuration of the device client instance during initialization.</param>
         /// <returns>A disposable DeviceClient instance</returns>
@@ -157,38 +121,6 @@ namespace Microsoft.Azure.Devices.Client
         public static DeviceClient CreateFromConnectionString(string connectionString, string deviceId, ClientOptions options = default)
         {
             return Create(() => ClientFactory.CreateFromConnectionString(connectionString, deviceId, options));
-        }
-
-        /// <summary>
-        /// Creates a disposable DeviceClient from the specified connection string using the specified transport type
-        /// </summary>
-        /// <param name="connectionString">Connection string for the IoT hub (including DeviceId)</param>
-        /// <param name="transportType">Specifies whether Http1, AMQP or MQTT transport is used, <see cref="TransportType"/></param>
-        /// <param name="options">The options that allow configuration of the device client instance during initialization.</param>
-        /// <returns>A disposable DeviceClient instance</returns>
-        public static DeviceClient CreateFromConnectionString(
-            string connectionString,
-            TransportType transportType,
-            ClientOptions options = default)
-        {
-            return Create(() => ClientFactory.CreateFromConnectionString(connectionString, transportType, options));
-        }
-
-        /// <summary>
-        /// Creates a disposable DeviceClient from the specified connection string using the specified transport type
-        /// </summary>
-        /// <param name="connectionString">IoT hub-Scope Connection string for the IoT hub (without DeviceId)</param>
-        /// <param name="deviceId">Id of the device</param>
-        /// <param name="transportType">The transportType used (Http1, AMQP or MQTT), <see cref="TransportType"/></param>
-        /// <param name="options">The options that allow configuration of the device client instance during initialization.</param>
-        /// <returns>A disposable DeviceClient instance</returns>
-        public static DeviceClient CreateFromConnectionString(
-            string connectionString,
-            string deviceId,
-            TransportType transportType,
-            ClientOptions options = default)
-        {
-            return Create(() => ClientFactory.CreateFromConnectionString(connectionString, deviceId, transportType, options));
         }
 
         /// <summary>

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Devices.Client
                 ModuleEventCallback = OnModuleEventMessageReceivedAsync,
                 DeviceEventCallback = OnDeviceMessageReceivedAsync,
                 ProductInfo = _productInfo,
-                ClientOptions = options
+                ClientOptions = options,
             };
 
             IDelegatingHandler innerHandler = pipelineBuilder.Build(pipelineContext);

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -98,34 +98,6 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="hostname">The fully-qualified DNS host name of IoT hub.</param>
         /// <param name="authenticationMethod">The authentication method that is used.</param>
-        /// <param name="transportType">The transportType used (Http1 or AMQP).</param>
-        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
-        /// <returns>ModuleClient</returns>
-        public static ModuleClient Create(string hostname, IAuthenticationMethod authenticationMethod, TransportType transportType, ClientOptions options = default)
-        {
-            return Create(() => ClientFactory.Create(hostname, authenticationMethod, transportType, options));
-        }
-
-        /// <summary>
-        /// Creates a ModuleClient from individual parameters.
-        /// </summary>
-        /// <param name="hostname">The fully-qualified DNS host name of IoT hub.</param>
-        /// <param name="gatewayHostname">The fully-qualified DNS host name of Gateway.</param>
-        /// <param name="authenticationMethod">The authentication method that is used.</param>
-        /// <param name="transportType">The transportType used (Http1 or AMQP).</param>
-        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
-        /// <returns>ModuleClient</returns>
-        public static ModuleClient Create(string hostname, string gatewayHostname, IAuthenticationMethod authenticationMethod,
-            TransportType transportType, ClientOptions options = default)
-        {
-            return Create(() => ClientFactory.Create(hostname, gatewayHostname, authenticationMethod, transportType, options));
-        }
-
-        /// <summary>
-        /// Creates a ModuleClient from individual parameters.
-        /// </summary>
-        /// <param name="hostname">The fully-qualified DNS host name of IoT hub.</param>
-        /// <param name="authenticationMethod">The authentication method that is used.</param>
         /// <param name="transportSettings">Prioritized list of transportTypes and their settings.</param>
         /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>ModuleClient</returns>
@@ -162,18 +134,6 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Creates ModuleClient from the specified connection string using the specified transport type.
-        /// </summary>
-        /// <param name="connectionString">Connection string for the IoT hub (including DeviceId).</param>
-        /// <param name="transportType">Specifies whether AMQP or HTTP transport is used.</param>
-        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
-        /// <returns>ModuleClient</returns>
-        public static ModuleClient CreateFromConnectionString(string connectionString, TransportType transportType, ClientOptions options = default)
-        {
-            return Create(() => ClientFactory.CreateFromConnectionString(connectionString, transportType, options));
-        }
-
-        /// <summary>
         /// Creates ModuleClient from the specified connection string using a prioritized list of transports.
         /// </summary>
         /// <param name="connectionString">Connection string for the IoT hub (with DeviceId).</param>
@@ -190,21 +150,16 @@ namespace Microsoft.Azure.Devices.Client
         /// Creates a ModuleClient instance in an IoT Edge deployment based on environment variables.
         /// </summary>
         /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
+        /// 
         /// <returns>ModuleClient instance</returns>
         public static Task<ModuleClient> CreateFromEnvironmentAsync(ClientOptions options = default)
         {
-            return CreateFromEnvironmentAsync(TransportType.Amqp, options);
-        }
+            if (options == default)
+            {
+                options = new();
+            }
 
-        /// <summary>
-        /// Creates a ModuleClient instance in an IoT Edge deployment based on environment variables.
-        /// </summary>
-        /// <param name="transportType">Specifies whether AMQP or HTTP transport is used.</param>
-        /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
-        /// <returns>ModuleClient instance</returns>
-        public static Task<ModuleClient> CreateFromEnvironmentAsync(TransportType transportType, ClientOptions options = default)
-        {
-            return CreateFromEnvironmentAsync(ClientFactory.GetTransportSettings(transportType), options);
+            return CreateFromEnvironmentAsync(ClientFactory.GetTransportSettings(options.TransportType), options);
         }
 
         /// <summary>

--- a/iothub/device/tests/Authentication/DeviceClientConnectionStringExceptionTests.cs
+++ b/iothub/device/tests/Authentication/DeviceClientConnectionStringExceptionTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [ExpectedException(typeof(ArgumentException))]
         public void DeviceClientConnectionStringEmptyConnectionStringExceptionTest()
         {
             string connectionString = "";

--- a/iothub/device/tests/DeviceClientTests.cs
+++ b/iothub/device/tests/DeviceClientTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             string hostName = "acme.azure-devices.net";
             var authMethod = new DeviceAuthenticationWithX509Certificate("device1", null);
 
-            Action act = () => DeviceClient.Create(hostName, authMethod, TransportType.Amqp_WebSocket_Only);
+            Action act = () => DeviceClient.Create(hostName, authMethod, new ClientOptions { TransportType = TransportType.Amqp_WebSocket_Only });
             act.Should().Throw<ArgumentException>();
         }
 
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             string hostName = "acme.azure-devices.net";
             var authMethod = new DeviceAuthenticationWithSakRefresh("device1", s_cs);
 
-            var deviceClient = DeviceClient.Create(hostName, authMethod, TransportType.Amqp_WebSocket_Only);
+            var deviceClient = DeviceClient.Create(hostName, authMethod, new ClientOptions { TransportType = TransportType.Amqp_WebSocket_Only });
         }
 
         [TestMethod]
@@ -87,7 +87,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             string gatewayHostname = "gateway.acme.azure-devices.net";
             var authMethod = new DeviceAuthenticationWithSakRefresh("device1", s_cs);
 
-            using var deviceClient = DeviceClient.Create(hostName, gatewayHostname, authMethod, TransportType.Amqp_WebSocket_Only);
+            using var deviceClient = DeviceClient.Create(
+                hostName,
+                gatewayHostname,
+                authMethod,
+                new ClientOptions { TransportType = TransportType.Amqp_WebSocket_Only });
         }
 
         [TestMethod]
@@ -126,7 +130,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             string gatewayHostname = "myGatewayDevice";
             var authMethod = new DeviceAuthenticationWithSakRefresh("device1", s_cs);
 
-            using var deviceClient = DeviceClient.Create(gatewayHostname, authMethod, TransportType.Amqp_WebSocket_Only);
+            using var deviceClient = DeviceClient.Create(gatewayHostname, authMethod, new ClientOptions { TransportType = TransportType.Amqp_WebSocket_Only });
         }
 
         // This is for the scenario where an IoT Edge device is defined as the downstream device's transparent gateway.
@@ -202,7 +206,8 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public void DeviceClient_StartDiagLocallyThatDoNotSupport_ThrowException()
         {
-            using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString, TransportType.Http1);
+            var options = new ClientOptions { TransportType = TransportType.Http1 };
+            using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString, options);
             try
             {
                 deviceClient.DiagnosticSamplingPercentage = 100;
@@ -1286,6 +1291,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             int sasTokenRenewalBuffer = 50;
             var options = new ClientOptions
             {
+                TransportType = TransportType.Mqtt,
                 SasTokenTimeToLive = sasTokenTimeToLive,
                 SasTokenRenewalBuffer = sasTokenRenewalBuffer,
             };
@@ -1293,7 +1299,11 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // act
             DateTime startTime = DateTime.UtcNow;
-            InternalClient internalClient = ClientFactory.CreateFromConnectionString(FakeConnectionString, null, TransportType.Mqtt, pipelineBuilderSubstitute, options);
+            InternalClient internalClient = ClientFactory.CreateFromConnectionString(
+                FakeConnectionString,
+                null,
+                pipelineBuilderSubstitute,
+                options);
 
             // assert
             var authMethod = internalClient.IotHubConnectionString.TokenRefresher;
@@ -1321,6 +1331,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             int sasTokenRenewalBuffer = 50;
             var options = new ClientOptions
             {
+                TransportType = TransportType.Mqtt,
                 SasTokenTimeToLive = sasTokenTimeToLive,
                 SasTokenRenewalBuffer = sasTokenRenewalBuffer,
             };
@@ -1334,7 +1345,11 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // act
             DateTime startTime = DateTime.UtcNow;
-            InternalClient internalClient = ClientFactory.CreateFromConnectionString(FakeConnectionString, authMethod1, TransportType.Mqtt, pipelineBuilderSubstitute, options);
+            InternalClient internalClient = ClientFactory.CreateFromConnectionString(
+                FakeConnectionString,
+                authMethod1,
+                pipelineBuilderSubstitute,
+                options);
 
             // assert
             // Clients created with their own specific AuthenticationWithTokenRefresh IAuthenticationMethod will ignore the sas token renewal options specified in ClientOptions.
@@ -1371,12 +1386,13 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             var clientOptions = new ClientOptions
             {
+                TransportType = TransportType.Http1,
                 ModelId = TestModelId,
             };
 
             // act
 
-            Action act = () => DeviceClient.CreateFromConnectionString(FakeConnectionString, TransportType.Http1, clientOptions);
+            Action act = () => DeviceClient.CreateFromConnectionString(FakeConnectionString, clientOptions);
 
             // assert
 
@@ -1445,9 +1461,10 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public void DeviceClient_InitWithHttpTransportButNoModelId_DoesNotThrow()
         {
+            var options = new ClientOptions { TransportType = TransportType.Http1 };
             // act and assert
             FluentActions
-                .Invoking(() => { using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString, TransportType.Http1); })
+                .Invoking(() => { using var deviceClient = DeviceClient.CreateFromConnectionString(FakeConnectionString, options); })
                 .Should()
                 .NotThrow();
         }

--- a/iothub/device/tests/Edge/EdgeModuleClientFactoryTest.cs
+++ b/iothub/device/tests/Edge/EdgeModuleClientFactoryTest.cs
@@ -64,7 +64,8 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
         public async Task TestCreate_FromConnectionStringEnvironment_SetTransportType_ShouldCreateClient()
         {
             Environment.SetEnvironmentVariable(EdgehubConnectionstringVariableName, s_iotHubConnectionString);
-            ModuleClient dc = await ModuleClient.CreateFromEnvironmentAsync(TransportType.Mqtt_Tcp_Only);
+            var options = new ClientOptions { TransportType = TransportType.Mqtt_Tcp_Only };
+            ModuleClient dc = await ModuleClient.CreateFromEnvironmentAsync(options);
 
             Assert.IsNotNull(dc);
 

--- a/iothub/device/tests/ModuleClientTests.cs
+++ b/iothub/device/tests/ModuleClientTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public void ModuleClient_CreateFromConnectionString_NoTransportSettings()
         {
-            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, TransportType.Mqtt_Tcp_Only);
+            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString);
             Assert.IsNotNull(moduleClient);
         }
 
@@ -89,8 +89,8 @@ namespace Microsoft.Azure.Devices.Client.Test
         // Tests_SRS_DEVICECLIENT_33_003: [** It shall EnableEventReceiveAsync when called for the first time. **]**
         public async Task ModuleClient_SetReceiveCallbackAsync_SetCallback_Mqtt()
         {
-            var transportType = TransportType.Mqtt_Tcp_Only;
-            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, transportType);
+            var options = new ClientOptions { TransportType = TransportType.Mqtt_Tcp_Only };
+            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, options);
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -106,8 +106,8 @@ namespace Microsoft.Azure.Devices.Client.Test
         // Tests_SRS_DEVICECLIENT_33_004: [** It shall call DisableEventReceiveAsync when the last delegate has been removed. **]**
         public async Task ModuleClient_SetReceiveCallbackAsync_RemoveCallback_Mqtt()
         {
-            var transportType = TransportType.Mqtt_Tcp_Only;
-            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, transportType);
+            var options = new ClientOptions { TransportType = TransportType.Mqtt_Tcp_Only };
+            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, options);
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -137,8 +137,8 @@ namespace Microsoft.Azure.Devices.Client.Test
         // Tests_SRS_DEVICECLIENT_33_003: [** It shall EnableEventReceiveAsync when called for the first time. **]**
         public async Task ModuleClient_SetDefaultReceiveCallbackAsync_SetCallback_Mqtt()
         {
-            var transportType = TransportType.Mqtt_Tcp_Only;
-            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, transportType);
+            var options = new ClientOptions { TransportType = TransportType.Mqtt_Tcp_Only };
+            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, options);
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -153,8 +153,8 @@ namespace Microsoft.Azure.Devices.Client.Test
         // Tests_SRS_DEVICECLIENT_33_004: [** It shall call DisableEventReceiveAsync when the last delegate has been removed. **]**
         public async Task ModuleClient_SetDefaultReceiveCallbackAsync_RemoveCallback_Mqtt()
         {
-            var transportType = TransportType.Mqtt_Tcp_Only;
-            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, transportType);
+            var options = new ClientOptions { TransportType = TransportType.Mqtt_Tcp_Only };
+            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, options);
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public async Task ModuleClient_SetReceiveCallbackAsync_SetCallback_Amqp()
         {
-            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, TransportType.Amqp_Tcp_Only);
+            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString);
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public async Task ModuleClient_SetReceiveCallbackAsync_RemoveCallback_Amqp()
         {
-            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, TransportType.Amqp_Tcp_Only);
+            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString);
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -212,7 +212,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public async Task ModuleClient_SetDefaultReceiveCallbackAsync_SetCallback_Amqp()
         {
-            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, TransportType.Amqp_Tcp_Only);
+            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString);
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public async Task ModuleClient_SetDefaultReceiveCallbackAsync_RemoveCallback_Amqp()
         {
-            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, TransportType.Amqp_Tcp_Only);
+            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString);
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -246,7 +246,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         // Tests_SRS_DEVICECLIENT_33_001: [** If the given eventMessageInternal argument is null, fail silently **]**
         public async Task ModuleClient_OnReceiveEventMessageCalled_NullMessageRequest()
         {
-            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, TransportType.Mqtt_Tcp_Only);
+            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString);
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         // Tests_SRS_DEVICECLIENT_33_005: [** It shall lazy-initialize the receiveEventEndpoints property. **]**
         public async Task ModuleClient_OnReceiveEventMessageCalled_DefaultCallbackCalled()
         {
-            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, TransportType.Mqtt_Tcp_Only);
+            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString);
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
@@ -312,7 +312,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         // Tests_SRS_DEVICECLIENT_33_002: [** The OnReceiveEventMessageCalled shall invoke the specified delegate. **]**
         public async Task ModuleClient_OnReceiveEventMessageCalled_SpecifiedCallbackCalled()
         {
-            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString, TransportType.Mqtt_Tcp_Only);
+            var moduleClient = ModuleClient.CreateFromConnectionString(FakeConnectionString);
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 


### PR DESCRIPTION
In order to reduce the number of factory methods (soon to be ctors), we'll start by moving parameters to `ClientOptions`, starting with `TransportType`.