### PR TITLE
Updated/Improved service client logging

### DIFF
--- a/iothub/service/src/Amqp/AmqpConnectionHandler.cs
+++ b/iothub/service/src/Amqp/AmqpConnectionHandler.cs
@@ -318,7 +318,7 @@ namespace Microsoft.Azure.Devices.Amqp
                         // Configure proxy server
                         websocket.Options.Proxy = webProxy;
                         if (Logging.IsEnabled)
-                            Logging.Info(this, " Setting ClientWebSocket.Options.Proxy", nameof(CreateClientWebSocketAsync));
+                            Logging.Info(this, "Setting ClientWebSocket.Options.Proxy", nameof(CreateClientWebSocketAsync));
                     }
                 }
                 catch (PlatformNotSupportedException)

--- a/iothub/service/src/Amqp/AmqpConnectionHandler.cs
+++ b/iothub/service/src/Amqp/AmqpConnectionHandler.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Devices.Amqp
         internal async Task OpenAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Opening amqp connection.");
+                Logging.Enter(this, "Opening amqp connection.", nameof(OpenAsync));
 
             _openCloseSemaphore.Wait(cancellationToken);
 
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Devices.Amqp
                 }
 
                 if (Logging.IsEnabled)
-                    Logging.Info(this, $"Initialized AMQP transport, ws={_useWebSocketOnly}");
+                    Logging.Info(this, $"Initialized AMQP transport, ws={_useWebSocketOnly}", nameof(OpenAsync));
 
                 var amqpConnectionSettings = new AmqpConnectionSettings
                 {
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Devices.Amqp
                 _connection = new AmqpConnection(_transport, amqpSettings, amqpConnectionSettings);
 
                 if (Logging.IsEnabled)
-                    Logging.Info(this, $"{nameof(AmqpConnection)} created.");
+                    Logging.Info(this, $"{nameof(AmqpConnection)} created.", nameof(OpenAsync));
 
                 _connection.Closed += _connectionLossHandler;
 
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Devices.Amqp
             {
                 _openCloseSemaphore.Release();
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Opening amqp connection.");
+                    Logging.Exit(this, "Opening amqp connection.", nameof(OpenAsync));
             }
         }
 
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Devices.Amqp
         internal async Task CloseAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Closing amqp connection.");
+                Logging.Enter(this, "Closing amqp connection.", nameof(CloseAsync));
 
             _openCloseSemaphore.Wait(cancellationToken);
 
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.Devices.Amqp
             {
                 _openCloseSemaphore.Release();
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Closing amqp connection.");
+                    Logging.Exit(this, "Closing amqp connection.", nameof(CloseAsync));
             }
         }
 
@@ -318,14 +318,14 @@ namespace Microsoft.Azure.Devices.Amqp
                         // Configure proxy server
                         websocket.Options.Proxy = webProxy;
                         if (Logging.IsEnabled)
-                            Logging.Info(this, $"{nameof(CreateClientWebSocketAsync)} Setting ClientWebSocket.Options.Proxy");
+                            Logging.Info(this, " Setting ClientWebSocket.Options.Proxy", nameof(CreateClientWebSocketAsync));
                     }
                 }
                 catch (PlatformNotSupportedException)
                 {
                     // .NET Core 2.0 doesn't support proxy. Ignore this setting.
                     if (Logging.IsEnabled)
-                        Logging.Error(this, $"{nameof(CreateClientWebSocketAsync)} PlatformNotSupportedException thrown as .NET Core 2.0 doesn't support proxy");
+                        Logging.Error(this, "PlatformNotSupportedException thrown as .NET Core 2.0 doesn't support proxy", nameof(CreateClientWebSocketAsync));
                 }
 
                 await websocket.ConnectAsync(websocketUri, cancellationToken).ConfigureAwait(false);

--- a/iothub/service/src/Amqp/AmqpReceivingLinkHandler.cs
+++ b/iothub/service/src/Amqp/AmqpReceivingLinkHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.Amqp
             _linkName = "ReceiverLink-" + Guid.NewGuid();
 
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Opening receiving link with address {_linkAddress} and link name {_linkName}");
+                Logging.Enter(this, $"Opening receiving link with address {_linkAddress} and link name {_linkName}", nameof(OpenAsync));
 
             try
             {
@@ -71,14 +71,14 @@ namespace Microsoft.Azure.Devices.Amqp
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Opening receiving link with address {_linkAddress} and link name {_linkName}");
+                    Logging.Exit(this, $"Opening receiving link with address {_linkAddress} and link name {_linkName}", nameof(OpenAsync));
             }
         }
 
         internal async Task CloseAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Closing receiving link with address {_linkAddress} and link name {_linkName}");
+                Logging.Enter(this, $"Closing receiving link with address {_linkAddress} and link name {_linkName}", nameof(CloseAsync));
 
             try
             {
@@ -90,14 +90,14 @@ namespace Microsoft.Azure.Devices.Amqp
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Closing receiving link with address {_linkAddress} and link name {_linkName}");
+                    Logging.Exit(this, $"Closing receiving link with address {_linkAddress} and link name {_linkName}", nameof(CloseAsync));
             }
         }
 
         internal async Task AcknowledgeMessageAsync(ArraySegment<byte> deliveryTag, Outcome outcome, CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Acknowledging message with delivery tag {deliveryTag} on receiving link with address {_linkAddress} and link name {_linkName}");
+                Logging.Enter(this, $"Acknowledging message with delivery tag {deliveryTag} on receiving link with address {_linkAddress} and link name {_linkName}", nameof(AcknowledgeMessageAsync));
 
             try
             {
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Devices.Amqp
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Acknowledging message with delivery tag {deliveryTag} on receiving link with address {_linkAddress} and link name {_linkName}");
+                    Logging.Exit(this, $"Acknowledging message with delivery tag {deliveryTag} on receiving link with address {_linkAddress} and link name {_linkName}", nameof(AcknowledgeMessageAsync));
             }
         }
     }

