### PR TITLE
Update MQTT layer from additional feedback on #2373

### DIFF
--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -312,38 +312,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                 .ConfigureAwait(false);
         }
 
-        [LoggedTestMethod, Timeout(TestTimeoutMilliseconds)]
-        public async Task Twin_ClientHandlesRejectionInvalidPropertyName_Mqtt()
-        {
-            await Twin_ClientHandlesRejectionInvalidPropertyNameAsync(
-                    new IotHubClientMqttSettings())
-                .ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod, Timeout(TestTimeoutMilliseconds)]
-        public async Task Twin_ClientHandlesRejectionInvalidPropertyName_MqttWs()
-        {
-            await Twin_ClientHandlesRejectionInvalidPropertyNameAsync(
-                    new IotHubClientMqttSettings(IotHubClientTransportProtocol.WebSocket))
-                .ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod, Timeout(TestTimeoutMilliseconds)]
-        public async Task Twin_ClientHandlesRejectionInvalidPropertyName_Amqp()
-        {
-            await Twin_ClientHandlesRejectionInvalidPropertyNameAsync(
-                    new IotHubClientAmqpSettings())
-                .ConfigureAwait(false);
-        }
-
-        [LoggedTestMethod, Timeout(TestTimeoutMilliseconds)]
-        public async Task Twin_ClientHandlesRejectionInvalidPropertyName_AmqpWs()
-        {
-            await Twin_ClientHandlesRejectionInvalidPropertyNameAsync(
-                    new IotHubClientAmqpSettings(IotHubClientTransportProtocol.WebSocket))
-                .ConfigureAwait(false);
-        }
-
         [DataTestMethod, Timeout(LongRunningTestTimeoutMilliseconds)]
         [DataRow(IotHubClientTransportProtocol.Tcp)]
         [DataRow(IotHubClientTransportProtocol.WebSocket)]
@@ -623,40 +591,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             Assert.IsTrue(serviceTwin.Properties.Reported.Contains(propName1));
             string value2 = serviceTwin.Properties.Reported[propName1].ToString();
             Assert.AreEqual(value2, propEmptyValue);
-        }
-
-        private async Task Twin_ClientHandlesRejectionInvalidPropertyNameAsync(IotHubClientTransportSettings transportSettings)
-        {
-            string propName1 = "$" + Guid.NewGuid().ToString();
-            string propName2 = Guid.NewGuid().ToString();
-
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(Logger, _devicePrefix).ConfigureAwait(false);
-            using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            var options = new IotHubClientOptions(transportSettings);
-            using var deviceClient = new IotHubDeviceClient(testDevice.ConnectionString, options);
-            await deviceClient.OpenAsync().ConfigureAwait(false);
-
-            bool exceptionThrown = false;
-            try
-            {
-                await deviceClient
-                    .UpdateReportedPropertiesAsync(
-                        new Client.TwinCollection
-                        {
-                            [propName1] = 123,
-                            [propName2] = "abcd",
-                        })
-                    .ConfigureAwait(false);
-            }
-            catch (IotHubClientException)
-            {
-                exceptionThrown = true;
-            }
-
-            Assert.IsTrue(exceptionThrown, "IotHubClientException was expected for updating reported property with an invalid property name, but was not thrown.");
-
-            Twin serviceTwin = await serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
-            Assert.IsFalse(serviceTwin.Properties.Reported.Contains(propName1));
         }
 
         [DataTestMethod, Timeout(LongRunningTestTimeoutMilliseconds)]

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -354,12 +354,12 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (result.ReasonCode != MqttClientPublishReasonCode.Success)
                 {
-                    throw new IotHubClientException($"Failed to publish the MQTT packet for message with correlation Id {message.CorrelationId} with reason code {result.ReasonCode}");
+                    throw new IotHubClientException($"Failed to publish the MQTT packet for message with correlation Id {message.CorrelationId} with reason code {result.ReasonCode}", IotHubStatusCode.NetworkErrors);
                 }
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not InvalidOperationException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to send message.", ex);
+                throw new IotHubClientException("Failed to send message.", IotHubStatusCode.NetworkErrors, ex);
             }
         }
 
