### PR TITLE
IotHubConnectionStringBuilder - part 2

### DIFF
--- a/iothub/device/src/Authentication/AuthenticationMethodFactory.cs
+++ b/iothub/device/src/Authentication/AuthenticationMethodFactory.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Devices.Client
     /// </summary>
     public sealed class AuthenticationMethodFactory
     {
-        internal static IAuthenticationMethod GetAuthenticationMethod(IotHubConnectionStringBuilder csBuilder)
+        internal static IAuthenticationMethod GetAuthenticationMethodFromConnectionString(IotHubConnectionStringBuilder csBuilder)
         {
             if (csBuilder.SharedAccessKeyName != null)
             {
@@ -40,10 +40,6 @@ namespace Microsoft.Azure.Devices.Client
                         csBuilder.DeviceId,
                         csBuilder.ModuleId,
                         csBuilder.SharedAccessSignature);
-            }
-            else if (csBuilder.UsingX509Cert)
-            {
-                return new DeviceAuthenticationWithX509Certificate(csBuilder.DeviceId, csBuilder.Certificate);
             }
 
             throw new InvalidOperationException($"Unsupported authentication method in '{csBuilder}'.");

--- a/iothub/device/src/Authentication/DeviceAuthenticationWithX509Certificate.cs
+++ b/iothub/device/src/Authentication/DeviceAuthenticationWithX509Certificate.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Azure.Devices.Client
             }
 
             iotHubConnectionStringBuilder.DeviceId = DeviceId;
-            iotHubConnectionStringBuilder.UsingX509Cert = true;
             iotHubConnectionStringBuilder.Certificate = Certificate;
             iotHubConnectionStringBuilder.ChainCertificates = ChainCertificates;
             iotHubConnectionStringBuilder.SharedAccessSignature = null;

--- a/iothub/device/src/Authentication/IotHubConnectionStringBuilder.cs
+++ b/iothub/device/src/Authentication/IotHubConnectionStringBuilder.cs
@@ -191,9 +191,12 @@ namespace Microsoft.Azure.Devices.Client
             }
 
             // Either shared access key, shared access signature or X.509 certificate is required for authenticating the client with IoT hub.
+            // These values should be populated in the constructor. The only exception to this scenario is when the authentication method is
+            // AuthenticationWithTokenRefresh, in which case the shared access signature is initially null and is generated on demand during client authentication.
             if (Certificate == null
                 && SharedAccessKey.IsNullOrWhiteSpace()
-                    && SharedAccessSignature.IsNullOrWhiteSpace())
+                && SharedAccessSignature.IsNullOrWhiteSpace()
+                && AuthenticationMethod is not AuthenticationWithTokenRefresh)
             {
                 throw new ArgumentException(
                         "Should specify either SharedAccessKey, SharedAccessSignature or X.509 certificate for authenticating the client with IoT hub.");

--- a/iothub/device/src/Authentication/IotHubConnectionStringBuilder.cs
+++ b/iothub/device/src/Authentication/IotHubConnectionStringBuilder.cs
@@ -24,15 +24,6 @@ namespace Microsoft.Azure.Devices.Client
         private const string SharedAccessSignaturePropertyName = "SharedAccessSignature";
         private const string GatewayHostNamePropertyName = "GatewayHostName";
 
-        // For some reason, the .NET SDK originally expected "X509Cert=true" in a connection string to inform the SDK that it would not
-        // include a shared access key, and to not error when parsing a connection string. However, the other SDK languages all followed
-        // the same key/value pair of "x509=true".
-        // So now we're adding support for it to work either way, so we stay compliant with the past but can improve documentation so all
-        // SDK languages refer to the same key/value pair naming.
-        private const string X509CertPropertyName = "X509Cert";
-
-        private const string CommonX509CertPropertyName = "x509";
-
         /// <summary>
         /// Creates an instnace of this class based on an authentication method and the hostname of the IoT hub.
         /// </summary>
@@ -65,7 +56,7 @@ namespace Microsoft.Azure.Devices.Client
 
             // We'll parse the connection string and use that to build an auth method
             ExtractPropertiesFromConnectionString(iotHubConnectionString);
-            AuthenticationMethod = AuthenticationMethodFactory.GetAuthenticationMethod(this);
+            AuthenticationMethod = AuthenticationMethodFactory.GetAuthenticationMethodFromConnectionString(this);
 
             Validate();
         }
@@ -73,32 +64,32 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Gets or sets the value of the fully-qualified DNS hostname of the IoT hub service.
         /// </summary>
