### PR TITLE
Remove internal ReceiveAsync style methods for c2d messaging

### DIFF
--- a/iothub/device/samples/getting started/MessageReceiveSample/MessageReceiveSample.cs
+++ b/iothub/device/samples/getting started/MessageReceiveSample/MessageReceiveSample.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
             Console.WriteLine($"\n{DateTime.Now}> Subscribed to receive C2D messages over callback.");
 
             // Now wait to receive C2D messages through the callback.
-            // Since you are subscribed to receive messages through the callback, any call to the polling ReceiveAsync() API will now return "null".
             Console.WriteLine($"\n{DateTime.Now}> Device waiting for C2D messages from the hub...");
             Console.WriteLine($"{DateTime.Now}> Use the Azure Portal IoT Hub blade or Azure IoT Explorer to send a message to this device.");
 

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Net.Sockets;
 using System.Net.WebSockets;
@@ -563,20 +564,7 @@ namespace Microsoft.Azure.Devices.Client
             if (Logging.IsEnabled)
                 Logging.Enter(this, message, nameof(OnMessageReceivedAsync));
 
-            if (message == null)
-            {
-                if (Logging.IsEnabled)
-                    Logging.Error(this, "Received a null message. Abandoning message.", nameof(OnMessageReceivedAsync));
-
-                if (_clientOptions.TransportSettings is IotHubClientMqttSettings)
-                {
-                    // MQTT does not support abandoning received messages, so we have no choice
-                    // but to complete it
-                    return MessageAcknowledgement.Complete;
-                }
-
-                return MessageAcknowledgement.Abandon;
-            }
+            Debug.Assert(message != null, "Received a null message");
 
             // Grab this semaphore so that there is no chance that the _receiveMessageCallback instance is set in between the read of the
             // item1 and the read of the item2

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -565,6 +565,16 @@ namespace Microsoft.Azure.Devices.Client
 
             if (message == null)
             {
+                if (Logging.IsEnabled)
+                    Logging.Error(this, "Received a null message. Abandoning message.", nameof(OnMessageReceivedAsync));
+
+                if (_clientOptions.TransportSettings is IotHubClientMqttSettings)
+                {
+                    // MQTT does not support abandoning received messages, so we have no choice
+                    // but to complete it
+                    return MessageAcknowledgement.Complete;
+                }
+
                 return MessageAcknowledgement.Abandon;
             }
 
@@ -583,7 +593,7 @@ namespace Microsoft.Azure.Devices.Client
 
                 // The SDK should only receive messages when the user sets a listener, so this should never happen.
                 if (Logging.IsEnabled)
-                    Logging.Info(this, "Received a message when no listener was set. Abandoning message.", nameof(OnMessageReceivedAsync));
+                    Logging.Error(this, "Received a message when no listener was set. Abandoning message.", nameof(OnMessageReceivedAsync));
 
                 return MessageAcknowledgement.Abandon;
             }

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -558,14 +558,14 @@ namespace Microsoft.Azure.Devices.Client
             return !isFound ? default : (T)handler;
         }
 
-        internal async Task OnMessageReceivedAsync(Message message)
+        internal async Task<MessageAcknowledgement> OnMessageReceivedAsync(Message message)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, message, nameof(OnMessageReceivedAsync));
 
             if (message == null)
             {
-                return;
+                return MessageAcknowledgement.Abandon;
             }
 
             // Grab this semaphore so that there is no chance that the _receiveMessageCallback instance is set in between the read of the
@@ -578,38 +578,22 @@ namespace Microsoft.Azure.Devices.Client
 
                 if (callback != null)
                 {
-                    MessageAcknowledgement response = await callback.Invoke(message).ConfigureAwait(false);
-
-                    try
-                    {
-                        switch (response)
-                        {
-                            case MessageAcknowledgement.Complete:
-                                await InnerHandler.CompleteMessageAsync(message.LockToken, CancellationToken.None).ConfigureAwait(false);
-                                break;
-
-                            case MessageAcknowledgement.Abandon:
-                                await InnerHandler.AbandonMessageAsync(message.LockToken, CancellationToken.None).ConfigureAwait(false);
-                                break;
-
-                            case MessageAcknowledgement.Reject:
-                                await InnerHandler.RejectMessageAsync(message.LockToken, CancellationToken.None).ConfigureAwait(false);
-                                break;
-                        }
-                    }
-                    catch (Exception ex) when (Logging.IsEnabled)
-                    {
-                        Logging.Error(this, ex, nameof(OnMessageReceivedAsync));
-                    }
+                    return await callback.Invoke(message).ConfigureAwait(false);
                 }
