### PR TITLE
Refactor ServiceClient ETag usage to match track 2

### DIFF
--- a/e2e/test/iothub/service/ConfigurationsClientE2ETests.cs
+++ b/e2e/test/iothub/service/ConfigurationsClientE2ETests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             {
                 try
                 {
-                    // If this fails, we shall let it throw an exception and fail the test
+                    // If this fails, it won't fail the test
                     await serviceClient.Configurations.DeleteAsync(configurationId).ConfigureAwait(false);
                 }
                 catch (DeviceNotFoundException)

--- a/e2e/test/iothub/service/ConfigurationsClientE2ETests.cs
+++ b/e2e/test/iothub/service/ConfigurationsClientE2ETests.cs
@@ -134,19 +134,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             }
             finally
             {
-                try
-                {
-                    // If this fails, we shall let it throw an exception and fail the test
-                    await serviceClient.Configurations.DeleteAsync(configurationId).ConfigureAwait(false);
-                }
-                catch (DeviceNotFoundException)
-                {
-                    // configuration was already deleted during the normal test flow
-                }
-                catch (Exception ex)
-                {
-                    Logger.Trace($"Failed to clean up configuration due to {ex}");
-                }
+                await serviceClient.Configurations.DeleteAsync(configurationId).ConfigureAwait(false);
             }
         }
 
@@ -192,18 +180,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             }
             finally
             {
-                try
-                {
-                    await serviceClient.Configurations.DeleteAsync(configurationId).ConfigureAwait(false);
-                }
-                catch (DeviceNotFoundException)
-                {
-                    // configuration was already deleted during the normal test flow
-                }
-                catch (Exception ex)
-                {
-                    Logger.Trace($"Failed to clean up configuration due to {ex}");
-                }
+                await serviceClient.Configurations.DeleteAsync(configurationId).ConfigureAwait(false);
             }
         }
     }

--- a/e2e/test/iothub/service/ConfigurationsClientE2ETests.cs
+++ b/e2e/test/iothub/service/ConfigurationsClientE2ETests.cs
@@ -134,7 +134,19 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             }
             finally
             {
-                await serviceClient.Configurations.DeleteAsync(configurationId).ConfigureAwait(false);
+                try
+                {
+                    // If this fails, we shall let it throw an exception and fail the test
+                    await serviceClient.Configurations.DeleteAsync(configurationId).ConfigureAwait(false);
+                }
+                catch (DeviceNotFoundException)
+                {
+                    // configuration was already deleted during the normal test flow
+                }
+                catch (Exception ex)
+                {
+                    Logger.Trace($"Failed to clean up configuration due to {ex}");
+                }
             }
         }
 
@@ -180,7 +192,18 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             }
             finally
             {
-                await serviceClient.Configurations.DeleteAsync(configurationId).ConfigureAwait(false);
+                try
+                {
+                    await serviceClient.Configurations.DeleteAsync(configurationId).ConfigureAwait(false);
+                }
+                catch (DeviceNotFoundException)
+                {
+                    // configuration was already deleted during the normal test flow
+                }
+                catch (Exception ex)
+                {
+                    Logger.Trace($"Failed to clean up configuration due to {ex}");
+                }
             }
         }
     }

--- a/e2e/test/iothub/service/RegistryE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryE2ETests.cs
@@ -501,7 +501,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         public async Task DevicesClient_SetDevicesETag_Works()
         {
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IoTHub.ConnectionString);
-            Device device = new Device(_idPrefix + Guid.NewGuid());
+            var device = new Device(_idPrefix + Guid.NewGuid());
             device = await serviceClient.Devices.CreateAsync(device).ConfigureAwait(false);
 
             try
@@ -567,7 +567,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         public async Task DevicesClient_DeleteDevicesETag_Works()
         {
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IoTHub.ConnectionString);
-            Device device = new Device(_idPrefix + Guid.NewGuid());
+            var device = new Device(_idPrefix + Guid.NewGuid());
             device = await serviceClient.Devices.CreateAsync(device).ConfigureAwait(false);
 
             try
@@ -617,6 +617,140 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 catch (Exception ex)
                 {
                     Logger.Trace($"Failed to clean up devices due to {ex}");
+                }
+            }
+        }
+
+        [LoggedTestMethod, Timeout(TestTimeoutMilliseconds)]
+        public async Task ModulesClient_SetModulesETag_Works()
+        {
+            using var serviceClient = new IotHubServiceClient(TestConfiguration.IoTHub.ConnectionString);
+            string deviceId = _idPrefix + Guid.NewGuid();
+            string moduleId = _idPrefix + Guid.NewGuid();
+            var module = new Module(deviceId, moduleId);
+            Device device = await serviceClient.Devices.CreateAsync(new Device(deviceId)).ConfigureAwait(false);
+            module = await serviceClient.Modules.CreateAsync(module).ConfigureAwait(false);
+            module = await serviceClient.Modules.GetAsync(deviceId, moduleId).ConfigureAwait(false);
+
+            try
+            {
+                ETag oldEtag = module.ETag;
+
+                module.ManagedBy = "test";
+
+                // Update the device once so that the last ETag falls out of date.
+                module = await serviceClient.Modules.SetAsync(module).ConfigureAwait(false);
+
+                // Deliberately set the ETag to an older version to test that the SDK is setting the If-Match
+                // header appropriately when sending the request.
+                module.ETag = oldEtag;
+
+                try
+                {
+                    // set the 'onlyIfUnchanged' flag to true to check that, with an out of date ETag, the request throws a PreconditionFailedException.
+                    await serviceClient.Modules.SetAsync(module, true).ConfigureAwait(false);
+                    throw new AssertFailedException("Expected test to throw a precondition failed exception since it updated a module with an out of date ETag");
+                }
+                catch (DeviceMessageLockLostException)
+                {
+                    // expected thrown exception, continue the test without throwing anything
+                }
+
+                try
+                {
+                    // set the 'onlyIfUnchanged' flag to false to check that, even with an out of date ETag, the request performs without exception.
+                    module = await serviceClient.Modules.SetAsync(module, false).ConfigureAwait(false);
+                }
+                catch (DeviceMessageLockLostException)
+                {
+                    throw new AssertFailedException("Did not expect test to throw a precondition failed exception since 'onlyIfUnchanged' was set to false");
+                }
+
+                try
+                {
+                    module.ManagedBy = "";
+
+                    // set the 'onlyIfUnchanged' flag to true to check that, with an up-to-date ETag, the request performs without exception.
+                    await serviceClient.Modules.SetAsync(module, true).ConfigureAwait(false);
+                }
+                catch (DeviceMessageLockLostException)
+                {
+                    throw new AssertFailedException("Did not expect test to throw a precondition failed exception since 'onlyIfUnchanged' was set to false");
+                }
+            }
+            finally
+            {
+                try
+                {
+                    await serviceClient.Modules.DeleteAsync(deviceId, moduleId).ConfigureAwait(false);
+                    await CleanupAsync(serviceClient, deviceId).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Trace($"Failed to clean up module due to {ex}");
+                }
+            }
+        }
+
+        [LoggedTestMethod, Timeout(TestTimeoutMilliseconds)]
+        public async Task ModulesClient_DeleteModulesETag_Works()
+        {
+            using var serviceClient = new IotHubServiceClient(TestConfiguration.IoTHub.ConnectionString);
+            string deviceId = _idPrefix + Guid.NewGuid();
+            string moduleId = _idPrefix + Guid.NewGuid();
+            var module = new Module(deviceId, moduleId);
+            Device device = await serviceClient.Devices.CreateAsync(new Device(deviceId)).ConfigureAwait(false);
+            module = await serviceClient.Modules.CreateAsync(module).ConfigureAwait(false);
+            module = await serviceClient.Modules.GetAsync(deviceId, moduleId).ConfigureAwait(false);
+
+            try
+            {
+                ETag oldEtag = module.ETag;
+
+                module.ManagedBy = "test";
+
+                // Update the device once so that the last ETag falls out of date.
+                module = await serviceClient.Modules.SetAsync(module).ConfigureAwait(false);
+
+                // Deliberately set the ETag to an older version to test that the SDK is setting the If-Match
+                // header appropriately when sending the request.
+                module.ETag = oldEtag;
+
+                try
+                {
+                    // set the 'onlyIfUnchanged' flag to true to check that, with an out of date ETag, the request throws a PreconditionFailedException.
+                    await serviceClient.Modules.DeleteAsync(module, true).ConfigureAwait(false);
+                    throw new AssertFailedException("Expected test to throw a precondition failed exception since it updated a device with an out of date ETag");
+                }
+                catch (DeviceMessageLockLostException)
+                {
+                    // expected thrown exception, continue the test without throwing anything
+                }
+
+                try
+                {
+                    // set the 'onlyIfUnchanged' flag to false to check that, even with an out of date ETag, the request performs without exception.
+                    await serviceClient.Modules.DeleteAsync(module, false).ConfigureAwait(false);
+                }
+                catch (DeviceMessageLockLostException)
+                {
+                    throw new AssertFailedException("Did not expect test to throw a precondition failed exception since 'onlyIfUnchanged' was set to false");
+                }
+            }
+            finally
+            {
+                try
+                {
+                    await serviceClient.Modules.DeleteAsync(deviceId, moduleId).ConfigureAwait(false);
+                    await CleanupAsync(serviceClient, deviceId).ConfigureAwait(false);
+                }
+                catch (DeviceNotFoundException)
+                {
+                    // device was already deleted during the normal test flow
+                }
+                catch (Exception ex)
+                {
+                    Logger.Trace($"Failed to clean up module due to {ex}");
                 }
             }
         }

