### PR TITLE
Increase timeout for token refresh tests

### DIFF
--- a/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
@@ -157,17 +157,10 @@ namespace Microsoft.Azure.Devices.E2ETests
             Logger.Trace($"[{testDevice.Id}]: Waiting for device disconnect.");
             await deviceDisconnected.WaitAsync(tokenRefreshCts.Token).ConfigureAwait(false);
 
-            try
-            {
-                Logger.Trace($"[{testDevice.Id}]: SendEventAsync (2)");
-                using var cts2 = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
-                await deviceClient.SendEventAsync(message, cts2.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException ex)
-            {
-                Assert.Fail($"{testDevice.Id} did not refresh token after expected ttl of {sasTokenTimeToLive}: {ex}");
-                throw;
-            }
+            // Test that the client is able to send messages
+            Logger.Trace($"[{testDevice.Id}]: SendEventAsync (2)");
+            using var cts2 = new CancellationTokenSource(timeout);
+            await deviceClient.SendEventAsync(message, cts2.Token).ConfigureAwait(false);
         }
 
         private async Task IotHubDeviceClient_TokenIsRefreshed_Internal(IotHubClientTransportSettings transportSettings, int ttl = 20)

--- a/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             await IotHubDeviceClient_TokenIsRefreshed_Internal(new IotHubClientAmqpSettings()).ConfigureAwait(false);
         }
 
-        [LoggedTestMethod, Timeout(TestTimeoutMilliseconds)]
+        [LoggedTestMethod, Timeout(TokenRefreshTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
         public async Task IotHubDeviceClient_TokenIsRefreshed_Ok_Mqtt()
         {
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         // The easiest way to test that sas tokens expire with custom expiration time via the CreateFromConnectionString flow is
         // by initializing a DeviceClient instance over Mqtt (since sas token expiration over Mqtt is accompanied by a disconnect).
-        [LoggedTestMethod, Timeout(TestTimeoutMilliseconds)]
+        [LoggedTestMethod, Timeout(TokenRefreshTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
         public async Task IotHubDeviceClient_CreateFromConnectionString_TokenIsRefreshed_Mqtt()
         {


### PR DESCRIPTION
These tests take > 5mins to test their feature (token refresh).