+
+                // The SDK should only receive messages when the user sets a listener, so this should never happen.
+                if (Logging.IsEnabled)
+                    Logging.Info(this, "Received a message when no listener was set. Abandoning message.", nameof(OnMessageReceivedAsync));
+
+                return MessageAcknowledgement.Abandon;
             }
             finally
             {
+                if (Logging.IsEnabled)
+                    Logging.Exit(this, message, nameof(OnMessageReceivedAsync));
+
                 _receiveMessageSemaphore.Release();
             }
-
-            if (Logging.IsEnabled)
-                Logging.Exit(this, message, nameof(OnMessageReceivedAsync));
         }
 
         private Task EnableReceiveMessageAsync(CancellationToken cancellationToken = default)

--- a/iothub/device/src/Messaging/Message.cs
+++ b/iothub/device/src/Messaging/Message.cs
@@ -186,23 +186,9 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Unique string for identifying a received message when acknowledging it.
-        /// </summary>
-        internal string LockToken
-        {
-            get => GetSystemProperty<string>(MessageSystemPropertyNames.LockToken);
-            set => SystemProperties[MessageSystemPropertyNames.LockToken] = value;
-        }
-
-        /// <summary>
         /// Gets the dictionary of system properties which are managed internally.
         /// </summary>
         internal IDictionary<string, object> SystemProperties { get; private set; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-
-        /// <summary>
-        /// Gets or sets the deliveryTag which is used for server side check-pointing.
-        /// </summary>
-        internal ArraySegment<byte> DeliveryTag { get; set; }
 
         /// <summary>
         /// For outgoing messages, contains the Mqtt topic that the message is being sent to.

--- a/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
@@ -72,12 +72,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return NextHandler.WaitForTransportClosedAsync();
         }
 
-        public virtual Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken)
-        {
-            ThrowIfDisposed();
-            return NextHandler.ReceiveMessageAsync(cancellationToken);
-        }
-
         public virtual Task EnableReceiveMessageAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
@@ -88,24 +82,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             ThrowIfDisposed();
             return NextHandler.DisableReceiveMessageAsync(cancellationToken);
-        }
-
-        public virtual Task CompleteMessageAsync(string lockToken, CancellationToken cancellationToken)
-        {
-            ThrowIfDisposed();
-            return NextHandler?.CompleteMessageAsync(lockToken, cancellationToken) ?? Task.CompletedTask;
-        }
-
-        public virtual Task AbandonMessageAsync(string lockToken, CancellationToken cancellationToken)
-        {
-            ThrowIfDisposed();
-            return NextHandler?.AbandonMessageAsync(lockToken, cancellationToken) ?? Task.CompletedTask;
-        }
-
-        public virtual Task RejectMessageAsync(string lockToken, CancellationToken cancellationToken)
-        {
-            ThrowIfDisposed();
-            return NextHandler?.RejectMessageAsync(lockToken, cancellationToken) ?? Task.CompletedTask;
         }
 
         public virtual Task SendEventAsync(Message message, CancellationToken cancellationToken)

--- a/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
@@ -38,11 +38,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return ExecuteWithErrorHandlingAsync(() => base.OpenAsync(cancellationToken));
         }
 
-        public override Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken)
-        {
-            return ExecuteWithErrorHandlingAsync(() => base.ReceiveMessageAsync(cancellationToken));
-        }
-
         public override Task EnableReceiveMessageAsync(CancellationToken cancellationToken)
         {
             return ExecuteWithErrorHandlingAsync(() => base.EnableReceiveMessageAsync(cancellationToken));
@@ -81,21 +76,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
         public override Task<long> SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
             return ExecuteWithErrorHandlingAsync(() => base.SendTwinPatchAsync(reportedProperties, cancellationToken));
-        }
-
-        public override Task AbandonMessageAsync(string lockToken, CancellationToken cancellationToken)
-        {
-            return ExecuteWithErrorHandlingAsync(() => base.AbandonMessageAsync(lockToken, cancellationToken));
-        }
-
-        public override Task CompleteMessageAsync(string lockToken, CancellationToken cancellationToken)
-        {
-            return ExecuteWithErrorHandlingAsync(() => base.CompleteMessageAsync(lockToken, cancellationToken));
-        }
-
-        public override Task RejectMessageAsync(string lockToken, CancellationToken cancellationToken)
-        {
-            return ExecuteWithErrorHandlingAsync(() => base.RejectMessageAsync(lockToken, cancellationToken));
         }
 
         public override Task SendEventAsync(IEnumerable<Message> messages, CancellationToken cancellationToken)

