### PR TITLE
Return updated twin version from reported property update call

### DIFF
--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -405,7 +405,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             var props = new Client.TwinCollection();
             props[propName] = propValue;
             await deviceClient.OpenAsync().ConfigureAwait(false);
-            int newTwinVersion = await deviceClient.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
+            long newTwinVersion = await deviceClient.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
 
             // Validate the updated twin from the device-client
             Client.Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);

--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -405,7 +405,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             var props = new Client.TwinCollection();
             props[propName] = propValue;
             await deviceClient.OpenAsync().ConfigureAwait(false);
-            await deviceClient.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
+            int newTwinVersion = await deviceClient.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
 
             // Validate the updated twin from the device-client
             Client.Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
@@ -416,6 +416,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             Twin completeTwin = await _serviceClient.Twins.GetAsync(deviceId).ConfigureAwait(false);
             dynamic actualProp = completeTwin.Properties.Reported[propName];
             Assert.AreEqual(JsonConvert.SerializeObject(actualProp), JsonConvert.SerializeObject(propValue));
+            Assert.AreEqual(completeTwin.Properties.Reported.Version, newTwinVersion);
         }
 
         public static async Task<Task> SetTwinPropertyUpdateCallbackHandlerAsync(IotHubDeviceClient deviceClient, string expectedPropName, object expectedPropValue, MsTestLogger logger)

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -392,7 +392,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <returns>The new version of the updated twin if the update was successful.</returns>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        public async Task<int> UpdateReportedPropertiesAsync(TwinCollection reportedProperties, CancellationToken cancellationToken = default)
+        public async Task<long> UpdateReportedPropertiesAsync(TwinCollection reportedProperties, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(reportedProperties, nameof(reportedProperties));
             cancellationToken.ThrowIfCancellationRequested();

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client.Exceptions;
 using Microsoft.Azure.Devices.Client.Transport;
+using Microsoft.Azure.Devices.Client.Transport.Mqtt;
 using Microsoft.Azure.Devices.Client.Utilities;
 
 namespace Microsoft.Azure.Devices.Client
@@ -29,6 +30,7 @@ namespace Microsoft.Azure.Devices.Client
 
         // Method callback information
         private bool _isDeviceMethodEnabled;
+
         private volatile Tuple<Func<DirectMethodRequest, object, Task<DirectMethodResponse>>, object> _deviceDefaultMethodCallback;
 
         // Twin property update request callback information
@@ -388,14 +390,15 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="reportedProperties">Reported properties to push</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        /// <returns>The new version of the updated twin if the update was successful.</returns>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        public async Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties, CancellationToken cancellationToken = default)
+        public async Task<int> UpdateReportedPropertiesAsync(TwinCollection reportedProperties, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(reportedProperties, nameof(reportedProperties));
             cancellationToken.ThrowIfCancellationRequested();
 
             // `UpdateReportedPropertiesAsync` shall call `SendTwinPatchAsync` on the transport to update the reported properties.
-            await InnerHandler.SendTwinPatchAsync(reportedProperties, cancellationToken).ConfigureAwait(false);
+            return await InnerHandler.SendTwinPatchAsync(reportedProperties, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Devices.Client.Transport.Mqtt;
 
 namespace Microsoft.Azure.Devices.Client.Transport
 {
@@ -156,10 +157,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return NextHandler?.SendTwinGetAsync(cancellationToken) ?? Task.FromResult((Twin)null);
         }
 
-        public virtual Task SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
+        public virtual Task<int> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
-            return NextHandler?.SendTwinPatchAsync(reportedProperties, cancellationToken) ?? Task.CompletedTask;
+            return NextHandler?.SendTwinPatchAsync(reportedProperties, cancellationToken) ?? Task.FromResult(0);
         }
 
         public virtual Task EnableEventReceiveAsync(bool isAnEdgeModule, CancellationToken cancellationToken)

--- a/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.Devices.Client.Transport.Mqtt;
 
 namespace Microsoft.Azure.Devices.Client.Transport
 {
@@ -157,10 +156,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return NextHandler?.SendTwinGetAsync(cancellationToken) ?? Task.FromResult((Twin)null);
         }
 
-        public virtual Task<int> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
+        public virtual Task<long> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
-            return NextHandler?.SendTwinPatchAsync(reportedProperties, cancellationToken) ?? Task.FromResult(0);
+            return NextHandler?.SendTwinPatchAsync(reportedProperties, cancellationToken) ?? Task.FromResult(0L);
         }
 
         public virtual Task EnableEventReceiveAsync(bool isAnEdgeModule, CancellationToken cancellationToken)

--- a/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return ExecuteWithErrorHandlingAsync(() => base.SendTwinGetAsync(cancellationToken));
         }
 