--- a/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
+++ b/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             var twinPatch = new Twin();
             twinPatch.Properties.Desired[propName] = propValue;
 
-            await serviceClient.Twins.UpdateAsync(deviceId, twinPatch, new ETag("*")).ConfigureAwait(false);
+            await serviceClient.Twins.UpdateAsync(deviceId, twinPatch).ConfigureAwait(false);
         }
 
         private async Task Twin_DeviceDesiredPropertyUpdateRecoveryAsync(

--- a/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
+++ b/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
 using Microsoft.Azure.Devices.E2ETests.Helpers.Templates;
@@ -256,7 +257,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             var twinPatch = new Twin();
             twinPatch.Properties.Desired[propName] = propValue;
 
-            await serviceClient.Twins.UpdateAsync(deviceId, twinPatch, "*").ConfigureAwait(false);
+            await serviceClient.Twins.UpdateAsync(deviceId, twinPatch, new ETag("*")).ConfigureAwait(false);
         }
 
         private async Task Twin_DeviceDesiredPropertyUpdateRecoveryAsync(

--- a/iothub/service/src/Configurations/ConfigurationsClient.cs
+++ b/iothub/service/src/Configurations/ConfigurationsClient.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 using Microsoft.Azure.Devices.Common.Exceptions;
 
 namespace Microsoft.Azure.Devices
@@ -71,7 +72,7 @@ namespace Microsoft.Azure.Devices
             try
             {
                 Argument.AssertNotNull(configuration, nameof(configuration));
-                if (!string.IsNullOrEmpty(configuration.ETag))
+                if (!string.IsNullOrEmpty(configuration.ETag.ToString()))
                 {
                     throw new ArgumentException(ETagSetWhileCreatingConfiguration);
                 }
@@ -187,33 +188,15 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <summary>
-        /// Replace the mutable fields of the configuration registration.
-        /// </summary>
-        /// <param name="configuration">The configuration object with replaced fields.</param>
-        /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
-        /// <returns>The configuration object with replaced ETags.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="configuration"/> is null.</exception>
-        /// <exception cref="IotHubException">
-        /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubThrottledException"/> is thrown. For a complete list of possible
-        /// error cases, see <see cref="Common.Exceptions"/>.
-        /// </exception>
-        /// <exception cref="HttpRequestException">
-        /// If the HTTP request fails due to an underlying issue such as network connectivity, DNS failure, or server
-        /// certificate validation.
-        /// </exception>
-        /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual Task<Configuration> SetAsync(Configuration configuration, CancellationToken cancellationToken = default)
-        {
-            return SetAsync(configuration, false, cancellationToken);
-        }
-
-        /// <summary>
         /// replace the mutable fields of the configuration registration.
         /// </summary>
         /// <param name="configuration">The configuration object with replaced fields.</param>
-        /// <param name="forceUpdate">Forces the configuration object to be replaced even if it was replaced since it was retrieved last time
-        /// (i.e., the <see cref="Configuration.ETag"/> does not match the service's.</param>
+        /// <param name="onlyIfUnchanged">
+        /// If false, this operation will be performed even if the provided device identity has
+        /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
+        /// if the provided configuration has an out of date ETag. An up-to-date ETag can be
+        /// retrieved using <see cref="GetAsync(string, CancellationToken)"/>.
+        /// </param>
         /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
         /// <returns>The configuration object with replaced ETags.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="configuration"/> is null.</exception>
@@ -227,22 +210,22 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided cancellation token has requested cancellation.</exception>
-        public virtual async Task<Configuration> SetAsync(Configuration configuration, bool forceUpdate, CancellationToken cancellationToken = default)
+        public virtual async Task<Configuration> SetAsync(Configuration configuration, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Updating configuration: {configuration?.Id} - Force update: {forceUpdate}", nameof(SetAsync));
+                Logging.Enter(this, $"Updating configuration: {configuration?.Id} - only if changed: {onlyIfUnchanged}", nameof(SetAsync));
 
             try
             {
                 Argument.AssertNotNull(configuration, nameof(configuration));
-                if (string.IsNullOrWhiteSpace(configuration.ETag) && !forceUpdate)
+                if (string.IsNullOrWhiteSpace(configuration.ETag.ToString()) && onlyIfUnchanged)
                 {
                     throw new ArgumentException(ETagNotSetWhileUpdatingConfiguration);
                 }
                 cancellationToken.ThrowIfCancellationRequested();
 
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Put, GetConfigurationRequestUri(configuration.Id), _credentialProvider, configuration);
-                HttpMessageHelper.ConditionallyInsertETag(request, configuration.ETag);
+                HttpMessageHelper.ConditionallyInsertETag(request, configuration.ETag, onlyIfUnchanged);
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.OK, response).ConfigureAwait(false);
                 return await HttpMessageHelper.DeserializeResponseAsync<Configuration>(response).ConfigureAwait(false);
@@ -256,7 +239,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Updating configuration: {configuration?.Id} - Force update: {forceUpdate}", nameof(SetAsync));
+                    Logging.Exit(this, $"Updating configuration: {configuration?.Id} - only if changed: {onlyIfUnchanged}", nameof(SetAsync));
             }
         }
 
