### PR TITLE
Remove userContext as a callback param

### DIFF
--- a/e2e/test/helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/helpers/TestDeviceCallbackHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         {
             await _deviceClient.OpenAsync().ConfigureAwait(false);
             await _deviceClient.SetMethodHandlerAsync(
-                (request, context) =>
+                (request) =>
                 {
                     try
                     {
@@ -80,8 +80,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                         // Always notify that we got the callback.
                         _methodCallbackSemaphore.Release();
                     }
-                },
-                null).ConfigureAwait(false);
+                }).ConfigureAwait(false);
         }
 
         public async Task WaitForMethodCallbackAsync(CancellationToken ct)
@@ -92,13 +91,11 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
         public async Task SetTwinPropertyUpdateCallbackHandlerAsync(string expectedPropName)
         {
-            string userContext = "myContext";
-
             await _deviceClient.OpenAsync().ConfigureAwait(false);
             await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(
-                (patch, context) =>
+                (patch) =>
                 {
-                    _logger.Trace($"{nameof(SetTwinPropertyUpdateCallbackHandlerAsync)}: DeviceClient {_testDevice.Id} callback twin: DesiredProperty: {patch}, {context}");
+                    _logger.Trace($"{nameof(SetTwinPropertyUpdateCallbackHandlerAsync)}: DeviceClient {_testDevice.Id} callback twin: DesiredProperty: {patch}");
 
                     try
                     {
@@ -107,7 +104,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
                         string propertyValue = patch[expectedPropName];
                         propertyValue.Should().Be(ExpectedTwinPropertyValue, "The property value should match what was set by service");
-                        context.Should().Be(userContext, "The context should match what was set by service");
                     }
                     catch (Exception ex)
                     {
@@ -120,7 +116,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                     }
 
                     return Task.FromResult<bool>(true);
-                }, userContext).ConfigureAwait(false);
+                }).ConfigureAwait(false);
         }
 
         public async Task WaitForTwinCallbackAsync(CancellationToken ct)
@@ -132,16 +128,16 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         public async Task SetMessageReceiveCallbackHandlerAsync()
         {
             await _deviceClient.OpenAsync().ConfigureAwait(false);
-            await _deviceClient.SetReceiveMessageHandlerAsync(OnC2dMessageReceivedAsync, null).ConfigureAwait(false);
+            await _deviceClient.SetReceiveMessageHandlerAsync(OnC2dMessageReceivedAsync).ConfigureAwait(false);
         }
 
         public async Task UnsetMessageReceiveCallbackHandlerAsync()
         {
             await _deviceClient.OpenAsync().ConfigureAwait(false);
-            await _deviceClient.SetReceiveMessageHandlerAsync(null, null).ConfigureAwait(false);
+            await _deviceClient.SetReceiveMessageHandlerAsync(null).ConfigureAwait(false);
         }
 
-        private Task<MessageAcknowledgement> OnC2dMessageReceivedAsync(Client.Message message, object context)
+        private Task<MessageAcknowledgement> OnC2dMessageReceivedAsync(Client.Message message)
         {
             _logger.Trace($"{nameof(SetMessageReceiveCallbackHandlerAsync)}: DeviceClient {_testDevice.Id} received message with Id: {message.MessageId}.");
 

--- a/e2e/test/helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/helpers/TestDeviceCallbackHandler.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             set => Volatile.Write(ref _expectedMessageSentByService, value);
         }
 
-        public async Task SetDeviceReceiveMethodAsync(string methodName, object deviceResponseJson, object expectedServiceRequestJson)
+        public async Task SetDeviceReceiveMethodAsync<T>(string methodName, object deviceResponseJson, T expectedServiceRequestJson)
         {
             await _deviceClient.OpenAsync().ConfigureAwait(false);
             await _deviceClient.SetMethodHandlerAsync(
@@ -57,7 +57,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                     {
                         _logger.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: DeviceClient {_testDevice.Id} callback method: {request.MethodName} with timeout {request.ResponseTimeout}.");
                         request.MethodName.Should().Be(methodName, "The expected method name should match what was sent from service");
-                        request.Payload.Should().Be(expectedServiceRequestJson, "The expected method data should match what was sent from service");
+                        request.TryGetPayload(out T actualRequestPayload).Should().BeTrue();
+                        actualRequestPayload.Should().BeEquivalentTo(expectedServiceRequestJson, "The expected method data should match what was sent from service");
 
                         var response = new Client.DirectMethodResponse(200)
                         {

--- a/e2e/test/iothub/NoRetryE2ETests.cs
+++ b/e2e/test/iothub/NoRetryE2ETests.cs
@@ -115,16 +115,14 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             await deviceClient1
                 .SetMethodHandlerAsync(
-                    (methodRequest, userContext) => Task.FromResult(response),
-                    deviceClient1)
+                    (methodRequest) => Task.FromResult(response))
                 .ConfigureAwait(false);
 
             Logger.Trace($"{nameof(DuplicateDevice_NoRetry_NoPingpong_OpenAsync)}: device client instance 2 calling OpenAsync...");
             await deviceClient2.OpenAsync().ConfigureAwait(false);
             await deviceClient2
                 .SetMethodHandlerAsync(
-                    (methodRequest, userContext) => Task.FromResult(response),
-                    deviceClient2)
+                    (methodRequest) => Task.FromResult(response))
                 .ConfigureAwait(false);
 
             Logger.Trace($"{nameof(DuplicateDevice_NoRetry_NoPingpong_OpenAsync)}: waiting device client instance 1 to be kicked off...");

--- a/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
@@ -109,12 +109,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
                 using var cts = new CancellationTokenSource(s_oneMinute);
                 var c2dMessageReceived = new TaskCompletionSource<Client.Message>(TaskCreationOptions.RunContinuationsAsynchronously);
-                Func<Client.Message, object, Task<MessageAcknowledgement>> OnC2DMessageReceived = (message, context) =>
+                Func<Client.Message, Task<MessageAcknowledgement>> OnC2DMessageReceived = (message) =>
                 {
                     c2dMessageReceived.TrySetResult(message);
                     return Task.FromResult(MessageAcknowledgement.Complete);
                 };
-                await dc.SetReceiveMessageHandlerAsync(OnC2DMessageReceived, null).ConfigureAwait(false);
+                await dc.SetReceiveMessageHandlerAsync(OnC2DMessageReceived).ConfigureAwait(false);
 
                 Client.Message receivedMessage = await TaskCompletionSourceHelper.GetTaskCompletionSourceResultAsync(c2dMessageReceived, cts.Token).ConfigureAwait(false);
 
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             // This will make the client unsubscribe from the mqtt c2d topic/close the amqp c2d link. Neither event
             // should close the connection as a whole, though.
-            await deviceClient.SetReceiveMessageHandlerAsync(null, null).ConfigureAwait(false);
+            await deviceClient.SetReceiveMessageHandlerAsync(null).ConfigureAwait(false);
 
             await Task.Delay(1000).ConfigureAwait(false);
 

--- a/e2e/test/iothub/method/MethodE2ECustomPayloadTests.cs
+++ b/e2e/test/iothub/method/MethodE2ECustomPayloadTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
                 .SetMethodHandlerAsync(
-                    (request, context) =>
+                    (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_booleanPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
 
@@ -178,8 +178,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                         };
 
                         return Task.FromResult(response);
-                    },
-                    null)
+                    })
                 .ConfigureAwait(false);
 
             // Return the task that tells us we have received the callback.
