### PR TITLE
When using TCS, use them appropriately

### DIFF
--- a/iothub/service/src/Amqp/ClientWebSocketTransport.cs
+++ b/iothub/service/src/Amqp/ClientWebSocketTransport.cs
@@ -383,7 +383,7 @@ namespace Microsoft.Azure.Devices
                 return task;
             }
 
-            var tcs = new TaskCompletionSource<TResult>(state);
+            var tcs = new TaskCompletionSource<TResult>(state, TaskCreationOptions.RunContinuationsAsynchronously);
             task.ContinueWith(
                 _ =>
                 {

--- a/provisioning/device/src/Transports/Amqp/AmqpClientConnection.cs
+++ b/provisioning/device/src/Transports/Amqp/AmqpClientConnection.cs
@@ -169,14 +169,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
             {
                 _connectionSemaphore.Release();
             }
-        }
 
         internal void Close()
         {
             AmqpConnection connection = AmqpConnection;
             if (connection != null)
             {
-                connection.Close();
+                _connectionSemaphore.Release();
             }
         }
 

--- a/provisioning/device/src/Transports/Amqp/AmqpClientConnection.cs
+++ b/provisioning/device/src/Transports/Amqp/AmqpClientConnection.cs
@@ -169,14 +169,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
             {
                 _connectionSemaphore.Release();
             }
-
-        internal void Close()
-        {
-            AmqpConnection connection = AmqpConnection;
-            if (connection != null)
-            {
-                _connectionSemaphore.Release();
-            }
         }
 
         internal AmqpClientSession CreateSession()

--- a/provisioning/device/src/Transports/Amqp/TaskHelpers.cs
+++ b/provisioning/device/src/Transports/Amqp/TaskHelpers.cs
@@ -19,14 +19,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                         (t, st) => ((AsyncCallback)state)(t),
                         callback,
                         CancellationToken.None,
-                        TaskContinuationOptions.ExecuteSynchronously,
+                        TaskContinuationOptions.RunContinuationsAsynchronously,
                         TaskScheduler.Default);
                 }
 
                 return task;
             }
 
-            var tcs = new TaskCompletionSource<T>(state);
+            var tcs = new TaskCompletionSource<T>(state, TaskCreationOptions.RunContinuationsAsynchronously);
             task.ContinueWith(
                 t =>
                 {
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                     callback?.Invoke(tcs.Task);
                 },
                 CancellationToken.None,
-                TaskContinuationOptions.ExecuteSynchronously,
+                TaskContinuationOptions.RunContinuationsAsynchronously,
                 TaskScheduler.Default);
 
             return tcs.Task;


### PR DESCRIPTION
Following guidance at https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#always-create-taskcompletionsourcet-with-taskcreationoptionsruncontinuationsasynchronously.

I looked for opportunity to remove these, but for the most part we're stuck using them for 2 reasons:
* AMQP/MQTT pub/sub pattern requires using a TCS to complete it when the ack message comes in.
* AMQP library has some base classes abstract methods that need to be async but aren't defined that way.