-        public string HostName { get; internal set; }
+        public string HostName { get; private set; }
 
         /// <summary>
         /// Gets the optional name of the gateway to connect to
         /// </summary>
-        public string GatewayHostName { get; internal set; }
+        public string GatewayHostName { get; private set; }
 
         /// <summary>
         /// Gets the device identifier of the device connecting to the service.
         /// </summary>
-        public string DeviceId { get; internal set; }
+        public string DeviceId { get; set; }
 
         /// <summary>
         /// Gets the module identifier of the module connecting to the service.
         /// </summary>
-        public string ModuleId { get; internal set; }
+        public string ModuleId { get; set; }
 
         /// <summary>
         /// Gets the shared access key name used to connect the device to the IoT hub service.
         /// </summary>
-        public string SharedAccessKeyName { get; internal set; }
+        public string SharedAccessKeyName { get; set; }
 
         /// <summary>
         /// Gets the shared access key used to connect to the IoT hub service.
         /// </summary>
-        public string SharedAccessKey { get; internal set; }
+        public string SharedAccessKey { get; set; }
 
         /// <summary>
         /// Gets the shared access signature used to connect to the IoT hub service.
@@ -109,28 +100,22 @@ namespace Microsoft.Azure.Devices.Client
         /// SAS token, when that token expires, the client must be disposed, and if desired, recreated
         /// with a newly derived SAS token.
         /// </remarks>
-        public string SharedAccessSignature { get; internal set; }
-
-        /// <summary>
-        /// Gets or sets the authentication method to be used with the IoT hub service.
-        /// </summary>
-        public IAuthenticationMethod AuthenticationMethod { get; }
-
-        /// <summary>
-        /// Indicates if the connection string indicates if an x509 certificate is specified for authentication.
-        /// </summary>
-        public bool UsingX509Cert { get; internal set; }
+        public string SharedAccessSignature { get; set; }
 
         /// <summary>
         /// The client X509 certificates used for authenticating with IoT hub.
         /// </summary>
-        // Device certificate
-        internal X509Certificate2 Certificate { get; set; }
+        public X509Certificate2 Certificate { get; set; }
 
         /// <summary>
         /// The full chain of certificates from the one used to sign the client certificate to the one uploaded to the service.
         /// </summary>
-        internal X509Certificate2Collection ChainCertificates { get; set; }
+        public X509Certificate2Collection ChainCertificates { get; set; }
+
+        /// <summary>
+        /// Gets or sets the authentication method to be used with the IoT hub service.
+        /// </summary>
+        internal IAuthenticationMethod AuthenticationMethod { get; }
 
         // The suggested time to live value for tokens generated for SAS authenticated clients.
         internal TimeSpan SasTokenTimeToLive { get; set; }
@@ -154,7 +139,6 @@ namespace Microsoft.Azure.Devices.Client
             stringBuilder.AppendKeyValuePairIfNotEmpty(SharedAccessKeyNamePropertyName, SharedAccessKeyName);
             stringBuilder.AppendKeyValuePairIfNotEmpty(SharedAccessKeyPropertyName, SharedAccessKey);
             stringBuilder.AppendKeyValuePairIfNotEmpty(SharedAccessSignaturePropertyName, SharedAccessSignature);
-            stringBuilder.AppendKeyValuePairIfNotEmpty(CommonX509CertPropertyName, UsingX509Cert);
             stringBuilder.AppendKeyValuePairIfNotEmpty(GatewayHostNamePropertyName, GatewayHostName);
             if (stringBuilder.Length > 0)
             {
@@ -169,14 +153,12 @@ namespace Microsoft.Azure.Devices.Client
             IDictionary<string, string> map = iotHubConnectionString.ToDictionary(ValuePairDelimiter, ValuePairSeparator);
 
             HostName = GetConnectionStringValue(map, HostNamePropertyName);
+            GatewayHostName = GetConnectionStringOptionalValue(map, GatewayHostNamePropertyName);
             DeviceId = GetConnectionStringOptionalValue(map, DeviceIdPropertyName);
             ModuleId = GetConnectionStringOptionalValue(map, ModuleIdPropertyName);
             SharedAccessKeyName = GetConnectionStringOptionalValue(map, SharedAccessKeyNamePropertyName);
             SharedAccessKey = GetConnectionStringOptionalValue(map, SharedAccessKeyPropertyName);
             SharedAccessSignature = GetConnectionStringOptionalValue(map, SharedAccessSignaturePropertyName);
-            UsingX509Cert = GetConnectionStringOptionalValueOrDefault<bool>(map, X509CertPropertyName, ParseX509, true)
-                || GetConnectionStringOptionalValueOrDefault<bool>(map, CommonX509CertPropertyName, ParseX509, true);
-            GatewayHostName = GetConnectionStringOptionalValue(map, GatewayHostNamePropertyName);
         }
 
         internal void Validate()
