### PR TITLE
Catch TpmException or TssException and rethrow them as other types

### DIFF
--- a/iothub/device/src/Authentication/DeviceAuthenticationWithTpm.cs
+++ b/iothub/device/src/Authentication/DeviceAuthenticationWithTpm.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Authentication;
+using Tpm2Lib;
 
 namespace Microsoft.Azure.Devices.Client
 {
@@ -68,7 +69,16 @@ namespace Microsoft.Azure.Devices.Client
                 Debug.Assert(key == null);
 
                 byte[] encodedBytes = Encoding.UTF8.GetBytes(requestString);
-                byte[] hmac = _authenticationProvider.Sign(encodedBytes);
+                byte[] hmac = Array.Empty<byte>();
+                try
+                {
+                    hmac = _authenticationProvider.Sign(encodedBytes);
+                }
+                catch (Exception ex) when (ex is TssException || ex is TpmException)
+                {
+                    throw new IotHubClientException(ex.Message, false, ex);
+                }
+
                 return Convert.ToBase64String(hmac);
             }
         }

--- a/provisioning/device/src/Transports/Http/ProvisioningTransportHandlerHttp.cs
+++ b/provisioning/device/src/Transports/Http/ProvisioningTransportHandlerHttp.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                         false);
                 }
             }
-            catch (Exception ex) when (!(ex is DeviceProvisioningClientException))
+            catch (Exception ex) when (ex is not DeviceProvisioningClientException)
             {
                 if (Logging.IsEnabled)
                     Logging.Error(this, $"{nameof(ProvisioningTransportHandlerHttp)} threw exception {ex}", nameof(RegisterAsync));


### PR DESCRIPTION
For the hub device client and DPS device client, it can potentially throw `TpmException` or `TssException` if the users' TPM hardware does not support the relevant API call ([ref](https://github.com/Azure/azure-iot-sdk-csharp/blob/brycewang/inner-exception/authentication/src/AuthenticationProviderTpmHsm.cs#L38)). This PR is remapping these 2 types of exception to our new exception types - `IotHubClientException` for the hub device & `DeviceProvisioningClientException` for the DPS device.