@@ -192,7 +191,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
                 .SetMethodHandlerAsync(
-                    (request, context) =>
+                    (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_customPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
 
@@ -215,8 +214,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                         };
 
                         return Task.FromResult(response);
-                    },
-                    null)
+                    })
                 .ConfigureAwait(false);
 
             // Return the task that tells us we have received the callback.
@@ -229,7 +227,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
                 .SetMethodHandlerAsync(
-                    (request, context) =>
+                    (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_listPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
 
@@ -252,8 +250,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                         };
 
                         return Task.FromResult(response);
-                    },
-                    null)
+                    })
                 .ConfigureAwait(false);
 
             // Return the task that tells us we have received the callback.
@@ -266,7 +263,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
                 .SetMethodHandlerAsync(
-                    (request, context) =>
+                    (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_dictionaryPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
 
@@ -289,8 +286,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                         };
 
                         return Task.FromResult(response);
-                    },
-                    null)
+                    })
                 .ConfigureAwait(false);
 
             // Return the task that tells us we have received the callback.
@@ -303,7 +299,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
                 .SetMethodHandlerAsync(
-                    (request, context) =>
+                    (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_arrayPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
 
@@ -326,8 +322,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                         };
 
                         return Task.FromResult(response);
-                    },
-                    null)
+                    })
                 .ConfigureAwait(false);
 
             // Return the task that tells us we have received the callback.

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -525,13 +525,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
 
         internal class DeviceResponsePayload
         {
-            [JsonPropertyName("currentState")]
+            [JsonProperty(PropertyName = "currentState")]
             public string CurrentState { get; set; }
         }
 
         internal class ServiceRequestPayload
         {
-            [JsonPropertyName("desiredState")]
+            [JsonProperty(PropertyName = "desiredState")]
             public string DesiredState { get; set; }
         }
     }

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -207,15 +207,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                 await deviceClient.OpenAsync().ConfigureAwait(false);
                 await deviceClient
                     .SetMethodHandlerAsync(
-                        (methodRequest, userContext) =>
+                        (methodRequest) =>
                         {
                             methodRequest.MethodName.Should().Be(commandName);
                             deviceMethodCalledSuccessfully = true;
                             var response = new Client.DirectMethodResponse(200);
 
                             return Task.FromResult(response);
-                        },
-                        null)
+                        })
                     .ConfigureAwait(false);
 
                 using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
@@ -240,7 +239,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             {
                 // clean up
 
-                await deviceClient.SetMethodHandlerAsync(null, null).ConfigureAwait(false);
+                await deviceClient.SetMethodHandlerAsync(null).ConfigureAwait(false);
                 await deviceClient.CloseAsync().ConfigureAwait(false);
                 await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
             }
@@ -343,7 +342,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
                 .SetMethodHandlerAsync(
-                (request, context) =>
+                (request) =>
                 {
                     // This test only verifies that unsubscripion works.
                     // For this reason, the direct method subscription callback does not implement any method-specific dispatcher.
@@ -354,11 +353,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     };
 
                         return Task.FromResult(response);
-                    },
-                    null)
+                    })
                 .ConfigureAwait(false);
 
-            await deviceClient.SetMethodHandlerAsync(null, null).ConfigureAwait(false);
+            await deviceClient.SetMethodHandlerAsync(null).ConfigureAwait(false);
 
             // Return the task that tells us we have received the callback.
             return methodCallReceived.Task;
@@ -370,7 +368,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
                 .SetMethodHandlerAsync(
-                    (request, context) =>
+                    (request) =>
                         {
                             logger.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
 
@@ -397,8 +395,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                             {
                                 methodCallReceived.TrySetResult(true);
                             }
-                        },
-                    null)
+                        })
                 .ConfigureAwait(false);
 
             // Return the task that tells us we have received the callback.
@@ -410,7 +407,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             await moduleClient.OpenAsync().ConfigureAwait(false);
             await moduleClient.SetMethodHandlerAsync(
-                (request, context) =>
+                (request) =>
                 {
                     logger.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: ModuleClient method: {request.MethodName} {request.ResponseTimeout}.");
 
@@ -438,8 +435,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     {
                         methodCallReceived.TrySetResult(true);
                     }
-                },
-                null).ConfigureAwait(false);
+                }).ConfigureAwait(false);
 
             // Return the task that tells us we have received the callback.
             return methodCallReceived.Task;

--- a/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
+++ b/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
@@ -57,11 +57,11 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 response.ETag.Should().NotBeNull();
 
                 // Set callback handler for receiving root-level twin property updates.
-                await deviceClient.SetDesiredPropertyUpdateCallbackAsync((patch, context) =>
+                await deviceClient.SetDesiredPropertyUpdateCallbackAsync((patch) =>
                 {
-                    Logger.Trace($"{nameof(DigitalTwinWithComponentOperationsAsync)}: DesiredProperty update received: {patch}, {context}");
+                    Logger.Trace($"{nameof(DigitalTwinWithComponentOperationsAsync)}: DesiredProperty update received: {patch}.");
                     return Task.FromResult(true);
-                }, deviceClient);
+                });
 
                 // Update the root-level property "targetTemperature".
                 string propertyName = "targetTemperature";
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 int expectedCommandStatus = 200;
                 string commandName = "getMaxMinReport";
                 await deviceClient.SetMethodHandlerAsync(
-                    (request, context) =>
+                    (request) =>
                     {
                         Logger.Trace($"{nameof(DigitalTwinWithOnlyRootComponentOperationsAsync)}: Digital twin command received: {request.MethodName}.");
                         var response = new Client.DirectMethodResponse(404);
@@ -87,8 +87,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                         }
 
                         return Task.FromResult(response);
-                    },
-                    null);
+                    });
 
                 // Invoke the root-level command "getMaxMinReport" on the digital twin.
                 DateTimeOffset since = DateTimeOffset.Now.Subtract(TimeSpan.FromMinutes(1));
@@ -143,11 +142,11 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 string componentName = "thermostat1";
 
                 // Set callback handler for receiving twin property updates.
