### PR TITLE
Take provisioning service client query as a string

### DIFF
--- a/e2e/test/provisioning/ProvisioningCertificateValidationE2ETest.cs
+++ b/e2e/test/provisioning/ProvisioningCertificateValidationE2ETest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             using var provisioningServiceClient = new ProvisioningServiceClient(
                 TestConfiguration.Provisioning.ConnectionStringInvalidServiceCertificate);
             Query q = provisioningServiceClient.CreateEnrollmentGroupQuery(
-                new QuerySpecification("SELECT * FROM enrollmentGroups"));
+                "SELECT * FROM enrollmentGroups");
 
             ProvisioningServiceClientTransportException exception = await Assert.ThrowsExceptionAsync<ProvisioningServiceClientTransportException>(
                 () => q.NextAsync()).ConfigureAwait(false);

--- a/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
@@ -249,8 +249,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         private static async Task ProvisioningServiceClient_IndividualEnrollments_Query_Ok(string proxyServerAddress)
         {
             using ProvisioningServiceClient provisioningServiceClient = CreateProvisioningService(proxyServerAddress);
-            var querySpecification = new QuerySpecification("SELECT * FROM enrollments");
-            Query query = provisioningServiceClient.CreateIndividualEnrollmentQuery(querySpecification);
+            var queryString = "SELECT * FROM enrollments";
+            Query query = provisioningServiceClient.CreateIndividualEnrollmentQuery(queryString);
             while (query.HasNext())
             {
                 QueryResult queryResult = await query.NextAsync().ConfigureAwait(false);

--- a/provisioning/service/src/Enrollments/QuerySpecification.cs
+++ b/provisioning/service/src/Enrollments/QuerySpecification.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// <summary>
     /// Representation of a single Device Provisioning Service query specification with a JSON serializer.
     /// </summary>
-    public class QuerySpecification
+    internal class QuerySpecification
     {
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="query"></param>
-        public QuerySpecification(string query)
+        internal QuerySpecification(string query)
         {
             Query = query;
         }
@@ -23,6 +23,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Operation mode
         /// </summary>
         [JsonProperty(PropertyName = "query", Required = Required.Always)]
-        public string Query { get; set; }
+        internal string Query { get; set; }
     }
 }

--- a/provisioning/service/src/Manager/EnrollmentGroupManager.cs
+++ b/provisioning/service/src/Manager/EnrollmentGroupManager.cs
@@ -109,14 +109,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
 
         internal static Query CreateQuery(
             ServiceConnectionString provisioningConnectionString,
-            QuerySpecification querySpecification,
+            string query,
             IContractApiHttp contractApiHttp,
             CancellationToken cancellationToken,
             int pageSize = 0)
         {
-            if (querySpecification == null)
+            if (query == null)
             {
-                throw new ArgumentNullException(nameof(querySpecification));
+                throw new ArgumentNullException(nameof(query));
             }
 
             if (pageSize < 0)
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ArgumentException($"{nameof(pageSize)} cannot be negative");
             }
 
-            return new Query(provisioningConnectionString, ServiceName, querySpecification, contractApiHttp, pageSize, cancellationToken);
+            return new Query(provisioningConnectionString, ServiceName, query, contractApiHttp, pageSize, cancellationToken);
         }
 
         private static Uri GetEnrollmentUri(string enrollmentGroupId)

--- a/provisioning/service/src/Manager/IndividualEnrollmentManager.cs
+++ b/provisioning/service/src/Manager/IndividualEnrollmentManager.cs
@@ -153,14 +153,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
 
         internal static Query CreateQuery(
             ServiceConnectionString provisioningConnectionString,
-            QuerySpecification querySpecification,
+            string query,
             IContractApiHttp contractApiHttp,
             CancellationToken cancellationToken,
             int pageSize = 0)
         {
-            if (querySpecification == null)
+            if (query == null)
             {
-                throw new ArgumentNullException(nameof(querySpecification));
+                throw new ArgumentNullException(nameof(query));
             }
 
             if (pageSize < 0)
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ArgumentException($"{nameof(pageSize)} cannot be negative");
             }
 
-            return new Query(provisioningConnectionString, ServiceName, querySpecification, contractApiHttp, pageSize, cancellationToken);
+            return new Query(provisioningConnectionString, ServiceName, query, contractApiHttp, pageSize, cancellationToken);
         }
 
         private static Uri GetEnrollmentUri(string registrationId)