@@ -286,13 +269,10 @@ namespace Microsoft.Azure.Devices
             {
                 Argument.AssertNotNullOrWhiteSpace(configurationId, nameof(configurationId));
                 cancellationToken.ThrowIfCancellationRequested();
+                var configuration = new Configuration(configurationId);
+                configuration.ETag = new ETag(HttpMessageHelper.ETagForce);
 
-                // use wild-card ETag
-                var eTag = "*";
-                using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Delete, GetConfigurationRequestUri(configurationId), _credentialProvider);
-                HttpMessageHelper.ConditionallyInsertETag(request, eTag);
-                HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-                await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.NoContent, response).ConfigureAwait(false);
+                await DeleteAsync(configuration, default, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -311,6 +291,12 @@ namespace Microsoft.Azure.Devices
         /// Deletes a configuration from IoT hub.
         /// </summary>
         /// <param name="configuration">The configuration being deleted.</param>
+        /// <param name="onlyIfUnchanged">
+        /// If false, this delete operation will be performed even if the provided device identity has
+        /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
+        /// if the provided configuration has an out of date ETag. An up-to-date ETag can be
+        /// retrieved using <see cref="GetAsync(string, CancellationToken)"/>.
+        /// </param>
         /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="configuration"/> is null.</exception>
         /// <exception cref="IotHubException">
@@ -323,20 +309,20 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task DeleteAsync(Configuration configuration, CancellationToken cancellationToken = default)
+        public virtual async Task DeleteAsync(Configuration configuration, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Deleting configuration: {configuration?.Id}", nameof(DeleteAsync));
+                Logging.Enter(this, $"Deleting configuration: {configuration?.Id} - only if changed: {onlyIfUnchanged}", nameof(DeleteAsync));
             try
             {
                 Argument.AssertNotNull(configuration, nameof(configuration));
                 cancellationToken.ThrowIfCancellationRequested();
-                if (string.IsNullOrWhiteSpace(configuration.ETag))
+                if (string.IsNullOrWhiteSpace(configuration.ETag.ToString()) && onlyIfUnchanged)
                 {
                     throw new ArgumentException(ETagNotSetWhileDeletingConfiguration);
                 }
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Delete, GetConfigurationRequestUri(configuration.Id), _credentialProvider);
-                HttpMessageHelper.ConditionallyInsertETag(request, configuration.ETag);
+                HttpMessageHelper.ConditionallyInsertETag(request, configuration.ETag, onlyIfUnchanged);
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.NoContent, response).ConfigureAwait(false);
             }
@@ -349,7 +335,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Deleting configuration: {configuration?.Id}", nameof(DeleteAsync));
+                    Logging.Exit(this, $"Deleting configuration: {configuration?.Id} - only if changed: {onlyIfUnchanged}", nameof(DeleteAsync));
             }
         }
 

--- a/iothub/service/src/Configurations/ConfigurationsClient.cs
+++ b/iothub/service/src/Configurations/ConfigurationsClient.cs
@@ -218,10 +218,6 @@ namespace Microsoft.Azure.Devices
             try
             {
                 Argument.AssertNotNull(configuration, nameof(configuration));
-                if (string.IsNullOrWhiteSpace(configuration.ETag.ToString()) && onlyIfUnchanged)
-                {
-                    throw new ArgumentException(ETagNotSetWhileUpdatingConfiguration);
-                }
                 cancellationToken.ThrowIfCancellationRequested();
 
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Put, GetConfigurationRequestUri(configuration.Id), _credentialProvider, configuration);

--- a/iothub/service/src/Configurations/Models/Configuration.cs
+++ b/iothub/service/src/Configurations/Models/Configuration.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using Azure;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices
@@ -113,8 +114,9 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// The ETag of the configuration.
         /// </summary>
-        [JsonProperty(PropertyName = "etag", NullValueHandling = NullValueHandling.Ignore)]
-        public string ETag { get; set; }
+        [JsonProperty(PropertyName = "etag")]
+        [JsonConverter(typeof(NewtonsoftJsonETagConverter))] // NewtonsoftJsonETagConverter is used here because otherwise the ETag isn't serialized properly.
+        public ETag ETag { get; set; }
 
         /// <summary>
         /// For use in serialization.

--- a/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Devices
 
                 if (!string.IsNullOrWhiteSpace(requestOptions?.IfMatch))
                 {
-                    HttpMessageHelper.ConditionallyInsertETag(request, requestOptions?.IfMatch);
+                    HttpMessageHelper.ConditionallyInsertETag(request, new ETag(requestOptions?.IfMatch), false);
                 }
 
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);

--- a/iothub/service/src/Exceptions/ErrorCode.cs
+++ b/iothub/service/src/Exceptions/ErrorCode.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.Common.Exceptions
         ArgumentNull = 400005,
 
         /// <summary>
-        /// Returned by the service if a JSON object provided by this library cannot be parsed, for instance, if the JSON provided for <see cref="TwinsClient.UpdateAsync(string, Twin, ETag, bool, System.Threading.CancellationToken)"/> is invalid.
+        /// Returned by the service if a JSON object provided by this library cannot be parsed, for instance, if the JSON provided for <see cref="TwinsClient.UpdateAsync(string, Twin, bool, System.Threading.CancellationToken)"/> is invalid.
         /// </summary>
         IotHubFormatError = 400006,
 

--- a/iothub/service/src/Exceptions/ErrorCode.cs
+++ b/iothub/service/src/Exceptions/ErrorCode.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using Azure;
 using Microsoft.Azure.Devices;
 
 namespace Microsoft.Azure.Devices.Common.Exceptions
@@ -51,7 +52,7 @@ namespace Microsoft.Azure.Devices.Common.Exceptions
         ArgumentNull = 400005,
 
         /// <summary>
-        /// Returned by the service if a JSON object provided by this library cannot be parsed, for instance, if the JSON provided for <see cref="TwinsClient.UpdateAsync(string, Twin, string, System.Threading.CancellationToken)"/> is invalid.
+        /// Returned by the service if a JSON object provided by this library cannot be parsed, for instance, if the JSON provided for <see cref="TwinsClient.UpdateAsync(string, Twin, ETag, bool, System.Threading.CancellationToken)"/> is invalid.
         /// </summary>
         IotHubFormatError = 400006,
 
@@ -135,7 +136,7 @@ namespace Microsoft.Azure.Devices.Common.Exceptions
 
         /// <summary>
         /// The operation failed because it attempted to add a module to a device when that device already has a module registered to it with the same Id. This issue can be
-        /// fixed by removing the existing module from the device first with <see cref="ModulesClient.DeleteAsync(Module, System.Threading.CancellationToken)"/>. This error code is only returned from
+        /// fixed by removing the existing module from the device first with <see cref="ModulesClient.DeleteAsync(Module, bool, System.Threading.CancellationToken)"/>. This error code is only returned from
         /// methods like <see cref="ModulesClient.CreateAsync(Module, System.Threading.CancellationToken)"/>.
         /// </summary>
         ModuleAlreadyExistsOnDevice = 409301,

--- a/iothub/service/src/Http/HttpMessageHelper.cs
+++ b/iothub/service/src/Http/HttpMessageHelper.cs
@@ -90,24 +90,12 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         /// <param name="requestMessage">The request to add the If-Match header to.</param>
         /// <param name="eTag">The If-Match header value to sanitize before adding.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="requestMessage"/> or <paramref name="requestMessage"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown if the <paramref name="eTag"/> is empty or white space.</exception>
-        internal static void ConditionallyInsertETag(HttpRequestMessage requestMessage, string eTag)
-        {
-            ConditionallyInsertETag(requestMessage, new ETag(eTag), false);
-        }
-
-        /// <summary>
-        /// Adds the appropriate If-Match header value to the provided HTTP request.
-        /// </summary>
-        /// <param name="requestMessage">The request to add the If-Match header to.</param>
-        /// <param name="eTag">The If-Match header value to sanitize before adding.</param>
         /// <param name="onlyIfUnchanged">
         /// If true, the inserted IfMatch header value will be "*". If false, the IfMatch header value will be equal to the provided eTag.
         /// </param>
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="requestMessage"/> or <paramref name="requestMessage"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown if the <paramref name="eTag"/> is empty or white space.</exception>
-        internal static void ConditionallyInsertETag(HttpRequestMessage requestMessage, ETag eTag, bool onlyIfUnchanged = false)
+        internal static void ConditionallyInsertETag(HttpRequestMessage requestMessage, ETag eTag, bool onlyIfUnchanged)
         {
             Argument.AssertNotNull(requestMessage, nameof(requestMessage));
 

--- a/iothub/service/src/Registry/DevicesClient.cs
+++ b/iothub/service/src/Registry/DevicesClient.cs
@@ -9,6 +9,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 using Microsoft.Azure.Devices.Common.Exceptions;
 
 namespace Microsoft.Azure.Devices
@@ -973,7 +974,7 @@ namespace Microsoft.Azure.Devices
                 cancellationToken.ThrowIfCancellationRequested();
 
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Delete, GetJobUri(jobId), _credentialProvider);
-                HttpMessageHelper.ConditionallyInsertETag(request, jobId);
+                HttpMessageHelper.ConditionallyInsertETag(request, new ETag(jobId), false);
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.NoContent, response).ConfigureAwait(false);
             }

