### PR TITLE
Fix E2E test failures - part 1

### DIFF
--- a/e2e/test/E2EMsTestBase.cs
+++ b/e2e/test/E2EMsTestBase.cs
@@ -33,6 +33,9 @@ namespace Microsoft.Azure.Devices.E2ETests
         // The test timeout for long running e2e tests
         protected const int LongRunningTestTimeoutMilliseconds = 5 * 60 * 1000; // 5 minutes
 
+        // The test timeout for long running e2e tests the inspect the connection status change logic on disabling a device.
+        protected const int ConnectionStateChangeTestTimeoutMilliseconds = 10 * 60 * 1000; // 10 minutes
+
         // The test timeout for e2e tests that involve testing token refresh
         protected const int TokenRefreshTestTimeoutMilliseconds = 20 * 60 * 1000; // 20 minutes
 

--- a/e2e/test/helpers/TestDevice.cs
+++ b/e2e/test/helpers/TestDevice.cs
@@ -167,24 +167,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
         public Client.IAuthenticationMethod AuthenticationMethod { get; private set; }
 
-        public IotHubDeviceClient CreateDeviceClient(IotHubClientOptions options = default)
-        {
-            IotHubDeviceClient deviceClient = null;
-
-            if (AuthenticationMethod == null)
-            {
-                deviceClient = IotHubDeviceClient.CreateFromConnectionString(ConnectionString, options);
-                s_logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(IotHubDeviceClient)} {Device.Id} from connection string: {options.TransportSettings} Id={TestLogger.IdOf(deviceClient)}");
-            }
-            else
-            {
-                deviceClient = IotHubDeviceClient.Create(IotHubHostName, AuthenticationMethod, options);
-                s_logger.Trace($"{nameof(CreateDeviceClient)}: Created {nameof(IotHubDeviceClient)} {Device.Id} from IAuthenticationMethod: {options.TransportSettings} Id={TestLogger.IdOf(deviceClient)}");
-            }
-
-            return deviceClient;
-        }
-
         public IotHubDeviceClient CreateDeviceClient(IotHubClientOptions options = default, ConnectionStringAuthScope authScope = ConnectionStringAuthScope.Device)
         {
             IotHubDeviceClient deviceClient = null;

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -111,6 +111,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                     throw;
                 }
             }
+            catch (OperationCanceledException ex) when (transportSettings is IotHubClientMqttSettings)
+            {
+                // For MQTT, FaultInjection will terminate the connection prior to a PUBACK
+                // which leads to an infinite loop trying to resend the FaultInjection message, which will eventually throw an OperationCanceledException.
+                // We will suppress this exception.
+                logger.Trace($"{nameof(ActivateFaultInjectionAsync)}.{nameof(ActivateFaultInjectionAsync)} over MQTT (suppress): {ex}");
+            }
             finally
             {
                 logger.Trace($"{nameof(ActivateFaultInjectionAsync)}: Fault injection requested.");

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                 // For MQTT, FaultInjection will terminate the connection prior to a PUBACK
                 // which leads to an infinite loop trying to resend the FaultInjection message, which will eventually throw an OperationCanceledException.
                 // We will suppress this exception.
-                logger.Trace($"{nameof(ActivateFaultInjectionAsync)}.{nameof(ActivateFaultInjectionAsync)} over MQTT (suppress): {ex}");
+                logger.Trace($"{nameof(ActivateFaultInjectionAsync)}.{nameof(ActivateFaultInjectionAsync)} over MQTT (suppressed): {ex}");
             }
             finally
             {

--- a/e2e/test/iothub/ConnectionStateChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStateChangeHandlerTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 async (r, d) => await r.Devices.DeleteAsync(d).ConfigureAwait(false)).ConfigureAwait(false);
         }
 
-        [LoggedTestMethod, Timeout(TestTimeoutMilliseconds)]
+        [LoggedTestMethod, Timeout(ConnectionStateChangeTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
         public async Task IotHubDeviceClient_DeviceDisabled_Gives_ConnectionState_DeviceDisabled_AmqpTcp()
         {
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 }).ConfigureAwait(false);
         }
 
