### PR TITLE
Fix service API query string being added twice to device statistics r…

### DIFF
--- a/e2e/test/iothub/service/RegistryE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryE2ETests.cs
@@ -574,6 +574,24 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
             }
         }
 
+        [LoggedTestMethod]
+        public async Task DevicesClient_GetStatistics()
+        {
+            using var serviceClient = new IotHubServiceClient(TestConfiguration.IoTHub.ConnectionString);
+
+            // No great way to test the accuracy of these statistics, but making the request successfully should
+            // be enough to indicate that this API works as intended
+            ServiceStatistics serviceStatistics = await serviceClient.Devices.GetServiceStatisticsAsync().ConfigureAwait(false);
+            serviceStatistics.ConnectedDeviceCount.Should().BeGreaterOrEqualTo(0);
+
+            // No great way to test the accuracy of these statistics, but making the request successfully should
+            // be enough to indicate that this API works as intended
+            RegistryStatistics registryStatistics = await serviceClient.Devices.GetRegistryStatisticsAsync().ConfigureAwait(false);
+            registryStatistics.DisabledDeviceCount.Should().BeGreaterOrEqualTo(0);
+            registryStatistics.EnabledDeviceCount.Should().BeGreaterOrEqualTo(0);
+            registryStatistics.TotalDeviceCount.Should().BeGreaterOrEqualTo(0);
+        }
+
         private static async Task CleanupAsync(IotHubServiceClient serviceClient, string deviceId)
         {
             if (deviceId == null)

--- a/iothub/service/src/Registry2/DevicesClient.cs
+++ b/iothub/service/src/Registry2/DevicesClient.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices
         private const string JobsListUriFormat = "/jobs";
         private const string JobsCreateUriFormat = "/jobs/create";
         private const string DeviceStatisticsUriFormat = "/statistics/devices";
-        private const string ServiceStatisticsUriFormat = "/statistics/service?" + ClientApiVersionHelper.ApiVersionQueryString;
+        private const string ServiceStatisticsUriFormat = "/statistics/service";
         private const string AdminUriFormat = "/$admin/{0}";
 
         /// <summary>
@@ -1170,7 +1170,7 @@ namespace Microsoft.Azure.Devices
 
         private static Uri GetDeviceStatisticsUri()
         {
-            return new Uri(DeviceStatisticsUriFormat.FormatInvariant(ClientApiVersionHelper.ApiVersionQueryString), UriKind.Relative);
+            return new Uri(DeviceStatisticsUriFormat, UriKind.Relative);
         }
 
         private static Uri GetServiceStatisticsUri()


### PR DESCRIPTION
…equests

Also add a basic e2e test to ensure that these statistics requests can be made