--- a/iothub/service/src/Registry/Models/Module.cs
+++ b/iothub/service/src/Registry/Models/Module.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using Azure;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -59,7 +60,8 @@ namespace Microsoft.Azure.Devices
         /// Module's ETag.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string ETag { get; set; }
+        [JsonConverter(typeof(NewtonsoftJsonETagConverter))] // NewtonsoftJsonETagConverter is used here because otherwise the ETag isn't serialized properly.
+        public ETag ETag { get; set; }
 
         /// <summary>
         /// Modules's connection state.

--- a/iothub/service/src/Registry/ModulesClient.cs
+++ b/iothub/service/src/Registry/ModulesClient.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 using Microsoft.Azure.Devices.Common.Exceptions;
 
 namespace Microsoft.Azure.Devices
@@ -140,32 +141,10 @@ namespace Microsoft.Azure.Devices
         /// Replace a module identity's state with the provided module identity's state.
         /// </summary>
         /// <param name="module">The module identity's new state.</param>
-        /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
-        /// <returns>The newly updated module identity including its new ETag.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the provided module is null.</exception>
-        /// <exception cref="IotHubException">
-        /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubThrottledException"/> is thrown. For a complete list of possible
-        /// error cases, see <see cref="Common.Exceptions"/>.
-        /// </exception>
-        /// <exception cref="HttpRequestException">
-        /// If the HTTP request fails due to an underlying issue such as network connectivity, DNS failure, or server
-        /// certificate validation.
-        /// </exception>
-        /// <exception cref="OperationCanceledException">If the provided cancellation token has requested cancellation.</exception>
-        public virtual async Task<Module> SetAsync(Module module, CancellationToken cancellationToken = default)
-        {
-            return await SetAsync(module, false, cancellationToken).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Replace a module identity's state with the provided module identity's state.
-        /// </summary>
-        /// <param name="module">The module identity's new state.</param>
-        /// <param name="forceUpdate">
-        /// If true, this update operation will execute even if the provided module identity has
-        /// an out of date ETag. If false, the operation will throw a <see cref="PreconditionFailedException"/>
-        /// if the provided module identity has an out of date ETag. An up-to-date ETag can be
+        /// <param name="onlyIfUnchanged">
+        /// If false, this operation will be performed even if the provided device identity has
+        /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
+        /// if the provided module has an out of date ETag. An up-to-date ETag can be
         /// retrieved using <see cref="GetAsync(string, string, CancellationToken)"/>.
         /// </param>
         /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
@@ -181,10 +160,10 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided cancellation token has requested cancellation.</exception>
-        public virtual async Task<Module> SetAsync(Module module, bool forceUpdate, CancellationToken cancellationToken = default)
+        public virtual async Task<Module> SetAsync(Module module, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Updating module: {module?.Id} on device: {module?.DeviceId}", nameof(SetAsync));
+                Logging.Enter(this, $"Updating module: {module?.Id} on device: {module?.DeviceId} - only if changed: {onlyIfUnchanged}", nameof(SetAsync));
 
             try
             {
@@ -192,13 +171,13 @@ namespace Microsoft.Azure.Devices
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (string.IsNullOrWhiteSpace(module.ETag) && !forceUpdate)
+                if (string.IsNullOrWhiteSpace(module.ETag.ToString()) && onlyIfUnchanged)
                 {
                     throw new ArgumentException(ETagNotSetWhileUpdatingDevice);
                 }
 
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Put, GetModulesRequestUri(module.DeviceId, module.Id), _credentialProvider, module);
-                HttpMessageHelper.ConditionallyInsertETag(request, module.ETag);
+                HttpMessageHelper.ConditionallyInsertETag(request, module.ETag, onlyIfUnchanged);
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.OK, response).ConfigureAwait(false);
                 return await HttpMessageHelper.DeserializeResponseAsync<Module>(response).ConfigureAwait(false);
@@ -212,7 +191,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Updating module: {module?.Id} on device: {module?.DeviceId}", nameof(SetAsync));
+                    Logging.Exit(this, $"Updating module: {module?.Id} on device: {module?.DeviceId} - only if changed: {onlyIfUnchanged}", nameof(SetAsync));
             }
         }
 
@@ -240,8 +219,8 @@ namespace Microsoft.Azure.Devices
             Argument.AssertNotNullOrWhiteSpace(moduleId, nameof(moduleId));
 
             var module = new Module(deviceId, moduleId);
-            module.ETag = HttpMessageHelper.ETagForce;
-            await DeleteAsync(module, cancellationToken).ConfigureAwait(false);
+            module.ETag = new ETag(HttpMessageHelper.ETagForce);
+            await DeleteAsync(module, default, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -253,6 +232,12 @@ namespace Microsoft.Azure.Devices
         /// An up-to-date ETag can be retrieved using <see cref="GetAsync(string, string, CancellationToken)"/>.
         /// To force the operation to execute regardless of ETag, set the module identity's ETag to "*" or
         /// use <see cref="DeleteAsync(string, string, CancellationToken)"/>.
+        /// </param>
+        /// <param name="onlyIfUnchanged">
+        /// If false, this delete operation will be performed even if the provided device identity has
+        /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
+        /// if the provided module has an out of date ETag. An up-to-date ETag can be
+        /// retrieved using <see cref="GetAsync(string, string, CancellationToken)"/>.
         /// </param>
         /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
         /// <exception cref="ArgumentNullException">Thrown when the provided module is null.</exception>
@@ -266,16 +251,16 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided cancellation token has requested cancellation.</exception>
-        public virtual async Task DeleteAsync(Module module, CancellationToken cancellationToken = default)
+        public virtual async Task DeleteAsync(Module module, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Deleting module: {module?.Id} on device: {module?.DeviceId}", nameof(DeleteAsync));
+                Logging.Enter(this, $"Deleting module: {module?.Id} on device: {module?.DeviceId} - only if changed: {onlyIfUnchanged}", nameof(DeleteAsync));
 
             try
             {
                 Argument.AssertNotNull(module, nameof(module));
 
-                if (module.ETag == null)
+                if (string.IsNullOrWhiteSpace(module.ETag.ToString()) && onlyIfUnchanged)
                 {
                     throw new ArgumentException(ETagNotSetWhileDeletingDevice);
                 }
@@ -283,7 +268,7 @@ namespace Microsoft.Azure.Devices
                 cancellationToken.ThrowIfCancellationRequested();
 
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Delete, GetModulesRequestUri(module.DeviceId, module.Id), _credentialProvider);
-                HttpMessageHelper.ConditionallyInsertETag(request, module.ETag);
+                HttpMessageHelper.ConditionallyInsertETag(request, module.ETag, onlyIfUnchanged);
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.NoContent, response).ConfigureAwait(false);
             }
@@ -296,7 +281,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Deleting module: {module?.Id} on device: {module?.DeviceId}", nameof(DeleteAsync));
+                    Logging.Exit(this, $"Deleting module: {module?.Id} on device: {module?.DeviceId} - only if changed: {onlyIfUnchanged}", nameof(DeleteAsync));
             }
         }
 

--- a/iothub/service/src/Registry/ModulesClient.cs
+++ b/iothub/service/src/Registry/ModulesClient.cs
@@ -168,13 +168,7 @@ namespace Microsoft.Azure.Devices
             try
             {
                 Argument.AssertNotNull(module, nameof(module));
-
                 cancellationToken.ThrowIfCancellationRequested();
-
-                if (string.IsNullOrWhiteSpace(module.ETag.ToString()) && onlyIfUnchanged)
-                {
-                    throw new ArgumentException(ETagNotSetWhileUpdatingDevice);
-                }
 
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Put, GetModulesRequestUri(module.DeviceId, module.Id), _credentialProvider, module);
                 HttpMessageHelper.ConditionallyInsertETag(request, module.ETag, onlyIfUnchanged);