-                await deviceClient.SetDesiredPropertyUpdateCallbackAsync((patch, context) =>
+                await deviceClient.SetDesiredPropertyUpdateCallbackAsync((patch) =>
                 {
-                    Logger.Trace($"{nameof(DigitalTwinWithComponentOperationsAsync)}: DesiredProperty update received: {patch}, {context}");
+                    Logger.Trace($"{nameof(DigitalTwinWithComponentOperationsAsync)}: DesiredProperty update received: {patch}.");
                     return Task.FromResult(true);
-                }, deviceClient);
+                });
 
                 // Update the property "targetTemperature" under component "thermostat1" on the digital twin.
                 // NOTE: since this is the first operation on the digital twin, the component "thermostat1" doesn't exist on it yet.
@@ -173,7 +172,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 string componentCommandName = "getMaxMinReport";
                 string componentCommandNamePnp = $"{componentName}*{componentCommandName}";
                 await deviceClient.SetMethodHandlerAsync(
-                    (request, context) =>
+                    (request) =>
                     {
                         Logger.Trace($"{nameof(DigitalTwinWithOnlyRootComponentOperationsAsync)}: Digital twin command received: {request.MethodName}.");
                         var response = new Client.DirectMethodResponse(404);
@@ -186,8 +185,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                         }
 
                         return Task.FromResult(response);
-                    },
-                    null);
+                    });
 
                 // Invoke the root-level command "reboot" on the digital twin.
                 int delay = 1;

--- a/e2e/test/iothub/service/MessageFeedbackReceiverE2ETest.cs
+++ b/e2e/test/iothub/service/MessageFeedbackReceiverE2ETest.cs
@@ -65,12 +65,12 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 await deviceClient.OpenAsync().ConfigureAwait(false);
 
                 var c2dMessageReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                Func<Client.Message, object, Task<MessageAcknowledgement>> OnC2DMessageReceived = (message, context) =>
+                Func<Client.Message, Task<MessageAcknowledgement>> OnC2DMessageReceived = (message) =>
                 {
                     c2dMessageReceived.TrySetResult(true);
                     return Task.FromResult(MessageAcknowledgement.Complete);
                 };
-                await deviceClient.SetReceiveMessageHandlerAsync(OnC2DMessageReceived, null).ConfigureAwait(false);
+                await deviceClient.SetReceiveMessageHandlerAsync(OnC2DMessageReceived).ConfigureAwait(false);
 
                 await Task
                     .WhenAny(

--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -390,19 +390,17 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
         public static async Task<Task> SetTwinPropertyUpdateCallbackHandlerAsync(IotHubDeviceClient deviceClient, string expectedPropName, object expectedPropValue, MsTestLogger logger)
         {
             var propertyUpdateReceived = new TaskCompletionSource<bool>();
-            string userContext = "myContext";
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
                 .SetDesiredPropertyUpdateCallbackAsync(
-                    (patch, context) =>
+                    (patch) =>
                     {
-                        logger.Trace($"{nameof(SetTwinPropertyUpdateCallbackHandlerAsync)}: DesiredProperty: {patch}, {context}");
+                        logger.Trace($"{nameof(SetTwinPropertyUpdateCallbackHandlerAsync)}: DesiredProperty: {patch}.");
 
                         try
                         {
                             Assert.AreEqual(JsonConvert.SerializeObject(expectedPropValue), JsonConvert.SerializeObject(patch[expectedPropName]));
-                            Assert.AreEqual(userContext, context, "Context");
                         }
                         catch (Exception e)
                         {
@@ -414,8 +412,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                         }
 
                         return Task.FromResult<bool>(true);
-                    },
-                    userContext)
+                    })
                 .ConfigureAwait(false);
 
             return propertyUpdateReceived.Task;
@@ -443,21 +440,20 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             // Set a callback
             await deviceClient.
                 SetDesiredPropertyUpdateCallbackAsync(
-                    (patch, context) =>
+                    (patch) =>
                     {
-                        Logger.Trace($"{nameof(SetTwinPropertyUpdateCallbackHandlerAsync)}: DesiredProperty: {patch}, {context}");
+                        Logger.Trace($"{nameof(SetTwinPropertyUpdateCallbackHandlerAsync)}: DesiredProperty: {patch}.");
 
                         // After unsubscribing it should never reach here
                         Assert.IsNull(patch);
 
                         return Task.FromResult<bool>(true);
-                    },
-                    null)
+                    })
                 .ConfigureAwait(false);
 
             // Unsubscribe
             await deviceClient
-                .SetDesiredPropertyUpdateCallbackAsync(null, null)
+                .SetDesiredPropertyUpdateCallbackAsync(null)
                 .ConfigureAwait(false);
 
             await RegistryManagerUpdateDesiredPropertyAsync(testDevice.Id, propName, propValue)
@@ -495,7 +491,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             dynamic actualProp = completeTwin.Properties.Desired[propName];
             Assert.AreEqual(JsonConvert.SerializeObject(actualProp), JsonConvert.SerializeObject(propValue));
 
-            await deviceClient.SetDesiredPropertyUpdateCallbackAsync(null, null).ConfigureAwait(false);
+            await deviceClient.SetDesiredPropertyUpdateCallbackAsync(null).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);
         }
 

--- a/iothub/device/samples/getting started/MessageReceiveSample/MessageReceiveSample.cs
+++ b/iothub/device/samples/getting started/MessageReceiveSample/MessageReceiveSample.cs
@@ -17,12 +17,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
     {
         private readonly TimeSpan? _maxRunTime;
         private readonly IotHubDeviceClient _deviceClient;
-        private readonly Transport _transport;
 
-        public MessageReceiveSample(IotHubDeviceClient deviceClient, Transport transportType, TimeSpan? maxRunTime)
+        public MessageReceiveSample(IotHubDeviceClient deviceClient, TimeSpan? maxRunTime)
         {
             _deviceClient = deviceClient ?? throw new ArgumentNullException(nameof(deviceClient));
-            _transport = transportType;
             _maxRunTime = maxRunTime;
         }
 
@@ -40,7 +38,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             Console.WriteLine($"{DateTime.Now}> Press Control+C at any time to quit the sample.");
 
             // Now subscribe to receive C2D messages through a callback (which isn't supported over HTTP).
-            await _deviceClient.SetReceiveMessageHandlerAsync(OnC2dMessageReceivedAsync, _deviceClient);
+            await _deviceClient.SetReceiveMessageHandlerAsync(OnC2dMessageReceivedAsync);
             Console.WriteLine($"\n{DateTime.Now}> Subscribed to receive C2D messages over callback.");
 
             // Now wait to receive C2D messages through the callback.
@@ -58,10 +56,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
 
             // Now unsubscibe from receiving the callback.
-            await _deviceClient.SetReceiveMessageHandlerAsync(null, null);
+            await _deviceClient.SetReceiveMessageHandlerAsync(null);
         }
 