--- a/iothub/device/src/Pipeline/IDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/IDelegatingHandler.cs
@@ -24,18 +24,9 @@ namespace Microsoft.Azure.Devices.Client
 
         Task SendEventAsync(IEnumerable<Message> messages, CancellationToken cancellationToken);
 
-        // Telemetry downlink for devices.
-        Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken);
-
         Task EnableReceiveMessageAsync(CancellationToken cancellationToken);
 
         Task DisableReceiveMessageAsync(CancellationToken cancellationToken);
-
-        Task RejectMessageAsync(string lockToken, CancellationToken cancellationToken);
-
-        Task AbandonMessageAsync(string lockToken, CancellationToken cancellationToken);
-
-        Task CompleteMessageAsync(string lockToken, CancellationToken cancellationToken);
 
         // Methods.
         Task EnableMethodsAsync(CancellationToken cancellationToken);

--- a/iothub/device/src/Pipeline/PipelineContext.cs
+++ b/iothub/device/src/Pipeline/PipelineContext.cs
@@ -22,6 +22,6 @@ namespace Microsoft.Azure.Devices.Client
 
         internal Func<DirectMethodRequest, Task> MethodCallback { get; set; }
 
-        internal Func<Message, Task> MessageEventCallback { get; set; }
+        internal Func<Message, Task<MessageAcknowledgement>> MessageEventCallback { get; set; }
     }
 }

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -135,30 +135,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
-        public override async Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken)
-        {
-            try
-            {
-                if (Logging.IsEnabled)
-                    Logging.Enter(this, cancellationToken, nameof(ReceiveMessageAsync));
-
-                return await _internalRetryPolicy
-                    .RunWithRetryAsync(
-                        async () =>
-                        {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
-                            return await base.ReceiveMessageAsync(cancellationToken).ConfigureAwait(false);
-                        },
-                        cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            finally
-            {
-                if (Logging.IsEnabled)
-                    Logging.Exit(this, cancellationToken, nameof(ReceiveMessageAsync));
-            }
-        }
-
         public override async Task EnableReceiveMessageAsync(CancellationToken cancellationToken)
         {
             try
@@ -412,78 +388,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
             {
                 if (Logging.IsEnabled)
                     Logging.Exit(this, reportedProperties, cancellationToken, nameof(SendTwinPatchAsync));
-            }
-        }
-
-        public override async Task CompleteMessageAsync(string lockToken, CancellationToken cancellationToken)
-        {
-            try
-            {
-                if (Logging.IsEnabled)
-                    Logging.Enter(this, lockToken, cancellationToken, nameof(CompleteMessageAsync));
-
-                await _internalRetryPolicy
-                    .RunWithRetryAsync(
-                        async () =>
-                        {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
-                            await base.CompleteMessageAsync(lockToken, cancellationToken).ConfigureAwait(false);
-                        },
-                        cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            finally
-            {
-                if (Logging.IsEnabled)
-                    Logging.Exit(this, lockToken, cancellationToken, nameof(CompleteMessageAsync));
-            }
-        }
-
-        public override async Task AbandonMessageAsync(string lockToken, CancellationToken cancellationToken)
-        {
-            try
-            {
-                if (Logging.IsEnabled)
-                    Logging.Enter(this, lockToken, cancellationToken, nameof(AbandonMessageAsync));
-
-                await _internalRetryPolicy
-                    .RunWithRetryAsync(
-                        async () =>
-                        {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
-                            await base.AbandonMessageAsync(lockToken, cancellationToken).ConfigureAwait(false);
-                        },
-                        cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            finally
-            {
-                if (Logging.IsEnabled)
-                    Logging.Exit(this, lockToken, cancellationToken, nameof(AbandonMessageAsync));
-            }
-        }
-
-        public override async Task RejectMessageAsync(string lockToken, CancellationToken cancellationToken)
-        {
-            try
-            {
-                if (Logging.IsEnabled)
-                    Logging.Enter(this, lockToken, cancellationToken, nameof(RejectMessageAsync));
-
-                await _internalRetryPolicy
-                    .RunWithRetryAsync(
-                        async () =>
-                        {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
-                            await base.RejectMessageAsync(lockToken, cancellationToken).ConfigureAwait(false);
-                        },
-                        cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            finally
-            {
-                if (Logging.IsEnabled)
-                    Logging.Exit(this, lockToken, cancellationToken, nameof(RejectMessageAsync));
             }
         }
 

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             IotHubClientAmqpSettings amqpSettings,
             Func<DirectMethodRequest, Task> onMethodCallback,
             Action<Twin, string, TwinCollection, IotHubClientException> twinMessageListener,
-            Func<Message, Task> onMessageReceivedCallback,
+            Func<Message, Task<MessageAcknowledgement>> onMessageReceivedCallback,
             Action onUnitDisconnected)
         {
             if (Logging.IsEnabled)

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionPool.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             IotHubClientAmqpSettings amqpSettings,
             Func<DirectMethodRequest, Task> onMethodCallback,
             Action<Twin, string, TwinCollection, IotHubClientException> twinMessageListener,
-            Func<Message, Task> onMessageReceivedCallback,
+            Func<Message, Task<MessageAcknowledgement>> onMessageReceivedCallback,
             Action onUnitDisconnected)
         {
             if (Logging.IsEnabled)

--- a/iothub/device/src/Transport/Amqp/AmqpUnit.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnit.cs
@@ -531,19 +531,19 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
             AmqpIotOutcome disposeOutcome;
             if (string.IsNullOrWhiteSpace(_connectionCredentials.ModuleId) || string.IsNullOrWhiteSpace(_connectionCredentials.GatewayHostName))
             {
-                await EnableEdgeModuleEventReceiveAsync(cancellationToken).ConfigureAwait(false);
+                await EnsureMessageReceivingLinkIsOpenAsync(cancellationToken).ConfigureAwait(false);
 
-                // Acknowledge the message over the edgehub to module message receiver link
-                disposeOutcome = await _eventReceivingLink
+                // Acknowledge the message over the cloud to device/module message receiver link
+                disposeOutcome = await _messageReceivingLink
                     .DisposeMessageAsync(deliveryTag, AmqpIotResultAdapter.GetResult(amqpAcknowledgementType), cancellationToken)
                     .ConfigureAwait(false);
             }
             else
             {
-                await EnsureMessageReceivingLinkIsOpenAsync(cancellationToken).ConfigureAwait(false);
+                await EnableEdgeModuleEventReceiveAsync(cancellationToken).ConfigureAwait(false);
 
-                // Acknowledge the message over the cloud to device/module message receiver link
-                disposeOutcome = await _messageReceivingLink
+                // Acknowledge the message over the edgehub to module message receiver link
+                disposeOutcome = await _eventReceivingLink
                     .DisposeMessageAsync(deliveryTag, AmqpIotResultAdapter.GetResult(amqpAcknowledgementType), cancellationToken)
                     .ConfigureAwait(false);
             }

--- a/iothub/device/src/Transport/Amqp/AmqpUnitManager.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnitManager.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             IotHubClientAmqpSettings amqpSettings,
             Func<DirectMethodRequest, Task> onMethodCallback,
             Action<Twin, string, TwinCollection, IotHubClientException> twinMessageListener,
-            Func<Message, Task> onMessageReceivedCallback,
+            Func<Message, Task<MessageAcknowledgement>> onMessageReceivedCallback,
             Action onUnitDisconnected)
         {
             IAmqpUnitManager amqpConnectionPool = ResolveConnectionPool(connectionCredentials.HostName);

--- a/iothub/device/src/Transport/Amqp/IAmqpUnitManager.cs
+++ b/iothub/device/src/Transport/Amqp/IAmqpUnitManager.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             IotHubClientAmqpSettings amqpSettings,
             Func<DirectMethodRequest, Task> onMethodCallback,
             Action<Twin, string, TwinCollection, IotHubClientException> twinMessageListener,
-            Func<Message, Task> onMessageReceivedCallback,
+            Func<Message, Task<MessageAcknowledgement>> onMessageReceivedCallback,
             Action onUnitDisconnected);
 
         void RemoveAmqpUnit(AmqpUnit amqpUnit);

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotMessageConverter.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotMessageConverter.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
         public static void UpdateMessageHeaderAndProperties(AmqpMessage amqpMessage, Message message)
         {
             Fx.AssertAndThrow(amqpMessage.DeliveryTag != null, "AmqpMessage should always contain delivery tag.");
-            message.DeliveryTag = amqpMessage.DeliveryTag;
 
             SectionFlag sections = amqpMessage.Sections;
             if ((sections & SectionFlag.Properties) != 0)
@@ -103,11 +102,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
 
             if ((sections & SectionFlag.MessageAnnotations) != 0)
             {
-                if (amqpMessage.MessageAnnotations.Map.TryGetValue(LockTokenName, out string lockToken))
-                {
-                    message.LockToken = lockToken;
-                }
-
                 if (amqpMessage.MessageAnnotations.Map.TryGetValue(SequenceNumberName, out ulong sequenceNumber))
                 {
                     message.SequenceNumber = sequenceNumber;

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         private readonly Func<DirectMethodRequest, Task> _methodListener;
         private readonly Action<TwinCollection> _onDesiredStatePatchListener;
-        private readonly Func<Message, Task> _messageReceivedListener;
+        private readonly Func<Message, Task<MessageAcknowledgement>> _messageReceivedListener;
 
         private readonly ConcurrentDictionary<string, TaskCompletionSource<GetTwinResponse>> _getTwinResponseCompletions = new();
         private readonly ConcurrentDictionary<string, TaskCompletionSource<PatchTwinResponse>> _reportedPropertyUpdateResponseCompletions = new();
@@ -417,13 +417,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             // is the recommended pattern for sending large numbers of messages over an asynchronous
             // protocol like MQTT
             await Task.WhenAll(messages.Select(x => SendEventAsync(x, cancellationToken))).ConfigureAwait(false);
-        }
-
-        public override Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken)
-        {
-            //TODO stubbing this method because we plan on removing it from the device client later.
-            Message message = null;
-            return Task.FromResult(message);
         }
 
         public override async Task EnableMethodsAsync(CancellationToken cancellationToken)
@@ -918,12 +911,15 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             if (_messageReceivedListener != null)
             {
-                // We are intentionally not awaiting _messageReceivedListener callback.
-                // This is a user-supplied callback that isn't required to be awaited by us. We can simply invoke it and continue.
-                _ = _messageReceivedListener.Invoke(receivedCloudToDeviceMessage);
+                MessageAcknowledgement acknowledgementType = await _messageReceivedListener.Invoke(receivedCloudToDeviceMessage);
 
-                // note that MQTT does not support Abandon or Reject, so always Complete by acknowledging the message like this.
-                // Also note that
+                if (acknowledgementType != MessageAcknowledgement.Complete)
+                {
+                    if (Logging.IsEnabled)
+                        Logging.Error(this, "Cannot 'reject' or 'abandon' a received message over MQTT. Message will be acknowledged as 'complete' instead.");
+                }
+
+                // Note that MQTT does not support Abandon or Reject, so always Complete by acknowledging the message like this.
                 try
                 {
                     await receivedEventArgs.AcknowledgeAsync(CancellationToken.None).ConfigureAwait(false);

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -107,10 +107,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         private static TimeSpan s_twinResponseTimeout = TimeSpan.FromMinutes(60);
 
-        // Used to correlate back to a received message when the user wants to acknowledge it. This is not a value
-        // that is sent over the wire, so we increment this value locally instead.
-        private int _nextLockToken;
-
         private readonly string _deviceId;
         private readonly string _moduleId;
         private readonly string _hostName;
@@ -1067,8 +1063,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         public void PopulateMessagePropertiesFromMqttMessage(Message message, MqttApplicationMessage mqttMessage)
         {
-            message.LockToken = (++_nextLockToken).ToString();
-
             // Device bound messages could be in 2 formats, depending on whether it is going to the device, or to a module endpoint
             // Format 1 - going to the device - devices/{deviceId}/messages/devicebound/{properties}/
             // Format 2 - going to module endpoint - devices/{deviceId}/modules/{moduleId/endpoints/{endpointId}/{properties}/

--- a/iothub/device/tests/IotHubModuleClientTests.cs
+++ b/iothub/device/tests/IotHubModuleClientTests.cs
@@ -143,7 +143,6 @@ namespace Microsoft.Azure.Devices.Client.Test
             var testMessage = new Message
             {
                 InputName = "endpoint1",
-                LockToken = "AnyLockToken",
             };
 
             await moduleClient.OnMessageReceivedAsync(testMessage).ConfigureAwait(false);

--- a/iothub/device/tests/IotHubModuleClientTests.cs
+++ b/iothub/device/tests/IotHubModuleClientTests.cs
@@ -103,27 +103,6 @@ namespace Microsoft.Azure.Devices.Client.Test
         }
 
         [TestMethod]
-        public async Task ModuleClient_OnReceiveEventMessageCalled_NullMessageRequest()
-        {
-            using var moduleClient = new IotHubModuleClient(FakeConnectionString);
-            IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
-            moduleClient.InnerHandler = innerHandler;
-
-            bool isMessageHandlerCalled = false;
-            await moduleClient
-                .SetMessageHandlerAsync(
-                    (message) =>
-                    {
-                        isMessageHandlerCalled = true;
-                        return Task.FromResult(MessageAcknowledgement.Complete);
-                    })
-                .ConfigureAwait(false);
-
-            await moduleClient.OnMessageReceivedAsync(null).ConfigureAwait(false);
-            Assert.IsFalse(isMessageHandlerCalled);
-        }
-
-        [TestMethod]
         public async Task ModuleClient_OnReceiveEventMessageCalled_DefaultCallbackCalled()
         {
             using var moduleClient = new IotHubModuleClient(FakeConnectionString);

--- a/iothub/device/tests/Pipeline/ErrorDelegatingHandlerTests.cs
+++ b/iothub/device/tests/Pipeline/ErrorDelegatingHandlerTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices.Client.Test
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Amqp;
-        using Microsoft.Azure.Devices.Client.Transport;
+    using Microsoft.Azure.Devices.Client.Transport;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using NSubstitute;
 
@@ -138,32 +138,6 @@ namespace Microsoft.Azure.Devices.Client.Test
                 di => di.OpenAsync(Arg.Any<CancellationToken>()),
                 di => di.OpenAsync(cancellationToken),
                 di => di.Received(2).OpenAsync(Arg.Any<CancellationToken>()),
-                thrownExceptionType, expectedExceptionType).ConfigureAwait(false);
-
-            string lockToken = "lockToken";
-
-            await OperationAsync_ExceptionThrownAndThenSucceed_OperationSuccessfullyCompleted(
-                di => di.CompleteMessageAsync(Arg.Is(lockToken), Arg.Any<CancellationToken>()),
-                di => di.CompleteMessageAsync(lockToken, cancellationToken),
-                di => di.Received(2).CompleteMessageAsync(Arg.Is(lockToken), Arg.Any<CancellationToken>()),
-                thrownExceptionType, expectedExceptionType).ConfigureAwait(false);
-
-            await OperationAsync_ExceptionThrownAndThenSucceed_OperationSuccessfullyCompleted(
-                di => di.AbandonMessageAsync(Arg.Is(lockToken), Arg.Any<CancellationToken>()),
-                di => di.AbandonMessageAsync(lockToken, cancellationToken),
-                di => di.Received(2).AbandonMessageAsync(Arg.Is(lockToken), Arg.Any<CancellationToken>()),
-                thrownExceptionType, expectedExceptionType).ConfigureAwait(false);
-
-            await OperationAsync_ExceptionThrownAndThenSucceed_OperationSuccessfullyCompleted(
-                di => di.RejectMessageAsync(Arg.Is(lockToken), Arg.Any<CancellationToken>()),
-                di => di.RejectMessageAsync(lockToken, cancellationToken),
-                di => di.Received(2).RejectMessageAsync(Arg.Is(lockToken), Arg.Any<CancellationToken>()),
-                thrownExceptionType, expectedExceptionType).ConfigureAwait(false);
-
-            await OperationAsync_ExceptionThrownAndThenSucceed_OperationSuccessfullyCompleted(
-                di => di.ReceiveMessageAsync(Arg.Any<CancellationToken>()),
-                di => di.ReceiveMessageAsync(cancellationToken),
-                di => di.Received(2).ReceiveMessageAsync(Arg.Any<CancellationToken>()),
                 thrownExceptionType, expectedExceptionType).ConfigureAwait(false);
         }
 

--- a/iothub/device/tests/Pipeline/RetryDelegatingHandlerImplicitOpenTests.cs
+++ b/iothub/device/tests/Pipeline/RetryDelegatingHandlerImplicitOpenTests.cs
@@ -38,21 +38,12 @@ namespace Microsoft.Azure.Devices.Client.Test
             nextHandlerMock.OpenAsync(Arg.Any<CancellationToken>()).Returns(t => Task.CompletedTask);
             nextHandlerMock.SendEventAsync(Arg.Any<Message>(), Arg.Any<CancellationToken>()).Returns(t => Task.CompletedTask);
             nextHandlerMock.SendEventAsync(Arg.Any<IEnumerable<Message>>(), Arg.Any<CancellationToken>()).Returns(t => Task.CompletedTask);
-            nextHandlerMock.ReceiveMessageAsync(Arg.Any<CancellationToken>()).Returns(t => Task.FromResult(new Message()));
-            nextHandlerMock.ReceiveMessageAsync(Arg.Any<CancellationToken>()).Returns(t => Task.FromResult(new Message()));
-            nextHandlerMock.AbandonMessageAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(t => Task.CompletedTask);
-            nextHandlerMock.CompleteMessageAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(t => Task.CompletedTask);
-            nextHandlerMock.RejectMessageAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(t => Task.CompletedTask);
             nextHandlerMock.WaitForTransportClosedAsync().Returns(Task.Delay(TimeSpan.FromSeconds(10)));
             var cancellationToken = new CancellationToken();
             var actions = new Func<IDelegatingHandler, Task>[]
             {
                 sut => sut.SendEventAsync(new Message(), cancellationToken),
                 sut => sut.SendEventAsync(new[] { new Message() }, cancellationToken),
-                sut => sut.ReceiveMessageAsync(cancellationToken),
-                sut => sut.AbandonMessageAsync(string.Empty, cancellationToken),
-                sut => sut.CompleteMessageAsync(string.Empty, cancellationToken),
-                sut => sut.RejectMessageAsync(string.Empty, cancellationToken),
             };
 
             foreach (Func<IDelegatingHandler, Task> action in actions)

--- a/iothub/device/tests/Transport/Amqp/AmqpTransportHandlerTests.cs
+++ b/iothub/device/tests/Transport/Amqp/AmqpTransportHandlerTests.cs
@@ -41,30 +41,6 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
         }
 
         [TestMethod]
-        public async Task AmqpTransportHandlerReceiveAsyncTokenCancellationRequested()
-        {
-            await TestOperationCanceledByToken(token => CreateFromConnectionString().ReceiveMessageAsync(token)).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task AmqpTransportHandlerCompleteAsyncTokenCancellationRequested()
-        {
-            await TestOperationCanceledByToken(token => CreateFromConnectionString().CompleteMessageAsync(Guid.NewGuid().ToString(), token)).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task AmqpTransportHandlerAbandonAsyncTokenCancellationRequested()
-        {
-            await TestOperationCanceledByToken(token => CreateFromConnectionString().AbandonMessageAsync(Guid.NewGuid().ToString(), token)).ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        public async Task AmqpTransportHandlerRejectAsyncTokenCancellationRequested()
-        {
-            await TestOperationCanceledByToken(token => CreateFromConnectionString().RejectMessageAsync(Guid.NewGuid().ToString(), token)).ConfigureAwait(false);
-        }
-
-        [TestMethod]
         public async Task AmqpTransport_Select_CorrectReceiverLink_ForModuleTwin()
         {
             var mockedMockAmqpTransportHandler = new Mock<MockableAmqpTransportHandler>();

--- a/iothub/device/tests/Transport/Amqp/MockableAmqpUnit.cs
+++ b/iothub/device/tests/Transport/Amqp/MockableAmqpUnit.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
             IAmqpConnectionHolder amqpConnectionHolder,
             Func<DirectMethodRequest, Task> onMethodCallback = null,
             Action<Twin, string, TwinCollection, IotHubClientException> twinMessageListener = null,
-            Func<Message, Task> onMessageReceivedCallback = null,
+            Func<Message, Task<MessageAcknowledgement>> onMessageReceivedCallback = null,
             Action onUnitDisconnected = null)
             : base(
                   connectionCredentials,


### PR DESCRIPTION
CompleteAsync/AbandonAsync/RejectAsync methods are also removed

Also removed lock token and delivery tag fields from the message class. Now that we use callback everywhere, we don't need these correlation fields in the message itself. The MQTT/AMQP layer can correlate this message without them.
