### PR TITLE
replaced <c> with <code>

### DIFF
--- a/provisioning/service/src/ProvisioningServiceClient.cs
+++ b/provisioning/service/src/ProvisioningServiceClient.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// This C# SDK can be represented in the follow diagram, the first layer are the public APIs the your application
     /// shall use:
     ///
-    /// <c>
+    /// <code>
     /// +===============+       +==========================================+                           +============+   +===+
     /// |    configs    |------>|         ProvisioningServiceClient        |                        +->|    Query   |   |   |
     /// +===============+       +==+=================+==================+==+                        |  +======+=====+   | e |
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     ///                        +-------------------------------------+------------------------------------------+
     ///                        |                              System.Net.Http                                   |
     ///                        +--------------------------------------------------------------------------------+
-    /// </c>
+    /// </code>
     /// </remarks>
     public class ProvisioningServiceClient : IDisposable
     {


### PR DESCRIPTION
ASCII Diagram in `ProvisioningServiceClient.cs` isn't rendering properly when the XML doc comment is parsed by Azure Docs. I used [this](https://marketplace.visualstudio.com/items?itemName=OlegShilo.DocPreview#:~:text=Open%20the%20preview%20window%20from%20Menu-%3EView-%3EOther%20Windows-%3EXml%20documentation,be%20rendered%20when%20you%20press%20the%20refresh%20icon%2Fbutton.) VS Extension to preview changes made to it.

<img width="935" alt="image" src="https://user-images.githubusercontent.com/110431552/191369293-85f4e6c6-d128-41ca-b19f-29972300f133.png">

After replacing `<c>` with `<code>` the following is rendered:
<img width="913" alt="image" src="https://user-images.githubusercontent.com/110431552/191369818-1d964dfb-c276-4aec-add3-dd04967b72c8.png">
