### PR TITLE
Add retry to a flakey step in an e2e test

### DIFF
--- a/e2e/test/helpers/RetryOperationHelper.cs
+++ b/e2e/test/helpers/RetryOperationHelper.cs
@@ -14,6 +14,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
     /// </summary>
     public class RetryOperationHelper
     {
+        // A conservative, basic retry policy that should be fine for most scenarios.
+        public static IRetryPolicy DefaultRetryPolicy = new ExponentialBackoff(
+            retryCount: 5,
+            minBackoff: TimeSpan.FromSeconds(2),
+            maxBackoff: TimeSpan.FromSeconds(10),
+            deltaBackoff: TimeSpan.FromMilliseconds(100));
+
         /// <summary>
         /// Rety an async operation based on the retry strategy supplied.
         /// </summary>

--- a/e2e/test/iothub/service/RegistryE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryE2ETests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         private readonly string _idPrefix = $"{nameof(RegistryE2ETests)}_";
 
         private static readonly IRetryPolicy s_provisioningServiceRetryPolicy = new ProvisioningServiceRetryPolicy();
+        // In particular, this should retry on "module not registered on this device" errors
         private static readonly HashSet<Type> s_retryableExceptions = new HashSet<Type> { typeof(IotHubServiceException) };
 
         [LoggedTestMethod, Timeout(TestTimeoutMilliseconds)]


### PR DESCRIPTION
The first call to get the module often fails with "The device does not have this module registered" because we very recently registered it and the service is slow. Adding retry here so that we call get twin until we don't see an error