### PR TITLE
[Draft] Mock design for making Model constructors protected internal

### DIFF
--- a/e2e/test/iothub/service/ConfigurationsClientE2ETests.cs
+++ b/e2e/test/iothub/service/ConfigurationsClientE2ETests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             try
             {
-                var expected = new Configuration(configurationId)
+                Configuration expected = new ConfigurationTest(configurationId)
                 {
                     Priority = 2,
                     Labels = { { "labelName", "labelValue" } },
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             string configurationId = (_idPrefix + Guid.NewGuid()).ToLower(); // Configuration Id characters must be all lower-case.
             try
             {
-                var configuration = new Configuration(configurationId)
+                Configuration configuration = new ConfigurationTest(configurationId)
                 {
                     Priority = 2,
                     Labels = { { "labelName", "labelValue" } },
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             string configurationId = (_idPrefix + Guid.NewGuid()).ToLower(); // Configuration Id characters must be all lower-case.
             try
             {
-                var configuration = new Configuration(configurationId)
+                Configuration configuration = new ConfigurationTest(configurationId)
                 {
                     Priority = 2,
                     Labels = { { "labelName", "labelValue" } },

--- a/iothub/service/src/Configurations/Models/Configuration.cs
+++ b/iothub/service/src/Configurations/Models/Configuration.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices
         /// The configuration Id.
         /// Lowercase and the following special characters are allowed: [-+%_*!'].
         /// </param>
-        public Configuration(string configurationId)
+        protected internal Configuration(string configurationId)
         {
             Id = configurationId;
         }

--- a/iothub/service/src/Configurations/Models/ConfigurationTest.cs
+++ b/iothub/service/src/Configurations/Models/ConfigurationTest.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public class ConfigurationTest : Configuration
+    {
+        /// <summary>
+        /// Initializes an instance of the class to be used for test purposes.
+        /// </summary>
+        /// <param name="configurationId"></param>
+        public ConfigurationTest(string configurationId) : base(configurationId)
+        {
+        }
+    }
+}


### PR DESCRIPTION
A draft PR to show how the service client models would look like if we change constructors to be protected internal.

We would have to create an inherited class that would be used in unit/e2e tests instead.