@@ -259,12 +253,6 @@ namespace Microsoft.Azure.Devices
             try
             {
                 Argument.AssertNotNull(module, nameof(module));
-
-                if (string.IsNullOrWhiteSpace(module.ETag.ToString()) && onlyIfUnchanged)
-                {
-                    throw new ArgumentException(ETagNotSetWhileDeletingDevice);
-                }
-
                 cancellationToken.ThrowIfCancellationRequested();
 
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Delete, GetModulesRequestUri(module.DeviceId, module.Id), _credentialProvider);

--- a/iothub/service/src/Twin/Models/Twin.cs
+++ b/iothub/service/src/Twin/Models/Twin.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using Azure;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -91,7 +92,9 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Twin's ETag.
         /// </summary>
-        public string ETag { get; set; }
+        [JsonProperty(PropertyName = "etag")]
+        [JsonConverter(typeof(NewtonsoftJsonETagConverter))] // NewtonsoftJsonETagConverter is used here because otherwise the ETag isn't serialized properly.
+        public ETag ETag { get; set; }
 
         /// <summary>
         /// Twin's version.

--- a/iothub/service/src/Twin/Models/TwinJsonConverter.cs
+++ b/iothub/service/src/Twin/Models/TwinJsonConverter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using Azure;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
@@ -256,7 +257,7 @@ namespace Microsoft.Azure.Devices
                         break;
 
                     case ETagJsonTag:
-                        twin.ETag = reader.Value as string;
+                        twin.ETag = new ETag(reader.Value as string);
                         break;
 
                     case TagsJsonTag:

--- a/iothub/service/src/Twin/Models/TwinJsonConverter.cs
+++ b/iothub/service/src/Twin/Models/TwinJsonConverter.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Devices
             }
 
             writer.WritePropertyName(ETagJsonTag);
-            writer.WriteValue(twin.ETag);
+            writer.WriteValue(twin.ETag.ToString());
 
             writer.WritePropertyName(VersionTag);
             writer.WriteValue(twin.Version);

--- a/iothub/service/src/Twin/TwinsClient.cs
+++ b/iothub/service/src/Twin/TwinsClient.cs
@@ -154,7 +154,6 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         /// <param name="deviceId">The device Id.</param>
         /// <param name="twinPatch">Twin with updated fields.</param>
-        /// <param name="etag">Twin's ETag.</param>
         /// <param name="onlyIfUnchanged">
         /// If false, this operation will be performed even if the provided device identity has
         /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
@@ -163,8 +162,8 @@ namespace Microsoft.Azure.Devices
         /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated device twin.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="twinPatch"/> or <paramref name="etag"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown if the <paramref name="deviceId"/> or <paramref name="etag"/> is empty or white space.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="twinPatch"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown if the <paramref name="deviceId"/> is empty or white space.</exception>
         /// <exception cref="IotHubException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
         /// request was throttled, <see cref="IotHubThrottledException"/> is thrown. For a complete list of possible