-        private Task<MessageAcknowledgement> OnC2dMessageReceivedAsync(Message receivedMessage, object _)
+        private Task<MessageAcknowledgement> OnC2dMessageReceivedAsync(Message receivedMessage)
         {
             Console.WriteLine($"{DateTime.Now}> C2D message callback - message received with Id={receivedMessage.MessageId}.");
             PrintMessage(receivedMessage);

--- a/iothub/device/samples/getting started/MessageReceiveSample/Program.cs
+++ b/iothub/device/samples/getting started/MessageReceiveSample/Program.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             using var deviceClient = new IotHubDeviceClient(
                 parameters.PrimaryConnectionString,
                 options);
-            var sample = new MessageReceiveSample(deviceClient, parameters.Transport, appRunTime);
+            var sample = new MessageReceiveSample(deviceClient, appRunTime);
             await sample.RunSampleAsync();
             await deviceClient.CloseAsync();
 

--- a/iothub/device/samples/getting started/MethodSample/MethodSample.cs
+++ b/iothub/device/samples/getting started/MethodSample/MethodSample.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Text;
-using System.Threading.Tasks;
-using System.Text.Json.Serialization;
-using System.Text.Json;
-using System.Threading;
 using System.Diagnostics;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Devices.Client.Samples
 {
@@ -42,7 +41,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
             // Setup a callback dispatcher for the incoming methods.
             await _deviceClient.SetMethodHandlerAsync(
                 OnDirectMethodCalledAsync,
-                null,
                 cts.Token);
 
             var timer = Stopwatch.StartNew();
@@ -57,19 +55,18 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
             // You can unsubscribe from receiving a callback for direct methods by setting a null callback handler.
             await _deviceClient.SetMethodHandlerAsync(
-                null,
                 null);
         }
 
-        private async Task<DirectMethodResponse> OnDirectMethodCalledAsync(DirectMethodRequest directMethodRequest, object userContext)
+        private async Task<DirectMethodResponse> OnDirectMethodCalledAsync(DirectMethodRequest directMethodRequest)
         {
             switch (directMethodRequest.MethodName)
             {
                 case "GetDeviceName":
-                    return await GetDeviceNameAsync(directMethodRequest, userContext);
+                    return await GetDeviceNameAsync(directMethodRequest);
 
                 case "WriteToConsole":
-                    return await WriteToConsoleAsync(directMethodRequest, userContext);
+                    return await WriteToConsoleAsync(directMethodRequest);
 
                 default:
                     return new DirectMethodResponse(400);
@@ -82,7 +79,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             Console.WriteLine($"Connection status changed reason is {connectionInfo.ChangeReason}.\n");
         }
 
-        private Task<DirectMethodResponse> WriteToConsoleAsync(DirectMethodRequest directMethodRequest, object userContext)
+        private Task<DirectMethodResponse> WriteToConsoleAsync(DirectMethodRequest directMethodRequest)
         {
             Console.WriteLine($"\t *** {directMethodRequest.MethodName} was called.");
             Console.WriteLine($"\t{directMethodRequest.PayloadAsJsonString}\n");
@@ -92,7 +89,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             return Task.FromResult(directMethodResponse);
         }
 
-        private Task<DirectMethodResponse> GetDeviceNameAsync(DirectMethodRequest directMethodRequest, object userContext)
+        private Task<DirectMethodResponse> GetDeviceNameAsync(DirectMethodRequest directMethodRequest)
         {
             Console.WriteLine($"\t *** {directMethodRequest.MethodName} was called.");
 

--- a/iothub/device/samples/getting started/TwinSample/TwinSample.cs
+++ b/iothub/device/samples/getting started/TwinSample/TwinSample.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 Console.WriteLine("Cancellation requested; will exit.");
             };
 
-            await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(OnDesiredPropertyChangedAsync, null);
+            await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(OnDesiredPropertyChangedAsync);
 
             Console.WriteLine("Retrieving twin...");
             Twin twin = await _deviceClient.GetTwinAsync();
@@ -54,10 +54,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
 
             // This is how one can unsubscribe a callback for properties using a null callback handler.
-            await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(null, null);
+            await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(null);
         }
 
-        private async Task OnDesiredPropertyChangedAsync(TwinCollection desiredProperties, object userContext)
+        private async Task OnDesiredPropertyChangedAsync(TwinCollection desiredProperties)
         {
             var reportedProperties = new TwinCollection();
 

--- a/iothub/device/samples/how to guides/DeviceReconnectionSample/DeviceReconnectionSample.cs
+++ b/iothub/device/samples/how to guides/DeviceReconnectionSample/DeviceReconnectionSample.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
                         s_deviceClient = new IotHubDeviceClient(_deviceConnectionStrings.First(), _clientOptions);
                         s_deviceClient.SetConnectionStatusChangeHandler(ConnectionStatusChangeHandlerAsync);
-                        await s_deviceClient.SetReceiveMessageHandlerAsync(OnMessageReceivedAsync, null, cancellationToken);
+                        await s_deviceClient.SetReceiveMessageHandlerAsync(OnMessageReceivedAsync, cancellationToken);
                         _logger.LogDebug("Initialized the client instance.");
                     }
                 }
@@ -276,7 +276,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                         if (serverDesiredPropertyVersion > s_localDesiredPropertyVersion)
                         {
                             _logger.LogDebug($"The desired property version cached on local is changing from {s_localDesiredPropertyVersion} to {serverDesiredPropertyVersion}.");
-                            await HandleTwinUpdateNotificationsAsync(twinCollection, cancellationToken);
+                            await HandleTwinUpdateNotificationsAsync(twinCollection);
                         }
                     },
                     shouldExecuteOperation: () => IsDeviceConnected,
@@ -290,9 +290,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
         }
 
-        private async Task HandleTwinUpdateNotificationsAsync(TwinCollection twinUpdateRequest, object userContext)
+        private async Task HandleTwinUpdateNotificationsAsync(TwinCollection twinUpdateRequest)
         {
-            var cancellationToken = (CancellationToken)userContext;
+            CancellationToken cancellationToken = s_cancellationTokenSource.Token;
 
             if (!cancellationToken.IsCancellationRequested)
             {
@@ -347,7 +347,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
         }
 
-        private Task<MessageAcknowledgement> OnMessageReceivedAsync(Message receivedMessage, object userContext)
+        private Task<MessageAcknowledgement> OnMessageReceivedAsync(Message receivedMessage)
         {
             string messageData = Encoding.ASCII.GetString(receivedMessage.Payload);
             var formattedMessage = new StringBuilder($"Received message: [{messageData}]");

--- a/iothub/device/samples/solutions/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iothub/device/samples/solutions/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -96,10 +96,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 }
             });
 
-            await _deviceClient.SetMethodHandlerAsync(OnDirectMethodAsync, null, cancellationToken);
+            await _deviceClient.SetMethodHandlerAsync(OnDirectMethodAsync, cancellationToken);
 
             _logger.LogDebug("Set handler to receive 'targetTemperature' updates.");
