### PR TITLE
Move param checking and cancellation check outside of try block

### DIFF
--- a/iothub/service/src/DirectMethod/DirectMethodsClient.cs
+++ b/iothub/service/src/DirectMethod/DirectMethodsClient.cs
@@ -63,13 +63,13 @@ namespace Microsoft.Azure.Devices
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Invoking device method for device id: {deviceId}", nameof(InvokeAsync));
 
+            Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
+            Argument.AssertNotNull(directMethodRequest, nameof(directMethodRequest));
+
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
-                Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
-                Argument.AssertNotNull(directMethodRequest, nameof(directMethodRequest));
-
-                cancellationToken.ThrowIfCancellationRequested();
-
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Post, GetDeviceMethodUri(deviceId), _credentialProvider, directMethodRequest);
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.OK, response).ConfigureAwait(false);
@@ -113,14 +113,14 @@ namespace Microsoft.Azure.Devices
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Invoking device method for device id: {deviceId} and module id: {moduleId}", nameof(InvokeAsync));
 
+            Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
+            Argument.AssertNotNullOrWhiteSpace(moduleId, nameof(moduleId));
+            Argument.AssertNotNull(directMethodRequest, nameof(directMethodRequest));
+
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
-                Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
-                Argument.AssertNotNullOrWhiteSpace(moduleId, nameof(moduleId));
-                Argument.AssertNotNull(directMethodRequest, nameof(directMethodRequest));
-
-                cancellationToken.ThrowIfCancellationRequested();
-
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Post, GetModuleMethodUri(deviceId, moduleId), _credentialProvider, directMethodRequest);
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.OK, response).ConfigureAwait(false);

--- a/iothub/service/src/Jobs/ScheduledJobsClient.cs
+++ b/iothub/service/src/Jobs/ScheduledJobsClient.cs
@@ -73,7 +73,6 @@ namespace Microsoft.Azure.Devices
                 Logging.Enter(this, $"Getting job {jobId}", nameof(GetAsync));
 
             Argument.AssertNotNullOrWhiteSpace(jobId, nameof(jobId));
-
             cancellationToken.ThrowIfCancellationRequested();
 
             try
@@ -140,11 +139,11 @@ namespace Microsoft.Azure.Devices
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Canceling job {jobId}", nameof(CancelAsync));
 
+            Argument.AssertNotNullOrWhiteSpace(jobId, nameof(jobId));
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
-                Argument.AssertNotNullOrWhiteSpace(jobId, nameof(jobId));
-                cancellationToken.ThrowIfCancellationRequested();
-
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(
                     HttpMethod.Post,
                     new Uri(

--- a/iothub/service/src/Messaging/MessagesClient.cs
+++ b/iothub/service/src/Messaging/MessagesClient.cs
@@ -279,7 +279,6 @@ namespace Microsoft.Azure.Devices
                 Logging.Enter(this, $"Purging message queue for device: {deviceId}", nameof(PurgeMessageQueueAsync));
 
             Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
-
             cancellationToken.ThrowIfCancellationRequested();
 
             try

--- a/iothub/service/src/Registry/DevicesClient.cs
+++ b/iothub/service/src/Registry/DevicesClient.cs
@@ -568,8 +568,6 @@ namespace Microsoft.Azure.Devices
 
             try
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
                 jobParameters.Type = JobType.ImportDevices;
                 return await CreateJobAsync(jobParameters, cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
Few instances where param check and cancellation token check were being performed in try-catch block.