--- a/provisioning/service/src/Manager/RegistrationStatusManager.cs
+++ b/provisioning/service/src/Manager/RegistrationStatusManager.cs
@@ -83,15 +83,15 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             Justification = "Public API cannot change parameter order.")]
         internal static Query CreateEnrollmentGroupQuery(
             ServiceConnectionString provisioningConnectionString,
-            QuerySpecification querySpecification,
+            string query,
             IContractApiHttp contractApiHttp,
             CancellationToken cancellationToken,
             string enrollmentGroupId,
             int pageSize = 0)
         {
-            if (querySpecification == null)
+            if (query == null)
             {
-                throw new ArgumentNullException(nameof(querySpecification));
+                throw new ArgumentNullException(nameof(query));
             }
 
             if (pageSize < 0)
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             return new Query(
                 provisioningConnectionString,
                 GetGetDeviceRegistrationStatus(enrollmentGroupId),
-                querySpecification,
+                query,
                 contractApiHttp,
                 pageSize,
                 cancellationToken);

--- a/provisioning/service/src/ProvisioningServiceClient.cs
+++ b/provisioning/service/src/ProvisioningServiceClient.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// <see cref="CreateOrUpdateIndividualEnrollmentAsync(IndividualEnrollment, CancellationToken)"/>.
     ///
     /// The IoT hub Device Provisioning Service supports SQL queries too. The application can create a new query using
-    /// one of the queries factories, for instance <see cref="CreateIndividualEnrollmentQuery(QuerySpecification, CancellationToken)"/>, passing
+    /// one of the queries factories, for instance <see cref="CreateIndividualEnrollmentQuery(string, CancellationToken)"/>, passing
     /// the <see cref="QuerySpecification"/>, with the SQL query. This factory returns a <see cref="Query"/> object, which is an
     /// active iterator.
     ///
@@ -223,15 +223,15 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
         /// <c>"SELECT * FROM enrollments"</c>.
         /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
+        /// <param name="query">The SQL query. It cannot be <c>null</c>.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
         /// <exception cref="ArgumentException">If the provided parameter is not correct.</exception>
-        public Query CreateIndividualEnrollmentQuery(QuerySpecification querySpecification, CancellationToken cancellationToken = default)
+        public Query CreateIndividualEnrollmentQuery(string query, CancellationToken cancellationToken = default)
         {
             return IndividualEnrollmentManager.CreateQuery(
                 _provisioningConnectionString,
-                querySpecification,
+                query,
                 _contractApiHttp,
                 cancellationToken);
         }
@@ -248,18 +248,18 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         ///
         /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
         /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification, CancellationToken)"/>.
+        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(string, CancellationToken)"/>.
         /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
+        /// <param name="query">The SQL query. It cannot be <c>null</c>.</param>
         /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
         /// <exception cref="ArgumentException">If the provided parameters are not correct.</exception>