-            await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(SetDesiredPropertyUpdateCallback, null, cancellationToken);
+            await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(SetDesiredPropertyUpdateCallback, cancellationToken);
             _desiredPropertyUpdateCallbacks.Add(Thermostat1, TargetTemperatureUpdateCallbackAsync);
             _desiredPropertyUpdateCallbacks.Add(Thermostat2, TargetTemperatureUpdateCallbackAsync);
 
@@ -132,11 +132,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
         }
 
-        private async Task<DirectMethodResponse> OnDirectMethodAsync(DirectMethodRequest request, object userContext)
+        private async Task<DirectMethodResponse> OnDirectMethodAsync(DirectMethodRequest request)
         {
             return request.MethodName switch
             {
-                "reboot" => await HandleRebootCommandAsync(request, userContext),
+                "reboot" => await HandleRebootCommandAsync(request),
                 "thermostat1*getMaxMinReport" => await HandleMaxMinReportCommand(request, Thermostat1),
                 "thermostat2*getMaxMinReport" => await HandleMaxMinReportCommand(request, Thermostat2),
                 _ => new DirectMethodResponse(400),
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         }
 
         // The callback to handle "reboot" command. This method will send a temperature update (of 0°C) over telemetry for both associated components.
-        private async Task<DirectMethodResponse> HandleRebootCommandAsync(DirectMethodRequest request, object userContext)
+        private async Task<DirectMethodResponse> HandleRebootCommandAsync(DirectMethodRequest request)
         {
             bool delayReceived = request.TryGetPayload(out int delay);
 
@@ -275,7 +275,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
         }
 
-        private Task SetDesiredPropertyUpdateCallback(TwinCollection desiredProperties, object userContext)
+        private Task SetDesiredPropertyUpdateCallback(TwinCollection desiredProperties)
         {
             bool callbackNotInvoked = true;
 

--- a/iothub/device/samples/solutions/PnpDeviceSamples/Thermostat/ThermostatSample.cs
+++ b/iothub/device/samples/solutions/PnpDeviceSamples/Thermostat/ThermostatSample.cs
@@ -78,10 +78,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
             });
 
             _logger.LogDebug($"Set handler to receive \"targetTemperature\" updates.");
-            await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(TargetTemperatureUpdateCallbackAsync, _deviceClient, cancellationToken);
+            await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(TargetTemperatureUpdateCallbackAsync, cancellationToken);
 
             _logger.LogDebug($"Set handler for \"getMaxMinReport\" command.");
-            await _deviceClient.SetMethodHandlerAsync(OnDirectMethodAsync, null, cancellationToken);
+            await _deviceClient.SetMethodHandlerAsync(OnDirectMethodAsync, cancellationToken);
 
             _logger.LogDebug("Check if the device properties are empty on the initial startup.");
             await CheckEmptyPropertiesAsync(cancellationToken);
@@ -101,11 +101,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
         }
 