@@ -201,28 +183,29 @@ namespace Microsoft.Azure.Devices.Client
             }
 
             // Shared access signature
-            if (!string.IsNullOrWhiteSpace(SharedAccessSignature))
+            if (!SharedAccessSignature.IsNullOrWhiteSpace())
             {
                 // Parse the supplied shared access signature string
                 // and throw exception if the string is not in the expected format.
                 _ = SharedAccessSignatureParser.Parse(SharedAccessSignature);
             }
 
-            if (!(SharedAccessKey.IsNullOrWhiteSpace() ^ SharedAccessSignature.IsNullOrWhiteSpace()))
+            // Either shared access key, shared access signature or X.509 certificate is required for authenticating the client with IoT hub.
+            if (Certificate == null
+                && SharedAccessKey.IsNullOrWhiteSpace()
+                    && SharedAccessSignature.IsNullOrWhiteSpace())
             {
-                if (!(UsingX509Cert || AuthenticationMethod is AuthenticationWithTokenRefresh))
-                {
-                    throw new ArgumentException(
-                        "Should specify either SharedAccessKey or SharedAccessSignature if X.509 certificate is not used");
-                }
+                throw new ArgumentException(
+                        "Should specify either SharedAccessKey, SharedAccessSignature or X.509 certificate for authenticating the client with IoT hub.");
             }
 
-            if ((UsingX509Cert || Certificate != null)
+            // If an X.509 certificate is supplied then neither shared access key nor shared access signature should be supplied.
+            if (Certificate != null
                 && (!SharedAccessKey.IsNullOrWhiteSpace()
                     || !SharedAccessSignature.IsNullOrWhiteSpace()))
             {
                 throw new ArgumentException(
-                    "Should not specify either SharedAccessKey or SharedAccessSignature if X.509 certificate is used");
+                    "Should not specify either SharedAccessKey or SharedAccessSignature if X.509 certificate is used for authenticating the client with IoT hub.");
             }
         }
 
@@ -240,44 +223,6 @@ namespace Microsoft.Azure.Devices.Client
         {
             map.TryGetValue(propertyName, out string value);
             return value;
-        }
-
-        private static TValue GetConnectionStringOptionalValueOrDefault<TValue>(
-            IDictionary<string, string> map,
-            string propertyName,
-            TryParse<string, TValue> tryParse,
-            bool ignoreCase)
-        {
-            var value = default(TValue);
-            if (map.TryGetValue(propertyName, out string stringValue)
-                && stringValue != null)
-            {
-                if (!tryParse(stringValue, ignoreCase, out value))
-                {
-                    throw new ArgumentException($"The connection string has an invalid value for property: {propertyName}");
-                }
-            }
-
-            return value;
-        }
-
-        private static bool ParseX509(string input, bool ignoreCase, out bool isUsingX509Cert)
-        {
-            isUsingX509Cert = false;
-
-            bool isMatch = string.Equals(
-                input,
-                "true",
-                ignoreCase
-                    ? StringComparison.OrdinalIgnoreCase
-                    : StringComparison.Ordinal);
-            if (isMatch)
-            {
-                isUsingX509Cert = true;
-            }
-
-            // Always returns true, but must return a bool because it is used in a delegate that requires that return.
-            return true;
         }
     }
 }

--- a/iothub/device/src/ClientFactory.cs
+++ b/iothub/device/src/ClientFactory.cs
@@ -27,11 +27,6 @@ namespace Microsoft.Azure.Devices.Client
             }
 
             var csBuilder = new IotHubConnectionStringBuilder(connectionString);
-            if (csBuilder.UsingX509Cert)
-            {
-                throw new ArgumentException("To use X509 certificates, use the initializer with the IAuthenticationMethod parameter.", nameof(connectionString));
-            }
-
             return CreateInternal(null, csBuilder, options);
         }
 

