### PR TITLE
Fix the order of updating local state vs executing callback for connection status

### DIFF
--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.Devices.Client
 
         // Connection state change information
         private volatile Action<ConnectionInfo> _connectionStateChangeHandler;
+
         internal ConnectionInfo _connectionInfo { get; private set; } = new ConnectionInfo();
 
         // Method callback information
@@ -1168,13 +1169,12 @@ namespace Microsoft.Azure.Devices.Client
                 if (_connectionInfo.State != state
                     || _connectionInfo.ChangeReason != reason)
                 {
-                    _connectionStateChangeHandler?.Invoke(connectionInfo);
+                    _connectionInfo = new ConnectionInfo(state, reason, DateTimeOffset.UtcNow);
+                    _connectionStateChangeHandler?.Invoke(_connectionInfo);
                 }
             }
             finally
             {
-                _connectionInfo = new ConnectionInfo(state, reason, DateTimeOffset.UtcNow);
-
                 if (Logging.IsEnabled)
                     Logging.Exit(this, state, reason, nameof(OnConnectionStateChanged));
             }


### PR DESCRIPTION
There is some risk of race conditions in our e2e tests if we check the locally saved connection state after the connection state callback is invoked if the SDK invokes the callback before updating its local state first.