### PR TITLE
Collapse provisioning service client APIs to use optional cancellation token

### DIFF
--- a/provisioning/service/src/Enrollments/BulkEnrollmentOperation.cs
+++ b/provisioning/service/src/Enrollments/BulkEnrollmentOperation.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Provisioning.Service
@@ -14,7 +15,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// <remarks>
     /// It is an internal class that creates a JSON for the bulk operations
     ///     over the IndividualEnrollment. To use bulk operations, please use
-    ///     the external API <see cref="ProvisioningServiceClient.RunBulkEnrollmentOperationAsync(BulkOperationMode, IEnumerable{IndividualEnrollment})"/>.
+    ///     the external API <see cref="ProvisioningServiceClient.RunBulkEnrollmentOperationAsync(BulkOperationMode, IEnumerable{IndividualEnrollment}, CancellationToken)"/>.
     ///
     /// The following JSON is an example of the result of this serializer.
     /// </remarks>
@@ -74,9 +75,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Creates a <c>string</c>, whose content represents the mode and the collection of
         ///     individualEnrollments in a JSON format.
         /// </remarks>
-        /// <param name="mode">the <see cref="BulkOperationMode"/> that defines the single operation to do over the 
+        /// <param name="mode">the <see cref="BulkOperationMode"/> that defines the single operation to do over the
         ///     individualEnrollments.</param>
-        /// <param name="individualEnrollments">the collection of <see cref="IndividualEnrollment"/> that contains the description 
+        /// <param name="individualEnrollments">the collection of <see cref="IndividualEnrollment"/> that contains the description
         ///     of each individualEnrollment.</param>
         /// <returns>The <c>string</c> with the content of this class.</returns>
         /// <exception cref="ArgumentNullException">if the individualEnrollments is null.</exception>

--- a/provisioning/service/src/Enrollments/BulkEnrollmentOperationError.cs
+++ b/provisioning/service/src/Enrollments/BulkEnrollmentOperationError.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Provisioning.Service
@@ -11,7 +12,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// </summary>
     /// <remarks>
     /// This error is returned as a result of the
-    ///     <see cref="ProvisioningServiceClient.RunBulkEnrollmentOperationAsync(BulkOperationMode, System.Collections.Generic.IEnumerable{IndividualEnrollment})"/>
+    ///     <see cref="ProvisioningServiceClient.RunBulkEnrollmentOperationAsync(BulkOperationMode, System.Collections.Generic.IEnumerable{IndividualEnrollment}, CancellationToken)"/>
     ///     as part of the <see cref="BulkEnrollmentOperationResult"/>.
     /// </remarks>
     /// <example>

--- a/provisioning/service/src/Enrollments/BulkEnrollmentOperationResult.cs
+++ b/provisioning/service/src/Enrollments/BulkEnrollmentOperationResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Threading;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Provisioning.Service
@@ -10,8 +11,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// Representation of a single Device Provisioning Service bulk operation result with a JSON deserializer.
     /// </summary>
     /// <remarks>
-    /// This error is returned as a result of the 
-    ///     <see cref="ProvisioningServiceClient.RunBulkEnrollmentOperationAsync(BulkOperationMode, IEnumerable{IndividualEnrollment})"/>.
+    /// This error is returned as a result of the
+    ///     <see cref="ProvisioningServiceClient.RunBulkEnrollmentOperationAsync(BulkOperationMode, IEnumerable{IndividualEnrollment}, CancellationToken)"/>.
     ///
     /// The provisioning service provides general bulk result in the isSuccessful, and a individual error result
     ///     for each enrollment in the bulk.

--- a/provisioning/service/src/Enrollments/IndividualEnrollment.cs
+++ b/provisioning/service/src/Enrollments/IndividualEnrollment.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -18,7 +19,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// This object is used to send and receive individualEnrollment information to and from the provisioning service.
     ///
     /// To create or update an Enrollment on the provisioning service you should fill this object and call the
-    /// public API <see cref="ProvisioningServiceClient.CreateOrUpdateIndividualEnrollmentAsync(IndividualEnrollment)"/>.
+    /// public API <see cref="ProvisioningServiceClient.CreateOrUpdateIndividualEnrollmentAsync(IndividualEnrollment, CancellationToken)"/>.
     ///
     /// The minimum information required by the provisioning service is the <c>RegistrationId</c> and the
     /// <c>Attestation</c>.

--- a/provisioning/service/src/ProvisioningServiceClient.cs
+++ b/provisioning/service/src/ProvisioningServiceClient.cs
@@ -29,10 +29,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// application shall call to create and maintain the Enrollments. The Objects in the <b>configs</b> package shall
     /// be filled and passed as parameters of the public API, for example, to create a new enrollment, the application
     /// shall create the object <see cref="IndividualEnrollment"/> with the appropriate enrollment configurations, and call the
-    /// <see cref="CreateOrUpdateIndividualEnrollmentAsync(IndividualEnrollment)"/>.
+    /// <see cref="CreateOrUpdateIndividualEnrollmentAsync(IndividualEnrollment, CancellationToken)"/>.
     ///
     /// The IoT hub Device Provisioning Service supports SQL queries too. The application can create a new query using
-    /// one of the queries factories, for instance <see cref="CreateIndividualEnrollmentQuery(QuerySpecification)"/>, passing
+    /// one of the queries factories, for instance <see cref="CreateIndividualEnrollmentQuery(QuerySpecification, CancellationToken)"/>, passing
     /// the <see cref="QuerySpecification"/>, with the SQL query. This factory returns a <see cref="Query"/> object, which is an
     /// active iterator.
     ///
@@ -125,128 +125,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         }
 
         /// <summary>