@@ -388,7 +388,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to enable receiving direct methods.", ex);
+                throw new IotHubClientException("Failed to enable receiving direct methods.", IotHubStatusCode.NetworkErrors, ex);
             }
         }
 
@@ -400,7 +400,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to disable receiving direct methods.", ex);
+                throw new IotHubClientException("Failed to disable receiving direct methods.", IotHubStatusCode.NetworkErrors, ex);
             }
         }
 
@@ -420,12 +420,12 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (result.ReasonCode != MqttClientPublishReasonCode.Success)
                 {
-                    throw new IotHubClientException($"Failed to send direct method response with reason code {result.ReasonCode}");
+                    throw new IotHubClientException($"Failed to send direct method response with reason code {result.ReasonCode}", IotHubStatusCode.NetworkErrors);
                 }
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to send direct method response.", ex);
+                throw new IotHubClientException("Failed to send direct method response.", IotHubStatusCode.NetworkErrors, ex);
             }
         }
 
@@ -437,7 +437,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to enable receiving messages.", ex);
+                throw new IotHubClientException("Failed to enable receiving messages.", IotHubStatusCode.NetworkErrors, ex);
             }
         }
 
@@ -449,7 +449,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to disable receiving messages.", ex);
+                throw new IotHubClientException("Failed to disable receiving messages.", IotHubStatusCode.NetworkErrors, ex);
             }
         }
 
@@ -468,7 +468,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to enable receiving messages.", ex);
+                throw new IotHubClientException("Failed to enable receiving messages.", IotHubStatusCode.NetworkErrors, ex);
             }
         }
 
@@ -487,7 +487,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to disable receiving messages.", ex);
+                throw new IotHubClientException("Failed to disable receiving messages.", IotHubStatusCode.NetworkErrors, ex);
             }
         }
 
@@ -499,7 +499,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to enable receiving twin patches.", ex);
+                throw new IotHubClientException("Failed to enable receiving twin patches.", IotHubStatusCode.NetworkErrors, ex);
             }
         }
 
@@ -511,7 +511,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to disable receiving twin patches.", ex);
+                throw new IotHubClientException("Failed to disable receiving twin patches.", IotHubStatusCode.NetworkErrors, ex);
             }
         }
 
@@ -541,7 +541,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (result.ReasonCode != MqttClientPublishReasonCode.Success)
                 {
-                    throw new IotHubClientException($"Failed to publish the MQTT packet for getting this client's twin with reason code {result.ReasonCode}");
+                    throw new IotHubClientException($"Failed to publish the MQTT packet for getting this client's twin with reason code {result.ReasonCode}", IotHubStatusCode.NetworkErrors);
                 }
 
                 if (Logging.IsEnabled)
@@ -559,14 +559,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (getTwinResponse.Status != 200)
                 {
-                    throw new IotHubClientException(getTwinResponse.Message);
+                    throw new IotHubClientException(getTwinResponse.Message, IotHubStatusCode.NetworkErrors);
                 }
 
                 return getTwinResponse.Twin;
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to get the twin.", ex);
+                throw new IotHubClientException("Failed to get the twin.", IotHubStatusCode.NetworkErrors, ex);
             }
             finally
             {
@@ -605,7 +605,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (result.ReasonCode != MqttClientPublishReasonCode.Success)
                 {
-                    throw new IotHubClientException($"Failed to publish the MQTT packet for patching this client's twin with reason code {result.ReasonCode}");
+                    throw new IotHubClientException($"Failed to publish the MQTT packet for patching this client's twin with reason code {result.ReasonCode}", IotHubStatusCode.NetworkErrors);
                 }
 
                 if (Logging.IsEnabled)
@@ -623,14 +623,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (patchTwinResponse.Status != 204)
                 {
-                    throw new IotHubClientException(patchTwinResponse.Message);
+                    throw new IotHubClientException(patchTwinResponse.Message, IotHubStatusCode.NetworkErrors);
                 }
 
                 return patchTwinResponse.Version;
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to send twin patch.", ex);
+                throw new IotHubClientException("Failed to send twin patch.", IotHubStatusCode.NetworkErrors, ex);
             }
             finally
             {
@@ -688,14 +688,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             if (subscribeResults?.Items == null)
             {
-                throw new IotHubClientException($"Failed to subscribe to topic {fullTopic}");
+                throw new IotHubClientException($"Failed to subscribe to topic {fullTopic}", IotHubStatusCode.NetworkErrors);
             }
 
             MqttClientSubscribeResultItem subscribeResult = subscribeResults.Items.FirstOrDefault();
 
             if (!subscribeResult.TopicFilter.Topic.Equals(fullTopic))
             {
-                throw new IotHubClientException($"Received unexpected subscription to topic {subscribeResult.TopicFilter.Topic}");
+                throw new IotHubClientException($"Received unexpected subscription to topic {subscribeResult.TopicFilter.Topic}", IotHubStatusCode.NetworkErrors);
             }
         }
 
