### PR TITLE
Revamp exceptions thrown by the dps device & service clients

### DIFF
--- a/e2e/test/helpers/RetryOperationHelper.cs
+++ b/e2e/test/helpers/RetryOperationHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client;
 
@@ -15,14 +16,22 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
     public class RetryOperationHelper
     {
         /// <summary>
-        /// Rety an async operation based on the retry strategy supplied.
+        /// Retry an async operation based on the retry strategy supplied.
         /// </summary>
+        /// <remarks>
+        /// This is for E2E tests of provisioning service clients .
+        /// </remarks>
         /// <param name="asyncOperation">The async operation to be retried.</param>
         /// <param name="retryPolicy">The retry policy to be applied.</param>
         /// <param name="retryableExceptions">The exceptions to be retried on.</param>
         /// <param name="logger">The <see cref="MsTestLogger"/> instance to be used.</param>
-        /// <returns></returns>
-        public static async Task RetryOperationsAsync(Func<Task> asyncOperation, IRetryPolicy retryPolicy, HashSet<Type> retryableExceptions, MsTestLogger logger)
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        public static async Task RetryOperationsAsync(
+            Func<Task> asyncOperation,
+            IRetryPolicy retryPolicy,
+            HashSet<Type> retryableExceptions,
+            MsTestLogger logger,
+            CancellationToken cancellationToken = default)
         {
             int counter = 0;
             bool shouldRetry;
@@ -47,19 +56,28 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                 }
 
                 logger.Trace($"Will retry operation in {retryInterval}.");
-                await Task.Delay(retryInterval).ConfigureAwait(false);
+                await Task.Delay(retryInterval, cancellationToken);
             }
-            while (shouldRetry);
+            while (shouldRetry && !cancellationToken.IsCancellationRequested);
         }
 
         /// <summary>
-        /// Rety an async operation based on the retry strategy supplied.
+        /// Retry an async operation based on the retry strategy supplied.
         /// </summary>
+        /// <remarks>
+        /// This is for E2E tests of hub service clients.
+        /// </remarks>
         /// <param name="asyncOperation">The async operation to be retried.</param>
         /// <param name="retryPolicy">The retry policy to be applied.</param>
         /// <param name="retryableStatusCodes">The errors to be retried on.</param>
         /// <param name="logger">The <see cref="MsTestLogger"/> instance to be used.</param>
-        public static async Task RetryOperationsAsync1(Func<Task> asyncOperation, IRetryPolicy retryPolicy, HashSet<IotHubErrorCode> retryableStatusCodes, MsTestLogger logger)
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        public static async Task RetryOperationsAsync(
+            Func<Task> asyncOperation,
+            IRetryPolicy retryPolicy,
+            HashSet<IotHubErrorCode> retryableStatusCodes,
+            MsTestLogger logger,
+            CancellationToken cancellationToken = default)
         {
             int counter = 0;
             bool shouldRetry;
@@ -84,9 +102,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                 }
 
                 logger.Trace($"Will retry operation in {retryInterval}.");
-                await Task.Delay(retryInterval).ConfigureAwait(false);
+                await Task.Delay(retryInterval, cancellationToken);
             }
-            while (shouldRetry);
+            while (shouldRetry && !cancellationToken.IsCancellationRequested);
         }
     }
 }

--- a/e2e/test/helpers/TestDevice.cs
+++ b/e2e/test/helpers/TestDevice.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         private X509Certificate2 _authCertificate;
 
         private static MsTestLogger s_logger;
-        private static CancellationTokenSource s_cancellationTokenSource = new CancellationTokenSource();
 
         private TestDevice(Device device, Client.IAuthenticationMethod authenticationMethod)
         {
@@ -112,7 +111,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                     s_exponentialBackoffRetryStrategy,
                     s_throttlingStatusCodes,
                     s_logger,
-                    s_cancellationTokenSource.Token)
+                    CancellationToken.None)
                 .ConfigureAwait(false);
 
             // Confirm the device exists in the registry before calling it good to avoid downstream test failures.