-        private async Task<DirectMethodResponse> OnDirectMethodAsync(DirectMethodRequest request, object userContext)
+        private async Task<DirectMethodResponse> OnDirectMethodAsync(DirectMethodRequest request)
         {
             return request.MethodName switch
             {
-                "getMaxMinReport" => await HandleMaxMinReportCommandAsync(request, userContext),
+                "getMaxMinReport" => await HandleMaxMinReportCommandAsync(request),
                 _ => new DirectMethodResponse(400),
             };
         }
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                     string propertyName = propertyUpdate.Key;
                     if (propertyName == TargetTemperatureProperty)
                     {
-                        await TargetTemperatureUpdateCallbackAsync(twinCollection, propertyName);
+                        await TargetTemperatureUpdateCallbackAsync(twinCollection);
                     }
                     else
                     {
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         // The desired property update callback, which receives the target temperature as a desired property update,
         // and updates the current temperature value over telemetry and reported property update.
-        private async Task TargetTemperatureUpdateCallbackAsync(TwinCollection desiredProperties, object userContext)
+        private async Task TargetTemperatureUpdateCallbackAsync(TwinCollection desiredProperties)
         {
             (bool targetTempUpdateReceived, double targetTemperature) = GetPropertyFromTwin<double>(desiredProperties, TargetTemperatureProperty);
             if (targetTempUpdateReceived)
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         // The callback to handle "getMaxMinReport" command. This method will returns the max, min and average temperature
         // from the specified time to the current time.
-        private Task<DirectMethodResponse> HandleMaxMinReportCommandAsync(DirectMethodRequest request, object userContext)
+        private Task<DirectMethodResponse> HandleMaxMinReportCommandAsync(DirectMethodRequest request)
         {
             try
             {

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -27,14 +27,11 @@ namespace Microsoft.Azure.Devices.Client
 
         // Method callback information
         private bool _isDeviceMethodEnabled;
-
-        private volatile Tuple<Func<DirectMethodRequest, object, Task<DirectMethodResponse>>, object> _deviceDefaultMethodCallback;
+        private volatile Func<DirectMethodRequest, Task<DirectMethodResponse>> _deviceDefaultMethodCallback;
 
         // Twin property update request callback information
         private bool _twinPatchSubscribedWithService;
-
-        private object _twinPatchCallbackContext;
-        private Func<TwinCollection, object, Task> _desiredPropertyUpdateCallback;
+        private Func<TwinCollection, Task> _desiredPropertyUpdateCallback;
 
         // Diagnostic information
 
@@ -226,16 +223,14 @@ namespace Microsoft.Azure.Devices.Client
         /// A method handler can be unset by setting <paramref name="methodHandler"/> to null.
         /// </remarks>
         /// <param name="methodHandler">The listener to be used when any method is called by the cloud service.</param>
-        /// <param name="userContext">Generic parameter to be interpreted by the client code.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
         public async Task SetMethodHandlerAsync(
-            Func<DirectMethodRequest, object, Task<DirectMethodResponse>> methodHandler,
-            object userContext,
+            Func<DirectMethodRequest, Task<DirectMethodResponse>> methodHandler,
             CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, methodHandler, userContext, nameof(SetMethodHandlerAsync));
+                Logging.Enter(this, methodHandler, nameof(SetMethodHandlerAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -246,7 +241,7 @@ namespace Microsoft.Azure.Devices.Client
                 if (methodHandler != null)
                 {
                     await HandleMethodEnableAsync(cancellationToken).ConfigureAwait(false);
-                    _deviceDefaultMethodCallback = new Tuple<Func<DirectMethodRequest, object, Task<DirectMethodResponse>>, object>(methodHandler, userContext);
+                    _deviceDefaultMethodCallback = methodHandler;
                 }
                 else
                 {
@@ -259,7 +254,7 @@ namespace Microsoft.Azure.Devices.Client
                 _methodsSemaphore.Release();
 
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, methodHandler, userContext, nameof(SetMethodHandlerAsync));
+                    Logging.Exit(this, methodHandler, nameof(SetMethodHandlerAsync));
             }
         }
 
@@ -305,16 +300,14 @@ namespace Microsoft.Azure.Devices.Client
         /// This has the side-effect of subscribing to the PATCH topic on the service.
         /// </remarks>
         /// <param name="callback">Callback to call after the state update has been received and applied.</param>
-        /// <param name="userContext">Context object that will be passed into callback.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
         public async Task SetDesiredPropertyUpdateCallbackAsync(
-            Func<TwinCollection, object, Task> callback,
-            object userContext,
+            Func<TwinCollection, Task> callback,
             CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, callback, userContext, nameof(SetDesiredPropertyUpdateCallbackAsync));
+                Logging.Enter(this, callback, nameof(SetDesiredPropertyUpdateCallbackAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -334,14 +327,13 @@ namespace Microsoft.Azure.Devices.Client
                 }
 
                 _desiredPropertyUpdateCallback = callback;
-                _twinPatchCallbackContext = userContext;
             }
             finally
             {
                 _twinDesiredPropertySemaphore.Release();
 
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, callback, userContext, nameof(SetDesiredPropertyUpdateCallbackAsync));
+                    Logging.Exit(this, callback, nameof(SetDesiredPropertyUpdateCallbackAsync));
             }
         }
 
@@ -443,11 +435,8 @@ namespace Microsoft.Azure.Devices.Client
             {
                 try
                 {
-                    Func<DirectMethodRequest, object, Task<DirectMethodResponse>> userSuppliedCallback = _deviceDefaultMethodCallback.Item1;
-                    object userSuppliedContext = _deviceDefaultMethodCallback.Item2;
-
-                    directMethodResponse = await userSuppliedCallback
-                        .Invoke(directMethodRequest, userSuppliedContext)
+                    directMethodResponse = await _deviceDefaultMethodCallback
+                        .Invoke(directMethodRequest)
                         .ConfigureAwait(false);
 
                     directMethodResponse.RequestId = directMethodRequest.RequestId;
@@ -480,7 +469,7 @@ namespace Microsoft.Azure.Devices.Client
             if (Logging.IsEnabled)
                 Logging.Info(this, patch.ToJson(), nameof(OnDesiredStatePatchReceived));
 
-            _ = _desiredPropertyUpdateCallback.Invoke(patch, _twinPatchCallbackContext);
+            _ = _desiredPropertyUpdateCallback.Invoke(patch);
         }
 
         private async Task SendDirectMethodResponseAsync(DirectMethodResponse directMethodResponse, CancellationToken cancellationToken = default)

--- a/iothub/device/tests/DeviceClientTwinApiTests.cs
+++ b/iothub/device/tests/DeviceClientTwinApiTests.cs
@@ -22,11 +22,10 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             var client = new IotHubDeviceClient(fakeConnectionString);
             client.InnerHandler = innerHandler;
-            Func<TwinCollection, object, Task> myCallback = (p, c) => Task.CompletedTask;
-            var context = new object();
+            Func<TwinCollection, Task> myCallback = (p) => Task.CompletedTask;
 
             // act
-            await client.SetDesiredPropertyUpdateCallbackAsync(myCallback, context).ConfigureAwait(false);
+            await client.SetDesiredPropertyUpdateCallbackAsync(myCallback).ConfigureAwait(false);
 
             // assert
             await innerHandler.
@@ -41,12 +40,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             var client = new IotHubDeviceClient(fakeConnectionString);
             client.InnerHandler = innerHandler;
-            Func<TwinCollection, object, Task> myCallback = (p, c) => Task.CompletedTask;
-            var context = new object();
+            Func<TwinCollection, Task> myCallback = (p) => Task.CompletedTask;
 
             // act
-            await client.SetDesiredPropertyUpdateCallbackAsync(myCallback, context).ConfigureAwait(false);
-            await client.SetDesiredPropertyUpdateCallbackAsync(null, null).ConfigureAwait(false);
+            await client.SetDesiredPropertyUpdateCallbackAsync(myCallback).ConfigureAwait(false);
+            await client.SetDesiredPropertyUpdateCallbackAsync(null).ConfigureAwait(false);
 
             // assert
             await innerHandler
@@ -62,12 +60,12 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             var client = new IotHubDeviceClient(fakeConnectionString);
             client.InnerHandler = innerHandler;
-            Func<TwinCollection, object, Task> myCallback = (p, c) => Task.CompletedTask;
+            Func<TwinCollection, Task> myCallback = (p) => Task.CompletedTask;
 
             // act
-            await client.SetDesiredPropertyUpdateCallbackAsync(myCallback, null).ConfigureAwait(false);
-            await client.SetDesiredPropertyUpdateCallbackAsync(myCallback, null).ConfigureAwait(false);
-            await client.SetDesiredPropertyUpdateCallbackAsync(myCallback, null).ConfigureAwait(false);
+            await client.SetDesiredPropertyUpdateCallbackAsync(myCallback).ConfigureAwait(false);
+            await client.SetDesiredPropertyUpdateCallbackAsync(myCallback).ConfigureAwait(false);
+            await client.SetDesiredPropertyUpdateCallbackAsync(myCallback).ConfigureAwait(false);
 
             // assert
             await innerHandler.
@@ -134,13 +132,13 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             int callCount = 0;
             TwinCollection receivedPatch = null;
-            Func<TwinCollection, object, Task> myCallback = (p, c) =>
+            Func<TwinCollection, Task> myCallback = (p) =>
             {
                 callCount++;
                 receivedPatch = p;
                 return Task.CompletedTask;
             };
-            await client.SetDesiredPropertyUpdateCallbackAsync(myCallback, null).ConfigureAwait(false);
+            await client.SetDesiredPropertyUpdateCallbackAsync(myCallback).ConfigureAwait(false);
 
             // act
             client.OnDesiredStatePatchReceived(myPatch);

--- a/iothub/device/tests/Edge/EdgeModuleClientHelperTest.cs
+++ b/iothub/device/tests/Edge/EdgeModuleClientHelperTest.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
 
             await innerHandler.Received().EnableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -270,14 +270,14 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
 
             await innerHandler.Received(1).EnableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
 
-            await moduleClient.SetMessageHandlerAsync(null, null).ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync(null).ConfigureAwait(false);
             await innerHandler.Received(1).EnableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.Received(1).DisableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -291,7 +291,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
 
             await innerHandler.Received(1).EnableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -305,13 +305,13 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
             await innerHandler.Received(1).EnableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
 
-            await moduleClient.SetMessageHandlerAsync(null, null).ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync(null).ConfigureAwait(false);
             await innerHandler.Received(1).EnableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.Received(1).DisableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -325,7 +325,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
 
             await innerHandler.Received(1).EnableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -339,13 +339,13 @@ namespace Microsoft.Azure.Devices.Client.Test.Edge
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
 
             await innerHandler.Received(1).EnableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
 
-            await moduleClient.SetMessageHandlerAsync(null, null).ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync(null).ConfigureAwait(false);
             await innerHandler.Received(1).EnableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.Received(1).DisableEventReceiveAsync(true, Arg.Any<CancellationToken>()).ConfigureAwait(false);

--- a/iothub/device/tests/IotHubDeviceClientTests.cs
+++ b/iothub/device/tests/IotHubDeviceClientTests.cs
@@ -294,11 +294,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             // act
             await deviceClient
                 .SetMethodHandlerAsync(
-                    (payload, context) => Task.FromResult(directMethodResponseWithPayload), "custom data")
+                    (payload) => Task.FromResult(directMethodResponseWithPayload))
                 .ConfigureAwait(false);
 
             await deviceClient
-                .SetMethodHandlerAsync(null, null)
+                .SetMethodHandlerAsync(null)
                 .ConfigureAwait(false);
 
             // assert
@@ -317,11 +317,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             deviceClient.InnerHandler = innerHandler;
 
             bool isMethodHandlerCalled = false;
-            await deviceClient.SetMethodHandlerAsync((payload, context) =>
+            await deviceClient.SetMethodHandlerAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 return Task.FromResult(directMethodResponseWithPayload);
-            }, "custom data").ConfigureAwait(false);
+            }).ConfigureAwait(false);
 
             // act
             await deviceClient.OnMethodCalledAsync(null).ConfigureAwait(false);