-        public override Task SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
+        public override Task<int> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
             return ExecuteWithErrorHandlingAsync(() => base.SendTwinPatchAsync(reportedProperties, cancellationToken));
         }

--- a/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return ExecuteWithErrorHandlingAsync(() => base.SendTwinGetAsync(cancellationToken));
         }
 
-        public override Task<int> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
+        public override Task<long> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
             return ExecuteWithErrorHandlingAsync(() => base.SendTwinPatchAsync(reportedProperties, cancellationToken));
         }

--- a/iothub/device/src/Pipeline/IDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/IDelegatingHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Devices.Client.Transport.Mqtt;
 
 namespace Microsoft.Azure.Devices.Client
 {
@@ -57,7 +58,7 @@ namespace Microsoft.Azure.Devices.Client
         // Twin.
         Task<Twin> SendTwinGetAsync(CancellationToken cancellationToken);
 
-        Task SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken);
+        Task<int> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken);
 
         Task EnableTwinPatchAsync(CancellationToken cancellationToken);
 

--- a/iothub/device/src/Pipeline/IDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/IDelegatingHandler.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Devices.Client
         // Twin.
         Task<Twin> SendTwinGetAsync(CancellationToken cancellationToken);
 
-        Task<int> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken);
+        Task<long> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken);
 
         Task EnableTwinPatchAsync(CancellationToken cancellationToken);
 

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client.Exceptions;
+using Microsoft.Azure.Devices.Client.Transport.Mqtt;
 
 namespace Microsoft.Azure.Devices.Client.Transport
 {
@@ -464,19 +465,19 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
-        public override async Task SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
+        public override async Task<int> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
             try
             {
                 if (Logging.IsEnabled)
                     Logging.Enter(this, reportedProperties, cancellationToken, nameof(SendTwinPatchAsync));
 
-                await _internalRetryPolicy
+                return await _internalRetryPolicy
                     .RunWithRetryAsync(
                         async () =>
                         {
                             await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
-                            await base.SendTwinPatchAsync(reportedProperties, cancellationToken).ConfigureAwait(false);
+                            return await base.SendTwinPatchAsync(reportedProperties, cancellationToken).ConfigureAwait(false);
                         },
                         cancellationToken)
                     .ConfigureAwait(false);

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
-        public override async Task<int> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
+        public override async Task<long> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
             try
             {

--- a/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
         }
 
-        public override async Task SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
+        public override async Task<int> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, reportedProperties, cancellationToken, nameof(SendTwinPatchAsync));
@@ -358,7 +358,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             try
             {
                 await EnableTwinPatchAsync(cancellationToken).ConfigureAwait(false);
-                await RoundTripTwinMessageAsync(AmqpTwinMessageType.Patch, reportedProperties, cancellationToken).ConfigureAwait(false);
+                Twin twin = await RoundTripTwinMessageAsync(AmqpTwinMessageType.Patch, reportedProperties, cancellationToken).ConfigureAwait(false);
+                return (int)twin.Version;
             }
             finally
             {

--- a/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
         }
 
-        public override async Task<int> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
+        public override async Task<long> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, reportedProperties, cancellationToken, nameof(SendTwinPatchAsync));
@@ -359,7 +359,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             {
                 await EnableTwinPatchAsync(cancellationToken).ConfigureAwait(false);
                 Twin twin = await RoundTripTwinMessageAsync(AmqpTwinMessageType.Patch, reportedProperties, cancellationToken).ConfigureAwait(false);
-                return (int)twin.Version;
+                return twin.Version ?? 0L;
             }
             finally
             {

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotReceivingLink.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotReceivingLink.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
 
                         twin = new Twin
                         {
-                            Version = Convert.ToInt32(amqpMessage.MessageAnnotations.Map["version"]),
+                            Version = long.Parse(amqpMessage.MessageAnnotations.Map["version"].ToString()),
                         };
                     }
                     else if (correlationId.StartsWith(AmqpTwinMessageType.Put.ToString(), StringComparison.OrdinalIgnoreCase))

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotReceivingLink.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotReceivingLink.cs
@@ -295,8 +295,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
                         if (Logging.IsEnabled)
                             Logging.Info("Updated twin reported properties successfully", nameof(OnTwinChangesReceived));
 