--- a/iothub/service/src/Amqp/AmqpSendingLinkHandler.cs
+++ b/iothub/service/src/Amqp/AmqpSendingLinkHandler.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.Amqp
             _linkName = "CloudToDevieMessageSenderLink-" + Guid.NewGuid();
 
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Opening sending link with address {_linkAddress} and link name {_linkName}");
+                Logging.Enter(this, $"Opening sending link with address {_linkAddress} and link name {_linkName}", nameof(OpenAsync));
 
             try
             {
@@ -67,14 +67,14 @@ namespace Microsoft.Azure.Devices.Amqp
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Opening sending link with address {_linkAddress} and link name {_linkName}");
+                    Logging.Exit(this, $"Opening sending link with address {_linkAddress} and link name {_linkName}", nameof(OpenAsync));
             }
         }
 
         public async Task CloseAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Closing sending link with address {_linkAddress} and link name {_linkName}");
+                Logging.Enter(this, $"Closing sending link with address {_linkAddress} and link name {_linkName}", nameof(CloseAsync));
 
             try
             {
@@ -86,14 +86,14 @@ namespace Microsoft.Azure.Devices.Amqp
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Enter(this, $"Closing sending link with address {_linkAddress} and link name {_linkName}");
+                    Logging.Exit(this, $"Closing sending link with address {_linkAddress} and link name {_linkName}", nameof(CloseAsync));
             }
         }
 
         public async Task<Outcome> SendAsync(AmqpMessage message, ArraySegment<byte> deliveryTag, CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Sending message with correlation Id {message.Properties?.CorrelationId} and delivery tag {deliveryTag} on link with address {_linkAddress} and link name {_linkName}");
+                Logging.Enter(this, $"Sending message with correlation Id {message.Properties?.CorrelationId} and delivery tag {deliveryTag} on link with address {_linkAddress} and link name {_linkName}", nameof(SendAsync));
 
             try
             {
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.Amqp
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Sending message with correlation Id {message.Properties?.CorrelationId} and delivery tag {deliveryTag} on link with address {_linkAddress} and link name {_linkName}");
+                    Logging.Exit(this, $"Sending message with correlation Id {message.Properties?.CorrelationId} and delivery tag {deliveryTag} on link with address {_linkAddress} and link name {_linkName}", nameof(SendAsync));
             }
         }
     }

--- a/iothub/service/src/Amqp/AmqpSessionHandler.cs
+++ b/iothub/service/src/Amqp/AmqpSessionHandler.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Devices.Amqp
         internal async Task OpenAsync(AmqpConnection connection, CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Opening worker session.");
+                Logging.Enter(this, "Opening worker session.", nameof(OpenAsync));
 
             try
             {
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Devices.Amqp
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Opening worker session.");
+                    Logging.Exit(this, "Opening worker session.", nameof(OpenAsync));
             }
         }
 
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Devices.Amqp
         internal async Task CloseAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Opening worker session.");
+                Logging.Enter(this, "Closing worker session.", nameof(CloseAsync));
 
             try
             {
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.Amqp
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Opening worker session.");
+                    Logging.Exit(this, "Closing worker session.", nameof(CloseAsync));
             }
         }
 

