### PR TITLE
Remove unused option from transport settings

### DIFF
--- a/iothub/device/src/TransportSettings/IotHubClientAmqpSettings.cs
+++ b/iothub/device/src/TransportSettings/IotHubClientAmqpSettings.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Azure.Devices.Client
         public IotHubClientAmqpSettings(IotHubClientTransportProtocol transportProtocol = IotHubClientTransportProtocol.Tcp)
         {
             Protocol = transportProtocol;
-            DefaultReceiveTimeout = TimeSpan.FromMinutes(1);
         }
 
         /// <summary>

--- a/iothub/device/src/TransportSettings/IotHubClientHttpSettings.cs
+++ b/iothub/device/src/TransportSettings/IotHubClientHttpSettings.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Azure.Devices.Client
         public IotHubClientHttpSettings()
         {
             Protocol = IotHubClientTransportProtocol.WebSocket;
-            DefaultReceiveTimeout = TimeSpan.FromMinutes(1);
         }
     }
 }

--- a/iothub/device/src/TransportSettings/IotHubClientTransportSettings.cs
+++ b/iothub/device/src/TransportSettings/IotHubClientTransportSettings.cs
@@ -19,11 +19,6 @@ namespace Microsoft.Azure.Devices.Client
         public IotHubClientTransportProtocol Protocol { get; protected set; }
 
         /// <summary>
-        /// The time to wait for a receive operation.
-        /// </summary>
-        public TimeSpan DefaultReceiveTimeout { get; protected set; }
-
-        /// <summary>
         /// The web proxy that will be used to connect to IoT hub using a web socket connection for AMQP, MQTT, or when using the
         /// HTTP protocol.
         /// </summary>


### PR DESCRIPTION
Now that there are no ReceiveAsync calls, we don't need a configurable default timeout for them.