### PR TITLE
Recycle a single HttpClient for all provisioning service client's requests

### DIFF
--- a/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         {
             using ProvisioningServiceClient provisioningServiceClient = CreateProvisioningService(proxyServerAddress);
             var querySpecification = new QuerySpecification("SELECT * FROM enrollments");
-            using Query query = provisioningServiceClient.CreateIndividualEnrollmentQuery(querySpecification);
+            Query query = provisioningServiceClient.CreateIndividualEnrollmentQuery(querySpecification);
             while (query.HasNext())
             {
                 QueryResult queryResult = await query.NextAsync().ConfigureAwait(false);

--- a/provisioning/service/src/Manager/EnrollmentGroupManager.cs
+++ b/provisioning/service/src/Manager/EnrollmentGroupManager.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         internal static Query CreateQuery(
             ServiceConnectionString provisioningConnectionString,
             QuerySpecification querySpecification,
-            ProvisioningServiceHttpSettings httpTransportSettings,
+            IContractApiHttp contractApiHttp,
             CancellationToken cancellationToken,
             int pageSize = 0)
         {
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ArgumentException($"{nameof(pageSize)} cannot be negative");
             }
 
-            return new Query(provisioningConnectionString, ServiceName, querySpecification, httpTransportSettings, pageSize, cancellationToken);
+            return new Query(provisioningConnectionString, ServiceName, querySpecification, contractApiHttp, pageSize, cancellationToken);
         }
 
         private static Uri GetEnrollmentUri(string enrollmentGroupId)

--- a/provisioning/service/src/Manager/IndividualEnrollmentManager.cs
+++ b/provisioning/service/src/Manager/IndividualEnrollmentManager.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         internal static Query CreateQuery(
             ServiceConnectionString provisioningConnectionString,
             QuerySpecification querySpecification,
-            ProvisioningServiceHttpSettings httpTransportSettings,
+            IContractApiHttp contractApiHttp,
             CancellationToken cancellationToken,
             int pageSize = 0)
         {
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ArgumentException($"{nameof(pageSize)} cannot be negative");
             }
 
-            return new Query(provisioningConnectionString, ServiceName, querySpecification, httpTransportSettings, pageSize, cancellationToken);
+            return new Query(provisioningConnectionString, ServiceName, querySpecification, contractApiHttp, pageSize, cancellationToken);
         }
 
         private static Uri GetEnrollmentUri(string registrationId)

--- a/provisioning/service/src/Manager/RegistrationStatusManager.cs
+++ b/provisioning/service/src/Manager/RegistrationStatusManager.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         internal static Query CreateEnrollmentGroupQuery(
             ServiceConnectionString provisioningConnectionString,
             QuerySpecification querySpecification,
-            ProvisioningServiceHttpSettings httpTransportSettings,
+            IContractApiHttp contractApiHttp,
             CancellationToken cancellationToken,
             string enrollmentGroupId,
             int pageSize = 0)
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 provisioningConnectionString,
                 GetGetDeviceRegistrationStatus(enrollmentGroupId),
                 querySpecification,
-                httpTransportSettings,
+                contractApiHttp,
                 pageSize,
                 cancellationToken);
         }

--- a/provisioning/service/src/ProvisioningServiceClient.cs
+++ b/provisioning/service/src/ProvisioningServiceClient.cs
@@ -224,29 +224,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <c>"SELECT * FROM enrollments"</c>.
         /// </remarks>
         /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