--- a/iothub/service/src/Configurations/ConfigurationsClient.cs
+++ b/iothub/service/src/Configurations/ConfigurationsClient.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Creating configuration: {configuration?.Id} threw an exception: {ex}", nameof(CreateAsync));
+                    Logging.Error(this, $"Creating configuration {configuration?.Id} threw an exception: {ex}", nameof(CreateAsync));
                 throw;
             }
             finally
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting configuration: {configurationId} threw an exception: {ex}", nameof(GetAsync));
+                    Logging.Error(this, $"Getting configuration {configurationId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
@@ -236,7 +236,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating configuration: {configuration?.Id} threw an exception: {ex}", nameof(SetAsync));
+                    Logging.Error(this, $"Updating configuration {configuration?.Id} threw an exception: {ex}", nameof(SetAsync));
                 throw;
             }
             finally
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Deleting configuration: {configuration?.Id} threw an exception: {ex}", nameof(DeleteAsync));
+                    Logging.Error(this, $"Deleting configuration {configuration?.Id} threw an exception: {ex}", nameof(DeleteAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/Configurations/ConfigurationsClient.cs
+++ b/iothub/service/src/Configurations/ConfigurationsClient.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="configuration"/> is null.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Creating configuration threw an exception: {ex}", nameof(CreateAsync));
+                    Logging.Error(this, $"Creating configuration: {configuration?.Id} threw an exception: {ex}", nameof(CreateAsync));
                 throw;
             }
             finally
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentException">Thrown if the <paramref name="configurationId"/> is empty or whitespace.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting configuration threw an exception: {ex}", nameof(GetAsync));
+                    Logging.Error(this, $"Getting configuration: {configurationId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentException">Thrown if the <paramref name="maxCount"/> value less than zero.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<IEnumerable<Configuration>> GetAsync(int maxCount, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Getting configurations", nameof(GetAsync));
+                Logging.Enter(this, "Getting configurations.", nameof(GetAsync));
 
             if (maxCount < 0)
             {
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Getting configurations", nameof(GetAsync));
+                    Logging.Exit(this, "Getting configurations.", nameof(GetAsync));
             }
         }
 
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="configuration"/> is null.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<Configuration> SetAsync(Configuration configuration, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Updating configuration {configuration?.Id}", nameof(SetAsync));
+                Logging.Enter(this, $"Updating configuration: {configuration?.Id}", nameof(SetAsync));
 
             Argument.AssertNotNull(configuration, nameof(configuration));
 
@@ -236,13 +236,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating configuration threw an exception: {ex}", nameof(SetAsync));
+                    Logging.Error(this, $"Updating configuration: {configuration?.Id} threw an exception: {ex}", nameof(SetAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Updating configuration {configuration?.Id}", nameof(SetAsync));
+                    Logging.Exit(this, $"Updating configuration: {configuration?.Id}", nameof(SetAsync));
             }
         }
 
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentException">Thrown if the <paramref name="configurationId"/> is empty or whitespace.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentNullException">Thrown when the provided <paramref name="configuration"/> is null.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Deleting configuration threw an exception: {ex}", nameof(DeleteAsync));
+                    Logging.Error(this, $"Deleting configuration: {configuration?.Id} threw an exception: {ex}", nameof(DeleteAsync));
                 throw;
             }
             finally
@@ -334,7 +334,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentException">Thrown if the <paramref name="deviceId"/> is empty or whitespace.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">

--- a/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentException">When the provided <paramref name="digitalTwinId"/> is empty or whitespace.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(GetAsync)} threw an exception: {ex}", nameof(GetAsync));
+                    Logging.Error(this, $"Getting digital twin with Id: {digitalTwinId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentException">When the provided <paramref name="digitalTwinId"/> or <paramref name="jsonPatch"/> is empty or whitespace.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(UpdateAsync)} threw an exception: {ex}", nameof(UpdateAsync));
+                    Logging.Error(this, $"Updating digital twin with Id: {digitalTwinId} threw an exception: {ex}", nameof(UpdateAsync));
                 throw;
             }
             finally
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentException">When the provided <paramref name="digitalTwinId"/> or <paramref name="commandName"/> is empty or whitespace.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -246,7 +246,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(InvokeCommandAsync)} threw an exception: {ex}", nameof(InvokeCommandAsync));
+                    Logging.Error(this, $"Invoking command on digital twin with Id: {digitalTwinId} threw an exception: {ex}", nameof(InvokeCommandAsync));
                 throw;
             }
             finally
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentException">When the provided <paramref name="digitalTwinId"/> or <paramref name="componentName"/> or <paramref name="commandName"/> is empty or whitespace.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -321,7 +321,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(InvokeComponentCommandAsync)} threw an exception: {ex}", nameof(InvokeComponentCommandAsync));
+                    Logging.Error(this, $"Invoking component command on digital twin with Id: {digitalTwinId} threw an exception: {ex}", nameof(InvokeComponentCommandAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting digital twin with Id: {digitalTwinId} threw an exception: {ex}", nameof(GetAsync));
+                    Logging.Error(this, $"Getting digital twin with Id {digitalTwinId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating digital twin with Id: {digitalTwinId} threw an exception: {ex}", nameof(UpdateAsync));
+                    Logging.Error(this, $"Updating digital twin with Id {digitalTwinId} threw an exception: {ex}", nameof(UpdateAsync));
                 throw;
             }
             finally
@@ -246,7 +246,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Invoking command on digital twin with Id: {digitalTwinId} threw an exception: {ex}", nameof(InvokeCommandAsync));
+                    Logging.Error(this, $"Invoking command on digital twin with Id {digitalTwinId} threw an exception: {ex}", nameof(InvokeCommandAsync));
                 throw;
             }
             finally