-        /// Create or update a individual Device Enrollment record.
-        /// </summary>
-        /// <remarks>
-        /// This API creates a new individualEnrollment or update a existed one. All enrollments in the Device Provisioning Service
-        /// contains a unique identifier called registrationId. If this API is called for an individualEnrollment with a
-        /// registrationId that already exists, it will replace the existed individualEnrollment information by the new one.
-        /// On the other hand, if the registrationId does not exit, this API will create a new individualEnrollment.
-        ///
-        /// If the registrationId already exists, this method will update existed enrollments. Note that update the
-        /// individualEnrollment will not change the status of the device that was already registered using the old individualEnrollment.
-        ///
-        /// To use the Device Provisioning Service API, you must include the follow package on your application.
-        /// <c>
-        /// // Include the following using to use the Device Provisioning Service APIs.
-        /// using Microsoft.Azure.Devices.Provisioning.Service;
-        /// </c>
-        /// </remarks>
-        /// <example>
-        /// The follow code will create a new individualEnrollment that will provisioning the registrationid-1 using TPM attestation.
-        /// <c>
-        /// // IndividualEnrollment information.
-        /// private const string PROVISIONING_CONNECTION_STRING = "HostName=ContosoProvisioning.azure-devices-provisioning.net;" +
-        ///    "SharedAccessKeyName=contosoprovisioningserviceowner;" +
-        ///    "SharedAccessKey=dGVzdFN0cmluZzE=";
-        /// private const string TPM_ENDORSEMENT_KEY = "tpm-endorsement-key";
-        /// private const string REGISTRATION_ID = "registrationid-1";
-        ///
-        /// static async Task Main(string[] args)
-        /// {
-        ///     await RunSample();
-        /// }
-        ///
-        /// public static async Task RunSample()
-        /// {
-        ///     using (ProvisioningServiceClient provisioningServiceClient =
-        ///         ProvisioningServiceClient.CreateFromConnectionString(PROVISIONING_CONNECTION_STRING))
-        ///     {
-        ///         // ************************************ Create the individualEnrollment ****************************************
-        ///         Console.WriteLine("\nCreate a new individualEnrollment...");
-        ///         Attestation attestation = new TpmAttestation(TPM_ENDORSEMENT_KEY);
-        ///         IndividualEnrollment individualEnrollment = new IndividualEnrollment(
-        ///             REGISTRATION_ID,
-        ///             attestation);
-        ///         individualEnrollment.ProvisioningStatus = ProvisioningStatus.Disabled;
-        ///         IndividualEnrollment individualEnrollmentResult =
-        ///         await provisioningServiceClient.CreateOrUpdateIndividualEnrollmentAsync(individualEnrollment).ConfigureAwait(false);
-        ///         Console.WriteLine("\nIndividualEnrollment created with success...");
-        ///     }
-        /// }
-        /// </c>
-        ///
-        /// The follow code will update the provisioningStatus of the previous individualEnrollment from <b>disabled</b> to <b>enabled</b>.
-        /// <c>
-        /// // IndividualEnrollment information.
-        /// private const string PROVISIONING_CONNECTION_STRING = "HostName=ContosoProvisioning.azure-devices-provisioning.net;" +
-        ///     "SharedAccessKeyName=contosoprovisioningserviceowner;" +
-        ///     "SharedAccessKey=dGVzdFN0cmluZzE=";
-        /// private const string REGISTRATION_ID = "registrationid-1";
-        ///
-        /// static async Task Main(string[] args)
-        /// {
-        ///     await RunSample();
-        /// }
-        ///
-        /// public static async Task RunSample()
-        /// {
-        ///     using (ProvisioningServiceClient provisioningServiceClient =
-        ///     ProvisioningServiceClient.CreateFromConnectionString(PROVISIONING_CONNECTION_STRING))
-        ///     {
-        ///         // ************************* Get the content of the previous individualEnrollment ******************************
-        ///         Console.WriteLine("\nGet the content of the previous individualEnrollment...");
-        ///         Attestation attestation = new TpmAttestation(TPM_ENDORSEMENT_KEY);
-        ///         IndividualEnrollment individualEnrollment =
-        ///             await deviceProvisioningServiceClient.GetIndividualEnrollmentAsync(REGISTRATION_ID).ConfigureAwait(false);
-        ///         individualEnrollment.ProvisioningStatus = ProvisioningStatus.Enabled;
-        ///         IndividualEnrollment individualEnrollmentResult = await provisioningServiceClient
-        ///             .CreateOrUpdateIndividualEnrollmentAsync(individualEnrollment)
-        ///             .ConfigureAwait(false);
-        ///         Console.WriteLine("\nIndividualEnrollment updated with success...");
-        ///     }
-        /// }
-        /// </c>
-        /// </example>
-        /// <param name="individualEnrollment">The <see cref="IndividualEnrollment"/> object that describes the individualEnrollment that will be created of updated. It cannot be <c>null</c>.</param>
-        /// <returns>An <see cref="IndividualEnrollment"/> object with the result of the create or update requested.</returns>
-        /// <exception cref="ArgumentException">If the provided parameter is not correct.</exception>
-        /// <exception cref="ProvisioningServiceClientTransportException">If the SDK failed to send the request to the Device Provisioning Service.</exception>
-        /// <exception cref="ProvisioningServiceClientException">If the Device Provisioning Service was not able to create or update the individualEnrollment.</exception>
-        public Task<IndividualEnrollment> CreateOrUpdateIndividualEnrollmentAsync(IndividualEnrollment individualEnrollment)
-        {
-            return IndividualEnrollmentManager.CreateOrUpdateAsync(_contractApiHttp, individualEnrollment, CancellationToken.None);
-        }
-
-        /// <summary>
         /// Creates or updates an individual enrollment.
         /// </summary>
         /// <param name="individualEnrollment">The individual enrollment object.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>An individual enrollment</returns>
-        public Task<IndividualEnrollment> CreateOrUpdateIndividualEnrollmentAsync(IndividualEnrollment individualEnrollment, CancellationToken cancellationToken)
+        public Task<IndividualEnrollment> CreateOrUpdateIndividualEnrollmentAsync(IndividualEnrollment individualEnrollment, CancellationToken cancellationToken = default)
         {
             return IndividualEnrollmentManager.CreateOrUpdateAsync(_contractApiHttp, individualEnrollment, cancellationToken);
-        }
-
-        /// <summary>
-        /// Create, update or delete a set of individual device enrollments.
-        /// </summary>
-        /// <remarks>
-        /// This API provide the means to do a single operation over multiple individualEnrollments. A valid operation
-        /// is determined by <see cref="BulkOperationMode"/>, and can be 'create', 'update', 'updateIfMatchETag', or 'delete'.
-        /// </remarks>
-        /// <param name="bulkOperationMode">The <see cref="BulkOperationMode"/> that defines the single operation to do over the individualEnrollments. It cannot be <c>null</c>.</param>
-        /// <param name="individualEnrollments">The collection of <see cref="IndividualEnrollment"/> that contains the description of each individualEnrollment. It cannot be <c>null</c> or empty.</param>
-        /// <returns>A <see cref="BulkEnrollmentOperationResult"/> object with the result of operation for each enrollment.</returns>
-        /// <exception cref="ArgumentException">If the provided parameters are not correct.</exception>
-        /// <exception cref="ProvisioningServiceClientTransportException">If the SDK failed to send the request to the Device Provisioning Service.</exception>
-        /// <exception cref="ProvisioningServiceClientException">If the Device Provisioning Service was not able to execute the bulk operation.</exception>
-        public Task<BulkEnrollmentOperationResult> RunBulkEnrollmentOperationAsync(
-            BulkOperationMode bulkOperationMode,
-            IEnumerable<IndividualEnrollment> individualEnrollments)
-        {
-            return IndividualEnrollmentManager.BulkOperationAsync(_contractApiHttp, bulkOperationMode, individualEnrollments, CancellationToken.None);
         }
 
         /// <summary>