-                        twin = new Twin();
-                        twin.Version = Convert.ToInt32(amqpMessage.MessageAnnotations.Map["version"]);
+                        twin = new Twin
+                        {
+                            Version = Convert.ToInt32(amqpMessage.MessageAnnotations.Map["version"]),
+                        };
                     }
                     else if (correlationId.StartsWith(AmqpTwinMessageType.Put.ToString(), StringComparison.OrdinalIgnoreCase))
                     {

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotReceivingLink.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotReceivingLink.cs
@@ -292,9 +292,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
                     else if (correlationId.StartsWith(AmqpTwinMessageType.Patch.ToString(), StringComparison.OrdinalIgnoreCase))
                     {
                         // This can be used to coorelate success response with updating reported properties
-                        // However currently we do not have it as request response style implementation
                         if (Logging.IsEnabled)
                             Logging.Info("Updated twin reported properties successfully", nameof(OnTwinChangesReceived));
+
+                        twin = new Twin();
+                        twin.Version = Convert.ToInt32(amqpMessage.MessageAnnotations.Map["version"]);
                     }
                     else if (correlationId.StartsWith(AmqpTwinMessageType.Put.ToString(), StringComparison.OrdinalIgnoreCase))
                     {

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
         }
 
-        public override async Task SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
+        public override async Task<int> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
             if (!_isSubscribedToTwinResponses)
             {
@@ -636,8 +636,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     throw new IotHubClientException(patchTwinResponse.Message);
                 }
 
-                //TODO new twin version should be returned here, but API surface doesn't currently allow it
-                //return patchTwinResponse.Version;
+                return patchTwinResponse.Version;
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
         }
 
-        public override async Task<int> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
+        public override async Task<long> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
             if (!_isSubscribedToTwinResponses)
             {
@@ -858,7 +858,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         private void HandleTwinResponse(MqttApplicationMessageReceivedEventArgs receivedEventArgs)
         {
-            if (ParseResponseTopic(receivedEventArgs.ApplicationMessage.Topic, out string receivedRequestId, out int status, out int version))
+            if (ParseResponseTopic(receivedEventArgs.ApplicationMessage.Topic, out string receivedRequestId, out int status, out long version))
             {
                 string payloadString = Encoding.UTF8.GetString(receivedEventArgs.ApplicationMessage.Payload ?? new byte[0]);
 
@@ -1046,7 +1046,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             return msg;
         }
 
-        private bool ParseResponseTopic(string topicName, out string rid, out int status, out int version)
+        private bool ParseResponseTopic(string topicName, out string rid, out int status, out long version)
         {
             rid = "";
             status = 500;

--- a/iothub/device/src/Transport/Mqtt/PatchTwinResponse.cs
+++ b/iothub/device/src/Transport/Mqtt/PatchTwinResponse.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         /// <summary>
         /// The new version of the twin after the patch.
         /// </summary>
-        internal int Version { get; set; }
+        internal long Version { get; set; }
 
         /// <summary>
         /// The error message if the request failed.


### PR DESCRIPTION
The service returns this new version after a successful reported properties update, but the SDK wasn't bubbling it up to the user in v1