@@ -321,7 +321,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Invoking component command on digital twin with Id: {digitalTwinId} threw an exception: {ex}", nameof(InvokeComponentCommandAsync));
+                    Logging.Error(this, $"Invoking component command on digital twin with Id {digitalTwinId} threw an exception: {ex}", nameof(InvokeComponentCommandAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/DirectMethod/DirectMethodsClient.cs
+++ b/iothub/service/src/DirectMethod/DirectMethodsClient.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentException">Thrown if the <paramref name="deviceId"/> is empty or white space.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(InvokeAsync)} threw an exception: {ex}", nameof(InvokeAsync));
+                    Logging.Error(this, $"Invoking device method for device id: {deviceId} threw an exception: {ex}", nameof(InvokeAsync));
                 throw;
             }
             finally
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentException">Thrown if the <paramref name="deviceId"/> or <paramref name="moduleId"/> is empty or white space.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(InvokeAsync)} threw an exception: {ex}", nameof(InvokeAsync));
+                    Logging.Error(this, $"Invoking device method for device id: {deviceId} and module id: {moduleId} threw an exception: {ex}", nameof(InvokeAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/DirectMethod/DirectMethodsClient.cs
+++ b/iothub/service/src/DirectMethod/DirectMethodsClient.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Invoking device method for device id: {deviceId} threw an exception: {ex}", nameof(InvokeAsync));
+                    Logging.Error(this, $"Invoking device method for device id {deviceId} threw an exception: {ex}", nameof(InvokeAsync));
                 throw;
             }
             finally
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Invoking device method for device id: {deviceId} and module id: {moduleId} threw an exception: {ex}", nameof(InvokeAsync));
+                    Logging.Error(this, $"Invoking device method for device id {deviceId} and module id {moduleId} threw an exception: {ex}", nameof(InvokeAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/Feedback/MessageFeedbackProcessorClient.cs
+++ b/iothub/service/src/Feedback/MessageFeedbackProcessorClient.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task OpenAsync(CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Opening MessageFeedbackProcessorClient", nameof(OpenAsync));
+                Logging.Enter(this, "Opening MessageFeedbackProcessorClient.", nameof(OpenAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -121,13 +121,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(OpenAsync)} threw an exception: {ex}", nameof(OpenAsync));
+                    Logging.Error(this, $"Opening MessageFeedbackProcessorClient threw an exception: {ex}", nameof(OpenAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Opening MessageFeedbackProcessorClient", nameof(OpenAsync));
+                    Logging.Exit(this, "Opening MessageFeedbackProcessorClient.", nameof(OpenAsync));
             }
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task CloseAsync(CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Closing MessageFeedbackProcessorClient", nameof(CloseAsync));
+                Logging.Enter(this, "Closing MessageFeedbackProcessorClient.", nameof(CloseAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -157,13 +157,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(CloseAsync)} threw an exception: {ex}", nameof(CloseAsync));
+                    Logging.Error(this, $"Closing MessageFeedbackProcessorClient threw an exception: {ex}", nameof(CloseAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Closing MessageFeedbackProcessorClient", nameof(CloseAsync));
+                    Logging.Exit(this, "Closing MessageFeedbackProcessorClient.", nameof(CloseAsync));
             }
         }
 

--- a/iothub/service/src/FileUpload/FileUploadNotificationProcessorClient.cs
+++ b/iothub/service/src/FileUpload/FileUploadNotificationProcessorClient.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(CloseAsync)} threw an exception: {ex}", nameof(CloseAsync));
+                    Logging.Error(this, $"Closing FileUploadNotificationProcessorClient threw an exception: {ex}", nameof(CloseAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/FileUpload/FileUploadNotificationProcessorClient.cs
+++ b/iothub/service/src/FileUpload/FileUploadNotificationProcessorClient.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task OpenAsync(CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Opening FileUploadNotificationProcessorClient", nameof(OpenAsync));
+                Logging.Enter(this, "Opening FileUploadNotificationProcessorClient.", nameof(OpenAsync));
 
             if (FileUploadNotificationProcessor == null)
             {
@@ -115,13 +115,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(OpenAsync)} threw an exception: {ex}", nameof(OpenAsync));
+                    Logging.Error(this, $"Opening FileUploadNotificationProcessorClient threw an exception: {ex}", nameof(OpenAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Opening FileUploadNotificationProcessorClient", nameof(OpenAsync));
+                    Logging.Exit(this, "Opening FileUploadNotificationProcessorClient.", nameof(OpenAsync));
             }
         }
 
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task CloseAsync(CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Closing FileUploadNotificationProcessorClient", nameof(CloseAsync));
+                Logging.Enter(this, "Closing FileUploadNotificationProcessorClient.", nameof(CloseAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Closing FileUploadNotificationProcessorClient", nameof(CloseAsync));
+                    Logging.Exit(this, "Closing FileUploadNotificationProcessorClient.", nameof(CloseAsync));
             }
         }
 

--- a/iothub/service/src/Jobs/ScheduledJobsClient.cs
+++ b/iothub/service/src/Jobs/ScheduledJobsClient.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<ScheduledJob> GetAsync(string jobId, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Getting job {jobId}", nameof(GetAsync));
+                Logging.Enter(this, $"Getting job: {jobId}", nameof(GetAsync));
 
             Argument.AssertNotNullOrWhiteSpace(jobId, nameof(jobId));
 
@@ -86,13 +86,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting job {jobId} threw an exception: {ex}", nameof(GetAsync));
+                    Logging.Error(this, $"Getting job: {jobId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Getting job {jobId}", nameof(GetAsync));
+                    Logging.Exit(this, $"Getting job: {jobId}", nameof(GetAsync));
             }
         }
 
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<ScheduledJob> CancelAsync(string jobId, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Canceling job {jobId}", nameof(CancelAsync));
+                Logging.Enter(this, $"Canceling job: {jobId}", nameof(CancelAsync));
 
             try
             {
@@ -161,13 +161,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Canceling job {jobId} threw an exception: {ex}", nameof(CancelAsync));
+                    Logging.Error(this, $"Canceling job: {jobId} threw an exception: {ex}", nameof(CancelAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Canceling job {jobId}", nameof(CancelAsync));
+                    Logging.Exit(this, $"Canceling job: {jobId}", nameof(CancelAsync));
             }
         }
 
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.Devices
             CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Scheduling direct method job {scheduledJobsOptions.JobId}", nameof(ScheduleDirectMethodAsync));
+                Logging.Enter(this, $"Scheduling direct method job: {scheduledJobsOptions.JobId}", nameof(ScheduleDirectMethodAsync));
 
             Argument.AssertNotNull(scheduledDirectMethod, nameof(scheduledDirectMethod));
 
@@ -229,13 +229,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Scheduling direct method job {scheduledJobsOptions.JobId} threw an exception: {ex}", nameof(ScheduleDirectMethodAsync));
+                    Logging.Error(this, $"Scheduling direct method job: {scheduledJobsOptions.JobId} threw an exception: {ex}", nameof(ScheduleDirectMethodAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Enter(this, $"Schedulign direct method job {scheduledJobsOptions.JobId}", nameof(ScheduleDirectMethodAsync));
+                    Logging.Enter(this, $"Scheduling direct method job: {scheduledJobsOptions.JobId}", nameof(ScheduleDirectMethodAsync));
             }
         }
 
@@ -274,7 +274,7 @@ namespace Microsoft.Azure.Devices
                 : scheduledJobsOptions.JobId;
 
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"queryCondition=[{scheduledJobsOptions.JobId}]", nameof(ScheduleDirectMethodAsync));
+                Logging.Enter(this, $"Scheduling twin update: {scheduledJobsOptions.JobId}", nameof(ScheduleDirectMethodAsync));
 
             Argument.AssertNotNull(scheduledTwinUpdate, nameof(scheduledTwinUpdate));
 
@@ -303,13 +303,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Scheduling twin update {scheduledJobsOptions.JobId} threw an exception: {ex}", nameof(ScheduleTwinUpdateAsync));
+                    Logging.Error(this, $"Scheduling twin update: {scheduledJobsOptions.JobId} threw an exception: {ex}", nameof(ScheduleTwinUpdateAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Enter(this, $"Scheduling twin update {scheduledJobsOptions.JobId}", nameof(ScheduleDirectMethodAsync));
+                    Logging.Exit(this, $"Scheduling twin update: {scheduledJobsOptions.JobId}", nameof(ScheduleDirectMethodAsync));
             }
         }
 

--- a/iothub/service/src/Jobs/ScheduledJobsClient.cs
+++ b/iothub/service/src/Jobs/ScheduledJobsClient.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting job: {jobId} threw an exception: {ex}", nameof(GetAsync));
+                    Logging.Error(this, $"Getting job {jobId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Canceling job: {jobId} threw an exception: {ex}", nameof(CancelAsync));
+                    Logging.Error(this, $"Canceling job {jobId} threw an exception: {ex}", nameof(CancelAsync));
                 throw;
             }
             finally
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Scheduling direct method job: {scheduledJobsOptions.JobId} threw an exception: {ex}", nameof(ScheduleDirectMethodAsync));
+                    Logging.Error(this, $"Scheduling direct method job {scheduledJobsOptions.JobId} threw an exception: {ex}", nameof(ScheduleDirectMethodAsync));
                 throw;
             }
             finally
@@ -303,7 +303,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Scheduling twin update: {scheduledJobsOptions.JobId} threw an exception: {ex}", nameof(ScheduleTwinUpdateAsync));
+                    Logging.Error(this, $"Scheduling twin update {scheduledJobsOptions.JobId} threw an exception: {ex}", nameof(ScheduleTwinUpdateAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/Messaging/MessagesClient.cs
+++ b/iothub/service/src/Messaging/MessagesClient.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task OpenAsync(CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Opening MessagingClient", nameof(OpenAsync));
+                Logging.Enter(this, "Opening MessagingClient.", nameof(OpenAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -95,13 +95,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(OpenAsync)} threw an exception: {ex}", nameof(OpenAsync));
+                    Logging.Error(this, $"Opening MessagingClient threw an exception: {ex}", nameof(OpenAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Opening MessagingClient", nameof(OpenAsync));
+                    Logging.Exit(this, "Opening MessagingClient.", nameof(OpenAsync));
             }
         }
 
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task CloseAsync(CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Closing MessagingClient", nameof(CloseAsync));
+                Logging.Enter(this, "Closing MessagingClient.", nameof(CloseAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -128,13 +128,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(CloseAsync)} threw an exception: {ex}", nameof(CloseAsync));
+                    Logging.Error(this, $"Closing MessagingClient threw an exception: {ex}", nameof(CloseAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Closing MessagingClient", nameof(CloseAsync));
+                    Logging.Exit(this, "Closing MessagingClient.", nameof(CloseAsync));
             }
         }
 
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex) when (ex is not TimeoutException && !Fx.IsFatal(ex))
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(SendAsync)} threw an exception: {ex}", nameof(SendAsync));
+                    Logging.Error(this, $"Sending message with Id [{message?.MessageId}] for device {deviceId} threw an exception: {ex}", nameof(SendAsync));
 
                 throw AmqpClientHelper.ToIotHubClientContract(ex);
             }
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex) when (!Fx.IsFatal(ex))
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(SendAsync)} threw an exception: {ex}", nameof(SendAsync));
+                    Logging.Error(this, $"Sending message with Id [{message?.MessageId}] for device {deviceId}, module {moduleId} threw an exception: {ex}", nameof(SendAsync));
 
                 throw AmqpClientHelper.ToIotHubClientContract(ex);
             }
@@ -299,7 +299,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(PurgeMessageQueueAsync)} threw an exception: {ex}", nameof(PurgeMessageQueueAsync));
+                    Logging.Error(this, $"Purging message queue for device: {deviceId} threw an exception: {ex}", nameof(PurgeMessageQueueAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/Messaging/MessagesClient.cs
+++ b/iothub/service/src/Messaging/MessagesClient.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Purging message queue for device: {deviceId} threw an exception: {ex}", nameof(PurgeMessageQueueAsync));
+                    Logging.Error(this, $"Purging message queue for device {deviceId} threw an exception: {ex}", nameof(PurgeMessageQueueAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/Query/QueryClient.cs
+++ b/iothub/service/src/Query/QueryClient.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<QueryResponse<T>> CreateAsync<T>(string query, QueryOptions options = default, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Creating query", nameof(CreateAsync));
+                Logging.Enter(this, "Creating query.", nameof(CreateAsync));
 
             Argument.AssertNotNullOrWhiteSpace(query, nameof(query));
 
@@ -130,13 +130,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(CreateAsync)} threw an exception: {ex}", nameof(CreateAsync));
+                    Logging.Error(this, $"Creating query threw an exception: {ex}", nameof(CreateAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Creating query", nameof(CreateAsync));
+                    Logging.Exit(this, "Creating query.", nameof(CreateAsync));
             }
         }
 
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<QueryResponse<ScheduledJob>> CreateJobsQueryAsync(JobQueryOptions options = default, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"jobType=[{options?.JobType}], jobStatus=[{options?.JobStatus}], pageSize=[{options?.PageSize}]", nameof(CreateAsync));
+                Logging.Enter(this, $"Creating query with jobType: {options?.JobType}, jobStatus: {options?.JobStatus}, pageSize: {options?.PageSize}", nameof(CreateAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -201,13 +201,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(CreateAsync)} threw an exception: {ex}", nameof(CreateAsync));
+                    Logging.Error(this, $"Creating query with jobType: {options?.JobType}, jobStatus: {options?.JobStatus}, pageSize: {options?.PageSize} threw an exception: {ex}", nameof(CreateAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"jobType=[{options?.JobType}], jobStatus=[{options?.JobStatus}], pageSize=[{options?.PageSize}]", nameof(CreateAsync));
+                    Logging.Exit(this, $"Creating query with jobType: {options?.JobType}, jobStatus: {options?.JobStatus}, pageSize: {options?.PageSize}", nameof(CreateAsync));
             }
         }
 

--- a/iothub/service/src/Registry/DevicesClient.cs
+++ b/iothub/service/src/Registry/DevicesClient.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Creating device threw an exception: {ex}", nameof(CreateAsync));
+                    Logging.Error(this, $"Creating device: {device?.Id} threw an exception: {ex}", nameof(CreateAsync));
                 throw;
             }
             finally
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<Device> GetAsync(string deviceId, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Getting device {deviceId}", nameof(GetAsync));
+                Logging.Enter(this, $"Getting device: {deviceId}", nameof(GetAsync));
 
             Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
 
@@ -133,13 +133,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting device threw an exception: {ex}", nameof(GetAsync));
+                    Logging.Error(this, $"Getting device: {deviceId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Getting device {deviceId}", nameof(GetAsync));
+                    Logging.Exit(this, $"Getting device: {deviceId}", nameof(GetAsync));
             }
         }
 
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<Device> SetAsync(Device device, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Updating device {device?.Id}", nameof(SetAsync));
+                Logging.Enter(this, $"Updating device: {device?.Id}", nameof(SetAsync));
 
             Argument.AssertNotNull(device, nameof(device));
 
@@ -187,13 +187,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating device threw an exception: {ex}", nameof(SetAsync));
+                    Logging.Error(this, $"Updating device: {device?.Id} threw an exception: {ex}", nameof(SetAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Updating device {device?.Id}", nameof(SetAsync));
+                    Logging.Exit(this, $"Updating device: {device?.Id}", nameof(SetAsync));
             }
         }
 
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task DeleteAsync(Device device, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Deleting device {device?.Id}", nameof(DeleteAsync));
+                Logging.Enter(this, $"Deleting device: {device?.Id}", nameof(DeleteAsync));
 
             Argument.AssertNotNull(device, nameof(device));
 
@@ -268,13 +268,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Deleting device threw an exception: {ex}", nameof(DeleteAsync));
+                    Logging.Error(this, $"Deleting device: {device?.Id} threw an exception: {ex}", nameof(DeleteAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Deleting device {device?.Id}", nameof(DeleteAsync));
+                    Logging.Exit(this, $"Deleting device: {device?.Id}", nameof(DeleteAsync));
             }
         }
 
@@ -303,7 +303,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<BulkRegistryOperationResult> CreateWithTwinAsync(Device device, Twin twin, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Creating device with twin {device?.Id}", nameof(CreateWithTwinAsync));
+                Logging.Enter(this, $"Creating device with twin: {device?.Id}", nameof(CreateWithTwinAsync));
 
             Argument.AssertNotNull(device, nameof(device));
             Argument.AssertNotNull(twin, nameof(twin));
@@ -330,13 +330,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Creating device with twin threw an exception: {ex}", nameof(CreateWithTwinAsync));
+                    Logging.Error(this, $"Creating device with twin: {device?.Id} threw an exception: {ex}", nameof(CreateWithTwinAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Creating device with twin {device?.Id}", nameof(CreateWithTwinAsync));
+                    Logging.Exit(this, $"Creating device with twin: {device?.Id}", nameof(CreateWithTwinAsync));
             }
         }
 
@@ -361,7 +361,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<IEnumerable<Module>> GetModulesAsync(string deviceId, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Getting modules on device {deviceId}", nameof(GetModulesAsync));
+                Logging.Enter(this, $"Getting modules on device: {deviceId}", nameof(GetModulesAsync));
 
             Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
 
@@ -377,13 +377,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting modules on device threw an exception: {ex}", nameof(GetModulesAsync));
+                    Logging.Error(this, $"Getting modules on device: {deviceId} threw an exception: {ex}", nameof(GetModulesAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Getting modules on device {deviceId}", nameof(GetModulesAsync));
+                    Logging.Exit(this, $"Getting modules on device: {deviceId}", nameof(GetModulesAsync));
             }
         }
 
@@ -412,7 +412,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<BulkRegistryOperationResult> CreateAsync(IEnumerable<Device> devices, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Creating devices", nameof(CreateAsync));
+                Logging.Enter(this, "Creating devices", nameof(CreateAsync));
 
             Argument.AssertNotNullOrEmpty(devices, nameof(devices));
 
@@ -432,7 +432,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Creating devices", nameof(CreateAsync));
+                    Logging.Exit(this, "Creating devices", nameof(CreateAsync));
             }
         }
 
@@ -463,7 +463,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<BulkRegistryOperationResult> SetAsync(IEnumerable<Device> devices, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Updating multiple devices ", nameof(SetAsync));
+                Logging.Enter(this, "Updating multiple devices", nameof(SetAsync));
 
             Argument.AssertNotNullOrEmpty(devices, nameof(devices));
 
@@ -484,7 +484,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Updating multiple devices", nameof(SetAsync));
+                    Logging.Exit(this, "Updating multiple devices", nameof(SetAsync));
             }
         }
 
@@ -515,7 +515,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<BulkRegistryOperationResult> DeleteAsync(IEnumerable<Device> devices, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Deleting devices", nameof(DeleteAsync));
+                Logging.Enter(this, "Deleting devices", nameof(DeleteAsync));
 
             Argument.AssertNotNullOrEmpty(devices, nameof(devices));
 
@@ -536,7 +536,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Deleting devices", nameof(DeleteAsync));
+                    Logging.Exit(this, "Deleting devices", nameof(DeleteAsync));
             }
         }
 
@@ -560,7 +560,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<JobProperties> ImportAsync(JobProperties jobParameters, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Running import job", nameof(ImportAsync));
+                Logging.Enter(this, "Running import job", nameof(ImportAsync));
 
             Argument.AssertNotNull(jobParameters, nameof(jobParameters));
 
@@ -582,7 +582,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Running import job", nameof(ImportAsync));
+                    Logging.Exit(this, "Running import job", nameof(ImportAsync));
             }
         }
 
@@ -652,7 +652,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<JobProperties> GetJobAsync(string jobId, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Getting job {jobId}", nameof(GetJobsAsync));
+                Logging.Enter(this, $"Getting job: {jobId}", nameof(GetJobsAsync));
 
             Argument.AssertNotNullOrWhiteSpace(jobId, nameof(jobId));
 
@@ -668,13 +668,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting job {jobId} threw an exception: {ex}", nameof(GetJobsAsync));
+                    Logging.Error(this, $"Getting job: {jobId} threw an exception: {ex}", nameof(GetJobsAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Getting job {jobId}", nameof(GetJobsAsync));
+                    Logging.Exit(this, $"Getting job: {jobId}", nameof(GetJobsAsync));
             }
         }
 
@@ -696,7 +696,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<IEnumerable<JobProperties>> GetJobsAsync(CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Getting jobs", nameof(GetJobsAsync));
+                Logging.Enter(this, "Getting jobs", nameof(GetJobsAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -716,7 +716,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Getting jobs", nameof(GetJobsAsync));
+                    Logging.Exit(this, "Getting jobs", nameof(GetJobsAsync));
             }
         }
 
@@ -740,7 +740,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task CancelJobAsync(string jobId, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Canceling job {jobId}", nameof(CancelJobAsync));
+                Logging.Enter(this, $"Canceling job: {jobId}", nameof(CancelJobAsync));
 
             Argument.AssertNotNullOrWhiteSpace(jobId, nameof(jobId));
 
@@ -756,13 +756,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Canceling job {jobId} threw an exception: {ex}", nameof(CancelJobAsync));
+                    Logging.Error(this, $"Canceling job: {jobId} threw an exception: {ex}", nameof(CancelJobAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Canceling job {jobId}", nameof(CancelJobAsync));
+                    Logging.Exit(this, $"Canceling job: {jobId}", nameof(CancelJobAsync));
             }
         }
 
@@ -784,7 +784,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<RegistryStatistics> GetRegistryStatisticsAsync(CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Getting registry statistics", nameof(GetRegistryStatisticsAsync));
+                Logging.Enter(this, "Getting registry statistics", nameof(GetRegistryStatisticsAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -804,7 +804,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Getting registry statistics", nameof(GetRegistryStatisticsAsync));
+                    Logging.Exit(this, "Getting registry statistics", nameof(GetRegistryStatisticsAsync));
             }
         }
 
@@ -826,7 +826,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<ServiceStatistics> GetServiceStatisticsAsync(CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Getting service statistics", nameof(GetServiceStatisticsAsync));
+                Logging.Enter(this, "Getting service statistics", nameof(GetServiceStatisticsAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -846,7 +846,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Getting service statistics", nameof(GetServiceStatisticsAsync));
+                    Logging.Exit(this, "Getting service statistics", nameof(GetServiceStatisticsAsync));
             }
         }
 

--- a/iothub/service/src/Registry/DevicesClient.cs
+++ b/iothub/service/src/Registry/DevicesClient.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Creating device: {device?.Id} threw an exception: {ex}", nameof(CreateAsync));
+                    Logging.Error(this, $"Creating device {device?.Id} threw an exception: {ex}", nameof(CreateAsync));
                 throw;
             }
             finally
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting device: {deviceId} threw an exception: {ex}", nameof(GetAsync));
+                    Logging.Error(this, $"Getting device {deviceId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating device: {device?.Id} threw an exception: {ex}", nameof(SetAsync));
+                    Logging.Error(this, $"Updating device {device?.Id} threw an exception: {ex}", nameof(SetAsync));
                 throw;
             }
             finally
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Deleting device: {device?.Id} threw an exception: {ex}", nameof(DeleteAsync));
+                    Logging.Error(this, $"Deleting device {device?.Id} threw an exception: {ex}", nameof(DeleteAsync));
                 throw;
             }
             finally
@@ -330,7 +330,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Creating device with twin: {device?.Id} threw an exception: {ex}", nameof(CreateWithTwinAsync));
+                    Logging.Error(this, $"Creating device with twin {device?.Id} threw an exception: {ex}", nameof(CreateWithTwinAsync));
                 throw;
             }
             finally
@@ -377,7 +377,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting modules on device: {deviceId} threw an exception: {ex}", nameof(GetModulesAsync));
+                    Logging.Error(this, $"Getting modules on device {deviceId} threw an exception: {ex}", nameof(GetModulesAsync));
                 throw;
             }
             finally
@@ -668,7 +668,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting job: {jobId} threw an exception: {ex}", nameof(GetJobsAsync));
+                    Logging.Error(this, $"Getting job {jobId} threw an exception: {ex}", nameof(GetJobsAsync));
                 throw;
             }
             finally
@@ -756,7 +756,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Canceling job: {jobId} threw an exception: {ex}", nameof(CancelJobAsync));
+                    Logging.Error(this, $"Canceling job {jobId} threw an exception: {ex}", nameof(CancelJobAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/Registry/ModulesClient.cs
+++ b/iothub/service/src/Registry/ModulesClient.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentNullException">Thrown when the provided module is null.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Creating device module threw an exception: {ex}", nameof(CreateAsync));
+                    Logging.Error(this, $"Creating module: {module?.Id} on device: {module?.DeviceId} threw an exception: {ex}", nameof(CreateAsync));
                 throw;
             }
             finally
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentException">Thrown when the provided device Id or module Id is empty or whitespace.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting device module threw an exception: {ex}", nameof(GetAsync));
+                    Logging.Error(this, $"Getting module: {moduleId} on device: {deviceId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentNullException">Thrown when the provided module is null.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating device module threw an exception: {ex}", nameof(SetAsync));
+                    Logging.Error(this, $"Updating module: {module?.Id} on device: {module?.DeviceId} - only if changed: {onlyIfUnchanged} threw an exception: {ex}", nameof(SetAsync));
                 throw;
             }
             finally
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentException">Thrown when the provided device Id or module Id is empty or whitespace.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="ArgumentNullException">Thrown when the provided module is null.</exception>
         /// <exception cref="IotHubServiceException">
         /// Thrown if IoT hub responded to the request with a non-successful status code. For example, if the provided
-        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown. 
+        /// request was throttled, <see cref="IotHubServiceException"/> with <see cref="IotHubErrorCode.ThrottlingException"/> is thrown.
         /// For a complete list of possible error cases, see <see cref="IotHubErrorCode"/>.
         /// </exception>
         /// <exception cref="HttpRequestException">
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Deleting device module threw an exception: {ex}", nameof(DeleteAsync));
+                    Logging.Error(this, $"Deleting module: {module?.Id} on device: {module?.DeviceId} - only if changed: {onlyIfUnchanged} threw an exception: {ex}", nameof(DeleteAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/Registry/ModulesClient.cs
+++ b/iothub/service/src/Registry/ModulesClient.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Creating module: {module?.Id} on device: {module?.DeviceId} threw an exception: {ex}", nameof(CreateAsync));
+                    Logging.Error(this, $"Creating module {module?.Id} on device {module?.DeviceId} threw an exception: {ex}", nameof(CreateAsync));
                 throw;
             }
             finally
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting module: {moduleId} on device: {deviceId} threw an exception: {ex}", nameof(GetAsync));
+                    Logging.Error(this, $"Getting module {moduleId} on device {deviceId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating module: {module?.Id} on device: {module?.DeviceId} - only if changed: {onlyIfUnchanged} threw an exception: {ex}", nameof(SetAsync));
+                    Logging.Error(this, $"Updating module {module?.Id} on device {module?.DeviceId} - only if changed {onlyIfUnchanged} threw an exception: {ex}", nameof(SetAsync));
                 throw;
             }
             finally
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Deleting module: {module?.Id} on device: {module?.DeviceId} - only if changed: {onlyIfUnchanged} threw an exception: {ex}", nameof(DeleteAsync));
+                    Logging.Error(this, $"Deleting module {module?.Id} on device {module?.DeviceId} - only if changed {onlyIfUnchanged} threw an exception: {ex}", nameof(DeleteAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/Twin/TwinsClient.cs
+++ b/iothub/service/src/Twin/TwinsClient.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting device threw an exception: {ex}", nameof(GetAsync));
+                    Logging.Error(this, $"Getting device twin: {deviceId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting device module twin threw an exception: {ex}", nameof(GetAsync));
+                    Logging.Error(this, $"Getting device module twin: {deviceId}/{moduleId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
@@ -266,7 +266,7 @@ namespace Microsoft.Azure.Devices
         public virtual async Task<BulkRegistryOperationResult> UpdateAsync(IEnumerable<Twin> twins, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Updating twins", nameof(UpdateAsync));
+                Logging.Enter(this, "Updating twins", nameof(UpdateAsync));
 
             Argument.AssertNotNullOrEmpty(twins, nameof(twins));
 
@@ -292,7 +292,7 @@ namespace Microsoft.Azure.Devices
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Updating twins", nameof(UpdateAsync));
+                    Logging.Exit(this, "Updating twins", nameof(UpdateAsync));
             }
         }
 
@@ -374,7 +374,7 @@ namespace Microsoft.Azure.Devices
             CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Updating device twin {deviceId} - is replace: {isReplace}", nameof(UpdateAsync));
+                Logging.Enter(this, $"Updating device twin: {deviceId} - is replace: {isReplace}", nameof(UpdateAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -395,7 +395,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating device twin threw an exception: {ex}", nameof(UpdateAsync));
+                    Logging.Error(this, $"Updating device twin: {deviceId} - is replace: {isReplace} threw an exception: {ex}", nameof(UpdateAsync));
                 throw;
             }
             finally
@@ -415,7 +415,7 @@ namespace Microsoft.Azure.Devices
             CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Updating device module twin {deviceId}/{moduleId} - is replace: {isReplace}", nameof(UpdateAsync));
+                Logging.Enter(this, $"Updating device module twin: {deviceId}/{moduleId} - is replace: {isReplace}", nameof(UpdateAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -437,13 +437,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating device module twin threw an exception: {ex}", nameof(UpdateAsync));
+                    Logging.Error(this, $"Updating device twin: {deviceId}/{moduleId} - is replace: {isReplace} threw an exception: {ex}", nameof(UpdateAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Updating device twin {deviceId}/{moduleId} - is replace: {isReplace}", nameof(UpdateAsync));
+                    Logging.Exit(this, $"Updating device twin: {deviceId}/{moduleId} - is replace: {isReplace}", nameof(UpdateAsync));
             }
         }
 
@@ -470,7 +470,7 @@ namespace Microsoft.Azure.Devices
                     case ImportMode.UpdateTwinIfMatchETag:
                         if (string.IsNullOrWhiteSpace(twin.ETag.ToString()))
                         {
-                            throw new InvalidOperationException($"Twin {twin.DeviceId} missing an ETag when conditionally updating.");
+                            throw new InvalidOperationException($"Twin: {twin.DeviceId} missing an ETag when conditionally updating.");
                         }
                         break;
 

--- a/iothub/service/src/Twin/TwinsClient.cs
+++ b/iothub/service/src/Twin/TwinsClient.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting device module twin: {deviceId}/{moduleId} threw an exception: {ex}", nameof(GetAsync));
+                    Logging.Error(this, $"Getting device module twin {deviceId}/{moduleId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
@@ -395,7 +395,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating device twin: {deviceId} - is replace: {isReplace} threw an exception: {ex}", nameof(UpdateAsync));
+                    Logging.Error(this, $"Updating device twin {deviceId} - is replace {isReplace} threw an exception: {ex}", nameof(UpdateAsync));
                 throw;
             }
             finally
@@ -437,7 +437,7 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating device twin: {deviceId}/{moduleId} - is replace: {isReplace} threw an exception: {ex}", nameof(UpdateAsync));
+                    Logging.Error(this, $"Updating device {deviceId}/{moduleId} - is replace {isReplace} threw an exception: {ex}", nameof(UpdateAsync));
                 throw;
             }
             finally


### PR DESCRIPTION
In a typical service client API, the logging of the enter/exit doesn't match much with the log statements within.
For instance:

Logging.Enter(this, $**"Creating device: {device?.Id}"**, nameof(CreateAsync));
Logging.Error(this, $**"{nameof(CreateAsync)}** threw an exception: {ex}", nameof(CreateAsync));
Logging.Exit(this, $**"Creating device: {device?.Id}"**, nameof(CreateAsync));