@@ -133,7 +132,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                     s_exponentialBackoffRetryStrategy,
                     s_retryableStatusCodes,
                     s_logger,
-                    s_cancellationTokenSource.Token)
+                    CancellationToken.None)
                 .ConfigureAwait(false);
 
             return device == null
@@ -212,7 +211,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                     s_exponentialBackoffRetryStrategy,
                     s_throttlingStatusCodes,
                     s_logger,
-                    s_cancellationTokenSource.Token)
+                    CancellationToken.None)
                 .ConfigureAwait(false);
         }
 

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
         private static DirectoryInfo s_x509CertificatesFolder;
         private static string s_intermediateCertificateSubject;
-        private static CancellationTokenSource s_cancellationTokenSource = new CancellationTokenSource();
 
         [ClassInitialize]
         public static void TestClassSetup(TestContext _)
@@ -1433,7 +1432,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                             s_provisioningServiceRetryPolicy,
                             s_retryableExceptions,
                             logger,
-                            s_cancellationTokenSource.Token)
+                            CancellationToken.None)
                         .ConfigureAwait(false);
                 }
                 else if (enrollmentType == EnrollmentType.Group)
@@ -1447,7 +1446,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                             s_provisioningServiceRetryPolicy,
                             s_retryableExceptions,
                             logger,
-                            s_cancellationTokenSource.Token)
+                            CancellationToken.None)
                         .ConfigureAwait(false);
                 }
             }

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
         private static DirectoryInfo s_x509CertificatesFolder;
         private static string s_intermediateCertificateSubject;
+        private static CancellationTokenSource s_cancellationTokenSource = new CancellationTokenSource();
 
         [ClassInitialize]
         public static void TestClassSetup(TestContext _)
@@ -1431,7 +1432,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                             },
                             s_provisioningServiceRetryPolicy,
                             s_retryableExceptions,
-                            logger)
+                            logger,
+                            s_cancellationTokenSource.Token)
                         .ConfigureAwait(false);
                 }
                 else if (enrollmentType == EnrollmentType.Group)
@@ -1444,7 +1446,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                             },
                             s_provisioningServiceRetryPolicy,
                             s_retryableExceptions,
-                            logger)
+                            logger,
+                            s_cancellationTokenSource.Token)
                         .ConfigureAwait(false);
                 }
             }

--- a/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
@@ -25,6 +26,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
         private static readonly HashSet<Type> s_retryableExceptions = new HashSet<Type> { typeof(ProvisioningServiceClientHttpException) };
         private static readonly IRetryPolicy s_provisioningServiceRetryPolicy = new ProvisioningServiceRetryPolicy();
+
+        private static CancellationTokenSource s_cancellationTokenSource = new CancellationTokenSource();
 
 #pragma warning disable CA1823
         private readonly VerboseTestLogger _verboseLog = VerboseTestLogger.GetInstance();
@@ -161,7 +164,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     },
                     s_provisioningServiceRetryPolicy,
                     s_retryableExceptions,
-                    Logger)
+                    Logger,
+                    s_cancellationTokenSource.Token)
                 .ConfigureAwait(false);
 
             if (attestationMechanism == null)
@@ -210,7 +214,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     },
                     s_provisioningServiceRetryPolicy,
                     s_retryableExceptions,
-                    Logger)
+                    Logger,
+                    s_cancellationTokenSource.Token)
                 .ConfigureAwait(false);
 
             if (attestationMechanism == null)
@@ -302,7 +307,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     },
                     s_provisioningServiceRetryPolicy,
                     s_retryableExceptions,
-                    Logger)
+                    Logger,
+                    s_cancellationTokenSource.Token)
                 .ConfigureAwait(false);
 
             if (individualEnrollmentResult == null)
@@ -367,7 +373,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         },
                         s_provisioningServiceRetryPolicy,
                         s_retryableExceptions,