@@ -340,11 +340,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             deviceClient.InnerHandler = innerHandler;
 
             bool isMethodHandlerCalled = false;
-            await deviceClient.SetMethodHandlerAsync((payload, context) =>
+            await deviceClient.SetMethodHandlerAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 return Task.FromResult(directMethodResponseWithPayload);
-            }, "custom data").ConfigureAwait(false);
+            }).ConfigureAwait(false);
 
             var DirectMethodRequest = new DirectMethodRequest()
             {
@@ -367,11 +367,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             deviceClient.InnerHandler = innerHandler;
             bool isMethodHandlerCalled = false;
-            await deviceClient.SetMethodHandlerAsync((payload, context) =>
+            await deviceClient.SetMethodHandlerAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 return Task.FromResult(directMethodResponseWithPayload);
-            }, "custom data").ConfigureAwait(false);
+            }).ConfigureAwait(false);
 
             var DirectMethodRequest = new DirectMethodRequest()
             {
@@ -398,13 +398,13 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool responseReceivedAsExpected = false;
             bool response = false;
             string responseAsString = null;
-            await deviceClient.SetMethodHandlerAsync((payload, context) =>
+            await deviceClient.SetMethodHandlerAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 responseReceivedAsExpected = payload.TryGetPayload(out response);
                 responseAsString = payload.PayloadAsJsonString;
                 return Task.FromResult(directMethodResponseWithPayload);
-            }, "custom data").ConfigureAwait(false);
+            }).ConfigureAwait(false);
 
             bool boolean = true;
             var DirectMethodRequest = new DirectMethodRequest()
@@ -435,13 +435,13 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool responseReceivedAsExpected = false;
             byte[] response = null;
             string responseAsString = null;
-            await deviceClient.SetMethodHandlerAsync((payload, context) =>
+            await deviceClient.SetMethodHandlerAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 responseReceivedAsExpected = payload.TryGetPayload(out response);
                 responseAsString = payload.PayloadAsJsonString;
                 return Task.FromResult(directMethodResponseWithPayload);
-            }, "custom data").ConfigureAwait(false);
+            }).ConfigureAwait(false);
 
             byte[] bytes = new byte[] { 1, 2, 3 };
             var DirectMethodRequest = new DirectMethodRequest()
@@ -472,13 +472,13 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool responseReceivedAsExpected = false;
             List<double> response = null;
             string responseAsString = null;
-            await deviceClient.SetMethodHandlerAsync((payload, context) =>
+            await deviceClient.SetMethodHandlerAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 responseReceivedAsExpected = payload.TryGetPayload(out response);
                 responseAsString = payload.PayloadAsJsonString;
                 return Task.FromResult(directMethodResponseWithPayload);
-            }, "custom data").ConfigureAwait(false);
+            }).ConfigureAwait(false);
 
             List<double> list = new List<double>() { 1.0, 2.0, 3.0 };
             var DirectMethodRequest = new DirectMethodRequest()
@@ -509,13 +509,13 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool responseReceivedAsExpected = false;
             Dictionary<string, object> response = null;
             string responseAsString = null;
-            await deviceClient.SetMethodHandlerAsync((payload, context) =>
+            await deviceClient.SetMethodHandlerAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 responseReceivedAsExpected = payload.TryGetPayload(out response);
                 responseAsString = payload.PayloadAsJsonString;
                 return Task.FromResult(directMethodResponseWithPayload);
-            }, "custom data").ConfigureAwait(false);
+            }).ConfigureAwait(false);
 
             Dictionary<string, object> map = new Dictionary<string, object>() { { "key1", "val1" }, { "key2", 2 } };
             var DirectMethodRequest = new DirectMethodRequest()
@@ -543,11 +543,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             deviceClient.InnerHandler = innerHandler;
             bool isMethodHandlerCalled = false;
