### PR TITLE
Fix build error in Tpm simulator

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -259,8 +259,13 @@ try
         # We must disable package testing here as the E2E csproj may reference new APIs that are not available in existing NuGet packages.
         $packageTempPath = $env:AZURE_IOT_LOCALPACKAGES
         $env:AZURE_IOT_LOCALPACKAGES = ""
+        
         # SDK binaries
         BuildProject . "Azure IoT C# SDK Solution"
+
+        # Samples
+        BuildProject security\tpm\samples "SecurityProvider for TPM Samples"
+
         $env:AZURE_IOT_LOCALPACKAGES = $packageTempPath
     }
 
@@ -365,9 +370,6 @@ try
         RunTests "E2E tests" -filterTestCategory $testCategory -framework $framework
 
         $verbosity = $oldVerbosity
-
-        # Samples
-        BuildProject security\tpm\samples "SecurityProvider for TPM Samples"
     }
 
     if ($stresstests)

--- a/security/tpm/samples/AuthenticationProviderTpmSimulator/AuthenticationProviderTpmSimulator.csproj
+++ b/security/tpm/samples/AuthenticationProviderTpmSimulator/AuthenticationProviderTpmSimulator.csproj
@@ -7,8 +7,13 @@
     <RootNamespace>Microsoft.Azure.Devices.Provisioning.Security</RootNamespace>
   </PropertyGroup>
 
+  <!--Project reference dependencies-->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Security.Tpm" Version="1.*" />
+    <ProjectReference Include="..\..\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj" />
+  </ItemGroup>
+
+  <!--Nuget package dependencies-->
+  <ItemGroup>
     <PackageReference Include="Microsoft.TSS" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 


### PR DESCRIPTION
The TPM simulato sample was referencing a nuget package instead of the sourcecode project. This was causing the build to fail since Microsoft.Azure.Devices.Authentication nuget isn't released yet.