@@ -711,18 +711,18 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             if (unsubscribeResults?.Items == null || unsubscribeResults.Items.Count != 1)
             {
-                throw new IotHubClientException($"Failed to unsubscribe to topic {fullTopic}");
+                throw new IotHubClientException($"Failed to unsubscribe to topic {fullTopic}", IotHubStatusCode.NetworkErrors);
             }
 
             MqttClientUnsubscribeResultItem unsubscribeResult = unsubscribeResults.Items.FirstOrDefault();
             if (!unsubscribeResult.TopicFilter.Equals(fullTopic))
             {
-                throw new IotHubClientException($"Received unexpected unsubscription from topic {unsubscribeResult.TopicFilter}");
+                throw new IotHubClientException($"Received unexpected unsubscription from topic {unsubscribeResult.TopicFilter}", IotHubStatusCode.NetworkErrors);
             }
 
             if (unsubscribeResult.ResultCode != MqttClientUnsubscribeResultCode.Success)
             {
-                throw new IotHubClientException($"Failed to unsubscribe from topic {fullTopic} with reason {unsubscribeResult.ResultCode}");
+                throw new IotHubClientException($"Failed to unsubscribe from topic {fullTopic} with reason {unsubscribeResult.ResultCode}", IotHubStatusCode.NetworkErrors);
             }
         }
 

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
     internal sealed class MqttTransportHandler : TransportHandler, IDisposable
     {
         private const int ProtocolGatewayPort = 8883;
-        private const int MaxMessageSize = 256 * 1024;
-        private const int MaxTopicNameLength = 65535;
 
         private const string DeviceToCloudMessagesTopicFormat = "devices/{0}/messages/events/";
         private const string ModuleToCloudMessagesTopicFormat = "devices/{0}/modules/{1}/messages/events/";
@@ -250,9 +248,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 }
             }
 
-            _mqttClient.ApplicationMessageReceivedAsync += HandleReceivedMessageAsync;
-            _mqttClient.DisconnectedAsync += HandleDisconnectionAsync;
-
             _publishingQualityOfService = _mqttTransportSettings.PublishToServerQoS == QualityOfService.AtLeastOnce
                 ? MqttQualityOfServiceLevel.AtLeastOnce : MqttQualityOfServiceLevel.AtMostOnce;
 
@@ -349,11 +344,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 string baseTopicName = _moduleId == null ? _deviceToCloudMessagesTopic : _moduleToCloudMessagesTopic;
                 string topicName = PopulateMessagePropertiesFromMessage(baseTopicName, message);
 
-                if (message.HasPayload && message.Payload.Length > MaxMessageSize)
-                {
-                    throw new InvalidOperationException($"Message size ({message.Payload.Length} bytes) is too big to process. Maximum allowed payload size is {MaxMessageSize}");
-                }
-
                 MqttApplicationMessage mqttMessage = new MqttApplicationMessageBuilder()
                     .WithTopic(topicName)
                     .WithPayload(message.Payload)