-        public Query CreateIndividualEnrollmentQuery(QuerySpecification querySpecification, int pageSize, CancellationToken cancellationToken = default)
+        public Query CreateIndividualEnrollmentQuery(string query, int pageSize, CancellationToken cancellationToken = default)
         {
             return IndividualEnrollmentManager.CreateQuery(
                 _provisioningConnectionString,
-                querySpecification,
+                query,
                 _contractApiHttp,
                 cancellationToken,
                 pageSize);
@@ -384,15 +384,15 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
         /// <c>"SELECT * FROM enrollments"</c>.
         /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
+        /// <param name="query">The SQL query. It cannot be <c>null</c>.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
         /// <exception cref="ArgumentException">If the provided parameter is not correct.</exception>
-        public Query CreateEnrollmentGroupQuery(QuerySpecification querySpecification, CancellationToken cancellationToken = default)
+        public Query CreateEnrollmentGroupQuery(string query, CancellationToken cancellationToken = default)
         {
             return EnrollmentGroupManager.CreateQuery(
                 _provisioningConnectionString,
-                querySpecification,
+                query,
                 _contractApiHttp,
                 cancellationToken);
         }
@@ -409,18 +409,18 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         ///
         /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
         /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateEnrollmentGroupQuery(QuerySpecification, CancellationToken)"/>.
+        /// default pageSize or use the API <see cref="CreateEnrollmentGroupQuery(string, CancellationToken)"/>.
         /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
+        /// <param name="query">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
         /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
         /// <exception cref="ArgumentException">If the provided parameters are not correct.</exception>
-        public Query CreateEnrollmentGroupQuery(QuerySpecification querySpecification, int pageSize, CancellationToken cancellationToken = default)
+        public Query CreateEnrollmentGroupQuery(string query, int pageSize, CancellationToken cancellationToken = default)
         {
             return EnrollmentGroupManager.CreateQuery(
                 _provisioningConnectionString,
-                querySpecification,
+                query,
                 _contractApiHttp,
                 cancellationToken,
                 pageSize);
@@ -519,18 +519,18 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// The Device Provisioning Service expects a SQL query in the <see cref="QuerySpecification"/>, for instance
         /// <c>"SELECT * FROM enrollments"</c>.
         /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
+        /// <param name="query">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
         /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
         public Query CreateEnrollmentGroupRegistrationStateQuery(
-            QuerySpecification querySpecification,
+            string query,
             string enrollmentGroupId,
             CancellationToken cancellationToken = default)
         {
             return RegistrationStatusManager.CreateEnrollmentGroupQuery(
                 _provisioningConnectionString,
-                querySpecification,
+                query,
                 _contractApiHttp,
                 cancellationToken,
                 enrollmentGroupId);
@@ -548,23 +548,23 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         ///
         /// For each iteration, the Query will return a List of objects correspondent to the query result. The maximum
         /// number of items per iteration can be specified by the pageSize. It is optional, you can provide <b>0</b> for
-        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(QuerySpecification, CancellationToken)"/>.
+        /// default pageSize or use the API <see cref="CreateIndividualEnrollmentQuery(string, CancellationToken)"/>.
         /// </remarks>
-        /// <param name="querySpecification">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
+        /// <param name="query">The <see cref="QuerySpecification"/> with the SQL query. It cannot be <c>null</c>.</param>
         /// <param name="enrollmentGroupId">The <c>string</c> that identifies the enrollmentGroup. It cannot be <c>null</c> or empty.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="pageSize">The <c>int</c> with the maximum number of items per iteration. It can be 0 for default, but not negative.</param>
         /// <returns>The <see cref="Query"/> iterator.</returns>
         /// <exception cref="ArgumentException">If the provided parameters are not correct.</exception>
         public Query CreateEnrollmentGroupRegistrationStateQuery(
-            QuerySpecification querySpecification,
+            string query,
             string enrollmentGroupId,
             int pageSize,
             CancellationToken cancellationToken = default)
         {
             return RegistrationStatusManager.CreateEnrollmentGroupQuery(
                 _provisioningConnectionString,
-                querySpecification,
+                query,
                 _contractApiHttp,
                 cancellationToken,
                 enrollmentGroupId,

--- a/provisioning/service/src/Query.cs
+++ b/provisioning/service/src/Query.cs
@@ -19,17 +19,17 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// <list type="bullet">
     ///     <item>
     ///         <description>
-    ///         <see cref="ProvisioningServiceClient.CreateIndividualEnrollmentQuery(QuerySpecification, int, CancellationToken)">IndividualEnrollment</see>
+    ///         <see cref="ProvisioningServiceClient.CreateIndividualEnrollmentQuery(string, int, CancellationToken)">IndividualEnrollment</see>
     ///     </description>
     ///     </item>
     ///     <item>
     ///         <description>
-    ///         <see cref="ProvisioningServiceClient.CreateEnrollmentGroupQuery(QuerySpecification, int, CancellationToken)">EnrollmentGroup</see>
+    ///         <see cref="ProvisioningServiceClient.CreateEnrollmentGroupQuery(string, int, CancellationToken)">EnrollmentGroup</see>
     ///         </description>
     ///     </item>
     ///     <item>
     ///         <description>
-    ///         <see cref="ProvisioningServiceClient.CreateEnrollmentGroupRegistrationStateQuery(QuerySpecification, string, int, CancellationToken)">RegistrationStatus</see>
+    ///         <see cref="ProvisioningServiceClient.CreateEnrollmentGroupRegistrationStateQuery(string, string, int, CancellationToken)">RegistrationStatus</see>
     ///         </description>
     ///     </item>
     /// </list>
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         internal Query(
             ServiceConnectionString serviceConnectionString,
             string serviceName,
-            QuerySpecification querySpecification,
+            string query,
             IContractApiHttp contractApiHttp,
             int pageSize,
             CancellationToken cancellationToken)
@@ -87,9 +87,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ArgumentException($"{nameof(serviceName)} cannot be an empty string");
             }
 
-            if (querySpecification == null)
+            if (query == null)
             {
-                throw new ArgumentNullException(nameof(querySpecification));
+                throw new ArgumentNullException(nameof(query));
             }
 
             if (pageSize < 0)
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             PageSize = pageSize;
             _cancellationToken = cancellationToken;
 
-            _querySpecificationJson = JsonConvert.SerializeObject(querySpecification);
+            _querySpecificationJson = JsonConvert.SerializeObject(new QuerySpecification(query));
 
             _queryPath = GetQueryUri(serviceName);
 


### PR DESCRIPTION
QuerySpecification wrapped this string previously. While we use that for json serialization purposes, there is no need to make the user construct it for us