@@ -266,28 +152,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         public Task<BulkEnrollmentOperationResult> RunBulkEnrollmentOperationAsync(
             BulkOperationMode bulkOperationMode,
             IEnumerable<IndividualEnrollment> individualEnrollments,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default)
         {
             return IndividualEnrollmentManager.BulkOperationAsync(_contractApiHttp, bulkOperationMode, individualEnrollments, cancellationToken);
-        }
-
-        /// <summary>
-        /// Retrieve the individualEnrollment information.
-        /// </summary>
-        /// <remarks>
-        /// This method will return the enrollment information for the provided registrationId. It will retrieve
-        /// the correspondent individualEnrollment from the Device Provisioning Service, and return it in the <see cref="IndividualEnrollment"/> object.
-        ///
-        /// If the registrationId do not exists, this method will throw <see cref="ProvisioningServiceClientException"/>.
-        /// </remarks>
-        /// <param name="registrationId">The <c>string</c> that identifies the individualEnrollment. It cannot be <c>null</c> or empty.</param>
-        /// <returns>The <see cref="IndividualEnrollment"/> with the content of the individualEnrollment in the Provisioning Device Service.</returns>
-        /// <exception cref="ArgumentException">If the provided parameter is not correct.</exception>
-        /// <exception cref="ProvisioningServiceClientTransportException">If the SDK failed to send the request to the Device Provisioning Service.</exception>
-        /// <exception cref="ProvisioningServiceClientException">If the Device Provisioning Service was not able to execute the bulk operation.</exception>
-        public Task<IndividualEnrollment> GetIndividualEnrollmentAsync(string registrationId)
-        {
-            return IndividualEnrollmentManager.GetAsync(_contractApiHttp, registrationId, CancellationToken.None);
         }
 
         /// <summary>
@@ -296,32 +163,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="registrationId">The registration Id.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The enrollment.</returns>
-        public Task<IndividualEnrollment> GetIndividualEnrollmentAsync(string registrationId, CancellationToken cancellationToken)
+        public Task<IndividualEnrollment> GetIndividualEnrollmentAsync(string registrationId, CancellationToken cancellationToken = default)
         {
             return IndividualEnrollmentManager.GetAsync(_contractApiHttp, registrationId, cancellationToken);
-        }
-
-        /// <summary>
-        /// Delete the individualEnrollment information.
-        /// </summary>
-        /// <remarks>
-        /// This method will remove the individualEnrollment from the Device Provisioning Service using the
-        /// provided <see cref="IndividualEnrollment"/> information. The Device Provisioning Service will care about the
-        /// registrationId and the eTag on the individualEnrollment. If you want to delete the individualEnrollment regardless the
-        /// eTag, you can set the <c>eTag="*"</c> into the individualEnrollment, or use the <see cref="DeleteDeviceRegistrationStateAsync(string)"/>
-        /// passing only the registrationId.
-        ///
-        /// Note that delete the individualEnrollment will not remove the Device itself from the IotHub.
-        ///
-        /// If the registrationId does not exists or the eTag not matches, this method will throw <see cref="ProvisioningServiceClientException"/>.
-        /// </remarks>
-        /// <param name="individualEnrollment">The <see cref="IndividualEnrollment"/> that identifies the individualEnrollment. It cannot be <c>null</c>.</param>
-        /// <exception cref="ArgumentException">If the provided parameter is not correct.</exception>
-        /// <exception cref="ProvisioningServiceClientTransportException">If the SDK failed to send the request to the Device Provisioning Service.</exception>
-        /// <exception cref="ProvisioningServiceClientException">If the Device Provisioning Service was not able to execute the bulk operation.</exception>
-        public Task DeleteIndividualEnrollmentAsync(IndividualEnrollment individualEnrollment)
-        {
-            return IndividualEnrollmentManager.DeleteAsync(_contractApiHttp, individualEnrollment, CancellationToken.None);
         }
 
         /// <summary>
@@ -330,30 +174,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="individualEnrollment">The individual enrollment.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        public Task DeleteIndividualEnrollmentAsync(IndividualEnrollment individualEnrollment, CancellationToken cancellationToken)
+        public Task DeleteIndividualEnrollmentAsync(IndividualEnrollment individualEnrollment, CancellationToken cancellationToken = default)
         {
             return IndividualEnrollmentManager.DeleteAsync(_contractApiHttp, individualEnrollment, cancellationToken);
-        }
-
-        /// <summary>
-        /// Delete the individualEnrollment information.
-        /// </summary>
-        /// <remarks>
-        /// This method will remove the individualEnrollment from the Device Provisioning Service using the
-        /// provided registrationId. It will delete the enrollment regardless the eTag. It means that this API
-        /// correspond to the <see cref="DeleteIndividualEnrollmentAsync(string, string)"/> with the <c>eTag="*"</c>.
-        ///
-        /// Note that delete the enrollment will not remove the Device itself from the IotHub.
-        ///
-        /// If the registrationId does not exists, this method will throw <see cref="ProvisioningServiceClientException"/>.
-        /// </remarks>
-        /// <param name="registrationId">The <c>string</c> that identifies the individualEnrollment. It cannot be <c>null</c> or empty.</param>
-        /// <exception cref="ArgumentException">If the provided registrationId is not correct.</exception>
-        /// <exception cref="ProvisioningServiceClientTransportException">If the SDK failed to send the request to the Device Provisioning Service.</exception>
-        /// <exception cref="ProvisioningServiceClientException">If the Device Provisioning Service was not able to execute the bulk operation.</exception>
-        public Task DeleteIndividualEnrollmentAsync(string registrationId)
-        {
-            return IndividualEnrollmentManager.DeleteAsync(_contractApiHttp, registrationId, CancellationToken.None);
         }
 
         /// <summary>
@@ -362,7 +185,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <remarks>
         /// This method will remove the individualEnrollment from the Device Provisioning Service using the
         /// provided registrationId. It will delete the enrollment regardless the eTag. It means that this API
-        /// correspond to the <see cref="DeleteIndividualEnrollmentAsync(string, string)"/> with the <c>eTag="*"</c>.
+        /// correspond to the <see cref="DeleteIndividualEnrollmentAsync(string, string, CancellationToken)"/> with the <c>eTag="*"</c>.
         ///
         /// Note that delete the enrollment will not remove the Device itself from the IotHub.
         ///
@@ -373,34 +196,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <exception cref="ArgumentException">If the provided registrationId is not correct.</exception>
         /// <exception cref="ProvisioningServiceClientTransportException">If the SDK failed to send the request to the Device Provisioning Service.</exception>
         /// <exception cref="ProvisioningServiceClientException">If the Device Provisioning Service was not able to execute the bulk operation.</exception>
