### PR TITLE
Abandon file upload notification message if the callback throws

### DIFF
--- a/iothub/service/src/FileUpload/FileUploadNotificationProcessorClient.cs
+++ b/iothub/service/src/FileUpload/FileUploadNotificationProcessorClient.cs
@@ -207,6 +207,8 @@ namespace Microsoft.Azure.Devices
                 {
                     ErrorProcessor?.Invoke(new ErrorContext(ioEx));
                 }
+
+                await _amqpConnection.AbandonMessageAsync(amqpMessage.DeliveryTag).ConfigureAwait(false);
             }
             finally
             {

--- a/iothub/service/src/FileUpload/FileUploadNotificationProcessorClient.cs
+++ b/iothub/service/src/FileUpload/FileUploadNotificationProcessorClient.cs
@@ -199,16 +199,24 @@ namespace Microsoft.Azure.Devices
                 if (Logging.IsEnabled)
                     Logging.Error(this, $"{nameof(OnNotificationMessageReceivedAsync)} threw an exception: {ex}", nameof(OnNotificationMessageReceivedAsync));
 
-                if (ex is IotHubServiceException hubEx)
+                try
                 {
-                    ErrorProcessor?.Invoke(new ErrorContext(hubEx));
-                }
-                else if (ex is IOException ioEx)
-                {
-                    ErrorProcessor?.Invoke(new ErrorContext(ioEx));
-                }
+                    if (ex is IotHubServiceException hubEx)
+                    {
+                        ErrorProcessor?.Invoke(new ErrorContext(hubEx));
+                    }
+                    else if (ex is IOException ioEx)
+                    {
+                        ErrorProcessor?.Invoke(new ErrorContext(ioEx));
+                    }
 
-                await _amqpConnection.AbandonMessageAsync(amqpMessage.DeliveryTag).ConfigureAwait(false);
+                    await _amqpConnection.AbandonMessageAsync(amqpMessage.DeliveryTag).ConfigureAwait(false);
+                }
+                catch (Exception ex2)
+                {
+                    if (Logging.IsEnabled)
+                        Logging.Error(this, $"{nameof(OnNotificationMessageReceivedAsync)} threw an exception during cleanup: {ex2}", nameof(OnNotificationMessageReceivedAsync));
+                }
             }
             finally
             {


### PR DESCRIPTION
- Abandons the file upload notification message if there is an exception thrown in FileUploadNotificationProcessorClient
- Reference: https://github.com/Azure/azure-iot-sdk-csharp/blob/previews/v2/iothub/service/src/Feedback/MessageFeedbackProcessorClient.cs#L218-L234