--- a/iothub/device/tests/Authentication/DeviceClientConnectionStringExceptionTests.cs
+++ b/iothub/device/tests/Authentication/DeviceClientConnectionStringExceptionTests.cs
@@ -122,22 +122,6 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void DeviceClientConnectionStringSASKeyX509CertExceptionTest()
-        {
-            string connectionString = "HostName=acme.azure-devices.net;X509=true;DeviceId=device;SharedAccessKey=dGVzdFN0cmluZzE=";
-            var deviceClient = IotHubDeviceClient.CreateFromConnectionString(connectionString);
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void DeviceClientConnectionStringSasSignatureX509ExceptionTest()
-        {
-            string connectionString = "HostName=acme.azure-devices.net;DeviceId=device1;X509=true;SharedAccessSignature=SharedAccessSignature sr=dh%3a%2f%2facme.azure-devices.net&sig=dGVzdFN0cmluZzU=&se=87824124985&skn=AllAccessKey";
-            var deviceClient = IotHubDeviceClient.CreateFromConnectionString(connectionString);
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
         public void DeviceClientConnectionStringX509CertFalseTest()
         {
             string connectionString = "HostName=acme.azure-devices.net;X509Cert=false;DeviceId=device";

--- a/iothub/device/tests/Authentication/IotHubConnectionStringBuilderTests.cs
+++ b/iothub/device/tests/Authentication/IotHubConnectionStringBuilderTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             csBuilder.AuthenticationMethod.Should().BeOfType<DeviceAuthenticationWithRegistrySymmetricKey>();
 
             csBuilder.SharedAccessSignature.Should().BeNull("SharedAccessKey and SharedAccessSignature are mutually exclusive");
-            csBuilder.UsingX509Cert.Should().BeFalse("SharedAccessKey and X509 are mutually exclusive");
+            csBuilder.Certificate.Should().BeNull("SharedAccessKey and X.509 are mutually exclusive");
         }
 
         [TestMethod]
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
 
             csBuilder.SharedAccessKey.Should().Be(SharedAccessKey);
             csBuilder.AuthenticationMethod.Should().BeOfType<DeviceAuthenticationWithRegistrySymmetricKey>();
-            csBuilder.UsingX509Cert.Should().BeFalse("SharedAccessKey and X509 are mutually exclusive");
+            csBuilder.Certificate.Should().BeNull("SharedAccessKey and X.509 are mutually exclusive");
         }
 
         [TestMethod]
@@ -130,53 +130,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             csBuilder.AuthenticationMethod.Should().BeOfType<DeviceAuthenticationWithToken>();
 
             csBuilder.SharedAccessKey.Should().BeNull("SharedAccessSignature and SharedAccessKey are mutually exclusive");
-            csBuilder.UsingX509Cert.Should().BeFalse("SharedAccessSignature and X509 are mutually exclusive");
-        }
-
-        [TestMethod]
-        [DataRow("true")]
-        [DataRow("True")]
-        [DataRow("TRUE")]
-        public void IotHubConnectionStringBuilder_ParamConnectionString_ParsesX509BoolCaseInsensitive(string value)
-        {
-            var connectionString = $"HostName={HostName};DeviceId={DeviceId};X509Cert={value}";
-            var csBuilder = new IotHubConnectionStringBuilder(connectionString);
-
-            csBuilder.UsingX509Cert.Should().BeTrue();
-
-            csBuilder.SharedAccessKey.Should().BeNull();
-            csBuilder.SharedAccessKeyName.Should().BeNull();
-            csBuilder.SharedAccessSignature.Should().BeNull();
-        }
-
-        /// <summary>
-        /// Ensure we support both and either x509Cert= and x509= in our connection string builder/parser, for backward compat and alignment with other SDKs.
-        /// If either is true, then we'll consider it true.
-        /// </summary>
-        [TestMethod]
-        [DataRow("true", "true")]
-        [DataRow("false", "true")]
-        [DataRow(null, "true")]
-        [DataRow("true", "false")]
-        [DataRow("true", null)]
-        public void IotHubConnectionStringBuilder_ParamConnectionString_ParsesX509Mix(string x509CertValue, string x509Value)
-        {
-            var connectionString = $"HostName={HostName};DeviceId={DeviceId}";
-            if (x509CertValue != null)
-            {
-                connectionString += $";X509Cert={x509CertValue}";
-            }
-            if (x509Value != null)
-            {
-                connectionString += $";x509={x509Value}";
-            }
-            var csBuilder = new IotHubConnectionStringBuilder(connectionString);
-
-            csBuilder.UsingX509Cert.Should().BeTrue();
-
-            csBuilder.SharedAccessKey.Should().BeNull();
-            csBuilder.SharedAccessKeyName.Should().BeNull();
-            csBuilder.SharedAccessSignature.Should().BeNull();
+            csBuilder.Certificate.Should().BeNull("SharedAccessSignature and X.509 are mutually exclusive");
         }
 
         [TestMethod]


### PR DESCRIPTION
This PR primarily removes x509 certificate information from the connection string flow.
Our device client constructors don't allow you to set both the connection string and client certificates.