### PR TITLE
Remove flakey assertions from query test

### DIFF
--- a/e2e/test/iothub/service/QueryClientE2ETests.cs
+++ b/e2e/test/iothub/service/QueryClientE2ETests.cs
@@ -130,8 +130,6 @@ namespace Microsoft.Azure.Devices.E2ETests.iothub.service
             // That's why these checks aren't more specific.
             queriedJob.JobId.Should().NotBeNull();
             queriedJob.JobType.Should().NotBeNull();
-            queriedJob.StartTimeUtc.Should().NotBeNull();
-            queriedJob.EndTimeUtc.Should().NotBeNull();
             queriedJob.CreatedTimeUtc.Should().NotBeNull();
             queriedJob.Status.Should().NotBeNull();
         }


### PR DESCRIPTION
start time and end time may not be set yet if the job has not started and/or ended yet