-            await deviceClient.SetMethodHandlerAsync((payload, context) =>
+            await deviceClient.SetMethodHandlerAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 return Task.FromResult(directMethodResponseWithNoPayload);
-            }, "custom data").ConfigureAwait(false);
+            }).ConfigureAwait(false);
 
             var DirectMethodRequest = new DirectMethodRequest()
             {
@@ -597,20 +597,17 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool methodCallbackCalled = false;
             string actualMethodName = string.Empty;
             string actualMethodBody = string.Empty;
-            object actualMethodUserContext = null;
-            Func<DirectMethodRequest, object, Task<DirectMethodResponse>> methodCallback = (methodRequest, userContext) =>
+            Func<DirectMethodRequest, Task<DirectMethodResponse>> methodCallback = (methodRequest) =>
             {
                 actualMethodName = methodRequest.MethodName;
                 actualMethodBody = (string)methodRequest.Payload;
-                actualMethodUserContext = userContext;
                 methodCallbackCalled = true;
                 return Task.FromResult(directMethodResponseWithEmptyByteArrayPayload);
             };
 
             string methodName = "TestMethodName";
-            string methodUserContext = "UserContext";
             string methodBody = "{\"grade\":\"good\"}";
-            await deviceClient.SetMethodHandlerAsync(methodCallback, methodUserContext).ConfigureAwait(false);
+            await deviceClient.SetMethodHandlerAsync(methodCallback).ConfigureAwait(false);
             var DirectMethodRequest = new DirectMethodRequest()
             {
                 MethodName = methodName,
@@ -625,25 +622,21 @@ namespace Microsoft.Azure.Devices.Client.Test
             methodCallbackCalled.Should().BeTrue();
             methodName.Should().Be(actualMethodName);
             methodBody.Should().Be(actualMethodBody);
-            methodUserContext.Should().Be((string)actualMethodUserContext);
 
             // arrange
             bool methodCallbackCalled2 = false;
             string actualMethodName2 = string.Empty;
             string actualMethodBody2 = string.Empty;
-            object actualMethodUserContext2 = null;
-            Func<DirectMethodRequest, object, Task<DirectMethodResponse>> methodCallback2 = (methodRequest, userContext) =>
+            Func<DirectMethodRequest, Task<DirectMethodResponse>> methodCallback2 = (methodRequest) =>
             {
                 actualMethodName2 = methodRequest.MethodName;
                 actualMethodBody2 = (string)methodRequest.Payload;
-                actualMethodUserContext2 = userContext;
                 methodCallbackCalled2 = true;
                 return Task.FromResult(directMethodResponseWithEmptyByteArrayPayload);
             };
 
-            string methodUserContext2 = "UserContext2";
             string methodBody2 = "{\"grade\":\"bad\"}";
-            await deviceClient.SetMethodHandlerAsync(methodCallback2, methodUserContext2).ConfigureAwait(false);
+            await deviceClient.SetMethodHandlerAsync(methodCallback2).ConfigureAwait(false);
             DirectMethodRequest = new DirectMethodRequest()
             {
                 MethodName = methodName,
@@ -658,7 +651,6 @@ namespace Microsoft.Azure.Devices.Client.Test
             methodCallbackCalled2.Should().BeTrue();
             methodName.Should().Be(actualMethodName2);
             methodBody2.Should().Be(actualMethodBody2);
-            methodUserContext2.Should().Be((string)actualMethodUserContext2);
         }
 
         [TestMethod]
@@ -674,20 +666,17 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool methodCallbackCalled = false;
             string actualMethodName = string.Empty;
             string actualMethodBody = string.Empty;
-            object actualMethodUserContext = null;
-            Func<DirectMethodRequest, object, Task<DirectMethodResponse>> methodCallback = (methodRequest, userContext) =>
+            Func<DirectMethodRequest, Task<DirectMethodResponse>> methodCallback = (methodRequest) =>
             {
                 actualMethodName = methodRequest.MethodName;
                 actualMethodBody = (string)methodRequest.Payload;
-                actualMethodUserContext = userContext;
                 methodCallbackCalled = true;
                 return Task.FromResult(directMethodResponseWithEmptyByteArrayPayload);
             };
 
             string methodName = "TestMethodName";
-            string methodUserContext = "UserContext";
             string methodBody = "{\"grade\":\"good\"}";
-            await deviceClient.SetMethodHandlerAsync(methodCallback, methodUserContext).ConfigureAwait(false);
+            await deviceClient.SetMethodHandlerAsync(methodCallback).ConfigureAwait(false);
             var DirectMethodRequest = new DirectMethodRequest()
             {
                 MethodName = methodName,
@@ -703,11 +692,10 @@ namespace Microsoft.Azure.Devices.Client.Test
             methodCallbackCalled.Should().BeTrue();
             methodName.Should().Be(actualMethodName);
             methodBody.Should().Be(actualMethodBody);
-            methodUserContext.Should().Be((string)actualMethodUserContext);
 
             // arrange
             methodCallbackCalled = false;
-            await deviceClient.SetMethodHandlerAsync(null, null).ConfigureAwait(false);
+            await deviceClient.SetMethodHandlerAsync(null).ConfigureAwait(false);
             DirectMethodRequest = new DirectMethodRequest()
             {
                 MethodName = methodName,
@@ -731,7 +719,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             deviceClient.InnerHandler = innerHandler;
 
-            await deviceClient.SetMethodHandlerAsync(null, null).ConfigureAwait(false);
+            await deviceClient.SetMethodHandlerAsync(null).ConfigureAwait(false);
             await innerHandler.DidNotReceive().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
         }
 
@@ -1356,8 +1344,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             cts.Cancel();
 
             Func<Task> act = async () => await deviceClient.SetDesiredPropertyUpdateCallbackAsync(
-                (patch, context) => Task.FromResult(true),
-                deviceClient,
+                (patch) => Task.FromResult(true),
                 cts.Token);
 
             // assert

--- a/iothub/device/tests/IotHubModuleClientTests.cs
+++ b/iothub/device/tests/IotHubModuleClientTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
 
             await innerHandler.Received().EnableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -112,14 +112,14 @@ namespace Microsoft.Azure.Devices.Client.Test
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
 
             await innerHandler.Received(1).EnableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
 
-            await moduleClient.SetMessageHandlerAsync(null, null).ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync(null).ConfigureAwait(false);
             await innerHandler.Received(1).EnableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.Received(1).DisableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
 
             await innerHandler.Received().EnableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -149,13 +149,13 @@ namespace Microsoft.Azure.Devices.Client.Test
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
 
             await innerHandler.Received(1).EnableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
 
-            await moduleClient.SetMessageHandlerAsync(null, null).ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync(null).ConfigureAwait(false);
             await innerHandler.Received(1).EnableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.Received(1).DisableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
 
             await innerHandler.Received(1).EnableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -182,13 +182,13 @@ namespace Microsoft.Azure.Devices.Client.Test
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
             await innerHandler.Received(1).EnableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
 
-            await moduleClient.SetMessageHandlerAsync(null, null).ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync(null).ConfigureAwait(false);
             await innerHandler.Received(1).EnableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.Received(1).DisableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
 
             await innerHandler.Received(1).EnableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -216,13 +216,13 @@ namespace Microsoft.Azure.Devices.Client.Test
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message, context) => Task.FromResult(MessageAcknowledgement.Complete), "custom data").ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
 
             await innerHandler.Received(1).EnableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
 
-            await moduleClient.SetMessageHandlerAsync(null, null).ConfigureAwait(false);
+            await moduleClient.SetMessageHandlerAsync(null).ConfigureAwait(false);
             await innerHandler.Received(1).EnableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.Received(1).DisableEventReceiveAsync(false, Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -238,12 +238,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool isMessageHandlerCalled = false;
             await moduleClient
                 .SetMessageHandlerAsync(
-                    (message, context) =>
+                    (message) =>
                     {
                         isMessageHandlerCalled = true;
                         return Task.FromResult(MessageAcknowledgement.Complete);
-                    },
-                    "custom data")
+                    })
                 .ConfigureAwait(false);
 
             await moduleClient.OnModuleEventMessageReceivedAsync(null).ConfigureAwait(false);
@@ -260,12 +259,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool isDefaultCallbackCalled = false;
             await moduleClient
                 .SetMessageHandlerAsync(
-                    (message, context) =>
+                    (message) =>
                     {
                         isDefaultCallbackCalled = true;
                         return Task.FromResult(MessageAcknowledgement.Complete);
-                    },
-                    "custom data")
+                    })
                 .ConfigureAwait(false);
 
             var testMessage = new Message


### PR DESCRIPTION
We only support "global" listeners for callback-based APIs. This makes the userContext parameter unnecessary. This PR removes this param.

For users wanted to pass in additional params to their callback implementation, they can make use of class variables.