-        public Task DeleteIndividualEnrollmentAsync(string registrationId, CancellationToken cancellationToken)
+        public Task DeleteIndividualEnrollmentAsync(string registrationId, CancellationToken cancellationToken = default)
         {
             return IndividualEnrollmentManager.DeleteAsync(_contractApiHttp, registrationId, cancellationToken);
-        }
-
-        /// <summary>
-        /// Delete the individualEnrollment information.
-        /// </summary>
-        /// <remarks>
-        /// This method will remove the individualEnrollment from the Device Provisioning Service using the
-        /// provided registrationId and eTag. If you want to delete the enrollment regardless the eTag, you can
-        /// use <see cref="DeleteIndividualEnrollmentAsync(string)"/> or you can pass the eTag as <c>null</c>, empty, or
-        /// <c>"*"</c>.
-        ///
-        /// Note that delete the enrollment will not remove the Device itself from the IotHub.
-        ///
-        /// If the registrationId does not exists or the eTag does not matches, this method will throw
-        /// <see cref="ProvisioningServiceClientException"/>. For more exceptions that this method can throw, please see
-        /// </remarks>
-        /// <param name="registrationId">The <c>string</c> that identifies the individualEnrollment. It cannot be <c>null</c> or empty.</param>
-        /// <param name="eTag">The <c>string</c> with the IndividualEnrollment eTag. It can be <c>null</c> or empty.
-        /// The Device Provisioning Service will ignore it in all of these cases.</param>
-        /// <exception cref="ArgumentException">If the provided registrationId is not correct.</exception>
-        /// <exception cref="ProvisioningServiceClientTransportException">If the SDK failed to send the request to the Device Provisioning Service.</exception>
-        /// <exception cref="ProvisioningServiceClientException">If the Device Provisioning Service was not able to execute the bulk operation.</exception>
-        public Task DeleteIndividualEnrollmentAsync(string registrationId, string eTag)
-        {
-            return IndividualEnrollmentManager.DeleteAsync(_contractApiHttp, registrationId, CancellationToken.None, eTag);
         }
 
         /// <summary>
@@ -410,31 +208,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="eTag">The eTag.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        public Task DeleteIndividualEnrollmentAsync(string registrationId, string eTag, CancellationToken cancellationToken)
+        public Task DeleteIndividualEnrollmentAsync(string registrationId, string eTag, CancellationToken cancellationToken = default)
         {
             return IndividualEnrollmentManager.DeleteAsync(_contractApiHttp, registrationId, cancellationToken, eTag);
-        }
-
-        /// <summary>
-        /// Factory to create a individualEnrollment query.
-        /// </summary>
-        /// <remarks>
-        /// This method will create a new individualEnrollment query for Device Provisioning Service and return it
-        /// as a <see cref="Query"/> iterator.
-        ///
-        /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
-        /// <c>"SELECT * FROM enrollments"</c>.
-        /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
-        /// <returns>The <see cref="Query"/> iterator.</returns>
-        /// <exception cref="ArgumentException">If the provided parameter is not correct.</exception>
-        public Query CreateIndividualEnrollmentQuery(QuerySpecification querySpecification)
-        {
-            return IndividualEnrollmentManager.CreateQuery(
-                _provisioningConnectionString,
-                querySpecification,
-                _options.ProvisioningServiceHttpSettings,
-                CancellationToken.None);
         }
 
         /// <summary>
@@ -474,7 +250,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
         /// <exception cref="ArgumentException">If the provided parameter is not correct.</exception>
-        public Query CreateIndividualEnrollmentQuery(QuerySpecification querySpecification, CancellationToken cancellationToken)
+        public Query CreateIndividualEnrollmentQuery(QuerySpecification querySpecification, CancellationToken cancellationToken = default)
         {
             return IndividualEnrollmentManager.CreateQuery(
                 _provisioningConnectionString,
@@ -495,42 +271,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         ///
         /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
         /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification)"/>.
-        /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
-        /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
-        /// <returns>The <see cref="Query"/> iterator.</returns>
-        /// <exception cref="ArgumentException">If the provided parameters are not correct.</exception>
-        public Query CreateIndividualEnrollmentQuery(QuerySpecification querySpecification, int pageSize)
-        {
-            return IndividualEnrollmentManager.CreateQuery(
-                _provisioningConnectionString,
-                querySpecification,
-                _options.ProvisioningServiceHttpSettings,
-                CancellationToken.None,
-                pageSize);
-        }
-
-        /// <summary>
-        /// Factory to create a individualEnrollment query.
-        /// </summary>
-        /// <remarks>
-        /// This method will create a new individualEnrollment query for Device Provisioning Service and return it
-        /// as a <see cref="Query"/> iterator.
-        ///
-        /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
-        /// <c>"SELECT * FROM enrollments"</c>.
-        ///
-        /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
-        /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification)"/>.
+        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification, CancellationToken)"/>.
         /// </remarks>
         /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
         /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
         /// <exception cref="ArgumentException">If the provided parameters are not correct.</exception>
-        public Query CreateIndividualEnrollmentQuery(QuerySpecification querySpecification, int pageSize, CancellationToken cancellationToken)
+        public Query CreateIndividualEnrollmentQuery(QuerySpecification querySpecification, int pageSize, CancellationToken cancellationToken = default)
         {
             return IndividualEnrollmentManager.CreateQuery(
                 _provisioningConnectionString,
@@ -552,7 +300,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         ///
         /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
         /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification)"/>.
+        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification, CancellationToken)"/>.
         /// </remarks>
         /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
         /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
@@ -585,53 +333,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </c>
         /// </remarks>
         /// <param name="enrollmentGroup">The <see cref="EnrollmentGroup"/> object that describes the individualEnrollment that will be created of updated.</param>
