### PR TITLE
Use the term callback for non-event-handler delegates

### DIFF
--- a/e2e/test/helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/helpers/TestDeviceCallbackHandler.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         public async Task SetDeviceReceiveMethodAsync<T>(string methodName, object deviceResponseJson, T expectedServiceRequestJson)
         {
             await _deviceClient.OpenAsync().ConfigureAwait(false);
-            await _deviceClient.SetMethodCallbackAsync(
+            await _deviceClient.SetDirectMethodCallbackAsync(
                 (request) =>
                 {
                     try

--- a/e2e/test/helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/helpers/TestDeviceCallbackHandler.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         public async Task SetDeviceReceiveMethodAsync<T>(string methodName, object deviceResponseJson, T expectedServiceRequestJson)
         {
             await _deviceClient.OpenAsync().ConfigureAwait(false);
-            await _deviceClient.SetMethodHandlerAsync(
+            await _deviceClient.SetMethodCallbackAsync(
                 (request) =>
                 {
                     try
@@ -129,13 +129,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         public async Task SetMessageReceiveCallbackHandlerAsync()
         {
             await _deviceClient.OpenAsync().ConfigureAwait(false);
-            await _deviceClient.SetMessageHandlerAsync(OnC2dMessageReceivedAsync).ConfigureAwait(false);
+            await _deviceClient.SetMessageCallbackAsync(OnC2dMessageReceivedAsync).ConfigureAwait(false);
         }
 
         public async Task UnsetMessageReceiveCallbackHandlerAsync()
         {
             await _deviceClient.OpenAsync().ConfigureAwait(false);
-            await _deviceClient.SetMessageHandlerAsync(null).ConfigureAwait(false);
+            await _deviceClient.SetMessageCallbackAsync(null).ConfigureAwait(false);
         }
 
         private Task<MessageAcknowledgement> OnC2dMessageReceivedAsync(Client.Message message)

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
 
             int connectionStatusChangeCount = 0;
 
-            deviceClient.SetConnectionStatusChangeHandler(connectionStatusInfo =>
+            deviceClient.SetConnectionStatusChangeCallback(connectionStatusInfo =>
             {
                 connectionStatusChangeCount++;
                 logger.Trace($"{nameof(FaultInjection)}.{nameof(TestErrorInjectionAsync)}: status={connectionStatusInfo.Status} statusChangeReason={connectionStatusInfo.ChangeReason} count={connectionStatusChangeCount}");

--- a/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                 IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSettings), authScope);
 
                 var amqpConnectionStatusesChange = new AmqpConnectionStatusChange(testDevice.Id, logger);
-                deviceClient.SetConnectionStatusChangeHandler(amqpConnectionStatusesChange.ConnectionStatusChangeHandler);
+                deviceClient.SetConnectionStatusChangeCallback(amqpConnectionStatusesChange.ConnectionStatusChangeHandler);
 
                 var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, logger);
 

--- a/e2e/test/helpers/templates/PoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/PoolingOverAmqp.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
 
                     // Set the device client connection status change handler
                     var amqpConnectionStatusChange = new AmqpConnectionStatusChange(logger);
-                    deviceClient.SetConnectionStatusChangeHandler(amqpConnectionStatusChange.ConnectionStatusChangeHandler);
+                    deviceClient.SetConnectionStatusChangeCallback(amqpConnectionStatusChange.ConnectionStatusChangeHandler);
 
                     var testDeviceCallbackHandler = new TestDeviceCallbackHandler(deviceClient, testDevice, logger);
 

--- a/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 }
             }
 
-            deviceClient.SetConnectionStatusChangeHandler(statusChangeHandler);
+            deviceClient.SetConnectionStatusChangeCallback(statusChangeHandler);
             Logger.Trace($"{nameof(IotHubDeviceClient_Gives_ConnectionStatus_Disconnected_ChangeReason_DeviceDisabled_Base)}: Created {nameof(IotHubDeviceClient)} with device Id={testDevice.Id}");
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             var options = new IotHubClientOptions(transportSettings);
 
             using var moduleClient = new IotHubModuleClient(testModule.ConnectionString, options);
-            moduleClient.SetConnectionStatusChangeHandler(statusChangeHandler);
+            moduleClient.SetConnectionStatusChangeCallback(statusChangeHandler);
             Logger.Trace($"{nameof(IotHubModuleClient_Gives_ConnectionStatus_Disconnected_ChangeReason_DeviceDisabled_Base)}: Created {nameof(IotHubModuleClient)} with moduleId={testModule.Id}");
 
             await moduleClient.OpenAsync().ConfigureAwait(false);

--- a/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             using IotHubDeviceClient deviceClient = new IotHubDeviceClient(testDevice.IotHubHostName, auth, options);
             Logger.Trace($"Created {nameof(IotHubDeviceClient)} instance for {testDevice.Id}.");
 
-            deviceClient.SetConnectionStatusChangeHandler((ConnectionStatusInfo connectionStatusInfo) =>
+            deviceClient.SetConnectionStatusChangeCallback((ConnectionStatusInfo connectionStatusInfo) =>
             {
                 ConnectionStatus status = connectionStatusInfo.Status;
                 ConnectionStatusChangeReason reason = connectionStatusInfo.ChangeReason;
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             if (transportSettings is IotHubClientMqttSettings
                 && transportSettings.Protocol == IotHubClientTransportProtocol.Tcp)
             {
-                deviceClient.SetConnectionStatusChangeHandler((ConnectionStatusInfo connectionStatusInfo) =>
+                deviceClient.SetConnectionStatusChangeCallback((ConnectionStatusInfo connectionStatusInfo) =>
                 {
                     ConnectionStatus status = connectionStatusInfo.Status;
                     ConnectionStatusChangeReason reason = connectionStatusInfo.ChangeReason;

--- a/e2e/test/iothub/NoRetryE2ETests.cs
+++ b/e2e/test/iothub/NoRetryE2ETests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             deviceClient.SetRetryPolicy(new NoRetry());
 
             var connectionStatusChange = new Dictionary<ConnectionStatus, int>();
-            deviceClient.SetConnectionStatusChangeHandler((connectionStatusInfo) =>
+            deviceClient.SetConnectionStatusChangeCallback((connectionStatusInfo) =>
             {
                 connectionStatusChange.TryGetValue(connectionStatusInfo.Status, out int count);
                 count++;
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             deviceClient1.SetRetryPolicy(new NoRetry());
 
             var connectionStatusChangeDevice1 = new Dictionary<ConnectionStatus, int>();
-            deviceClient1.SetConnectionStatusChangeHandler((connectionStatusInfo) =>
+            deviceClient1.SetConnectionStatusChangeCallback((connectionStatusInfo) =>
             {
                 connectionStatusChangeDevice1.TryGetValue(connectionStatusInfo.Status, out int count);
                 count++;
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             });
 
             var connectionStatusChangeDevice2 = new Dictionary<ConnectionStatus, int>();
-            deviceClient2.SetConnectionStatusChangeHandler((connectionStatusInfo) =>
+            deviceClient2.SetConnectionStatusChangeCallback((connectionStatusInfo) =>
             {
                 connectionStatusChangeDevice2.TryGetValue(connectionStatusInfo.Status, out int count);
                 count++;
@@ -114,14 +114,14 @@ namespace Microsoft.Azure.Devices.E2ETests
             var response = new Client.DirectMethodResponse(200);
 
             await deviceClient1
-                .SetMethodHandlerAsync(
+                .SetMethodCallbackAsync(
                     (methodRequest) => Task.FromResult(response))
                 .ConfigureAwait(false);
 
             Logger.Trace($"{nameof(DuplicateDevice_NoRetry_NoPingpong_OpenAsync)}: device client instance 2 calling OpenAsync...");
             await deviceClient2.OpenAsync().ConfigureAwait(false);
             await deviceClient2
-                .SetMethodHandlerAsync(
+                .SetMethodCallbackAsync(
                     (methodRequest) => Task.FromResult(response))
                 .ConfigureAwait(false);
 

--- a/e2e/test/iothub/NoRetryE2ETests.cs
+++ b/e2e/test/iothub/NoRetryE2ETests.cs
@@ -114,14 +114,14 @@ namespace Microsoft.Azure.Devices.E2ETests
             var response = new Client.DirectMethodResponse(200);
 
             await deviceClient1
-                .SetMethodCallbackAsync(
+                .SetDirectMethodCallbackAsync(
                     (methodRequest) => Task.FromResult(response))
                 .ConfigureAwait(false);
 
             Logger.Trace($"{nameof(DuplicateDevice_NoRetry_NoPingpong_OpenAsync)}: device client instance 2 calling OpenAsync...");
             await deviceClient2.OpenAsync().ConfigureAwait(false);
             await deviceClient2
-                .SetMethodCallbackAsync(
+                .SetDirectMethodCallbackAsync(
                     (methodRequest) => Task.FromResult(response))
                 .ConfigureAwait(false);
 

--- a/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                     c2dMessageReceived.TrySetResult(message);
                     return Task.FromResult(MessageAcknowledgement.Complete);
                 };
-                await dc.SetMessageHandlerAsync(OnC2DMessageReceived).ConfigureAwait(false);
+                await dc.SetMessageCallbackAsync(OnC2DMessageReceived).ConfigureAwait(false);
 
                 Client.Message receivedMessage = await TaskCompletionSourceHelper.GetTaskCompletionSourceResultAsync(c2dMessageReceived, cts.Token).ConfigureAwait(false);
 
@@ -247,7 +247,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             var options = new IotHubClientOptions(transportSettings);
             using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(options);
             bool lostConnection = false;
-            deviceClient.SetConnectionStatusChangeHandler(connectionStatusInfo =>
+            deviceClient.SetConnectionStatusChangeCallback(connectionStatusInfo =>
             {
                 if (connectionStatusInfo.Status == ConnectionStatus.Disconnected || connectionStatusInfo.Status == ConnectionStatus.DisconnectedRetrying)
                 {
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             // This will make the client unsubscribe from the mqtt c2d topic/close the amqp c2d link. Neither event
             // should close the connection as a whole, though.
-            await deviceClient.SetMessageHandlerAsync(null).ConfigureAwait(false);
+            await deviceClient.SetMessageCallbackAsync(null).ConfigureAwait(false);
 
             await Task.Delay(1000).ConfigureAwait(false);
 

--- a/e2e/test/iothub/method/MethodE2ECustomPayloadTests.cs
+++ b/e2e/test/iothub/method/MethodE2ECustomPayloadTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodHandlerAsync(
+                .SetMethodCallbackAsync(
                     (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_booleanPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodHandlerAsync(
+                .SetMethodCallbackAsync(
                     (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_customPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodHandlerAsync(
+                .SetMethodCallbackAsync(
                     (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_listPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodHandlerAsync(
+                .SetMethodCallbackAsync(
                     (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_dictionaryPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
@@ -298,7 +298,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodHandlerAsync(
+                .SetMethodCallbackAsync(
                     (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_arrayPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");

--- a/e2e/test/iothub/method/MethodE2ECustomPayloadTests.cs
+++ b/e2e/test/iothub/method/MethodE2ECustomPayloadTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodCallbackAsync(
+                .SetDirectMethodCallbackAsync(
                     (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_booleanPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodCallbackAsync(
+                .SetDirectMethodCallbackAsync(
                     (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_customPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodCallbackAsync(
+                .SetDirectMethodCallbackAsync(
                     (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_listPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodCallbackAsync(
+                .SetDirectMethodCallbackAsync(
                     (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_dictionaryPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
@@ -298,7 +298,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodCallbackAsync(
+                .SetDirectMethodCallbackAsync(
                     (request) =>
                     {
                         logger.Trace($"{nameof(SetDeviceReceiveMethod_arrayPayloadAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             {
                 await deviceClient.OpenAsync().ConfigureAwait(false);
                 await deviceClient
-                    .SetMethodHandlerAsync(
+                    .SetMethodCallbackAsync(
                         (methodRequest) =>
                         {
                             methodRequest.MethodName.Should().Be(commandName);
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             {
                 // clean up
 
-                await deviceClient.SetMethodHandlerAsync(null).ConfigureAwait(false);
+                await deviceClient.SetMethodCallbackAsync(null).ConfigureAwait(false);
                 await deviceClient.CloseAsync().ConfigureAwait(false);
                 await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
             }
@@ -341,7 +341,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodHandlerAsync(
+                .SetMethodCallbackAsync(
                 (request) =>
                 {
                     // This test only verifies that unsubscripion works.
@@ -356,7 +356,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     })
                 .ConfigureAwait(false);
 
-            await deviceClient.SetMethodHandlerAsync(null).ConfigureAwait(false);
+            await deviceClient.SetMethodCallbackAsync(null).ConfigureAwait(false);
 
             // Return the task that tells us we have received the callback.
             return methodCallReceived.Task;
@@ -367,7 +367,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodHandlerAsync(
+                .SetMethodCallbackAsync(
                     (request) =>
                         {
                             logger.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
@@ -406,7 +406,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
         {
             var methodCallReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             await moduleClient.OpenAsync().ConfigureAwait(false);
-            await moduleClient.SetMethodHandlerAsync(
+            await moduleClient.SetMethodCallbackAsync(
                 (request) =>
                 {
                     logger.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: ModuleClient method: {request.MethodName} {request.ResponseTimeout}.");

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             {
                 await deviceClient.OpenAsync().ConfigureAwait(false);
                 await deviceClient
-                    .SetMethodCallbackAsync(
+                    .SetDirectMethodCallbackAsync(
                         (methodRequest) =>
                         {
                             methodRequest.MethodName.Should().Be(commandName);
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             {
                 // clean up
 
-                await deviceClient.SetMethodCallbackAsync(null).ConfigureAwait(false);
+                await deviceClient.SetDirectMethodCallbackAsync(null).ConfigureAwait(false);
                 await deviceClient.CloseAsync().ConfigureAwait(false);
                 await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
             }
@@ -341,7 +341,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodCallbackAsync(
+                .SetDirectMethodCallbackAsync(
                 (request) =>
                 {
                     // This test only verifies that unsubscripion works.
@@ -356,7 +356,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                     })
                 .ConfigureAwait(false);
 
-            await deviceClient.SetMethodCallbackAsync(null).ConfigureAwait(false);
+            await deviceClient.SetDirectMethodCallbackAsync(null).ConfigureAwait(false);
 
             // Return the task that tells us we have received the callback.
             return methodCallReceived.Task;
@@ -367,7 +367,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             var methodCallReceived = new TaskCompletionSource<bool>();
             await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient
-                .SetMethodCallbackAsync(
+                .SetDirectMethodCallbackAsync(
                     (request) =>
                         {
                             logger.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: DeviceClient method: {request.MethodName} {request.ResponseTimeout}.");
@@ -406,7 +406,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
         {
             var methodCallReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             await moduleClient.OpenAsync().ConfigureAwait(false);
-            await moduleClient.SetMethodCallbackAsync(
+            await moduleClient.SetDirectMethodCallbackAsync(
                 (request) =>
                 {
                     logger.Trace($"{nameof(SetDeviceReceiveMethodAsync)}: ModuleClient method: {request.MethodName} {request.ResponseTimeout}.");

--- a/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
+++ b/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 // Set callback to handle root-level command invocation request.
                 int expectedCommandStatus = 200;
                 string commandName = "getMaxMinReport";
-                await deviceClient.SetMethodCallbackAsync(
+                await deviceClient.SetDirectMethodCallbackAsync(
                     (request) =>
                     {
                         Logger.Trace($"{nameof(DigitalTwinWithOnlyRootComponentOperationsAsync)}: Digital twin command received: {request.MethodName}.");
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 string rootCommandName = "reboot";
                 string componentCommandName = "getMaxMinReport";
                 string componentCommandNamePnp = $"{componentName}*{componentCommandName}";
-                await deviceClient.SetMethodCallbackAsync(
+                await deviceClient.SetDirectMethodCallbackAsync(
                     (request) =>
                     {
                         Logger.Trace($"{nameof(DigitalTwinWithOnlyRootComponentOperationsAsync)}: Digital twin command received: {request.MethodName}.");

--- a/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
+++ b/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 // Set callback to handle root-level command invocation request.
                 int expectedCommandStatus = 200;
                 string commandName = "getMaxMinReport";
-                await deviceClient.SetMethodHandlerAsync(
+                await deviceClient.SetMethodCallbackAsync(
                     (request) =>
                     {
                         Logger.Trace($"{nameof(DigitalTwinWithOnlyRootComponentOperationsAsync)}: Digital twin command received: {request.MethodName}.");
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 string rootCommandName = "reboot";
                 string componentCommandName = "getMaxMinReport";
                 string componentCommandNamePnp = $"{componentName}*{componentCommandName}";
-                await deviceClient.SetMethodHandlerAsync(
+                await deviceClient.SetMethodCallbackAsync(
                     (request) =>
                     {
                         Logger.Trace($"{nameof(DigitalTwinWithOnlyRootComponentOperationsAsync)}: Digital twin command received: {request.MethodName}.");

--- a/e2e/test/iothub/service/MessageFeedbackReceiverE2ETest.cs
+++ b/e2e/test/iothub/service/MessageFeedbackReceiverE2ETest.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                     c2dMessageReceived.TrySetResult(true);
                     return Task.FromResult(MessageAcknowledgement.Complete);
                 };
-                await deviceClient.SetMessageHandlerAsync(OnC2DMessageReceived).ConfigureAwait(false);
+                await deviceClient.SetMessageCallbackAsync(OnC2DMessageReceived).ConfigureAwait(false);
 
                 await Task
                     .WhenAny(

--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             {
                 Interlocked.Increment(ref connectionStatusChangeCount);
             }
-            deviceClient.SetConnectionStatusChangeHandler(connectionStatusChangeHandler);
+            deviceClient.SetConnectionStatusChangeCallback(connectionStatusChangeHandler);
 
             string propName = Guid.NewGuid().ToString();
             string propValue = Guid.NewGuid().ToString();

--- a/iothub/device/samples/getting started/MessageReceiveSample/MessageReceiveSample.cs
+++ b/iothub/device/samples/getting started/MessageReceiveSample/MessageReceiveSample.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             Console.WriteLine($"{DateTime.Now}> Press Control+C at any time to quit the sample.");
 
             // Now subscribe to receive C2D messages through a callback (which isn't supported over HTTP).
-            await _deviceClient.SetMessageHandlerAsync(OnC2dMessageReceivedAsync);
+            await _deviceClient.SetMessageCallbackAsync(OnC2dMessageReceivedAsync);
             Console.WriteLine($"\n{DateTime.Now}> Subscribed to receive C2D messages over callback.");
 
             // Now wait to receive C2D messages through the callback.
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
 
             // Now unsubscibe from receiving the callback.
-            await _deviceClient.SetMessageHandlerAsync(null);
+            await _deviceClient.SetMessageCallbackAsync(null);
         }
 
         private Task<MessageAcknowledgement> OnC2dMessageReceivedAsync(Message receivedMessage)

--- a/iothub/device/samples/getting started/MethodSample/MethodSample.cs
+++ b/iothub/device/samples/getting started/MethodSample/MethodSample.cs
@@ -36,10 +36,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 Console.WriteLine("Sample execution cancellation requested; will exit.");
             };
 
-            _deviceClient.SetConnectionStatusChangeHandler(ConnectionStatusChangeHandler);
+            _deviceClient.SetConnectionStatusChangeCallback(ConnectionStatusChangeHandler);
 
             // Setup a callback dispatcher for the incoming methods.
-            await _deviceClient.SetMethodHandlerAsync(
+            await _deviceClient.SetMethodCallbackAsync(
                 OnDirectMethodCalledAsync,
                 cts.Token);
 
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
 
             // You can unsubscribe from receiving a callback for direct methods by setting a null callback handler.
-            await _deviceClient.SetMethodHandlerAsync(
+            await _deviceClient.SetMethodCallbackAsync(
                 null);
         }
 

--- a/iothub/device/samples/getting started/MethodSample/MethodSample.cs
+++ b/iothub/device/samples/getting started/MethodSample/MethodSample.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             _deviceClient.SetConnectionStatusChangeCallback(ConnectionStatusChangeHandler);
 
             // Setup a callback dispatcher for the incoming methods.
-            await _deviceClient.SetMethodCallbackAsync(
+            await _deviceClient.SetDirectMethodCallbackAsync(
                 OnDirectMethodCalledAsync,
                 cts.Token);
 
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
 
             // You can unsubscribe from receiving a callback for direct methods by setting a null callback handler.
-            await _deviceClient.SetMethodCallbackAsync(
+            await _deviceClient.SetDirectMethodCallbackAsync(
                 null);
         }
 

--- a/iothub/device/samples/how to guides/DeviceReconnectionSample/DeviceReconnectionSample.cs
+++ b/iothub/device/samples/how to guides/DeviceReconnectionSample/DeviceReconnectionSample.cs
@@ -117,8 +117,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
                         }
 
                         s_deviceClient = new IotHubDeviceClient(_deviceConnectionStrings.First(), _clientOptions);
-                        s_deviceClient.SetConnectionStatusChangeHandler(ConnectionStatusChangeHandlerAsync);
-                        await s_deviceClient.SetMessageHandlerAsync(OnMessageReceivedAsync, cancellationToken);
+                        s_deviceClient.SetConnectionStatusChangeCallback(ConnectionStatusChangeHandlerAsync);
+                        await s_deviceClient.SetMessageCallbackAsync(OnMessageReceivedAsync, cancellationToken);
                         _logger.LogDebug("Initialized the client instance.");
                     }
                 }

--- a/iothub/device/samples/solutions/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iothub/device/samples/solutions/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             // -> Periodically send "temperature" over telemetry - on "Thermostat" components.
             // -> Send "maxTempSinceLastReboot" over property update, when a new max temperature is set - on "Thermostat" components.
 
-            _deviceClient.SetConnectionStatusChangeHandler(async (info) =>
+            _deviceClient.SetConnectionStatusChangeCallback(async (info) =>
             {
                 _logger.LogDebug($"Connection status change registered - status={info.Status}, reason={info.ChangeReason}.");
 
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 }
             });
 
-            await _deviceClient.SetMethodHandlerAsync(OnDirectMethodAsync, cancellationToken);
+            await _deviceClient.SetMethodCallbackAsync(OnDirectMethodAsync, cancellationToken);
 
             _logger.LogDebug("Set handler to receive 'targetTemperature' updates.");
             await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(SetDesiredPropertyUpdateCallback, cancellationToken);

--- a/iothub/device/samples/solutions/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iothub/device/samples/solutions/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 }
             });
 
-            await _deviceClient.SetMethodCallbackAsync(OnDirectMethodAsync, cancellationToken);
+            await _deviceClient.SetDirectMethodCallbackAsync(OnDirectMethodAsync, cancellationToken);
 
             _logger.LogDebug("Set handler to receive 'targetTemperature' updates.");
             await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(SetDesiredPropertyUpdateCallback, cancellationToken);

--- a/iothub/device/samples/solutions/PnpDeviceSamples/Thermostat/ThermostatSample.cs
+++ b/iothub/device/samples/solutions/PnpDeviceSamples/Thermostat/ThermostatSample.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             // -> Periodically send "temperature" over telemetry.
             // -> Send "maxTempSinceLastReboot" over property update, when a new max temperature is set.
 
-            _deviceClient.SetConnectionStatusChangeHandler(async (info) =>
+            _deviceClient.SetConnectionStatusChangeCallback(async (info) =>
             {
                 _logger.LogDebug($"Connection status change registered - status={info.Status}, reason={info.ChangeReason}.");
 
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(TargetTemperatureUpdateCallbackAsync, cancellationToken);
 
             _logger.LogDebug($"Set handler for \"getMaxMinReport\" command.");
-            await _deviceClient.SetMethodHandlerAsync(OnDirectMethodAsync, cancellationToken);
+            await _deviceClient.SetMethodCallbackAsync(OnDirectMethodAsync, cancellationToken);
 
             _logger.LogDebug("Check if the device properties are empty on the initial startup.");
             await CheckEmptyPropertiesAsync(cancellationToken);

--- a/iothub/device/samples/solutions/PnpDeviceSamples/Thermostat/ThermostatSample.cs
+++ b/iothub/device/samples/solutions/PnpDeviceSamples/Thermostat/ThermostatSample.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(TargetTemperatureUpdateCallbackAsync, cancellationToken);
 
             _logger.LogDebug($"Set handler for \"getMaxMinReport\" command.");
-            await _deviceClient.SetMethodCallbackAsync(OnDirectMethodAsync, cancellationToken);
+            await _deviceClient.SetDirectMethodCallbackAsync(OnDirectMethodAsync, cancellationToken);
 
             _logger.LogDebug("Check if the device properties are empty on the initial startup.");
             await CheckEmptyPropertiesAsync(cancellationToken);

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -247,17 +247,17 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <remarks>
         /// Calling this API more than once will result in the callback set last overwriting any previously set callback.
-        /// A method callback can be unset by setting <paramref name="methodCallback"/> to null.
+        /// A method callback can be unset by setting <paramref name="directMethodCallback"/> to null.
         /// </remarks>
-        /// <param name="methodCallback">The callback to be invoked when any method is invoked by the cloud service.</param>
+        /// <param name="directMethodCallback">The callback to be invoked when any method is invoked by the cloud service.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        public async Task SetMethodCallbackAsync(
-            Func<DirectMethodRequest, Task<DirectMethodResponse>> methodCallback,
+        public async Task SetDirectMethodCallbackAsync(
+            Func<DirectMethodRequest, Task<DirectMethodResponse>> directMethodCallback,
             CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, methodCallback, nameof(SetMethodCallbackAsync));
+                Logging.Enter(this, directMethodCallback, nameof(SetDirectMethodCallbackAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -265,10 +265,10 @@ namespace Microsoft.Azure.Devices.Client
 
             try
             {
-                if (methodCallback != null)
+                if (directMethodCallback != null)
                 {
                     await HandleMethodEnableAsync(cancellationToken).ConfigureAwait(false);
-                    _deviceDefaultMethodCallback = methodCallback;
+                    _deviceDefaultMethodCallback = directMethodCallback;
                 }
                 else
                 {
@@ -281,7 +281,7 @@ namespace Microsoft.Azure.Devices.Client
                 _methodsSemaphore.Release();
 
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, methodCallback, nameof(SetMethodCallbackAsync));
+                    Logging.Exit(this, directMethodCallback, nameof(SetDirectMethodCallbackAsync));
             }
         }
 

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Client
         private volatile Func<Message, Task<MessageAcknowledgement>> _receiveMessageCallback;
 
         // Connection status change information
-        private volatile Action<ConnectionStatusInfo> _connectionStatusChangeHandler;
+        private volatile Action<ConnectionStatusInfo> _connectionStatusChangeCallback;
 
         // Method callback information
         private bool _isDeviceMethodEnabled;
@@ -105,16 +105,16 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Sets a new listener for the connection status change callback. If a listener is already associated,
-        /// it will be replaced with the new listener.
+        /// Sets a new callback for receiving connection status change notifications. If a callback is already associated,
+        /// it will be replaced with the new callback.
         /// </summary>
-        /// <param name="statusChangeHandler">The listener for the connection status change callback.</param>
-        public void SetConnectionStatusChangeHandler(Action<ConnectionStatusInfo> statusChangeHandler)
+        /// <param name="statusChangeHandler">The callback for the connection status change notifications.</param>
+        public void SetConnectionStatusChangeCallback(Action<ConnectionStatusInfo> statusChangeHandler)
         {
             if (Logging.IsEnabled)
-                Logging.Info(this, statusChangeHandler, nameof(SetConnectionStatusChangeHandler));
+                Logging.Info(this, statusChangeHandler, nameof(SetConnectionStatusChangeCallback));
 
-            _connectionStatusChangeHandler = statusChangeHandler;
+            _connectionStatusChangeCallback = statusChangeHandler;
         }
 
         /// <summary>
@@ -191,45 +191,43 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Sets a new delegate for receiving a message from the device or module queue using a cancellation token.
+        /// Sets a callback for receiving a message from the device or module queue using a cancellation token.
         /// This instance must be opened already.
         /// </summary>
         /// <remarks>
-        /// <para>
-        /// If a delegate is already registered it will be replaced with the new delegate.
-        /// If a null delegate is passed, it will disable the callback triggered on receiving messages from the service.
-        /// </para>
+        /// Calling this API more than once will result in the callback set last overwriting any previously set callback.
+        /// A method callback can be unset by setting <paramref name="messageCallback"/> to null.
         /// </remarks>
-        /// <param name="messageHandler">The delegate to be used when a could to device message is received by the client.</param>
+        /// <param name="messageCallback">The callback to be invoked when a cloud-to-device message is received by the client.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="InvalidOperationException">Thrown if instance is not opened already.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        public async Task SetMessageHandlerAsync(
-            Func<Message, Task<MessageAcknowledgement>> messageHandler,
+        public async Task SetMessageCallbackAsync(
+            Func<Message, Task<MessageAcknowledgement>> messageCallback,
             CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, messageHandler, nameof(SetMessageHandlerAsync));
+                Logging.Enter(this, messageCallback, nameof(SetMessageCallbackAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
             // Wait to acquire the _deviceReceiveMessageSemaphore. This ensures that concurrently invoked
-            // SetMessageHandlerAsync calls are invoked in a thread-safe manner.
+            // SetMessageCallbackAsync calls are invoked in a thread-safe manner.
             await _receiveMessageSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             try
             {
-                // If a callback is already set on the client, calling SetMessageHandlerAsync
-                // again will cause the delegate to be overwritten.
-                if (messageHandler != null)
+                // If a callback is already set on the client, calling SetMessageCallbackAsync
+                // again will cause the callback to be overwritten.
+                if (messageCallback != null)
                 {
-                    // If this is the first time the delegate is being registered, then the telemetry downlink will be enabled.
+                    // If this is the first time the callback is being registered, then the telemetry downlink will be enabled.
                     await EnableReceiveMessageAsync(cancellationToken).ConfigureAwait(false);
-                    _receiveMessageCallback = new Func<Message, Task<MessageAcknowledgement>>(messageHandler);
+                    _receiveMessageCallback = new Func<Message, Task<MessageAcknowledgement>>(messageCallback);
                 }
                 else
                 {
-                    // If a null delegate is passed, it will disable the callback triggered on receiving messages from the service.
+                    // If a null callback is passed, it will disable the callback triggered on receiving messages from the service.
                     _receiveMessageCallback = null;
                     await DisableReceiveMessageAsync(cancellationToken).ConfigureAwait(false);
                 }
@@ -239,26 +237,27 @@ namespace Microsoft.Azure.Devices.Client
                 _receiveMessageSemaphore.Release();
 
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, messageHandler, nameof(SetMessageHandlerAsync));
+                    Logging.Exit(this, messageCallback, nameof(SetMessageCallbackAsync));
             }
         }
 
         /// <summary>
-        /// Sets the listener for all direct method calls from the service.
+        /// Sets the callback for all direct method calls from the service.
+        /// This instance must be opened already.
         /// </summary>
         /// <remarks>
-        /// Calling this API more than once will result in the listener set last overwriting any previously set listener.
-        /// A method handler can be unset by setting <paramref name="methodHandler"/> to null.
+        /// Calling this API more than once will result in the callback set last overwriting any previously set callback.
+        /// A method callback can be unset by setting <paramref name="methodCallback"/> to null.
         /// </remarks>
-        /// <param name="methodHandler">The listener to be used when any method is called by the cloud service.</param>
+        /// <param name="methodCallback">The callback to be invoked when any method is invoked by the cloud service.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        public async Task SetMethodHandlerAsync(
-            Func<DirectMethodRequest, Task<DirectMethodResponse>> methodHandler,
+        public async Task SetMethodCallbackAsync(
+            Func<DirectMethodRequest, Task<DirectMethodResponse>> methodCallback,
             CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, methodHandler, nameof(SetMethodHandlerAsync));
+                Logging.Enter(this, methodCallback, nameof(SetMethodCallbackAsync));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -266,10 +265,10 @@ namespace Microsoft.Azure.Devices.Client
 
             try
             {
-                if (methodHandler != null)
+                if (methodCallback != null)
                 {
                     await HandleMethodEnableAsync(cancellationToken).ConfigureAwait(false);
-                    _deviceDefaultMethodCallback = methodHandler;
+                    _deviceDefaultMethodCallback = methodCallback;
                 }
                 else
                 {
@@ -282,7 +281,7 @@ namespace Microsoft.Azure.Devices.Client
                 _methodsSemaphore.Release();
 
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, methodHandler, nameof(SetMethodHandlerAsync));
+                    Logging.Exit(this, methodCallback, nameof(SetMethodCallbackAsync));
             }
         }
 
@@ -322,12 +321,16 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <summary>
         /// Set a callback that will be called whenever the client receives a desired state update
-        /// from the service. A desired property handler can be unset by setting <paramref name="callback"/> to null.
+        /// from the service. The client instance must be opened already.
         /// </summary>
         /// <remarks>
+        /// Calling this API more than once will result in the callback set last overwriting any previously set callback.
+        /// A method callback can be unset by setting <paramref name="callback"/> to null.
+        ///  <para>
         /// This has the side-effect of subscribing to the PATCH topic on the service.
+        ///  </para>
         /// </remarks>
-        /// <param name="callback">Callback to call after the state update has been received and applied.</param>
+        /// <param name="callback">The callback to be invoked when a desired property update is received from the service.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
         public async Task SetDesiredPropertyUpdateCallbackAsync(
@@ -409,12 +412,12 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// The delegate for handling disrupted connection/links in the transport layer.
+        /// The callback for handling disrupted connection/links in the transport layer.
         /// </summary>
         internal void OnConnectionStatusChanged(ConnectionStatusInfo connectionStatusInfo)
         {
-            var status = connectionStatusInfo.Status;
-            var reason = connectionStatusInfo.ChangeReason;
+            ConnectionStatus status = connectionStatusInfo.Status;
+            ConnectionStatusChangeReason reason = connectionStatusInfo.ChangeReason;
 
             try
             {
@@ -425,7 +428,7 @@ namespace Microsoft.Azure.Devices.Client
                     || ConnectionStatusInfo.ChangeReason != reason)
                 {
                     ConnectionStatusInfo = new ConnectionStatusInfo(status, reason);
-                    _connectionStatusChangeHandler?.Invoke(ConnectionStatusInfo);
+                    _connectionStatusChangeCallback?.Invoke(ConnectionStatusInfo);
                 }
             }
             finally
@@ -436,7 +439,7 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// The delegate for handling direct methods received from service.
+        /// The callback for handling direct methods received from service.
         /// </summary>
         internal async Task OnMethodCalledAsync(DirectMethodRequest directMethodRequest)
         {
@@ -596,7 +599,7 @@ namespace Microsoft.Azure.Devices.Client
 
         private Task EnableReceiveMessageAsync(CancellationToken cancellationToken = default)
         {
-            // The telemetry downlink needs to be enabled only for the first time that the _receiveMessageCallback delegate is set.
+            // The telemetry downlink needs to be enabled only for the first time that the _receiveMessageCallback callback is set.
             return _receiveMessageCallback == null
                 ? InnerHandler.EnableReceiveMessageAsync(cancellationToken)
                 : Task.CompletedTask;
@@ -604,7 +607,7 @@ namespace Microsoft.Azure.Devices.Client
 
         private Task DisableReceiveMessageAsync(CancellationToken cancellationToken = default)
         {
-            // The telemetry downlink should be disabled only after _receiveMessageCallback delegate has been removed.
+            // The telemetry downlink should be disabled only after _receiveMessageCallback callback has been removed.
             return _receiveMessageCallback == null
                 ? InnerHandler.DisableReceiveMessageAsync(cancellationToken)
                 : Task.CompletedTask;

--- a/iothub/device/tests/IotHubDeviceClientTests.cs
+++ b/iothub/device/tests/IotHubDeviceClientTests.cs
@@ -247,12 +247,12 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // act
             await deviceClient
-                .SetMethodCallbackAsync(
+                .SetDirectMethodCallbackAsync(
                     (payload) => Task.FromResult(directMethodResponseWithPayload))
                 .ConfigureAwait(false);
 
             await deviceClient
-                .SetMethodCallbackAsync(null)
+                .SetDirectMethodCallbackAsync(null)
                 .ConfigureAwait(false);
 
             // assert
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             deviceClient.InnerHandler = innerHandler;
 
             bool isMethodHandlerCalled = false;
-            await deviceClient.SetMethodCallbackAsync((payload) =>
+            await deviceClient.SetDirectMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 return Task.FromResult(directMethodResponseWithPayload);
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             deviceClient.InnerHandler = innerHandler;
 
             bool isMethodHandlerCalled = false;
-            await deviceClient.SetMethodCallbackAsync((payload) =>
+            await deviceClient.SetDirectMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 return Task.FromResult(directMethodResponseWithPayload);
@@ -321,7 +321,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             deviceClient.InnerHandler = innerHandler;
             bool isMethodHandlerCalled = false;
-            await deviceClient.SetMethodCallbackAsync((payload) =>
+            await deviceClient.SetDirectMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 return Task.FromResult(directMethodResponseWithPayload);
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool responseReceivedAsExpected = false;
             bool response = false;
             string responseAsString = null;
-            await deviceClient.SetMethodCallbackAsync((payload) =>
+            await deviceClient.SetDirectMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 responseReceivedAsExpected = payload.TryGetPayload(out response);
@@ -389,7 +389,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool responseReceivedAsExpected = false;
             byte[] response = null;
             string responseAsString = null;
-            await deviceClient.SetMethodCallbackAsync((payload) =>
+            await deviceClient.SetDirectMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 responseReceivedAsExpected = payload.TryGetPayload(out response);
@@ -426,7 +426,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool responseReceivedAsExpected = false;
             List<double> response = null;
             string responseAsString = null;
-            await deviceClient.SetMethodCallbackAsync((payload) =>
+            await deviceClient.SetDirectMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 responseReceivedAsExpected = payload.TryGetPayload(out response);
@@ -463,7 +463,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool responseReceivedAsExpected = false;
             Dictionary<string, object> response = null;
             string responseAsString = null;
-            await deviceClient.SetMethodCallbackAsync((payload) =>
+            await deviceClient.SetDirectMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 responseReceivedAsExpected = payload.TryGetPayload(out response);
@@ -497,7 +497,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             deviceClient.InnerHandler = innerHandler;
             bool isMethodHandlerCalled = false;
-            await deviceClient.SetMethodCallbackAsync((payload) =>
+            await deviceClient.SetDirectMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 return Task.FromResult(directMethodResponseWithNoPayload);
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             string methodName = "TestMethodName";
             string methodBody = "{\"grade\":\"good\"}";
-            await deviceClient.SetMethodCallbackAsync(methodCallback).ConfigureAwait(false);
+            await deviceClient.SetDirectMethodCallbackAsync(methodCallback).ConfigureAwait(false);
             var DirectMethodRequest = new DirectMethodRequest()
             {
                 MethodName = methodName,
@@ -590,7 +590,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             };
 
             string methodBody2 = "{\"grade\":\"bad\"}";
-            await deviceClient.SetMethodCallbackAsync(methodCallback2).ConfigureAwait(false);
+            await deviceClient.SetDirectMethodCallbackAsync(methodCallback2).ConfigureAwait(false);
             DirectMethodRequest = new DirectMethodRequest()
             {
                 MethodName = methodName,
@@ -630,7 +630,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             string methodName = "TestMethodName";
             string methodBody = "{\"grade\":\"good\"}";
-            await deviceClient.SetMethodCallbackAsync(methodCallback).ConfigureAwait(false);
+            await deviceClient.SetDirectMethodCallbackAsync(methodCallback).ConfigureAwait(false);
             var DirectMethodRequest = new DirectMethodRequest()
             {
                 MethodName = methodName,
@@ -649,7 +649,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // arrange
             methodCallbackCalled = false;
-            await deviceClient.SetMethodCallbackAsync(null).ConfigureAwait(false);
+            await deviceClient.SetDirectMethodCallbackAsync(null).ConfigureAwait(false);
             DirectMethodRequest = new DirectMethodRequest()
             {
                 MethodName = methodName,
@@ -673,7 +673,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             deviceClient.InnerHandler = innerHandler;
 
-            await deviceClient.SetMethodCallbackAsync(null).ConfigureAwait(false);
+            await deviceClient.SetDirectMethodCallbackAsync(null).ConfigureAwait(false);
             await innerHandler.DidNotReceive().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
         }
 

--- a/iothub/device/tests/IotHubDeviceClientTests.cs
+++ b/iothub/device/tests/IotHubDeviceClientTests.cs
@@ -247,12 +247,12 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // act
             await deviceClient
-                .SetMethodHandlerAsync(
+                .SetMethodCallbackAsync(
                     (payload) => Task.FromResult(directMethodResponseWithPayload))
                 .ConfigureAwait(false);
 
             await deviceClient
-                .SetMethodHandlerAsync(null)
+                .SetMethodCallbackAsync(null)
                 .ConfigureAwait(false);
 
             // assert
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             deviceClient.InnerHandler = innerHandler;
 
             bool isMethodHandlerCalled = false;
-            await deviceClient.SetMethodHandlerAsync((payload) =>
+            await deviceClient.SetMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 return Task.FromResult(directMethodResponseWithPayload);
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             deviceClient.InnerHandler = innerHandler;
 
             bool isMethodHandlerCalled = false;
-            await deviceClient.SetMethodHandlerAsync((payload) =>
+            await deviceClient.SetMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 return Task.FromResult(directMethodResponseWithPayload);
@@ -321,7 +321,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             deviceClient.InnerHandler = innerHandler;
             bool isMethodHandlerCalled = false;
-            await deviceClient.SetMethodHandlerAsync((payload) =>
+            await deviceClient.SetMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 return Task.FromResult(directMethodResponseWithPayload);
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool responseReceivedAsExpected = false;
             bool response = false;
             string responseAsString = null;
-            await deviceClient.SetMethodHandlerAsync((payload) =>
+            await deviceClient.SetMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 responseReceivedAsExpected = payload.TryGetPayload(out response);
@@ -389,7 +389,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool responseReceivedAsExpected = false;
             byte[] response = null;
             string responseAsString = null;
-            await deviceClient.SetMethodHandlerAsync((payload) =>
+            await deviceClient.SetMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 responseReceivedAsExpected = payload.TryGetPayload(out response);
@@ -426,7 +426,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool responseReceivedAsExpected = false;
             List<double> response = null;
             string responseAsString = null;
-            await deviceClient.SetMethodHandlerAsync((payload) =>
+            await deviceClient.SetMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 responseReceivedAsExpected = payload.TryGetPayload(out response);
@@ -463,7 +463,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             bool responseReceivedAsExpected = false;
             Dictionary<string, object> response = null;
             string responseAsString = null;
-            await deviceClient.SetMethodHandlerAsync((payload) =>
+            await deviceClient.SetMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 responseReceivedAsExpected = payload.TryGetPayload(out response);
@@ -497,7 +497,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             deviceClient.InnerHandler = innerHandler;
             bool isMethodHandlerCalled = false;
-            await deviceClient.SetMethodHandlerAsync((payload) =>
+            await deviceClient.SetMethodCallbackAsync((payload) =>
             {
                 isMethodHandlerCalled = true;
                 return Task.FromResult(directMethodResponseWithNoPayload);
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             string methodName = "TestMethodName";
             string methodBody = "{\"grade\":\"good\"}";
-            await deviceClient.SetMethodHandlerAsync(methodCallback).ConfigureAwait(false);
+            await deviceClient.SetMethodCallbackAsync(methodCallback).ConfigureAwait(false);
             var DirectMethodRequest = new DirectMethodRequest()
             {
                 MethodName = methodName,
@@ -590,7 +590,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             };
 
             string methodBody2 = "{\"grade\":\"bad\"}";
-            await deviceClient.SetMethodHandlerAsync(methodCallback2).ConfigureAwait(false);
+            await deviceClient.SetMethodCallbackAsync(methodCallback2).ConfigureAwait(false);
             DirectMethodRequest = new DirectMethodRequest()
             {
                 MethodName = methodName,
@@ -630,7 +630,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             string methodName = "TestMethodName";
             string methodBody = "{\"grade\":\"good\"}";
-            await deviceClient.SetMethodHandlerAsync(methodCallback).ConfigureAwait(false);
+            await deviceClient.SetMethodCallbackAsync(methodCallback).ConfigureAwait(false);
             var DirectMethodRequest = new DirectMethodRequest()
             {
                 MethodName = methodName,
@@ -649,7 +649,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // arrange
             methodCallbackCalled = false;
-            await deviceClient.SetMethodHandlerAsync(null).ConfigureAwait(false);
+            await deviceClient.SetMethodCallbackAsync(null).ConfigureAwait(false);
             DirectMethodRequest = new DirectMethodRequest()
             {
                 MethodName = methodName,
@@ -673,7 +673,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             deviceClient.InnerHandler = innerHandler;
 
-            await deviceClient.SetMethodHandlerAsync(null).ConfigureAwait(false);
+            await deviceClient.SetMethodCallbackAsync(null).ConfigureAwait(false);
             await innerHandler.DidNotReceive().DisableMethodsAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
         }
 
@@ -688,7 +688,7 @@ namespace Microsoft.Azure.Devices.Client.Test
                 handlerCalled = true;
                 connectionStatusInfo = c;
             };
-            deviceClient.SetConnectionStatusChangeHandler(statusChangeHandler);
+            deviceClient.SetConnectionStatusChangeCallback(statusChangeHandler);
 
             // Connection status change from disconnected to connected
             deviceClient.OnConnectionStatusChanged(new ConnectionStatusInfo(ConnectionStatus.Connected, ConnectionStatusChangeReason.ConnectionOk));
@@ -709,8 +709,8 @@ namespace Microsoft.Azure.Devices.Client.Test
                 handlerCalled = true;
                 connectionStatusInfo = c;
             };
-            deviceClient.SetConnectionStatusChangeHandler(statusChangeHandler);
-            deviceClient.SetConnectionStatusChangeHandler(null);
+            deviceClient.SetConnectionStatusChangeCallback(statusChangeHandler);
+            deviceClient.SetConnectionStatusChangeCallback(null);
 
             // Connection status change from disconnected to connected
             deviceClient.OnConnectionStatusChanged(new ConnectionStatusInfo(ConnectionStatus.Connected, ConnectionStatusChangeReason.ConnectionOk));
@@ -729,7 +729,7 @@ namespace Microsoft.Azure.Devices.Client.Test
                 handlerCalled = true;
                 connectionStatusInfo = c;
             };
-            deviceClient.SetConnectionStatusChangeHandler(statusChangeHandler);
+            deviceClient.SetConnectionStatusChangeCallback(statusChangeHandler);
             // current status = disabled
 
             deviceClient.OnConnectionStatusChanged(new ConnectionStatusInfo(ConnectionStatus.Connected, ConnectionStatusChangeReason.ConnectionOk));
@@ -759,7 +759,7 @@ namespace Microsoft.Azure.Devices.Client.Test
                 handlerCalled = true;
                 connectionStatusInfo = c;
             };
-            deviceClient.SetConnectionStatusChangeHandler(statusChangeHandler);
+            deviceClient.SetConnectionStatusChangeCallback(statusChangeHandler);
 
             // current status = disabled
             deviceClient.OnConnectionStatusChanged(new ConnectionStatusInfo(ConnectionStatus.Connected, ConnectionStatusChangeReason.ConnectionOk));

--- a/iothub/device/tests/IotHubModuleClientTests.cs
+++ b/iothub/device/tests/IotHubModuleClientTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             IDelegatingHandler innerHandler = Substitute.For<IDelegatingHandler>();
             moduleClient.InnerHandler = innerHandler;
 
-            await moduleClient.SetMessageHandlerAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
+            await moduleClient.SetMessageCallbackAsync((message) => Task.FromResult(MessageAcknowledgement.Complete)).ConfigureAwait(false);
 
             await innerHandler.Received().EnableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
             await innerHandler.DidNotReceiveWithAnyArgs().DisableReceiveMessageAsync(Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             bool isDefaultCallbackCalled = false;
             await moduleClient
-                .SetMessageHandlerAsync(
+                .SetMessageCallbackAsync(
                     (message) =>
                     {
                         isDefaultCallbackCalled = true;


### PR DESCRIPTION
The Azure SDK team recommends the following naming conventions: https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#names-of-common-types

Of interest to us is the recommendadtion for System.Delegate implementing types, i.e. the callbacks that we expose on our public API for receiving cloud-to-device "events".

<html>
<body>
<!--StartFragment-->

System.Delegate | ✔️ DO add the suffix "EventHandler" to names of delegates that are used in events. </br>✔️ DO add the suffix "Callback" to names of delegates other than those used as event handlers. </br>❌ DO NOT add the suffix "Delegate" to a delegate. </br>
-- | --


<!--EndFragment-->
</body>
</html>

Based on this recommendation, this PR updates our method names, param names and doc comments to use the term "callback".