@@ -364,12 +354,12 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (result.ReasonCode != MqttClientPublishReasonCode.Success)
                 {
-                    throw new IotHubClientException($"Failed to publish the MQTT packet for message with correlation Id {message.CorrelationId} with reason code {result.ReasonCode}", true);
+                    throw new IotHubClientException($"Failed to publish the MQTT packet for message with correlation Id {message.CorrelationId} with reason code {result.ReasonCode}");
                 }
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not InvalidOperationException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to send message.", true, ex);
+                throw new IotHubClientException("Failed to send message.", ex);
             }
         }
 
@@ -398,7 +388,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to enable receiving direct methods.", true, ex);
+                throw new IotHubClientException("Failed to enable receiving direct methods.", ex);
             }
         }
 
@@ -410,7 +400,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to disable receiving direct methods.", true, ex);
+                throw new IotHubClientException("Failed to disable receiving direct methods.", ex);
             }
         }
 
@@ -430,12 +420,12 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (result.ReasonCode != MqttClientPublishReasonCode.Success)
                 {
-                    throw new IotHubClientException($"Failed to send direct method response with reason code {result.ReasonCode}", true);
+                    throw new IotHubClientException($"Failed to send direct method response with reason code {result.ReasonCode}");
                 }
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to send direct method response.", true, ex);
+                throw new IotHubClientException("Failed to send direct method response.", ex);
             }
         }
 
@@ -447,7 +437,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to enable receiving messages.", true, ex);
+                throw new IotHubClientException("Failed to enable receiving messages.", ex);
             }
         }
 
@@ -459,7 +449,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to disable receiving messages.", true, ex);
+                throw new IotHubClientException("Failed to disable receiving messages.", ex);
             }
         }
 
@@ -478,7 +468,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to enable receiving messages.", true, ex);
+                throw new IotHubClientException("Failed to enable receiving messages.", ex);
             }
         }
 
@@ -497,7 +487,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to disable receiving messages.", true, ex);
+                throw new IotHubClientException("Failed to disable receiving messages.", ex);
             }
         }
 
@@ -509,7 +499,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to enable receiving twin patches.", true, ex);
+                throw new IotHubClientException("Failed to enable receiving twin patches.", ex);
             }
         }
 
@@ -521,7 +511,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to disable receiving twin patches.", true, ex);
+                throw new IotHubClientException("Failed to disable receiving twin patches.", ex);
             }
         }
 
@@ -551,7 +541,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (result.ReasonCode != MqttClientPublishReasonCode.Success)
                 {
-                    throw new IotHubClientException($"Failed to publish the MQTT packet for getting this client's twin with reason code {result.ReasonCode}", true);
+                    throw new IotHubClientException($"Failed to publish the MQTT packet for getting this client's twin with reason code {result.ReasonCode}");
                 }
 
                 if (Logging.IsEnabled)