-                        Logger)
+                        Logger,
+                        s_cancellationTokenSource.Token)
                     .ConfigureAwait(false);
 
                 if (enrollmentGroupResult == null)
@@ -437,7 +444,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                                 },
                                 s_provisioningServiceRetryPolicy,
                                 s_retryableExceptions,
-                                logger)
+                                logger,
+                                s_cancellationTokenSource.Token)
                             .ConfigureAwait(false);
 
                         if (temporaryCreatedEnrollment == null)
@@ -458,7 +466,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                                 },
                                 s_provisioningServiceRetryPolicy,
                                 s_retryableExceptions,
-                                logger)
+                                logger,
+                                s_cancellationTokenSource.Token)
                             .ConfigureAwait(false);
 
                         if (createdEnrollment == null)
@@ -502,7 +511,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     },
                     s_provisioningServiceRetryPolicy,
                     s_retryableExceptions,
-                    logger)
+                    logger,
+                    s_cancellationTokenSource.Token)
                 .ConfigureAwait(false);
 
             if (createdEnrollment == null)
@@ -559,7 +569,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                    },
                    s_provisioningServiceRetryPolicy,
                    s_retryableExceptions,
-                   logger)
+                   logger,
+                   s_cancellationTokenSource.Token)
                .ConfigureAwait(false);
 
             if (createdEnrollmentGroup == null)
@@ -590,7 +601,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                             },
                             s_provisioningServiceRetryPolicy,
                             s_retryableExceptions,
-                            logger)
+                            logger,
+                            s_cancellationTokenSource.Token)
                         .ConfigureAwait(false);
                 }
                 else if (enrollmentType == EnrollmentType.Group)
@@ -603,7 +615,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                             },
                             s_provisioningServiceRetryPolicy,
                             s_retryableExceptions,
-                            logger)
+                            logger,
+                            s_cancellationTokenSource.Token)
                         .ConfigureAwait(false);
                 }
             }

--- a/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
@@ -27,8 +27,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         private static readonly HashSet<Type> s_retryableExceptions = new HashSet<Type> { typeof(ProvisioningServiceClientHttpException) };
         private static readonly IRetryPolicy s_provisioningServiceRetryPolicy = new ProvisioningServiceRetryPolicy();
 
-        private static CancellationTokenSource s_cancellationTokenSource = new CancellationTokenSource();
-
 #pragma warning disable CA1823
         private readonly VerboseTestLogger _verboseLog = VerboseTestLogger.GetInstance();
 #pragma warning restore CA1823
@@ -165,7 +163,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     s_provisioningServiceRetryPolicy,
                     s_retryableExceptions,
                     Logger,
-                    s_cancellationTokenSource.Token)
+                    CancellationToken.None)
                 .ConfigureAwait(false);
 
             if (attestationMechanism == null)
@@ -215,7 +213,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     s_provisioningServiceRetryPolicy,
                     s_retryableExceptions,
                     Logger,
-                    s_cancellationTokenSource.Token)
+                    CancellationToken.None)
                 .ConfigureAwait(false);
 
             if (attestationMechanism == null)
@@ -308,7 +306,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     s_provisioningServiceRetryPolicy,
                     s_retryableExceptions,
                     Logger,
-                    s_cancellationTokenSource.Token)
+                    CancellationToken.None)
                 .ConfigureAwait(false);
 
             if (individualEnrollmentResult == null)
@@ -374,7 +372,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         s_provisioningServiceRetryPolicy,
                         s_retryableExceptions,
                         Logger,
-                        s_cancellationTokenSource.Token)
+                        CancellationToken.None)
                     .ConfigureAwait(false);
 
                 if (enrollmentGroupResult == null)
@@ -445,7 +443,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                                 s_provisioningServiceRetryPolicy,
                                 s_retryableExceptions,
                                 logger,
-                                s_cancellationTokenSource.Token)
+                                CancellationToken.None)
                             .ConfigureAwait(false);
 
                         if (temporaryCreatedEnrollment == null)