@@ -175,17 +174,16 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> UpdateAsync(string deviceId, Twin twinPatch, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> UpdateAsync(string deviceId, Twin twinPatch, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Updating device twin on device: {deviceId}", nameof(UpdateAsync));
             try
             {
                 Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
-                Argument.AssertNotNullOrWhiteSpace(etag, nameof(etag));
                 Argument.AssertNotNull(twinPatch, nameof(twinPatch));
                 cancellationToken.ThrowIfCancellationRequested();
-                return await UpdateInternalAsync(deviceId, twinPatch, etag, false, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
+                return await UpdateInternalAsync(deviceId, twinPatch, twinPatch.ETag, false, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -205,7 +203,6 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         /// <param name="deviceId">The device Id.</param>
         /// <param name="jsonTwinPatch">Twin json with updated fields.</param>
-        /// <param name="etag">Twin's ETag.</param>
         /// <param name="onlyIfUnchanged">
         /// If false, this operation will be performed even if the provided device identity has
         /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
@@ -214,8 +211,8 @@ namespace Microsoft.Azure.Devices
         /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated device twin.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="jsonTwinPatch"/> or <paramref name="etag"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown if the <paramref name="deviceId"/> or <paramref name="jsonTwinPatch"/> or <paramref name="etag"/> is empty or white space.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="jsonTwinPatch"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown if the <paramref name="deviceId"/> or <paramref name="jsonTwinPatch"/> is empty or white space.</exception>
         /// <exception cref="IotHubException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
         /// request was throttled, <see cref="IotHubThrottledException"/> is thrown. For a complete list of possible
@@ -226,7 +223,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> UpdateAsync(string deviceId, string jsonTwinPatch, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> UpdateAsync(string deviceId, string jsonTwinPatch, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Updating device twin on device: {deviceId}", nameof(UpdateAsync));
@@ -235,12 +232,11 @@ namespace Microsoft.Azure.Devices
             {
                 Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
                 Argument.AssertNotNullOrWhiteSpace(jsonTwinPatch, nameof(jsonTwinPatch));
-                Argument.AssertNotNullOrWhiteSpace(etag, nameof(etag));
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // TODO: Do we need to deserialize Twin, only to serialize it again?
                 Twin twin = JsonConvert.DeserializeObject<Twin>(jsonTwinPatch);
-                return await UpdateAsync(deviceId, twin, etag, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
+                return await UpdateAsync(deviceId, twin, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -261,7 +257,6 @@ namespace Microsoft.Azure.Devices
         /// <param name="deviceId">The device Id.</param>
         /// <param name="moduleId">The module Id.</param>
         /// <param name="twinPatch">Twin with updated fields.</param>
-        /// <param name="etag">Twin's ETag.</param>
         /// <param name="onlyIfUnchanged">
         /// If false, this operation will be performed even if the provided device identity has
         /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
@@ -270,8 +265,8 @@ namespace Microsoft.Azure.Devices
         /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated device twin.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="twinPatch"/> or <paramref name="etag"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown if the <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="etag"/> is empty or white space.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="twinPatch"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown if the <paramref name="deviceId"/> or <paramref name="moduleId"/> is empty or white space.</exception>
         /// <exception cref="IotHubException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
         /// request was throttled, <see cref="IotHubThrottledException"/> is thrown. For a complete list of possible
@@ -282,7 +277,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> UpdateAsync(string deviceId, string moduleId, Twin twinPatch, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> UpdateAsync(string deviceId, string moduleId, Twin twinPatch, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Updating device twin on device: {deviceId}", nameof(UpdateAsync));
@@ -290,11 +285,10 @@ namespace Microsoft.Azure.Devices
             {
                 Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
                 Argument.AssertNotNullOrWhiteSpace(moduleId, nameof(moduleId));
-                Argument.AssertNotNullOrWhiteSpace(etag, nameof(etag));
                 Argument.AssertNotNull(twinPatch, nameof(twinPatch));
                 cancellationToken.ThrowIfCancellationRequested();
 
-                return await UpdateInternalAsync(deviceId, moduleId, twinPatch, etag, false, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
+                return await UpdateInternalAsync(deviceId, moduleId, twinPatch, twinPatch.ETag, false, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -315,7 +309,6 @@ namespace Microsoft.Azure.Devices
         /// <param name="deviceId">The device Id.</param>
         /// <param name="moduleId">The module Id.</param>
         /// <param name="jsonTwinPatch">Twin json with updated fields.</param>
-        /// <param name="etag">Twin's ETag.</param>
         /// <param name="onlyIfUnchanged">
         /// If false, this operation will be performed even if the provided device identity has
         /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
@@ -324,8 +317,8 @@ namespace Microsoft.Azure.Devices
         /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated module twin.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="jsonTwinPatch"/> or <paramref name="etag"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown if the <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="jsonTwinPatch"/> or <paramref name="etag"/> is empty or white space.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="jsonTwinPatch"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown if the <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="jsonTwinPatch"/> is empty or white space.</exception>
         /// <exception cref="IotHubException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
         /// request was throttled, <see cref="IotHubThrottledException"/> is thrown. For a complete list of possible
@@ -336,7 +329,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> UpdateAsync(string deviceId, string moduleId, string jsonTwinPatch, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> UpdateAsync(string deviceId, string moduleId, string jsonTwinPatch, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Updating device twin on device: {deviceId} and module: {moduleId}", nameof(UpdateAsync));
@@ -344,13 +337,12 @@ namespace Microsoft.Azure.Devices
             {
                 Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
                 Argument.AssertNotNullOrWhiteSpace(moduleId, nameof(moduleId));
-                Argument.AssertNotNullOrWhiteSpace(etag, nameof(etag));
                 Argument.AssertNotNull(jsonTwinPatch, nameof(jsonTwinPatch));
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // TODO: Do we need to deserialize Twin, only to serialize it again?
                 Twin twin = JsonConvert.DeserializeObject<Twin>(jsonTwinPatch);
-                return await UpdateAsync(deviceId, moduleId, twin, etag, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
+                return await UpdateAsync(deviceId, moduleId, twin, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -415,7 +407,6 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         /// <param name="deviceId">The device Id.</param>
         /// <param name="newTwin">New Twin object to replace with.</param>
-        /// <param name="etag">Twin's ETag.</param>
         /// <param name="onlyIfUnchanged">
         /// If false, this operation will be performed even if the provided device identity has
         /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
@@ -424,8 +415,8 @@ namespace Microsoft.Azure.Devices
         /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>updated twins.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="newTwin"/> or <paramref name="etag"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="etag"/> is empty or white space.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="newTwin"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the provided <paramref name="deviceId"/> is empty or white space.</exception>
         /// <exception cref="IotHubException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
         /// request was throttled, <see cref="IotHubThrottledException"/> is thrown. For a complete list of possible
@@ -436,18 +427,17 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> ReplaceAsync(string deviceId, Twin newTwin, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> ReplaceAsync(string deviceId, Twin newTwin, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Replacing device twin on device: {deviceId}", nameof(ReplaceAsync));
             try
             {
                 Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
-                Argument.AssertNotNullOrWhiteSpace(etag, nameof(etag));
                 Argument.AssertNotNull(newTwin, nameof(newTwin));
                 cancellationToken.ThrowIfCancellationRequested();
 
-                return await UpdateInternalAsync(deviceId, newTwin, etag, true, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
+                return await UpdateInternalAsync(deviceId, newTwin, newTwin.ETag, true, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -467,7 +457,6 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         /// <param name="deviceId">The device Id.</param>
         /// <param name="newTwinJson">New Twin json to replace with.</param>
-        /// <param name="etag">Twin's ETag.</param>
         /// <param name="onlyIfUnchanged">
         /// If false, this operation will be performed even if the provided device identity has
         /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
@@ -476,8 +465,8 @@ namespace Microsoft.Azure.Devices
         /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated device twin.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="newTwinJson"/> or <paramref name="etag"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="newTwinJson"/> or <paramref name="etag"/> is empty or white space.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="newTwinJson"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="newTwinJson"/> is empty or white space.</exception>
         /// <exception cref="IotHubException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
         /// request was throttled, <see cref="IotHubThrottledException"/> is thrown. For a complete list of possible
@@ -488,7 +477,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> ReplaceAsync(string deviceId, string newTwinJson, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> ReplaceAsync(string deviceId, string newTwinJson, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Replacing device twin on device: {deviceId}", nameof(ReplaceAsync));
@@ -496,12 +485,11 @@ namespace Microsoft.Azure.Devices
             {
                 Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
                 Argument.AssertNotNullOrWhiteSpace(newTwinJson, nameof(newTwinJson));
-                Argument.AssertNotNullOrWhiteSpace(etag, nameof(etag));
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // TODO: Do we need to deserialize Twin, only to serialize it again?
                 Twin twin = JsonConvert.DeserializeObject<Twin>(newTwinJson);
-                return await ReplaceAsync(deviceId, twin, etag, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
+                return await ReplaceAsync(deviceId, twin, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -522,7 +510,6 @@ namespace Microsoft.Azure.Devices
         /// <param name="deviceId">The device Id.</param>
         /// <param name="moduleId">The module Id.</param>
         /// <param name="newTwin">New Twin object to replace with.</param>
-        /// <param name="etag">Twin's ETag.</param>
         /// <param name="onlyIfUnchanged">
         /// If false, this operation will be performed even if the provided device identity has
         /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
@@ -531,8 +518,8 @@ namespace Microsoft.Azure.Devices
         /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated device twin.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="newTwin"/> or <paramref name="etag"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="etag"/> is empty or white space.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="newTwin"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> is empty or white space.</exception>
         /// <exception cref="IotHubException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
         /// request was throttled, <see cref="IotHubThrottledException"/> is thrown. For a complete list of possible
@@ -543,7 +530,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> ReplaceAsync(string deviceId, string moduleId, Twin newTwin, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> ReplaceAsync(string deviceId, string moduleId, Twin newTwin, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Replacing device twin on device: {deviceId} and module: {moduleId}", nameof(ReplaceAsync));
@@ -551,11 +538,10 @@ namespace Microsoft.Azure.Devices
             {
                 Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
                 Argument.AssertNotNullOrWhiteSpace(moduleId, nameof(moduleId));
-                Argument.AssertNotNullOrWhiteSpace(etag, nameof(etag));
                 Argument.AssertNotNull(newTwin, nameof(newTwin));
                 cancellationToken.ThrowIfCancellationRequested();
 
-                return await UpdateInternalAsync(deviceId, moduleId, newTwin, etag, true, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
+                return await UpdateInternalAsync(deviceId, moduleId, newTwin, newTwin.ETag, true, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -576,7 +562,6 @@ namespace Microsoft.Azure.Devices
         /// <param name="deviceId">The device Id.</param>
         /// <param name="moduleId">The module Id.</param>
         /// <param name="newTwinJson">New Twin json to replace with.</param>
-        /// <param name="etag">Twin's ETag.</param>
         /// <param name="onlyIfUnchanged">
         /// If false, this operation will be performed even if the provided device identity has
         /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
@@ -585,8 +570,8 @@ namespace Microsoft.Azure.Devices
         /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated module twin.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="newTwinJson"/> or <paramref name="etag"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="newTwinJson"/> or <paramref name="etag"/> is empty or white space.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="newTwinJson"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="newTwinJson"/> is empty or white space.</exception>
         /// <exception cref="IotHubException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
         /// request was throttled, <see cref="IotHubThrottledException"/> is thrown. For a complete list of possible
@@ -597,7 +582,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> ReplaceAsync(string deviceId, string moduleId, string newTwinJson, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> ReplaceAsync(string deviceId, string moduleId, string newTwinJson, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Replacing device twin on device: {deviceId} and module: {moduleId}", nameof(ReplaceAsync));
@@ -605,12 +590,11 @@ namespace Microsoft.Azure.Devices
             {
                 Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
                 Argument.AssertNotNullOrWhiteSpace(moduleId, nameof(moduleId));
-                Argument.AssertNotNullOrWhiteSpace(etag, nameof(etag));
                 Argument.AssertNotNullOrWhiteSpace(newTwinJson, nameof(newTwinJson));
                 cancellationToken.ThrowIfCancellationRequested();
                 // TODO: Do we need to deserialize Twin, only to serialize it again?
                 Twin twin = JsonConvert.DeserializeObject<Twin>(newTwinJson);
-                return await ReplaceAsync(deviceId, moduleId, twin, etag, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
+                return await ReplaceAsync(deviceId, moduleId, twin, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/iothub/service/src/Twin/TwinsClient.cs
+++ b/iothub/service/src/Twin/TwinsClient.cs
@@ -155,6 +155,12 @@ namespace Microsoft.Azure.Devices
         /// <param name="deviceId">The device Id.</param>
         /// <param name="twinPatch">Twin with updated fields.</param>
         /// <param name="etag">Twin's ETag.</param>
+        /// <param name="onlyIfUnchanged">
+        /// If false, this operation will be performed even if the provided device identity has
+        /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
+        /// if the provided device identity has an out of date ETag. An up-to-date ETag can be
+        /// retrieved using <see cref="GetAsync(string, string, CancellationToken)"/>.
+        /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated device twin.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="twinPatch"/> or <paramref name="etag"/> is null.</exception>
@@ -169,7 +175,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> UpdateAsync(string deviceId, Twin twinPatch, string etag, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> UpdateAsync(string deviceId, Twin twinPatch, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Updating device twin on device: {deviceId}", nameof(UpdateAsync));
@@ -179,7 +185,7 @@ namespace Microsoft.Azure.Devices
                 Argument.AssertNotNullOrWhiteSpace(etag, nameof(etag));
                 Argument.AssertNotNull(twinPatch, nameof(twinPatch));
                 cancellationToken.ThrowIfCancellationRequested();
-                return await UpdateInternalAsync(deviceId, twinPatch, etag, false, cancellationToken).ConfigureAwait(false);
+                return await UpdateInternalAsync(deviceId, twinPatch, etag, false, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -200,6 +206,12 @@ namespace Microsoft.Azure.Devices
         /// <param name="deviceId">The device Id.</param>
         /// <param name="jsonTwinPatch">Twin json with updated fields.</param>
         /// <param name="etag">Twin's ETag.</param>
+        /// <param name="onlyIfUnchanged">
+        /// If false, this operation will be performed even if the provided device identity has
+        /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
+        /// if the provided device identity has an out of date ETag. An up-to-date ETag can be
+        /// retrieved using <see cref="GetAsync(string, string, CancellationToken)"/>.
+        /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated device twin.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="jsonTwinPatch"/> or <paramref name="etag"/> is null.</exception>
@@ -214,7 +226,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> UpdateAsync(string deviceId, string jsonTwinPatch, string etag, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> UpdateAsync(string deviceId, string jsonTwinPatch, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Updating device twin on device: {deviceId}", nameof(UpdateAsync));
@@ -228,7 +240,7 @@ namespace Microsoft.Azure.Devices
 
                 // TODO: Do we need to deserialize Twin, only to serialize it again?
                 Twin twin = JsonConvert.DeserializeObject<Twin>(jsonTwinPatch);
-                return await UpdateAsync(deviceId, twin, etag, cancellationToken).ConfigureAwait(false);
+                return await UpdateAsync(deviceId, twin, etag, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -250,6 +262,12 @@ namespace Microsoft.Azure.Devices
         /// <param name="moduleId">The module Id.</param>
         /// <param name="twinPatch">Twin with updated fields.</param>
         /// <param name="etag">Twin's ETag.</param>
+        /// <param name="onlyIfUnchanged">
+        /// If false, this operation will be performed even if the provided device identity has
+        /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
+        /// if the provided device/module identity has an out of date ETag. An up-to-date ETag can be
+        /// retrieved using <see cref="GetAsync(string, string, CancellationToken)"/>.
+        /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated device twin.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="twinPatch"/> or <paramref name="etag"/> is null.</exception>
@@ -264,7 +282,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> UpdateAsync(string deviceId, string moduleId, Twin twinPatch, string etag, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> UpdateAsync(string deviceId, string moduleId, Twin twinPatch, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Updating device twin on device: {deviceId}", nameof(UpdateAsync));
@@ -276,7 +294,7 @@ namespace Microsoft.Azure.Devices
                 Argument.AssertNotNull(twinPatch, nameof(twinPatch));
                 cancellationToken.ThrowIfCancellationRequested();
 
-                return await UpdateInternalAsync(deviceId, moduleId, twinPatch, etag, false, cancellationToken).ConfigureAwait(false);
+                return await UpdateInternalAsync(deviceId, moduleId, twinPatch, etag, false, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -298,6 +316,12 @@ namespace Microsoft.Azure.Devices
         /// <param name="moduleId">The module Id.</param>
         /// <param name="jsonTwinPatch">Twin json with updated fields.</param>
         /// <param name="etag">Twin's ETag.</param>
+        /// <param name="onlyIfUnchanged">
+        /// If false, this operation will be performed even if the provided device identity has
+        /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
+        /// if the provided device/module identity has an out of date ETag. An up-to-date ETag can be
+        /// retrieved using <see cref="GetAsync(string, string, CancellationToken)"/>.
+        /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated module twin.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="jsonTwinPatch"/> or <paramref name="etag"/> is null.</exception>
@@ -312,7 +336,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> UpdateAsync(string deviceId, string moduleId, string jsonTwinPatch, string etag, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> UpdateAsync(string deviceId, string moduleId, string jsonTwinPatch, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Updating device twin on device: {deviceId} and module: {moduleId}", nameof(UpdateAsync));
@@ -326,7 +350,7 @@ namespace Microsoft.Azure.Devices
 
                 // TODO: Do we need to deserialize Twin, only to serialize it again?
                 Twin twin = JsonConvert.DeserializeObject<Twin>(jsonTwinPatch);
-                return await UpdateAsync(deviceId, moduleId, twin, etag, cancellationToken).ConfigureAwait(false);
+                return await UpdateAsync(deviceId, moduleId, twin, etag, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -392,6 +416,12 @@ namespace Microsoft.Azure.Devices
         /// <param name="deviceId">The device Id.</param>
         /// <param name="newTwin">New Twin object to replace with.</param>
         /// <param name="etag">Twin's ETag.</param>
+        /// <param name="onlyIfUnchanged">
+        /// If false, this operation will be performed even if the provided device identity has
+        /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
+        /// if the provided device identity has an out of date ETag. An up-to-date ETag can be
+        /// retrieved using <see cref="GetAsync(string, string, CancellationToken)"/>.
+        /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>updated twins.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="newTwin"/> or <paramref name="etag"/> is null.</exception>
@@ -406,7 +436,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> ReplaceAsync(string deviceId, Twin newTwin, string etag, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> ReplaceAsync(string deviceId, Twin newTwin, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Replacing device twin on device: {deviceId}", nameof(ReplaceAsync));
@@ -417,7 +447,7 @@ namespace Microsoft.Azure.Devices
                 Argument.AssertNotNull(newTwin, nameof(newTwin));
                 cancellationToken.ThrowIfCancellationRequested();
 
-                return await UpdateInternalAsync(deviceId, newTwin, etag, true, cancellationToken).ConfigureAwait(false);
+                return await UpdateInternalAsync(deviceId, newTwin, etag, true, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -438,6 +468,12 @@ namespace Microsoft.Azure.Devices
         /// <param name="deviceId">The device Id.</param>
         /// <param name="newTwinJson">New Twin json to replace with.</param>
         /// <param name="etag">Twin's ETag.</param>
+        /// <param name="onlyIfUnchanged">
+        /// If false, this operation will be performed even if the provided device identity has
+        /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
+        /// if the provided device identity has an out of date ETag. An up-to-date ETag can be
+        /// retrieved using <see cref="GetAsync(string, string, CancellationToken)"/>.
+        /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated device twin.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="newTwinJson"/> or <paramref name="etag"/> is null.</exception>
@@ -452,7 +488,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> ReplaceAsync(string deviceId, string newTwinJson, string etag, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> ReplaceAsync(string deviceId, string newTwinJson, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Replacing device twin on device: {deviceId}", nameof(ReplaceAsync));
@@ -465,7 +501,7 @@ namespace Microsoft.Azure.Devices
 
                 // TODO: Do we need to deserialize Twin, only to serialize it again?
                 Twin twin = JsonConvert.DeserializeObject<Twin>(newTwinJson);
-                return await ReplaceAsync(deviceId, twin, etag, cancellationToken).ConfigureAwait(false);
+                return await ReplaceAsync(deviceId, twin, etag, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -487,6 +523,12 @@ namespace Microsoft.Azure.Devices
         /// <param name="moduleId">The module Id.</param>
         /// <param name="newTwin">New Twin object to replace with.</param>
         /// <param name="etag">Twin's ETag.</param>
+        /// <param name="onlyIfUnchanged">
+        /// If false, this operation will be performed even if the provided device identity has
+        /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
+        /// if the provided device/module identity has an out of date ETag. An up-to-date ETag can be
+        /// retrieved using <see cref="GetAsync(string, string, CancellationToken)"/>.
+        /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated device twin.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="newTwin"/> or <paramref name="etag"/> is null.</exception>
@@ -501,7 +543,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> ReplaceAsync(string deviceId, string moduleId, Twin newTwin, string etag, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> ReplaceAsync(string deviceId, string moduleId, Twin newTwin, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Replacing device twin on device: {deviceId} and module: {moduleId}", nameof(ReplaceAsync));
@@ -513,7 +555,7 @@ namespace Microsoft.Azure.Devices
                 Argument.AssertNotNull(newTwin, nameof(newTwin));
                 cancellationToken.ThrowIfCancellationRequested();
 
-                return await UpdateInternalAsync(deviceId, moduleId, newTwin, etag, true, cancellationToken).ConfigureAwait(false);
+                return await UpdateInternalAsync(deviceId, moduleId, newTwin, etag, true, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -535,6 +577,12 @@ namespace Microsoft.Azure.Devices
         /// <param name="moduleId">The module Id.</param>
         /// <param name="newTwinJson">New Twin json to replace with.</param>
         /// <param name="etag">Twin's ETag.</param>
+        /// <param name="onlyIfUnchanged">
+        /// If false, this operation will be performed even if the provided device identity has
+        /// an out of date ETag. If true, the operation will throw a <see cref="PreconditionFailedException"/>
+        /// if the provided device/module identity has an out of date ETag. An up-to-date ETag can be
+        /// retrieved using <see cref="GetAsync(string, string, CancellationToken)"/>.
+        /// </param>
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <returns>Updated module twin.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="deviceId"/> or <paramref name="moduleId"/> or <paramref name="newTwinJson"/> or <paramref name="etag"/> is null.</exception>
@@ -549,7 +597,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> ReplaceAsync(string deviceId, string moduleId, string newTwinJson, string etag, CancellationToken cancellationToken = default)
+        public virtual async Task<Twin> ReplaceAsync(string deviceId, string moduleId, string newTwinJson, ETag etag, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Replacing device twin on device: {deviceId} and module: {moduleId}", nameof(ReplaceAsync));
@@ -562,7 +610,7 @@ namespace Microsoft.Azure.Devices
                 cancellationToken.ThrowIfCancellationRequested();
                 // TODO: Do we need to deserialize Twin, only to serialize it again?
                 Twin twin = JsonConvert.DeserializeObject<Twin>(newTwinJson);
-                return await ReplaceAsync(deviceId, moduleId, twin, etag, cancellationToken).ConfigureAwait(false);
+                return await ReplaceAsync(deviceId, moduleId, twin, etag, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -577,7 +625,7 @@ namespace Microsoft.Azure.Devices
             }
         }
 
-        private async Task<Twin> UpdateInternalAsync(string deviceId, Twin twin, string etag, bool isReplace, CancellationToken cancellationToken)
+        private async Task<Twin> UpdateInternalAsync(string deviceId, Twin twin, ETag etag, bool isReplace, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Replacing device twin on device: {deviceId} - is replace: {isReplace}", nameof(UpdateAsync));
@@ -586,7 +634,7 @@ namespace Microsoft.Azure.Devices
                 twin.DeviceId = deviceId;
 
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(isReplace ? HttpMethod.Put : _patch, GetTwinUri(deviceId), _credentialProvider, twin);
-                HttpMessageHelper.ConditionallyInsertETag(request, etag);
+                HttpMessageHelper.ConditionallyInsertETag(request, etag, onlyIfUnchanged);
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.OK, response).ConfigureAwait(false);
                 return await HttpMessageHelper.DeserializeResponseAsync<Twin>(response).ConfigureAwait(false);
@@ -604,7 +652,7 @@ namespace Microsoft.Azure.Devices
             }
         }
 
-        private async Task<Twin> UpdateInternalAsync(string deviceId, string moduleId, Twin twin, string etag, bool isReplace, CancellationToken cancellationToken)
+        private async Task<Twin> UpdateInternalAsync(string deviceId, string moduleId, Twin twin, ETag etag, bool isReplace, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Replacing device twin on device: {deviceId} - module: {moduleId} - is replace: {isReplace}", nameof(UpdateAsync));
@@ -614,7 +662,7 @@ namespace Microsoft.Azure.Devices
                 twin.ModuleId = moduleId;
 
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(isReplace ? HttpMethod.Put : _patch, GetModuleTwinRequestUri(deviceId, moduleId), _credentialProvider, twin);
-                HttpMessageHelper.ConditionallyInsertETag(request, etag);
+                HttpMessageHelper.ConditionallyInsertETag(request, etag, onlyIfUnchanged);
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.OK, response).ConfigureAwait(false);
                 return await HttpMessageHelper.DeserializeResponseAsync<Twin>(response).ConfigureAwait(false);
@@ -677,7 +725,7 @@ namespace Microsoft.Azure.Devices
                         break;
 
                     case ImportMode.UpdateTwinIfMatchETag:
-                        if (string.IsNullOrWhiteSpace(twin.ETag))
+                        if (string.IsNullOrWhiteSpace(twin.ETag.ToString()))
                         {
                             throw new ArgumentException(ETagNotSetWhileUpdatingTwin);
                         }
@@ -692,7 +740,7 @@ namespace Microsoft.Azure.Devices
                     Id = twin.DeviceId,
                     ModuleId = twin.ModuleId,
                     ImportMode = importMode,
-                    TwinETag = new ETag(twin.ETag),
+                    TwinETag = new ETag(twin.ETag.ToString()),
                     Tags = twin.Tags,
                     Properties = new ExportImportDevice.PropertyContainer(),
                 };

--- a/iothub/service/tests/Registry/DevicesTests.cs
+++ b/iothub/service/tests/Registry/DevicesTests.cs
@@ -365,7 +365,7 @@ namespace Microsoft.Azure.Devices.Tests
         [ExpectedException(typeof(ArgumentException))]
         public async Task UpdateTwinsAsyncWithETagMissingTest()
         {
-            var goodTwin = new Twin("123") { ETag = "234" };
+            var goodTwin = new Twin("123") { ETag = new ETag("234") };
             var badTwin = new Twin("234");
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
@@ -384,7 +384,7 @@ namespace Microsoft.Azure.Devices.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public async Task UpdateTwinsAsyncWithNullTwinTest()
         {
-            var goodTwin = new Twin("123") { ETag = "234" };
+            var goodTwin = new Twin("123") { ETag = new ETag("234") };
             Twin badTwin = null;
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
@@ -411,7 +411,7 @@ namespace Microsoft.Azure.Devices.Tests
         [ExpectedException(typeof(ArgumentException))]
         public async Task UpdateTwinsAsyncWithDeviceIdNullTest()
         {
-            var goodTwin = new Twin("123") { ETag = "234" };
+            var goodTwin = new Twin("123") { ETag = new ETag("234") };
             var badTwin = new Twin();
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
@@ -465,8 +465,8 @@ namespace Microsoft.Azure.Devices.Tests
         [TestMethod]
         public async Task UpdateTwinsAsyncForceUpdateFalseTest()
         {
-            var goodTwin1 = new Twin("123") { ETag = "234" };
-            var goodTwin2 = new Twin("234") { ETag = "123" };
+            var goodTwin1 = new Twin("123") { ETag = new ETag("234") };
+            var goodTwin2 = new Twin("234") { ETag = new ETag("234") };
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");


### PR DESCRIPTION
Extending work from the following PR to ConfigurationsClient, ModulesClient and TwinsClient:
https://github.com/Azure/azure-iot-sdk-csharp/pull/2646