### PR TITLE
Add unit tests for client operations without, before and after explicit OpenAsync

### DIFF
--- a/iothub/device/tests/IotHubDeviceClientTests.cs
+++ b/iothub/device/tests/IotHubDeviceClientTests.cs
@@ -1530,7 +1530,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        public void IotHubDeviceClient_SendEventAsync_AfterExplicitOpenAsync_ThrowsInvalidOperationException()
+        public void IotHubDeviceClient_SendEventAsync_AfterExplicitOpenAsync_DoesNotThrow()
         {
             // arrange
             using var deviceClient = IotHubDeviceClient.CreateFromConnectionString(FakeConnectionString);

--- a/iothub/device/tests/IotHubDeviceClientTests.cs
+++ b/iothub/device/tests/IotHubDeviceClientTests.cs
@@ -1382,7 +1382,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
 
             // We will setup the main handler which can be either MQTT or AMQP or HTTP handler to throw
-            // a cancellation token expiry exception (OperationCancelledException) To ensure that we mimic when a token expires.
+            // a cancellation token expiry exception (OperationCancelledException) to ensure that we mimic when a token expires.
             mainProtocolHandler
                 .When(x => x.ReceiveMessageAsync(Arg.Any<CancellationToken>()))
                 .Do(x => { throw new OperationCanceledException(); });
@@ -1413,7 +1413,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
 
             // We will setup the main handler which can be either MQTT or AMQP or HTTP handler to throw
-            // a cancellation token expiry exception (OperationCancelledException) To ensure that we mimic when a token expires.
+            // a cancellation token expiry exception (OperationCancelledException) to ensure that we mimic when a token expires.
             mainProtocolHandler
                 .When(x => x.CompleteMessageAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
                 .Do(x => { throw new OperationCanceledException(); });
@@ -1445,7 +1445,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
 
             // We will setup the main handler which can be either MQTT or AMQP or HTTP handler to throw
-            // a cancellation token expiry exception (OperationCancelledException) To ensure that we mimic when a token expires.
+            // a cancellation token expiry exception (OperationCancelledException) to ensure that we mimic when a token expires.
             mainProtocolHandler
                 .When(x => x.RejectMessageAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
                 .Do(x => { throw new OperationCanceledException(); });
@@ -1554,7 +1554,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
 
             // We will setup the main handler which can be either MQTT or AMQP or HTTP handler to throw
-            // a cancellation token expiry exception (OperationCancelledException) To ensure that we mimic when a token expires.
+            // a cancellation token expiry exception (OperationCancelledException) to ensure that we mimic when a token expires.
             mainProtocolHandler
                 .When(x => x.OpenAsync(Arg.Any<CancellationToken>()))
                 .Do(x => { throw new OperationCanceledException(); });
@@ -1585,7 +1585,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
 
             // We will setup the main handler which can be either MQTT or AMQP or HTTP handler to throw
-            // a cancellation token expiry exception (OperationCancelledException) To ensure that we mimic when a token expires.
+            // a cancellation token expiry exception (OperationCancelledException) to ensure that we mimic when a token expires.
             mainProtocolHandler
                 .When(x => x.AbandonMessageAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
                 .Do(x => { throw new OperationCanceledException(); });
@@ -1616,7 +1616,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
 
             // We will setup the main handler which can be either MQTT or AMQP or HTTP handler to throw
-            // a cancellation token expiry exception (OperationCancelledException) To ensure that we mimic when a token expires.
+            // a cancellation token expiry exception (OperationCancelledException) to ensure that we mimic when a token expires.
             mainProtocolHandler
                 .When(x => x.SendTwinPatchAsync(Arg.Any<TwinCollection>(), Arg.Any<CancellationToken>()))
                 .Do(x => { throw new OperationCanceledException(); });
@@ -1647,7 +1647,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
 
             // We will setup the main handler which can be either MQTT or AMQP or HTTP handler to throw
-            // a cancellation token expiry exception (OperationCancelledException) To ensure that we mimic when a token expires.
+            // a cancellation token expiry exception (OperationCancelledException) to ensure that we mimic when a token expires.
             mainProtocolHandler
                 .When(x => x.SendTwinGetAsync(Arg.Any<CancellationToken>()))
                 .Do(x => { throw new OperationCanceledException(); });
@@ -1678,7 +1678,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
 
             // We will setup the main handler which can be either MQTT or AMQP or HTTP handler to throw
-            // a cancellation token expiry exception (OperationCancelledException) To ensure that we mimic when a token expires.
+            // a cancellation token expiry exception (OperationCancelledException) to ensure that we mimic when a token expires.
             mainProtocolHandler
                 .When(x => x.CloseAsync(Arg.Any<CancellationToken>()))
                 .Do(x => { throw new OperationCanceledException(); });
@@ -1709,7 +1709,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
 
             // We will setup the main handler which can be either MQTT or AMQP or HTTP handler to throw
-            // a cancellation token expiry exception (OperationCancelledException) To ensure that we mimic when a token expires.
+            // a cancellation token expiry exception (OperationCancelledException) to ensure that we mimic when a token expires.
             mainProtocolHandler
                 .When(x => x.EnableTwinPatchAsync(Arg.Any<CancellationToken>()))
                 .Do(x => { throw new OperationCanceledException(); });

--- a/iothub/device/tests/IotHubDeviceClientTests.cs
+++ b/iothub/device/tests/IotHubDeviceClientTests.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Azure.Devices.Client.Exceptions;
 using Microsoft.Azure.Devices.Client.Transport;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
@@ -1400,7 +1401,6 @@ namespace Microsoft.Azure.Devices.Client.Test
             Func<Task> act = async () => await deviceClient.ReceiveMessageAsync(cts.Token);
 
             // assert
-
             act.Should().Throw<OperationCanceledException>();
         }
 
@@ -1408,7 +1408,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void IotHubDeviceClient_CompleteAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
-
             using var deviceClient = IotHubDeviceClient.CreateFromConnectionString(FakeConnectionString);
 
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
@@ -1441,7 +1440,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void IotHubDeviceClient_RejectAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
-
             using var deviceClient = IotHubDeviceClient.CreateFromConnectionString(FakeConnectionString);
 
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
@@ -1474,13 +1472,12 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void IotHubDeviceClient_SendEventAsync_Cancelled_ThrowsOperationCanceledException()
         {
             //arrange
-
             using var deviceClient = IotHubDeviceClient.CreateFromConnectionString(FakeConnectionString);
 
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
 
             // We will setup the main handler which can be either MQTT or AMQP or HTTP handler to throw
-            // a cancellation token expiry exception (OperationCancelledException) To ensure that we mimic when a token expires.
+            // a cancellation token expiry exception (OperationCancelledException) to ensure that we mimic when a token expires.
             mainProtocolHandler
                 .When(x => x.SendEventAsync(Arg.Any<Message>(), Arg.Any<CancellationToken>()))
                 .Do(x => { throw new OperationCanceledException(); });
@@ -1499,15 +1496,59 @@ namespace Microsoft.Azure.Devices.Client.Test
             Func<Task> act = async () => await deviceClient.SendEventAsync(new Message(), cts.Token);
 
             // assert
-
             act.Should().Throw<OperationCanceledException>();
+        }
+
+        [TestMethod]
+        public void IotHubDeviceClient_SendEventAsync_WithoutExplicitOpenAsync_ThrowsInvalidOperationException()
+        {
+            // arrange
+            using var deviceClient = IotHubDeviceClient.CreateFromConnectionString(FakeConnectionString);
+
+            // act
+            Func<Task> act = async () => await deviceClient.SendEventAsync(new Message());
+
+            // assert
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [TestMethod]
+        public void IotHubDeviceClient_SendEventAsync_BeforeExplicitOpenAsync_ThrowsInvalidOperationException()
+        {
+            // arrange
+            using var deviceClient = IotHubDeviceClient.CreateFromConnectionString(FakeConnectionString);
+
+            // act
+            Func<Task> act = async () => 
+            {
+                await deviceClient.SendEventAsync(new Message());
+                await deviceClient.OpenAsync();
+            };
+
+            // assert
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [TestMethod]
+        public void IotHubDeviceClient_SendEventAsync_AfterExplicitOpenAsync_ThrowsInvalidOperationException()
+        {
+            // arrange
+            using var deviceClient = IotHubDeviceClient.CreateFromConnectionString(FakeConnectionString);
+
+            // act
+            Func<Task> act = async () =>
+            {
+                await deviceClient.OpenAsync();
+                await deviceClient.SendEventAsync(new Message()); 
+            };
+
+            // should not throw
         }
 
         [TestMethod]
         public void IotHubDeviceClient_OpenAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
-
             using var deviceClient = IotHubDeviceClient.CreateFromConnectionString(FakeConnectionString);
 
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
@@ -1532,7 +1573,6 @@ namespace Microsoft.Azure.Devices.Client.Test
             Func<Task> act = async () => await deviceClient.OpenAsync(cts.Token);
 
             // assert
-
             act.Should().Throw<OperationCanceledException>();
         }
 
@@ -1540,7 +1580,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void IotHubDeviceClient_AbandonAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
-
             using var deviceClient = IotHubDeviceClient.CreateFromConnectionString(FakeConnectionString);
 
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
@@ -1565,7 +1604,6 @@ namespace Microsoft.Azure.Devices.Client.Test
             Func<Task> act = async () => await deviceClient.AbandonMessageAsync("SomeLockToken", cts.Token);
 
             // assert
-
             act.Should().Throw<OperationCanceledException>();
         }
 
@@ -1573,7 +1611,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void IotHubDeviceClient_UpdateReportedPropertiesAsync_Cancelled_ThrowsOperationCanceledException()
         {
             //arrange
-
             using var deviceClient = IotHubDeviceClient.CreateFromConnectionString(FakeConnectionString);
 
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
@@ -1598,7 +1635,6 @@ namespace Microsoft.Azure.Devices.Client.Test
             Func<Task> act = async () => await deviceClient.UpdateReportedPropertiesAsync(new TwinCollection(), cts.Token);
 
             // assert
-
             act.Should().Throw<OperationCanceledException>();
         }
 
@@ -1606,7 +1642,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void IotHubDeviceClient_GetTwinAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
-
             using var deviceClient = IotHubDeviceClient.CreateFromConnectionString(FakeConnectionString);
 
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
@@ -1631,7 +1666,6 @@ namespace Microsoft.Azure.Devices.Client.Test
             Func<Task> act = async () => await deviceClient.GetTwinAsync(cts.Token);
 
             // assert
-
             act.Should().Throw<OperationCanceledException>();
         }
 
@@ -1639,7 +1673,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void IotHubDeviceClient_CloseAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
-
             using var deviceClient = IotHubDeviceClient.CreateFromConnectionString(FakeConnectionString);
 
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
@@ -1664,7 +1697,6 @@ namespace Microsoft.Azure.Devices.Client.Test
             Func<Task> act = async () => await deviceClient.CloseAsync(cts.Token);
 
             // assert
-
             act.Should().Throw<OperationCanceledException>();
         }
 
@@ -1672,7 +1704,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         public void IotHubDeviceClient_SetDesiredPropertyCallbackAsync_Cancelled_ThrowsOperationCanceledException()
         {
             // arrange
-
             using var deviceClient = IotHubDeviceClient.CreateFromConnectionString(FakeConnectionString);
 
             var mainProtocolHandler = Substitute.For<IDelegatingHandler>();
@@ -1704,7 +1735,6 @@ namespace Microsoft.Azure.Devices.Client.Test
                 cts.Token);
 
             // assert
-
             act.Should().Throw<OperationCanceledException>();
         }
 


### PR DESCRIPTION
Now that we removed the implicit "OpenAsync()" call from client operations, adding unit tests to validate if an exception will be thrown and which type of exception will be thrown in different scenarios. 