@@ -467,7 +465,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                                 s_provisioningServiceRetryPolicy,
                                 s_retryableExceptions,
                                 logger,
-                                s_cancellationTokenSource.Token)
+                                CancellationToken.None)
                             .ConfigureAwait(false);
 
                         if (createdEnrollment == null)
@@ -512,7 +510,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     s_provisioningServiceRetryPolicy,
                     s_retryableExceptions,
                     logger,
-                    s_cancellationTokenSource.Token)
+                    CancellationToken.None)
                 .ConfigureAwait(false);
 
             if (createdEnrollment == null)
@@ -570,7 +568,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                    s_provisioningServiceRetryPolicy,
                    s_retryableExceptions,
                    logger,
-                   s_cancellationTokenSource.Token)
+                   CancellationToken.None)
                .ConfigureAwait(false);
 
             if (createdEnrollmentGroup == null)
@@ -602,7 +600,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                             s_provisioningServiceRetryPolicy,
                             s_retryableExceptions,
                             logger,
-                            s_cancellationTokenSource.Token)
+                            CancellationToken.None)
                         .ConfigureAwait(false);
                 }
                 else if (enrollmentType == EnrollmentType.Group)
@@ -616,7 +614,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                             s_provisioningServiceRetryPolicy,
                             s_retryableExceptions,
                             logger,
-                            s_cancellationTokenSource.Token)
+                            CancellationToken.None)
                         .ConfigureAwait(false);
                 }
             }

--- a/e2e/test/provisioning/ReprovisioningE2ETests.cs
+++ b/e2e/test/provisioning/ReprovisioningE2ETests.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
         private static DirectoryInfo s_x509CertificatesFolder;
         private static string s_intermediateCertificateSubject;
-        private static CancellationTokenSource s_cancellationTokenSource = new CancellationTokenSource();
 
         [ClassInitialize]
         public static void TestClassSetup(TestContext _)
@@ -763,7 +762,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         s_provisioningServiceRetryPolicy,
                         s_retryableExceptions,
                         Logger,
-                        s_cancellationTokenSource.Token)
+                        CancellationToken.None)
                     .ConfigureAwait(false);
 
                 if (retrievedEnrollment == null)
@@ -786,7 +785,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         s_provisioningServiceRetryPolicy,
                         s_retryableExceptions,
                         Logger,
-                        s_cancellationTokenSource.Token)
+                        CancellationToken.None)
                     .ConfigureAwait(false);
 
                 if (updatedEnrollment == null)
@@ -806,7 +805,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         s_provisioningServiceRetryPolicy,
                         s_retryableExceptions,
                         Logger,
-                        s_cancellationTokenSource.Token)
+                        CancellationToken.None)
                     .ConfigureAwait(false);
 
                 if (retrievedEnrollmentGroup == null)
@@ -827,7 +826,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         s_provisioningServiceRetryPolicy,
                         s_retryableExceptions,
                         Logger,
-                        s_cancellationTokenSource.Token)
+                        CancellationToken.None)
                     .ConfigureAwait(false);
 
                 if (updatedEnrollmentGroup == null)

--- a/e2e/test/provisioning/ReprovisioningE2ETests.cs
+++ b/e2e/test/provisioning/ReprovisioningE2ETests.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
         private static DirectoryInfo s_x509CertificatesFolder;
         private static string s_intermediateCertificateSubject;
+        private static CancellationTokenSource s_cancellationTokenSource = new CancellationTokenSource();
 
         [ClassInitialize]
         public static void TestClassSetup(TestContext _)
@@ -761,7 +762,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         },
                         s_provisioningServiceRetryPolicy,
                         s_retryableExceptions,
-                        Logger)
+                        Logger,
+                        s_cancellationTokenSource.Token)
                     .ConfigureAwait(false);
 
                 if (retrievedEnrollment == null)
@@ -783,7 +785,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         },
                         s_provisioningServiceRetryPolicy,
                         s_retryableExceptions,
-                        Logger)
+                        Logger,
+                        s_cancellationTokenSource.Token)
                     .ConfigureAwait(false);
 
                 if (updatedEnrollment == null)