-        /// <param name="httpTransportSettings"> Specifies the HTTP transport settings</param>
-        /// <returns>The <see cref="Query"/> iterator.</returns>
-        /// <exception cref="ArgumentException">If the provided parameter is not correct.</exception>
-        public Query CreateIndividualEnrollmentQuery(QuerySpecification querySpecification, ProvisioningServiceHttpSettings httpTransportSettings)
-        {
-            return IndividualEnrollmentManager.CreateQuery(
-                _provisioningConnectionString,
-                querySpecification,
-                httpTransportSettings,
-                CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Factory to create a individualEnrollment query.
-        /// </summary>
-        /// <remarks>
-        /// This method will create a new individualEnrollment query for Device Provisioning Service and return it
-        /// as a <see cref="Query"/> iterator.
-        ///
-        /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
-        /// <c>"SELECT * FROM enrollments"</c>.
-        /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
         /// <exception cref="ArgumentException">If the provided parameter is not correct.</exception>
@@ -255,7 +232,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             return IndividualEnrollmentManager.CreateQuery(
                 _provisioningConnectionString,
                 querySpecification,
-                _options.ProvisioningServiceHttpSettings,
+                _contractApiHttp,
                 cancellationToken);
         }
 
@@ -283,37 +260,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             return IndividualEnrollmentManager.CreateQuery(
                 _provisioningConnectionString,
                 querySpecification,
-                _options.ProvisioningServiceHttpSettings,
+                _contractApiHttp,
                 cancellationToken,
-                pageSize);
-        }
-
-        /// <summary>
-        /// Factory to create a individualEnrollment query.
-        /// </summary>
-        /// <remarks>
-        /// This method will create a new individualEnrollment query for Device Provisioning Service and return it
-        /// as a <see cref="Query"/> iterator.
-        ///
-        /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
-        /// <c>"SELECT * FROM enrollments"</c>.
-        ///
-        /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
-        /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification, CancellationToken)"/>.
-        /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
-        /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
-        /// <param name="httpTransportSettings"> Specifies the HTTP transport settings</param>
-        /// <returns>The <see cref="Query"/> iterator.</returns>
-        /// <exception cref="ArgumentException">If the provided parameters are not correct.</exception>
-        public Query CreateIndividualEnrollmentQuery(QuerySpecification querySpecification, int pageSize, ProvisioningServiceHttpSettings httpTransportSettings)
-        {
-            return IndividualEnrollmentManager.CreateQuery(
-                _provisioningConnectionString,
-                querySpecification,
-                httpTransportSettings,
-                CancellationToken.None,
                 pageSize);
         }
 
@@ -437,29 +385,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <c>"SELECT * FROM enrollments"</c>.
         /// </remarks>
         /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
-        /// <param name="httpTransportSettings"> Specifies the HTTP transport settings</param>
-        /// <returns>The <see cref="Query"/> iterator.</returns>
-        /// <exception cref="ArgumentException">If the provided parameter is not correct.</exception>
-        public Query CreateEnrollmentGroupQuery(QuerySpecification querySpecification, ProvisioningServiceHttpSettings httpTransportSettings)
-        {
-            return EnrollmentGroupManager.CreateQuery(
-                _provisioningConnectionString,
-                querySpecification,
-                httpTransportSettings,
-                CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Factory to create an enrollment group query.
-        /// </summary>
-        /// <remarks>
-        /// This method will create a new enrollment group query on Device Provisioning Service and return it as
-        /// a <see cref="Query"/> iterator.
-        ///
-        /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
-        /// <c>"SELECT * FROM enrollments"</c>.
-        /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
         /// <exception cref="ArgumentException">If the provided parameter is not correct.</exception>
@@ -468,7 +393,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             return EnrollmentGroupManager.CreateQuery(
                 _provisioningConnectionString,
                 querySpecification,
-                _options.ProvisioningServiceHttpSettings,
+                _contractApiHttp,
                 cancellationToken);
         }
 
@@ -496,37 +421,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             return EnrollmentGroupManager.CreateQuery(
                 _provisioningConnectionString,
                 querySpecification,
-                _options.ProvisioningServiceHttpSettings,
+                _contractApiHttp,
                 cancellationToken,
-                pageSize);
-        }
-
-        /// <summary>
-        /// Factory to create an enrollment group query.
-        /// </summary>
-        /// <remarks>
-        /// This method will create a new enrollment group query on Device Provisioning Service and return it as
-        /// a <see cref="Query"/> iterator.
-        ///
-        /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
-        /// <c>"SELECT * FROM enrollments"</c>.
-        ///
-        /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
-        /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateEnrollmentGroupQuery(QuerySpecification, CancellationToken)"/>.
-        /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
-        /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
-        /// <param name="httpTransportSettings"> Specifies the HTTP transport settings</param>
-        /// <returns>The <see cref="Query"/> iterator.</returns>
-        /// <exception cref="ArgumentException">If the provided parameters are not correct.</exception>
-        public Query CreateEnrollmentGroupQuery(QuerySpecification querySpecification, int pageSize, ProvisioningServiceHttpSettings httpTransportSettings)
-        {
-            return EnrollmentGroupManager.CreateQuery(
-                _provisioningConnectionString,
-                querySpecification,
-                httpTransportSettings,
-                CancellationToken.None,
                 pageSize);
         }
 
@@ -625,30 +521,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </remarks>
         /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
         /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
