### PR TITLE
Copy the default http settings from IoT hub service client to other clients

### DIFF
--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -28,6 +28,22 @@ namespace Microsoft.Azure.Devices.Client.Transport
         private HttpClientHandler _httpClientHandler;
         private readonly AdditionalClientInformation _additionalClientInformation;
 
+        // These default values are consistent with Azure.Core default values:
+        // https://github.com/Azure/azure-sdk-for-net/blob/7e3cf643977591e9041f4c628fd4d28237398e0b/sdk/core/Azure.Core/src/Pipeline/ServicePointHelpers.cs#L28
+        private const int DefaultMaxConnectionsPerServer = 50;
+
+        // How long, in milliseconds, a given cached TCP connection created by this client's HTTP layer will live before being closed.
+        // If this value is set to any negative value, the connection lease will be infinite. If this value is set to 0, then the TCP connection will close after
+        // each HTTP request and a new TCP connection will be opened upon the next request.
+        //
+        // By closing cached TCP connections and opening a new one upon the next request, the underlying HTTP client has a chance to do a DNS lookup
+        // to validate that it will send the requests to the correct IP address. While it is atypical for a given IoT hub to change its IP address, it does
+        // happen when a given IoT hub fails over into a different region.
+        //
+        // This default value is consistent with the default value used in Azure.Core
+        // https://github.com/Azure/azure-sdk-for-net/blob/7e3cf643977591e9041f4c628fd4d28237398e0b/sdk/core/Azure.Core/src/Pipeline/ServicePointHelpers.cs#L29
+        private static readonly TimeSpan DefaultConnectionLeaseTimeout = TimeSpan.FromMinutes(5);
+
         public HttpClientHelper(
             Uri baseAddress,
             IConnectionCredentials connectionCredentials,
@@ -58,6 +74,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 _httpClientHandler.UseProxy = proxy != null;
                 _httpClientHandler.Proxy = proxy;
             }
+
+            _httpClientHandler.MaxConnectionsPerServer = DefaultMaxConnectionsPerServer;
+            ServicePoint servicePoint = ServicePointManager.FindServicePoint(_baseAddress);
+            servicePoint.ConnectionLeaseTimeout = DefaultConnectionLeaseTimeout.Milliseconds;
 
             _httpClientObj = new HttpClient(_httpClientHandler)
             {

--- a/provisioning/device/src/Transports/Http/ProvisioningTransportHandlerHttp.cs
+++ b/provisioning/device/src/Transports/Http/ProvisioningTransportHandlerHttp.cs
@@ -22,6 +22,22 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         private static readonly TimeSpan s_defaultOperationPoolingIntervalMilliseconds = TimeSpan.FromSeconds(2);
         private const int DefaultHttpsPort = 443;
 
+        // These default values are consistent with Azure.Core default values:
+        // https://github.com/Azure/azure-sdk-for-net/blob/7e3cf643977591e9041f4c628fd4d28237398e0b/sdk/core/Azure.Core/src/Pipeline/ServicePointHelpers.cs#L28
+        private const int DefaultMaxConnectionsPerServer = 50;
+
+        // How long, in milliseconds, a given cached TCP connection created by this client's HTTP layer will live before being closed.
+        // If this value is set to any negative value, the connection lease will be infinite. If this value is set to 0, then the TCP connection will close after
+        // each HTTP request and a new TCP connection will be opened upon the next request.
+        //
+        // By closing cached TCP connections and opening a new one upon the next request, the underlying HTTP client has a chance to do a DNS lookup
+        // to validate that it will send the requests to the correct IP address. While it is atypical for a given IoT hub to change its IP address, it does
+        // happen when a given IoT hub fails over into a different region.
+        //
+        // This default value is consistent with the default value used in Azure.Core
+        // https://github.com/Azure/azure-sdk-for-net/blob/7e3cf643977591e9041f4c628fd4d28237398e0b/sdk/core/Azure.Core/src/Pipeline/ServicePointHelpers.cs#L29
+        private static readonly TimeSpan DefaultConnectionLeaseTimeout = TimeSpan.FromMinutes(5);
+
         /// <summary>
         /// Creates an instance of the ProvisioningTransportHandlerHttp class.
         /// </summary>
@@ -120,6 +136,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                     Host = message.GlobalDeviceEndpoint,
                     Port = Port,
                 };
+
+                httpClientHandler.MaxConnectionsPerServer = DefaultMaxConnectionsPerServer;
+                ServicePoint servicePoint = ServicePointManager.FindServicePoint(builder.Uri);
+                servicePoint.ConnectionLeaseTimeout = DefaultConnectionLeaseTimeout.Milliseconds;
 
                 using DeviceProvisioningServiceRuntimeClient client = authStrategy.CreateClient(builder.Uri, httpClientHandler);
                 client.HttpClient.DefaultRequestHeaders.Add("User-Agent", message.ProductInfo);

--- a/provisioning/service/src/Contract/ContractApiHttp.cs
+++ b/provisioning/service/src/Contract/ContractApiHttp.cs
@@ -27,6 +27,22 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
 
         private static readonly TimeSpan s_defaultOperationTimeout = TimeSpan.FromSeconds(100);
 
+        // These default values are consistent with Azure.Core default values:
+        // https://github.com/Azure/azure-sdk-for-net/blob/7e3cf643977591e9041f4c628fd4d28237398e0b/sdk/core/Azure.Core/src/Pipeline/ServicePointHelpers.cs#L28
+        private const int DefaultMaxConnectionsPerServer = 50;
+
+        // How long, in milliseconds, a given cached TCP connection created by this client's HTTP layer will live before being closed.
+        // If this value is set to any negative value, the connection lease will be infinite. If this value is set to 0, then the TCP connection will close after
+        // each HTTP request and a new TCP connection will be opened upon the next request.
+        //
+        // By closing cached TCP connections and opening a new one upon the next request, the underlying HTTP client has a chance to do a DNS lookup
+        // to validate that it will send the requests to the correct IP address. While it is atypical for a given IoT hub to change its IP address, it does
+        // happen when a given IoT hub fails over into a different region.
+        //
+        // This default value is consistent with the default value used in Azure.Core
+        // https://github.com/Azure/azure-sdk-for-net/blob/7e3cf643977591e9041f4c628fd4d28237398e0b/sdk/core/Azure.Core/src/Pipeline/ServicePointHelpers.cs#L29
+        private static readonly TimeSpan DefaultConnectionLeaseTimeout = TimeSpan.FromMinutes(5);
+
         public ContractApiHttp(
             Uri baseAddress,
             IAuthorizationHeaderProvider authenticationHeaderProvider,
@@ -50,6 +66,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 _httpClientHandler.UseProxy = true;
                 _httpClientHandler.Proxy = httpSettings.Proxy;
             }
+
+            _httpClientHandler.MaxConnectionsPerServer = DefaultMaxConnectionsPerServer;
+            ServicePoint servicePoint = ServicePointManager.FindServicePoint(_baseAddress);
+            servicePoint.ConnectionLeaseTimeout = DefaultConnectionLeaseTimeout.Milliseconds;
 
             _httpClientObj = new HttpClient(_httpClientHandler, false)
             {


### PR DESCRIPTION
Connection lease timeout and max connections per server are defaults we set in the IoT hub service client to better handle failover scenarios, but the other client libraries that use HTTP would benefit from having them, too