-        [LoggedTestMethod, Timeout(TestTimeoutMilliseconds)]
+        [LoggedTestMethod, Timeout(ConnectionStateChangeTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
         public async Task IotHubDeviceClient_DeviceDisabled_Gives_ConnectionState_DeviceDisabled_AmqpWs()
         {

--- a/e2e/test/iothub/method/MethodFaultInjectionTests.cs
+++ b/e2e/test/iothub/method/MethodFaultInjectionTests.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     var directMethodRequest = new DirectMethodRequest()
                     {
                         MethodName = methodName,
-                        Payload = respJson,
+                        Payload = reqJson,
                         ResponseTimeout = TimeSpan.FromMinutes(5),
                     };
 

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Azure.Devices.Client
             IDeviceClientPipelineBuilder pipelineBuilder = new DeviceClientPipelineBuilder()
                 .With((ctx, innerHandler) => new RetryDelegatingHandler(ctx, innerHandler))
                 .With((ctx, innerHandler) => new ErrorDelegatingHandler(ctx, innerHandler))
+                .With((ctx, innerHandler) => new TransportDelegatingHandler(ctx, innerHandler))
                 .With((ctx, innerHandler) => transporthandlerFactory.Create(ctx));
 
             return pipelineBuilder;

--- a/iothub/device/src/IotHubDeviceClient.cs
+++ b/iothub/device/src/IotHubDeviceClient.cs
@@ -166,9 +166,8 @@ namespace Microsoft.Azure.Devices.Client
         /// <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d#the-cloud-to-device-message-life-cycle"/>.
         /// </remarks>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <exception cref="IotHubCommunicationException">Thrown when the operation has been canceled. The inner exception will be
-        /// <see cref="OperationCanceledException"/>.</exception>
-        /// <returns>The received message or null if there was no message until cancellation token has expired</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
+        /// <returns>The received message.</returns>
         public Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken = default) => InternalClient.ReceiveMessageAsync(cancellationToken);
 
         /// <summary>

--- a/iothub/device/src/Pipeline/TransportDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/TransportDelegatingHandler.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Devices.Client.Transport
+{
+    /// <summary>
+    /// Transport delegating handler.
+    /// This handler is responsible for initializing the transport handler on initial connection and subsequent reconnects.
+    /// </summary>
+    internal class TransportDelegatingHandler : DefaultDelegatingHandler
+    {
+        private SemaphoreSlim _handlerLock = new(1, 1);
+
+        public TransportDelegatingHandler(PipelineContext context, IDelegatingHandler innerHandler)
+            : base(context, innerHandler)
+        {
+        }
+
+        public override async Task OpenAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (Logging.IsEnabled)
+                    Logging.Enter(this, cancellationToken, $"{nameof(TransportDelegatingHandler)}.{nameof(OpenAsync)}");
+
+                cancellationToken.ThrowIfCancellationRequested();
+                await _handlerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                try
+                {
+                    CreateNewTransportIfNotReady();
+                    await base.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                    // since Dispose is not synced with _handlerLock, double check if disposed.
+                    if (_disposed)
+                    {
+                        NextHandler?.Dispose();
+                        ThrowIfDisposed();
+                    }
+                }
+                finally
+                {
+                    _handlerLock.Release();
+                }
+            }
+            finally
+            {
+                if (Logging.IsEnabled)
+                    Logging.Exit(this, cancellationToken, $"{nameof(TransportDelegatingHandler)}.{nameof(OpenAsync)}");
+            }
+        }
+
+        private void CreateNewTransportIfNotReady()
+        {
+            if (NextHandler == null || !NextHandler.IsUsable)
+            {
+                IDelegatingHandler innerHandler = NextHandler;
+
+                // Ask the ContinuationFactory to attach the proper handler given the Context's ITransportSettings.
+                NextHandler = ContinuationFactory(Context, null);
+
+                innerHandler?.Dispose();
+            }
+        }
+
+        public override async Task WaitForTransportClosedAsync()
+        {
+            // Will throw OperationCancelledException if CloseAsync() or Dispose() has been called by the application.
+            await base.WaitForTransportClosedAsync().ConfigureAwait(false);
+
+            if (Logging.IsEnabled)
+                Logging.Info(this, "Client disconnected.", nameof(WaitForTransportClosedAsync));
+
+            await _handlerLock.WaitAsync().ConfigureAwait(false);
+            Debug.Assert(NextHandler != null);
+
+            // We don't need to double check since it's being handled in OpenAsync
+            CreateNewTransportIfNotReady();
+
+            // Operations above should never throw. If they do, it's not safe to continue.
+            _handlerLock.Release();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            _handlerLock?.Dispose();
+            _handlerLock = null;
+        }
+    }
+}

--- a/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
@@ -174,24 +174,16 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             if (Logging.IsEnabled)
                 Logging.Enter(this, cancellationToken, nameof(ReceiveMessageAsync));
 
-            Message message;
-            while (true)
+            try
             {
                 cancellationToken.ThrowIfCancellationRequested();
-
-                using var ctb = new CancellationTokenBundle(_transportSettings.DefaultReceiveTimeout, cancellationToken);
-                message = await _amqpUnit.ReceiveMessageAsync(ctb.Token).ConfigureAwait(false);
-
-                if (message != null)
-                {
-                    break;
-                }
+                return await _amqpUnit.ReceiveMessageAsync(cancellationToken).ConfigureAwait(false);
             }
-
-            if (Logging.IsEnabled)
-                Logging.Exit(this, cancellationToken, cancellationToken, nameof(ReceiveMessageAsync));
-
-            return message;
+            finally
+            {
+                if (Logging.IsEnabled)
+                    Logging.Exit(this, cancellationToken, nameof(ReceiveMessageAsync));
+            }
         }
 
         public override async Task EnableReceiveMessageAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Part 1 of addressing E2E test failures - failures down from [412](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/results?buildId=113494&view=ms.vss-test-web.build-test-results-tab) to [127](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/results?buildId=113558&view=ms.vss-test-web.build-test-results-tab).

Yesterday's nightly: https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/results?buildId=113531&view=ms.vss-test-web.build-test-results-tab