@@ -802,7 +805,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         },
                         s_provisioningServiceRetryPolicy,
                         s_retryableExceptions,
-                        Logger)
+                        Logger,
+                        s_cancellationTokenSource.Token)
                     .ConfigureAwait(false);
 
                 if (retrievedEnrollmentGroup == null)
@@ -822,7 +826,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         },
                         s_provisioningServiceRetryPolicy,
                         s_retryableExceptions,
-                        Logger)
+                        Logger,
+                        s_cancellationTokenSource.Token)
                     .ConfigureAwait(false);
 
                 if (updatedEnrollmentGroup == null)

--- a/provisioning/device/src/Transports/Amqp/ClientWebSocketTransport.cs
+++ b/provisioning/device/src/Transports/Amqp/ClientWebSocketTransport.cs
@@ -92,10 +92,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
             {
                 throw new IOException(httpListenerException.Message, httpListenerException);
             }
-            catch (TaskCanceledException taskCanceledException)
-            {
-                throw new TimeoutException(taskCanceledException.Message, taskCanceledException);
-            }
             finally
             {
                 if (!succeeded)
@@ -147,10 +143,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
             catch (HttpListenerException httpListenerException)
             {
                 throw new IOException(httpListenerException.Message, httpListenerException);
-            }
-            catch (TaskCanceledException taskCanceledException)
-            {
-                throw new TimeoutException(taskCanceledException.Message, taskCanceledException);
             }
             finally
             {

--- a/provisioning/service/src/Contract/ContractApiHttp.cs
+++ b/provisioning/service/src/Contract/ContractApiHttp.cs
@@ -97,9 +97,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="ifMatch">the optional <c>string</c> with the match condition, normally an eTag. It can be <c>null</c>.</param>
         /// <param name="cancellationToken">the task cancellation Token.</param>
         /// <returns>The <see cref="ContractApiResponse"/> with the HTTP response.</returns>
-        /// <exception cref="ProvisioningServiceClientException">if the cancellation was requested.</exception>
+        /// <exception cref="OperationCanceledException">if the cancellation was requested.</exception>
         /// <exception cref="ProvisioningServiceClientTransportException">if there is a error in the HTTP communication
-        ///     between client and service.</exception>
+        /// between client and service.</exception>
         /// <exception cref="ProvisioningServiceClientHttpException">if the service answer the request with error status.</exception>
         public async Task<ContractApiResponse> RequestAsync(
             HttpMethod httpMethod,

--- a/provisioning/service/src/Contract/ContractApiHttp.cs
+++ b/provisioning/service/src/Contract/ContractApiHttp.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                     // Unfortunately TaskCanceledException is thrown when HttpClient times out.
                     if (cancellationToken.IsCancellationRequested)
                     {
-                        throw new OperationCanceledException(ex.Message);
+                        throw new OperationCanceledException(ex.Message, ex);
                     }
 
                     throw new ProvisioningServiceClientTransportException($"The {httpMethod} operation timed out.", ex);

--- a/provisioning/service/src/Contract/ContractApiHttp.cs
+++ b/provisioning/service/src/Contract/ContractApiHttp.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                     // Unfortunately TaskCanceledException is thrown when HttpClient times out.
                     if (cancellationToken.IsCancellationRequested)
                     {
-                        throw new ProvisioningServiceClientException(ex.Message, ex);
+                        throw new OperationCanceledException(ex.Message);
                     }
 
                     throw new ProvisioningServiceClientTransportException($"The {httpMethod} operation timed out.", ex);


### PR DESCRIPTION
+ Pass `cancellationToken` into "RetryOperationsAsync" calls for e2e test ([ref](https://github.com/Azure/azure-iot-sdk-csharp/blob/previews/v2/e2e/test/helpers/RetryOperationHelper.cs))
+ Throw `TaskCanceledException` and `OperationCanceledException` as-is
+ Stop throwing `TimeoutException`