@@ -576,7 +566,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to get the twin.", true, ex);
+                throw new IotHubClientException("Failed to get the twin.", ex);
             }
             finally
             {
@@ -615,7 +605,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (result.ReasonCode != MqttClientPublishReasonCode.Success)
                 {
-                    throw new IotHubClientException($"Failed to publish the MQTT packet for patching this client's twin with reason code {result.ReasonCode}", true);
+                    throw new IotHubClientException($"Failed to publish the MQTT packet for patching this client's twin with reason code {result.ReasonCode}");
                 }
 
                 if (Logging.IsEnabled)
@@ -640,7 +630,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
             catch (Exception ex) when (ex is not IotHubClientException && ex is not OperationCanceledException)
             {
-                throw new IotHubClientException("Failed to send twin patch.", true, ex);
+                throw new IotHubClientException("Failed to send twin patch.", ex);
             }
             finally
             {
@@ -698,14 +688,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             if (subscribeResults?.Items == null)
             {
-                throw new IotHubClientException($"Failed to subscribe to topic {fullTopic}", true);
+                throw new IotHubClientException($"Failed to subscribe to topic {fullTopic}");
             }
 
             MqttClientSubscribeResultItem subscribeResult = subscribeResults.Items.FirstOrDefault();
 
             if (!subscribeResult.TopicFilter.Topic.Equals(fullTopic))
             {
-                throw new IotHubClientException($"Received unexpected subscription to topic {subscribeResult.TopicFilter.Topic}", true);
+                throw new IotHubClientException($"Received unexpected subscription to topic {subscribeResult.TopicFilter.Topic}");
             }
         }
 
@@ -721,18 +711,18 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             if (unsubscribeResults?.Items == null || unsubscribeResults.Items.Count != 1)
             {
-                throw new IotHubClientException($"Failed to unsubscribe to topic {fullTopic}", true);
+                throw new IotHubClientException($"Failed to unsubscribe to topic {fullTopic}");
             }
 
             MqttClientUnsubscribeResultItem unsubscribeResult = unsubscribeResults.Items.FirstOrDefault();
             if (!unsubscribeResult.TopicFilter.Equals(fullTopic))
             {
-                throw new IotHubClientException($"Received unexpected unsubscription from topic {unsubscribeResult.TopicFilter}", true);
+                throw new IotHubClientException($"Received unexpected unsubscription from topic {unsubscribeResult.TopicFilter}");
             }
 
             if (unsubscribeResult.ResultCode != MqttClientUnsubscribeResultCode.Success)
             {
-                throw new IotHubClientException($"Failed to unsubscribe from topic {fullTopic} with reason {unsubscribeResult.ResultCode}", true);
+                throw new IotHubClientException($"Failed to unsubscribe from topic {fullTopic} with reason {unsubscribeResult.ResultCode}");
             }
         }
 
@@ -1022,13 +1012,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             if (!topicName.EndsWith("/", StringComparison.Ordinal))
             {
                 msg += "/";
-            }
-
-            if (Encoding.UTF8.GetByteCount(msg) > MaxTopicNameLength)
-            {
-                throw new IotHubClientException($"TopicName for MQTT packet cannot be larger than {MaxTopicNameLength} bytes, " +
-                    $"current length is {Encoding.UTF8.GetByteCount(msg)}." +
-                    $" The probable cause is the list of message.Properties and/or message.systemProperties is too long.", false, IotHubStatusCode.MessageTooLarge);
             }
 
             return msg;

--- a/iothub/device/src/TransportSettings/IotHubClientMqttSettings.cs
+++ b/iothub/device/src/TransportSettings/IotHubClientMqttSettings.cs
@@ -56,16 +56,20 @@ namespace Microsoft.Azure.Devices.Client
         public bool CleanSession { get; set; }
 
         /// <summary>
-        /// The interval, in seconds, that the client establishes with the service, for sending protocol-level keep-alive pings.
-        /// The default is 300 seconds.
+        /// Specify client-side heartbeat interval.
+        /// The interval, that the client establishes with the service, for sending keep alive pings.
         /// </summary>
         /// <remarks>
-        /// The client will send a ping request 4 times per keep-alive duration set.
-        /// It will wait for 30 seconds for the ping response, else mark the connection as disconnected.
-        /// Setting a very low keep-alive value can cause aggressive reconnects, and might not give the
+        /// <para>
+        /// The default value is 2 minutes.
+        /// </para>
+        /// <para>
+        /// The client will consider the connection as disconnected if the keep alive ping fails.
+        /// Setting a very low idle timeout value can cause aggressive reconnects, and might not give the
         /// client enough time to establish a connection before disconnecting and reconnecting.
+        /// </para>
         /// </remarks>
-        public TimeSpan IdleTimeout { get; set; }
+        public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromMinutes(2);
 
         /// <summary>
         /// A keep-alive for the transport layer in sending ping/pong control frames when using web sockets.


### PR DESCRIPTION
- Let exceptions be marked as non-transient if we don't know for sure if they are or not
- Remove client side validation of MQTT topic string length and message size
- Update MQTT keep alive time to match AMQP, remove note about a ping being sent every 1/4 of keep alive time
- Add an IotHubStatusCode to errors with our best guess as to what happened in cases like these ([context](https://github.com/Azure/azure-iot-sdk-csharp/pull/2739#discussion_r979074575))