-        /// <param name="httpTransportSettings"> Specifies the HTTP transport settings</param>
-        /// <returns>The <see cref="Query"/> iterator.</returns>
-        public Query CreateEnrollmentGroupRegistrationStateQuery(QuerySpecification querySpecification, string enrollmentGroupId, ProvisioningServiceHttpSettings httpTransportSettings)
-        {
-            return RegistrationStatusManager.CreateEnrollmentGroupQuery(
-                _provisioningConnectionString,
-                querySpecification,
-                httpTransportSettings,
-                CancellationToken.None,
-                enrollmentGroupId);
-        }
-
-        /// <summary>
-        /// Factory to create a registration status query.
-        /// </summary>
-        /// <remarks>
-        /// This method will create a new registration status query for a specific enrollment group on the Device
-        /// Provisioning Service and return it as a <see cref="Query"/> iterator.
-        ///
-        /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
-        /// <c>"SELECT * FROM enrollments"</c>.
-        /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
-        /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
         public Query CreateEnrollmentGroupRegistrationStateQuery(
@@ -659,7 +531,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             return RegistrationStatusManager.CreateEnrollmentGroupQuery(
                 _provisioningConnectionString,
                 querySpecification,
-                _options.ProvisioningServiceHttpSettings,
+                _contractApiHttp,
                 cancellationToken,
                 enrollmentGroupId);
         }
@@ -680,41 +552,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </remarks>
         /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
         /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
-        /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
-        /// <param name="httpTransportSettings"> Specifies the HTTP transport settings</param>
-        /// <returns>The <see cref="Query"/> iterator.</returns>
-        /// <exception cref="ArgumentException">If the provided parameters are not correct.</exception>
-        public Query CreateEnrollmentGroupRegistrationStateQuery(
-            QuerySpecification querySpecification,
-            string enrollmentGroupId,
-            int pageSize,
-            ProvisioningServiceHttpSettings httpTransportSettings)
-        {
-            return RegistrationStatusManager.CreateEnrollmentGroupQuery(
-                _provisioningConnectionString,
-                querySpecification,
-                httpTransportSettings,
-                CancellationToken.None,
-                enrollmentGroupId,
-                pageSize);
-        }
-
-        /// <summary>
-        /// Factory to create a registration status query.
-        /// </summary>
-        /// <remarks>
-        /// This method will create a new registration status query for a specific enrollment group on the Device
-        /// Provisioning Service and return it as a <see cref="Query"/> iterator.
-        ///
-        /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
-        /// <c>"SELECT * FROM enrollments"</c>.
-        ///
-        /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
-        /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification, CancellationToken)"/>.
-        /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
-        /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
@@ -728,7 +565,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             return RegistrationStatusManager.CreateEnrollmentGroupQuery(
                 _provisioningConnectionString,
                 querySpecification,
-                _options.ProvisioningServiceHttpSettings,
+                _contractApiHttp,
                 cancellationToken,
                 enrollmentGroupId,
                 pageSize);

--- a/provisioning/service/src/Query.cs
+++ b/provisioning/service/src/Query.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     ///     the point where you stopped. Just recreating the query with the same <see cref="QuerySpecification"/> and calling
     ///     the <see cref="NextAsync(string)"/> passing the stored <c>ContinuationToken</c>.
     /// </remarks>
-    public class Query : IDisposable
+    public class Query
     {
         private const string ContinuationTokenHeaderKey = "x-ms-continuation";
         private const string ItemTypeHeaderKey = "x-ms-item-type";
@@ -197,31 +197,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             var result = new QueryResult(type, httpResponse.Body, ContinuationToken);
 
             return result;
-        }
-
-        /// <summary>
-        /// Dispose the HTTP resources.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Releases the unmanaged resources used by the Component and optionally releases the managed resources.
-        /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (_contractApiHttp != null)
-                {
-                    _contractApiHttp.Dispose();
-                    _contractApiHttp = null;
-                }
-            }
         }
 
         private static Uri GetQueryUri(string path)

--- a/provisioning/service/src/Query.cs
+++ b/provisioning/service/src/Query.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             ServiceConnectionString serviceConnectionString,
             string serviceName,
             QuerySpecification querySpecification,
-            ProvisioningServiceHttpSettings httpTransportSettings,
+            IContractApiHttp contractApiHttp,
             int pageSize,
             CancellationToken cancellationToken)
         {
@@ -97,10 +97,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ArgumentException($"{nameof(pageSize)} cannot be negative.");
             }
 
-            // TODO: Refactor ContractApiHttp being created again
-            _contractApiHttp = new ContractApiHttp(
-                serviceConnectionString.HttpsEndpoint,
-                serviceConnectionString, httpTransportSettings);
+            _contractApiHttp = contractApiHttp;
 
             PageSize = pageSize;
             _cancellationToken = cancellationToken;


### PR DESCRIPTION
The query APIs used to create a new instance of ContractApiHttp each request.

Also removes overloads of query APIs that took ProvisioningServiceHttpSettings since there is no reason to use a different HTTP client per query request