-        /// <returns>An <see cref="EnrollmentGroup"/> object with the result of the create or update requested.</returns>
-        /// <exception cref="ProvisioningServiceClientException">If the Provisioning was not able to create or update the enrollment.</exception>
-        public Task<EnrollmentGroup> CreateOrUpdateEnrollmentGroupAsync(EnrollmentGroup enrollmentGroup)
-        {
-            return EnrollmentGroupManager.CreateOrUpdateAsync(_contractApiHttp, enrollmentGroup, CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Create or update an enrollment group record.
-        /// </summary>
-        /// <remarks>
-        /// This API creates a new enrollment group or update a existed one. All enrollment group in the Device
-        /// Provisioning Service contains a unique identifier called enrollmentGroupId. If this API is called
-        /// with an enrollmentGroupId that already exists, it will replace the existed enrollment group information
-        /// by the new one. On the other hand, if the enrollmentGroupId does not exit, it will be created.
-        ///
-        /// To use the Device Provisioning Service API, you must include the follow package on your application.
-        /// <c>
-        /// // Include the following using to use the Device Provisioning Service APIs.
-        /// using Microsoft.Azure.Devices.Provisioning.Service;
-        /// </c>
-        /// </remarks>
-        /// <param name="enrollmentGroup">The <see cref="EnrollmentGroup"/> object that describes the individualEnrollment that will be created of updated.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>An <see cref="EnrollmentGroup"/> object with the result of the create or update requested.</returns>
         /// <exception cref="ProvisioningServiceClientException">If the Provisioning was not able to create or update the enrollment.</exception>
-        public Task<EnrollmentGroup> CreateOrUpdateEnrollmentGroupAsync(EnrollmentGroup enrollmentGroup, CancellationToken cancellationToken)
+        public Task<EnrollmentGroup> CreateOrUpdateEnrollmentGroupAsync(EnrollmentGroup enrollmentGroup, CancellationToken cancellationToken = default)
         {
             return EnrollmentGroupManager.CreateOrUpdateAsync(_contractApiHttp, enrollmentGroup, cancellationToken);
-        }
-
-        /// <summary>
-        /// Retrieve the enrollment group information.
-        /// </summary>
-        /// <remarks>
-        /// This method will return the enrollment group information for the provided enrollmentGroupId. It will retrieve
-        /// the correspondent enrollment group from the Device Provisioning Service, and return it in the
-        /// <see cref="EnrollmentGroup"/> object.
-        ///
-        /// If the enrollmentGroupId does not exists, this method will throw <see cref="ProvisioningServiceClientException"/>.
-        /// </remarks>
-        /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
-        /// <returns>The <see cref="EnrollmentGroup"/> with the content of the enrollment group in the Provisioning Device Service.</returns>
-        /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to retrieve the enrollment group information for the provided enrollmentGroupId.</exception>
-        public Task<EnrollmentGroup> GetEnrollmentGroupAsync(string enrollmentGroupId)
-        {
-            return EnrollmentGroupManager.GetAsync(_contractApiHttp, enrollmentGroupId, CancellationToken.None);
         }
 
         /// <summary>
@@ -649,7 +356,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <returns>The <see cref="EnrollmentGroup"/> with the content of the enrollment group in the Provisioning Device Service.</returns>
         /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to retrieve
         /// the enrollment group information for the provided enrollmentGroupId.</exception>
-        public Task<EnrollmentGroup> GetEnrollmentGroupAsync(string enrollmentGroupId, CancellationToken cancellationToken)
+        public Task<EnrollmentGroup> GetEnrollmentGroupAsync(string enrollmentGroupId, CancellationToken cancellationToken = default)
         {
             return EnrollmentGroupManager.GetAsync(_contractApiHttp, enrollmentGroupId, cancellationToken);
         }
@@ -661,28 +368,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// This method will remove the enrollment group from the Device Provisioning Service using the
         /// provided <see cref="EnrollmentGroup"/> information. The Device Provisioning Service will care about the
         /// enrollmentGroupId and the eTag on the enrollmentGroup. If you want to delete the enrollment regardless the
-        /// eTag, you can set the <c>eTag="*"</c> into the enrollmentGroup, or use the <see cref="DeleteEnrollmentGroupAsync(string)"/>.
-        /// passing only the enrollmentGroupId.
-        ///
-        /// Note that delete the enrollment group will not remove the Devices itself from the IotHub.
-        ///
-        /// If the enrollmentGroupId does not exists or the eTag does not matches, this method will throw <see cref="ProvisioningServiceClientException"/>.
-        /// </remarks>
-        /// <param name="enrollmentGroup">The <see cref="EnrollmentGroup"/> that identifies the enrollmentGroup. It cannot be <c>null</c>.</param>
-        /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to delete the enrollment group information for the provided enrollmentGroup.</exception>
-        public Task DeleteEnrollmentGroupAsync(EnrollmentGroup enrollmentGroup)
-        {
-            return EnrollmentGroupManager.DeleteAsync(_contractApiHttp, enrollmentGroup, CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Delete the enrollment group information.
-        /// </summary>
-        /// <remarks>
-        /// This method will remove the enrollment group from the Device Provisioning Service using the
-        /// provided <see cref="EnrollmentGroup"/> information. The Device Provisioning Service will care about the
-        /// enrollmentGroupId and the eTag on the enrollmentGroup. If you want to delete the enrollment regardless the
-        /// eTag, you can set the <c>eTag="*"</c> into the enrollmentGroup, or use the <see cref="DeleteEnrollmentGroupAsync(string)"/>.
+        /// eTag, you can set the <c>eTag="*"</c> into the enrollmentGroup, or use the <see cref="DeleteEnrollmentGroupAsync(string, CancellationToken)"/>.
         /// passing only the enrollmentGroupId.
         ///
         /// Note that delete the enrollment group will not remove the Devices itself from the IotHub.
@@ -692,7 +378,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="enrollmentGroup">The <see cref="EnrollmentGroup"/> that identifies the enrollmentGroup. It cannot be <c>null</c>.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to delete the enrollment group information for the provided enrollmentGroup.</exception>
-        public Task DeleteEnrollmentGroupAsync(EnrollmentGroup enrollmentGroup, CancellationToken cancellationToken)
+        public Task DeleteEnrollmentGroupAsync(EnrollmentGroup enrollmentGroup, CancellationToken cancellationToken = default)
         {
             return EnrollmentGroupManager.DeleteAsync(_contractApiHttp, enrollmentGroup, cancellationToken);
         }
@@ -703,26 +389,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <remarks>
         /// This method will remove the enrollment group from the Device Provisioning Service using the
         /// provided enrollmentGroupId. It will delete the enrollment group regardless the eTag. It means that this API
-        /// correspond to the <see cref="DeleteEnrollmentGroupAsync(string, string)"/> with the <c>eTag="*"</c>.
-        ///
-        /// Note that delete the enrollment group will not remove the Devices itself from the IotHub.
-        ///
-        /// If the enrollmentGroupId does not exists, this method will throw <see cref="ProvisioningServiceClientException"/>.
-        /// </remarks>
-        /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
-        /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to delete the enrollment group information for the provided enrollmentGroupId.</exception>
-        public Task DeleteEnrollmentGroupAsync(string enrollmentGroupId)
-        {
-            return EnrollmentGroupManager.DeleteAsync(_contractApiHttp, enrollmentGroupId, CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Delete the enrollment group information.
-        /// </summary>
-        /// <remarks>
-        /// This method will remove the enrollment group from the Device Provisioning Service using the
-        /// provided enrollmentGroupId. It will delete the enrollment group regardless the eTag. It means that this API
-        /// correspond to the <see cref="DeleteEnrollmentGroupAsync(string, string)"/> with the <c>eTag="*"</c>.
+        /// correspond to the <see cref="DeleteEnrollmentGroupAsync(string, string, CancellationToken)"/> with the <c>eTag="*"</c>.
         ///
         /// Note that delete the enrollment group will not remove the Devices itself from the IotHub.
         ///
@@ -731,7 +398,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to delete the enrollment group information for the provided enrollmentGroupId.</exception>
-        public Task DeleteEnrollmentGroupAsync(string enrollmentGroupId, CancellationToken cancellationToken)
+        public Task DeleteEnrollmentGroupAsync(string enrollmentGroupId, CancellationToken cancellationToken = default)
         {
             return EnrollmentGroupManager.DeleteAsync(_contractApiHttp, enrollmentGroupId, cancellationToken);
         }
@@ -742,29 +409,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <remarks>
         /// This method will remove the enrollment group from the Device Provisioning Service using the
         /// provided enrollmentGroupId and eTag. If you want to delete the enrollment group regardless the eTag, you can
-        /// use <see cref="DeleteEnrollmentGroupAsync(string)"/> or you can pass the eTag as <c>null</c>, empty, or
-        /// <c>"*"</c>.
-        ///
-        /// Note that delete the enrollment group will not remove the Device itself from the IotHub.
-        ///
-        /// If the enrollmentGroupId does not exists or eTag does not matches, this method will throw <see cref="ProvisioningServiceClientException"/>.
-        /// </remarks>
-        /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
-        /// <param name="eTag">The <c>string</c> with the enrollment group eTag. It can be <c>null</c> or empty.
-        /// The Device Provisioning Service will ignore it in all of these cases.</param>
-        /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to delete the enrollment group information for the provided enrollmentGroupId and eTag.</exception>
-        public Task DeleteEnrollmentGroupAsync(string enrollmentGroupId, string eTag)
-        {
-            return EnrollmentGroupManager.DeleteAsync(_contractApiHttp, enrollmentGroupId, CancellationToken.None, eTag);
-        }
-
-        /// <summary>
-        /// Delete the enrollment group information.
-        /// </summary>
-        /// <remarks>
-        /// This method will remove the enrollment group from the Device Provisioning Service using the
-        /// provided enrollmentGroupId and eTag. If you want to delete the enrollment group regardless the eTag, you can
-        /// use <see cref="DeleteEnrollmentGroupAsync(string)"/> or you can pass the eTag as <c>null</c>, empty, or
+        /// use <see cref="DeleteEnrollmentGroupAsync(string, CancellationToken)"/> or you can pass the eTag as <c>null</c>, empty, or
         /// <c>"*"</c>.
         ///
         /// Note that delete the enrollment group will not remove the Device itself from the IotHub.
@@ -776,31 +421,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// The Device Provisioning Service will ignore it in all of these cases.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to delete the enrollment group information for the provided enrollmentGroupId and eTag.</exception>
-        public Task DeleteEnrollmentGroupAsync(string enrollmentGroupId, string eTag, CancellationToken cancellationToken)
+        public Task DeleteEnrollmentGroupAsync(string enrollmentGroupId, string eTag, CancellationToken cancellationToken = default)
         {
             return EnrollmentGroupManager.DeleteAsync(_contractApiHttp, enrollmentGroupId, cancellationToken, eTag);
-        }
-
-        /// <summary>
-        /// Factory to create an enrollment group query.
-        /// </summary>
-        /// <remarks>
-        /// This method will create a new enrollment group query on Device Provisioning Service and return it as
-        /// a <see cref="Query"/> iterator.
-        ///
-        /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
-        /// <c>"SELECT * FROM enrollments"</c>.
-        /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
-        /// <returns>The <see cref="Query"/> iterator.</returns>
-        /// <exception cref="ArgumentException">If the provided parameter is not correct.</exception>
-        public Query CreateEnrollmentGroupQuery(QuerySpecification querySpecification)
-        {
-            return EnrollmentGroupManager.CreateQuery(
-                _provisioningConnectionString,
-                querySpecification,
-                _options.ProvisioningServiceHttpSettings,
-                CancellationToken.None);
         }
 
         /// <summary>
@@ -840,7 +463,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
         /// <exception cref="ArgumentException">If the provided parameter is not correct.</exception>
-        public Query CreateEnrollmentGroupQuery(QuerySpecification querySpecification, CancellationToken cancellationToken)
+        public Query CreateEnrollmentGroupQuery(QuerySpecification querySpecification, CancellationToken cancellationToken = default)
         {
             return EnrollmentGroupManager.CreateQuery(
                 _provisioningConnectionString,
@@ -861,42 +484,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         ///
         /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
         /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateEnrollmentGroupQuery(QuerySpecification)"/>.
-        /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
-        /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
-        /// <returns>The <see cref="Query"/> iterator.</returns>
-        /// <exception cref="ArgumentException">If the provided parameters are not correct.</exception>
-        public Query CreateEnrollmentGroupQuery(QuerySpecification querySpecification, int pageSize)
-        {
-            return EnrollmentGroupManager.CreateQuery(
-                _provisioningConnectionString,
-                querySpecification,
-                _options.ProvisioningServiceHttpSettings,
-                CancellationToken.None,
-                pageSize);
-        }
-
-        /// <summary>
-        /// Factory to create an enrollment group query.
-        /// </summary>
-        /// <remarks>
-        /// This method will create a new enrollment group query on Device Provisioning Service and return it as
-        /// a <see cref="Query"/> iterator.
-        ///
-        /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
-        /// <c>"SELECT * FROM enrollments"</c>.
-        ///
-        /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
-        /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateEnrollmentGroupQuery(QuerySpecification)"/>.
+        /// default pageSize or use the API <see cref="CreateEnrollmentGroupQuery(QuerySpecification, CancellationToken)"/>.
         /// </remarks>
         /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
         /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
         /// <exception cref="ArgumentException">If the provided parameters are not correct.</exception>
-        public Query CreateEnrollmentGroupQuery(QuerySpecification querySpecification, int pageSize, CancellationToken cancellationToken)
+        public Query CreateEnrollmentGroupQuery(QuerySpecification querySpecification, int pageSize, CancellationToken cancellationToken = default)
         {
             return EnrollmentGroupManager.CreateQuery(
                 _provisioningConnectionString,
@@ -918,7 +513,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         ///
         /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
         /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateEnrollmentGroupQuery(QuerySpecification)"/>.
+        /// default pageSize or use the API <see cref="CreateEnrollmentGroupQuery(QuerySpecification, CancellationToken)"/>.
         /// </remarks>
         /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
         /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
@@ -946,28 +541,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// If the id does not exist, this method will throw <see cref="ProvisioningServiceClientException"/>.
         /// </remarks>
         /// <param name="id">The <c>string</c> that identifies the DeviceRegistrationState. It cannot be <c>null</c> or empty.</param>
-        /// <returns>The <see cref="DeviceRegistrationState"/> with the content of the DeviceRegistrationState in the Provisioning Device Service.</returns>
-        /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to retrieve the DeviceRegistrationState information for the provided registrationId.</exception>
-        public Task<DeviceRegistrationState> GetDeviceRegistrationStateAsync(string id)
-        {
-            return RegistrationStatusManager.GetAsync(_contractApiHttp, id, CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Retrieve the registration status information.
-        /// </summary>
-        /// <remarks>
-        /// This method will return the DeviceRegistrationState for the provided id. It will retrieve
-        /// the correspondent DeviceRegistrationState from the Device Provisioning Service, and return it in the
-        /// <see cref="DeviceRegistrationState"/> object.
-        ///
-        /// If the id does not exist, this method will throw <see cref="ProvisioningServiceClientException"/>.
-        /// </remarks>
-        /// <param name="id">The <c>string</c> that identifies the DeviceRegistrationState. It cannot be <c>null</c> or empty.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="DeviceRegistrationState"/> with the content of the DeviceRegistrationState in the Provisioning Device Service.</returns>
         /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to retrieve the DeviceRegistrationState information for the provided registrationId.</exception>
-        public Task<DeviceRegistrationState> GetDeviceRegistrationStateAsync(string id, CancellationToken cancellationToken)
+        public Task<DeviceRegistrationState> GetDeviceRegistrationStateAsync(string id, CancellationToken cancellationToken = default)
         {
             return RegistrationStatusManager.GetAsync(_contractApiHttp, id, cancellationToken);
         }
@@ -979,26 +556,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// This method will remove the DeviceRegistrationState from the Device Provisioning Service using the
         /// provided <see cref="DeviceRegistrationState"/> information. The Device Provisioning Service will care about the
         /// id and the eTag on the DeviceRegistrationState. If you want to delete the DeviceRegistrationState regardless the
-        /// eTag, you can use the <see cref="DeleteDeviceRegistrationStateAsync(string)"/> passing only the id.
-        ///
-        /// If the id does not exists or the eTag does not matches, this method will throw
-        /// <see cref="ProvisioningServiceClientException"/>.
-        /// </remarks>
-        /// <param name="deviceRegistrationState">The <see cref="DeviceRegistrationState"/> that identifies the DeviceRegistrationState. It cannot be <c>null</c>.</param>
-        /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to delete the registration status information for the provided DeviceRegistrationState.</exception>
-        public Task DeleteDeviceRegistrationStateAsync(DeviceRegistrationState deviceRegistrationState)
-        {
-            return RegistrationStatusManager.DeleteAsync(_contractApiHttp, deviceRegistrationState, CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Delete the registration status information.
-        /// </summary>
-        /// <remarks>
-        /// This method will remove the DeviceRegistrationState from the Device Provisioning Service using the
-        /// provided <see cref="DeviceRegistrationState"/> information. The Device Provisioning Service will care about the
-        /// id and the eTag on the DeviceRegistrationState. If you want to delete the DeviceRegistrationState regardless the
-        /// eTag, you can use the <see cref="DeleteDeviceRegistrationStateAsync(string)"/> passing only the id.
+        /// eTag, you can use the <see cref="DeleteDeviceRegistrationStateAsync(string, CancellationToken)"/> passing only the id.
         ///
         /// If the id does not exists or the eTag does not matches, this method will throw
         /// <see cref="ProvisioningServiceClientException"/>.
@@ -1008,7 +566,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to
         /// delete the registration status information for the provided DeviceRegistrationState.</exception>
-        public Task DeleteDeviceRegistrationStateAsync(DeviceRegistrationState deviceRegistrationState, CancellationToken cancellationToken)
+        public Task DeleteDeviceRegistrationStateAsync(DeviceRegistrationState deviceRegistrationState, CancellationToken cancellationToken = default)
         {
             return RegistrationStatusManager.DeleteAsync(_contractApiHttp, deviceRegistrationState, cancellationToken);
         }
@@ -1019,25 +577,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <remarks>
         /// This method will remove the DeviceRegistrationState from the Device Provisioning Service using the
         /// provided id. It will delete the registration status regardless the eTag. It means that this API
-        /// correspond to the <see cref="DeleteDeviceRegistrationStateAsync(string, string)"/> with the <c>eTag="*"</c>.
-        ///
-        /// If the id does not exists, this method will throw <see cref="ProvisioningServiceClientException"/>.
-        /// </remarks>
-        /// <param name="id">The <c>string</c> that identifies the DeviceRegistrationState. It cannot be <c>null</c> or empty.</param>
-        /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to delete the
-        /// DeviceRegistrationState information for the provided registrationId.</exception>
-        public Task DeleteDeviceRegistrationStateAsync(string id)
-        {
-            return RegistrationStatusManager.DeleteAsync(_contractApiHttp, id, CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Delete the registration status information.
-        /// </summary>
-        /// <remarks>
-        /// This method will remove the DeviceRegistrationState from the Device Provisioning Service using the
-        /// provided id. It will delete the registration status regardless the eTag. It means that this API
-        /// correspond to the <see cref="DeleteDeviceRegistrationStateAsync(string, string)"/> with the <c>eTag="*"</c>.
+        /// correspond to the <see cref="DeleteDeviceRegistrationStateAsync(string, string, CancellationToken)"/> with the <c>eTag="*"</c>.
         ///
         /// If the id does not exists, this method will throw <see cref="ProvisioningServiceClientException"/>.
         /// </remarks>
@@ -1045,7 +585,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to delete the
         /// DeviceRegistrationState information for the provided registrationId.</exception>
-        public Task DeleteDeviceRegistrationStateAsync(string id, CancellationToken cancellationToken)
+        public Task DeleteDeviceRegistrationStateAsync(string id, CancellationToken cancellationToken = default)
         {
             return RegistrationStatusManager.DeleteAsync(_contractApiHttp, id, cancellationToken);
         }
@@ -1056,29 +596,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <remarks>
         /// This method will remove the registration status from the Device Provisioning Service using the
         /// provided id and eTag. If you want to delete the registration status regardless the eTag, you can
-        /// use <see cref="DeleteDeviceRegistrationStateAsync(string)"/> or you can pass the eTag as <c>null</c>, empty, or
-        /// <c>"*"</c>.
-        ///
-        /// If the id does not exists or the eTag does not matches, this method will throw
-        /// <see cref="ProvisioningServiceClientException"/>.
-        /// </remarks>
-        /// <param name="id">The <c>string</c> that identifies the DeviceRegistrationState. It cannot be <c>null</c> or empty.</param>
-        /// <param name="eTag">The <c>string</c> with the DeviceRegistrationState eTag. It can be <c>null</c> or empty.
-        /// The Device Provisioning Service will ignore it in all of these cases.</param>
-        /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to delete the
-        /// DeviceRegistrationState information for the provided registrationId and eTag.</exception>
-        public Task DeleteDeviceRegistrationStateAsync(string id, string eTag)
-        {
-            return RegistrationStatusManager.DeleteAsync(_contractApiHttp, id, CancellationToken.None, eTag);
-        }
-
-        /// <summary>
-        /// Delete the registration status information.
-        /// </summary>
-        /// <remarks>
-        /// This method will remove the registration status from the Device Provisioning Service using the
-        /// provided id and eTag. If you want to delete the registration status regardless the eTag, you can
-        /// use <see cref="DeleteDeviceRegistrationStateAsync(string)"/> or you can pass the eTag as <c>null</c>, empty, or
+        /// use <see cref="DeleteDeviceRegistrationStateAsync(string, CancellationToken)"/> or you can pass the eTag as <c>null</c>, empty, or
         /// <c>"*"</c>.
         ///
         /// If the id does not exists or the eTag does not matches, this method will throw
@@ -1090,32 +608,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ProvisioningServiceClientException">If the Provisioning Device Service was not able to delete the
         /// DeviceRegistrationState information for the provided registrationId and eTag.</exception>
-        public Task DeleteDeviceRegistrationStateAsync(string id, string eTag, CancellationToken cancellationToken)
+        public Task DeleteDeviceRegistrationStateAsync(string id, string eTag, CancellationToken cancellationToken = default)
         {
             return RegistrationStatusManager.DeleteAsync(_contractApiHttp, id, cancellationToken, eTag);
-        }
-
-        /// <summary>
-        /// Factory to create a registration status query.
-        /// </summary>
-        /// <remarks>
-        /// This method will create a new registration status query for a specific enrollment group on the Device
-        /// Provisioning Service and return it as a <see cref="Query"/> iterator.
-        ///
-        /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
-        /// <c>"SELECT * FROM enrollments"</c>.
-        /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
-        /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
-        /// <returns>The <see cref="Query"/> iterator.</returns>
-        public Query CreateEnrollmentGroupRegistrationStateQuery(QuerySpecification querySpecification, string enrollmentGroupId)
-        {
-            return RegistrationStatusManager.CreateEnrollmentGroupQuery(
-                _provisioningConnectionString,
-                querySpecification,
-                _options.ProvisioningServiceHttpSettings,
-                CancellationToken.None,
-                enrollmentGroupId);
         }
 
         /// <summary>
@@ -1159,7 +654,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         public Query CreateEnrollmentGroupRegistrationStateQuery(
             QuerySpecification querySpecification,
             string enrollmentGroupId,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default)
         {
             return RegistrationStatusManager.CreateEnrollmentGroupQuery(
                 _provisioningConnectionString,
@@ -1181,37 +676,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         ///
         /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
         /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification)"/>.
-        /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
-        /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
-        /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
-        /// <returns>The <see cref="Query"/> iterator.</returns>
-        /// <exception cref="ArgumentException">If the provided parameters are not correct.</exception>
-        public Query CreateEnrollmentGroupRegistrationStateQuery(QuerySpecification querySpecification, string enrollmentGroupId, int pageSize)
-        {
-            return RegistrationStatusManager.CreateEnrollmentGroupQuery(
-                _provisioningConnectionString,
-                querySpecification,
-                _options.ProvisioningServiceHttpSettings,
-                CancellationToken.None,
-                enrollmentGroupId,
-                pageSize);
-        }
-
-        /// <summary>
-        /// Factory to create a registration status query.
-        /// </summary>
-        /// <remarks>
-        /// This method will create a new registration status query for a specific enrollment group on the Device
-        /// Provisioning Service and return it as a <see cref="Query"/> iterator.
-        ///
-        /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
-        /// <c>"SELECT * FROM enrollments"</c>.
-        ///
-        /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
-        /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification)"/>.
+        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification, CancellationToken)"/>.
         /// </remarks>
         /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
         /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
@@ -1246,7 +711,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         ///
         /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
         /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification)"/>.
+        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification, CancellationToken)"/>.
         /// </remarks>
         /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
         /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
@@ -1258,7 +723,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             QuerySpecification querySpecification,
             string enrollmentGroupId,
             int pageSize,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default)
         {
             return RegistrationStatusManager.CreateEnrollmentGroupQuery(
                 _provisioningConnectionString,

--- a/provisioning/service/src/Query.cs
+++ b/provisioning/service/src/Query.cs
@@ -19,17 +19,17 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// <list type="bullet">
     ///     <item>
     ///         <description>
-    ///         <see cref="ProvisioningServiceClient.CreateIndividualEnrollmentQuery(QuerySpecification, int)">IndividualEnrollment</see>
+    ///         <see cref="ProvisioningServiceClient.CreateIndividualEnrollmentQuery(QuerySpecification, int, CancellationToken)">IndividualEnrollment</see>
     ///     </description>
     ///     </item>
     ///     <item>
     ///         <description>
-    ///         <see cref="ProvisioningServiceClient.CreateEnrollmentGroupQuery(QuerySpecification, int)">EnrollmentGroup</see>
+    ///         <see cref="ProvisioningServiceClient.CreateEnrollmentGroupQuery(QuerySpecification, int, CancellationToken)">EnrollmentGroup</see>
     ///         </description>
     ///     </item>
     ///     <item>
     ///         <description>
-    ///         <see cref="ProvisioningServiceClient.CreateEnrollmentGroupRegistrationStateQuery(QuerySpecification, String, int)">RegistrationStatus</see>
+    ///         <see cref="ProvisioningServiceClient.CreateEnrollmentGroupRegistrationStateQuery(QuerySpecification, string, int, CancellationToken)">RegistrationStatus</see>
     ///         </description>
     ///     </item>
     /// </list>


### PR DESCRIPTION
```csharp
public Task<IndividualEnrollment> CreateOrUpdateIndividualEnrollmentAsync(IndividualEnrollment individualEnrollment)
```
\+
```csharp
public Task<IndividualEnrollment> CreateOrUpdateIndividualEnrollmentAsync(IndividualEnrollment individualEnrollment, CancellationToken cancellationToken)
```
=

```csharp
public Task<IndividualEnrollment> CreateOrUpdateIndividualEnrollmentAsync(IndividualEnrollment individualEnrollment, CancellationToken cancellationToken = default)
```