### PR TITLE
reafctor(iot-device): Add protected parameterless constructor to allow for mocking

### DIFF
--- a/iothub/device/src/Convention/ClientProperties.cs
+++ b/iothub/device/src/Convention/ClientProperties.cs
@@ -8,10 +8,16 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     public class ClientProperties
     {
-        // TODO: Unit-testable and mockable
+        /// <summary>
+        /// Creates an instance of this class. Provided for unit testing purposes only.
+        /// </summary>
+        protected ClientProperties()
+        {
+
+        }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="ClientProperties"/> with the specified collections.
+        /// Creates an instance of this class with the specified collections. Provided for internal use only.
         /// </summary>
         /// <param name="writablePropertyRequestCollection">A collection of writable property requests returned from IoT Hub.</param>
         /// <param name="clientReportedPropertyCollection">A collection of client reported properties returned from IoT Hub.</param>

--- a/iothub/device/src/Convention/ClientProperties.cs
+++ b/iothub/device/src/Convention/ClientProperties.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         protected ClientProperties()
         {
-
         }
 
         /// <summary>

--- a/iothub/device/src/Convention/ClientPropertiesUpdateResponse.cs
+++ b/iothub/device/src/Convention/ClientPropertiesUpdateResponse.cs
@@ -9,9 +9,10 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     public class ClientPropertiesUpdateResponse
     {
-        // TODO: Unit-testable and mockable
-
-        internal ClientPropertiesUpdateResponse()
+        /// <summary>
+        /// Creates an instance of this class. Provided for internal use only, unless used in mocking for testing.
+        /// </summary>
+        protected internal ClientPropertiesUpdateResponse()
         {
         }
 

--- a/iothub/device/src/Convention/ClientProperty.cs
+++ b/iothub/device/src/Convention/ClientProperty.cs
@@ -8,9 +8,10 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     public class ClientProperty
     {
-        // TODO: Unit-testable and mockable
-
-        internal ClientProperty()
+        /// <summary>
+        /// Creates an instance of this class. Provided for internal use only, unless used in mocking for testing.
+        /// </summary>
+        protected internal ClientProperty()
         {
         }
 

--- a/iothub/device/src/Convention/ClientPropertyCollection.cs
+++ b/iothub/device/src/Convention/ClientPropertyCollection.cs
@@ -21,8 +21,6 @@ namespace Microsoft.Azure.Devices.Client
     {
         private const string VersionName = "$version";
 
-        // TODO: Unit-testable and mockable
-
         /// <summary>
         /// Initializes a new instance of this class.
         /// </summary>

--- a/iothub/device/src/Convention/CommandRequest.cs
+++ b/iothub/device/src/Convention/CommandRequest.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         protected CommandRequest()
         {
-
         }
 
         /// <summary>

--- a/iothub/device/src/Convention/CommandRequest.cs
+++ b/iothub/device/src/Convention/CommandRequest.cs
@@ -15,10 +15,16 @@ namespace Microsoft.Azure.Devices.Client
         private readonly ReadOnlyCollection<byte> _payload;
         private readonly PayloadConvention _payloadConvention;
 
-        // TODO: Unit-testable and mockable
+        /// <summary>
+        /// Creates an instance of this class. Provided for unit testing purposes only.
+        /// </summary>
+        protected CommandRequest()
+        {
+
+        }
 
         /// <summary>
-        /// For internal use only, unless used in mocking for testing.
+        /// Creates an instance of this class. Provided for internal use only.
         /// </summary>
         /// <param name="payloadConvention">The instance of the payload convention to use.</param>
         /// <param name="commandName">The name of the command.</param>

--- a/iothub/device/src/Convention/TelemetryCollection.cs
+++ b/iothub/device/src/Convention/TelemetryCollection.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     public class TelemetryCollection : IEnumerable<KeyValuePair<string, object>>
     {
-        // TODO: Unit-testable and mockable
-
         /// <summary>
         /// The underlying collection for the payload.
         /// </summary>

--- a/iothub/device/src/Convention/WritableClientProperty.cs
+++ b/iothub/device/src/Convention/WritableClientProperty.cs
@@ -13,8 +13,16 @@ namespace Microsoft.Azure.Devices.Client
     /// </remarks>
     public class WritableClientProperty
     {
-        // TODO: Unit-testable and mockable
+        /// <summary>
+        /// Creates an instance of this class. Provided for unit testing purposes only.
+        /// </summary>
+        protected WritableClientProperty()
+        {
+        }
 
+        /// <summary>
+        /// Creates an instance of this class. Provided for internal use only.
+        /// </summary>
         internal WritableClientProperty(long version, PayloadConvention payloadConvention)
         {
             Version = version;

--- a/iothub/device/src/Convention/WritableClientPropertyAcknowledgement.cs
+++ b/iothub/device/src/Convention/WritableClientPropertyAcknowledgement.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Azure.Devices.Client
     /// </remarks>
     public class WritableClientPropertyAcknowledgement
     {
-        // TODO: Unit-testable and mockable
-
         /// <summary>
         /// The name of the component for which an update request is received.
         /// This is <c>null</c> for an update request for a root-level writable property.

--- a/iothub/device/src/Convention/WritableClientPropertyCollection.cs
+++ b/iothub/device/src/Convention/WritableClientPropertyCollection.cs
@@ -23,8 +23,16 @@ namespace Microsoft.Azure.Devices.Client
     {
         private const string VersionName = "$version";
 
-        // TODO: Unit-testable and mockable
+        /// <summary>
+        /// Creates an instance of this class. Provided for unit testing purposes only.
+        /// </summary>
+        protected WritableClientPropertyCollection()
+        {
+        }
 
+        /// <summary>
+        /// Creates an instance of this class. Provided for internal use only.
+        /// </summary>
         internal WritableClientPropertyCollection(IDictionary<string, object> writableClientPropertyRequests, PayloadConvention payloadConvention)
         {
             Convention = payloadConvention;


### PR DESCRIPTION
As per Azure SDK guidelines, providing a protected parameterless constructor for mocking.