### PR TITLE
Make provisioning service client tests always clean up create enrollments

### DIFF
--- a/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
+using Microsoft.Azure.Devices.Provisioning.Client;
 using Microsoft.Azure.Devices.Provisioning.Security.Samples;
 using Microsoft.Azure.Devices.Provisioning.Service;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -183,47 +184,54 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     Logger)
                 .ConfigureAwait(false);
 
-            AttestationMechanism attestationMechanism = null;
-            await RetryOperationHelper
-                .RetryOperationsAsync(
-                    async () =>
-                    {
-                        attestationMechanism = await provisioningServiceClient.GetIndividualEnrollmentAttestationAsync(individualEnrollment.RegistrationId);
-                    },
-                    s_provisioningServiceRetryPolicy,
-                    s_retryableExceptions,
-                    Logger,
-                    CancellationToken.None)
-                .ConfigureAwait(false);
-
-            if (attestationMechanism == null)
+            try
             {
-                throw new ArgumentException($"The attestation mechanism for enrollment with registration Id {individualEnrollment.RegistrationId} could not retrieved, exiting test.");
+                AttestationMechanism attestationMechanism = null;
+                await RetryOperationHelper
+                    .RetryOperationsAsync(
+                        async () =>
+                        {
+                            attestationMechanism = await provisioningServiceClient.GetIndividualEnrollmentAttestationAsync(individualEnrollment.RegistrationId);
+                        },
+                        s_provisioningServiceRetryPolicy,
+                        s_retryableExceptions,
+                        Logger,
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                if (attestationMechanism == null)
+                {
+                    throw new ArgumentException($"The attestation mechanism for enrollment with registration Id {individualEnrollment.RegistrationId} could not retrieved, exiting test.");
+                }
+
+                if (attestationType == AttestationMechanismType.SymmetricKey)
+                {
+                    attestationMechanism.Type.Should().Be(AttestationMechanismType.SymmetricKey);
+
+                    var symmetricKeyAttestation = (SymmetricKeyAttestation)attestationMechanism.GetAttestation();
+                    symmetricKeyAttestation.PrimaryKey.Should().Be(((SymmetricKeyAttestation)individualEnrollment.Attestation).PrimaryKey);
+                    symmetricKeyAttestation.SecondaryKey.Should().Be(((SymmetricKeyAttestation)individualEnrollment.Attestation).SecondaryKey);
+                }
+                else if (attestationType == AttestationMechanismType.X509)
+                {
+                    attestationMechanism.Type.Should().Be(AttestationMechanismType.X509);
+
+                    var x509Attestation = (X509Attestation)attestationMechanism.GetAttestation();
+                    x509Attestation.GetPrimaryX509CertificateInfo().SHA1Thumbprint.Should().Be(((X509Attestation)individualEnrollment.Attestation).GetPrimaryX509CertificateInfo().SHA1Thumbprint);
+                    x509Attestation.GetSecondaryX509CertificateInfo().SHA1Thumbprint.Should().Be(((X509Attestation)individualEnrollment.Attestation).GetSecondaryX509CertificateInfo().SHA1Thumbprint);
+                }
+                else
+                {
+                    attestationMechanism.Type.Should().Be(AttestationMechanismType.Tpm);
+
+                    var tpmAttestation = (TpmAttestation)attestationMechanism.GetAttestation();
+                    tpmAttestation.EndorsementKey.Should().Be(((TpmAttestation)individualEnrollment.Attestation).EndorsementKey);
+                    tpmAttestation.StorageRootKey.Should().Be(((TpmAttestation)individualEnrollment.Attestation).StorageRootKey);
+                }
             }
-
-            if (attestationType == AttestationMechanismType.SymmetricKey)
+            finally
             {
-                attestationMechanism.Type.Should().Be(AttestationMechanismType.SymmetricKey);
-
-                var symmetricKeyAttestation = (SymmetricKeyAttestation)attestationMechanism.GetAttestation();
-                symmetricKeyAttestation.PrimaryKey.Should().Be(((SymmetricKeyAttestation)individualEnrollment.Attestation).PrimaryKey);
-                symmetricKeyAttestation.SecondaryKey.Should().Be(((SymmetricKeyAttestation)individualEnrollment.Attestation).SecondaryKey);
-            }
-            else if (attestationType == AttestationMechanismType.X509)
-            {
-                attestationMechanism.Type.Should().Be(AttestationMechanismType.X509);
-
-                var x509Attestation = (X509Attestation)attestationMechanism.GetAttestation();
-                x509Attestation.GetPrimaryX509CertificateInfo().SHA1Thumbprint.Should().Be(((X509Attestation)individualEnrollment.Attestation).GetPrimaryX509CertificateInfo().SHA1Thumbprint);
-                x509Attestation.GetSecondaryX509CertificateInfo().SHA1Thumbprint.Should().Be(((X509Attestation)individualEnrollment.Attestation).GetSecondaryX509CertificateInfo().SHA1Thumbprint);
-            }
-            else
-            {
-                attestationMechanism.Type.Should().Be(AttestationMechanismType.Tpm);
-
-                var tpmAttestation = (TpmAttestation)attestationMechanism.GetAttestation();
-                tpmAttestation.EndorsementKey.Should().Be(((TpmAttestation)individualEnrollment.Attestation).EndorsementKey);
-                tpmAttestation.StorageRootKey.Should().Be(((TpmAttestation)individualEnrollment.Attestation).StorageRootKey);
+                await DeleteCreatedEnrollmentAsync(EnrollmentType.Individual, individualEnrollment.RegistrationId, null, Logger);
             }
         }
 
@@ -233,44 +241,51 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             string groupId = AttestationTypeToString(attestationType) + "-" + Guid.NewGuid();
             EnrollmentGroup enrollmentGroup = await CreateEnrollmentGroupAsync(provisioningServiceClient, attestationType, groupId, null, AllocationPolicy.Static, null, null, null, Logger);
 
-            AttestationMechanism attestationMechanism = null;
-            await RetryOperationHelper
-                .RetryOperationsAsync(
-                    async () =>
-                    {
-                        attestationMechanism = await provisioningServiceClient.GetEnrollmentGroupAttestationAsync(enrollmentGroup.EnrollmentGroupId);
-                    },
-                    s_provisioningServiceRetryPolicy,
-                    s_retryableExceptions,
-                    Logger,
-                    CancellationToken.None)
-                .ConfigureAwait(false);
-
-            if (attestationMechanism == null)
+            try
             {
-                throw new ArgumentException($"The attestation mechanism for enrollment with group Id {enrollmentGroup.EnrollmentGroupId} could not retrieved, exiting test.");
+                AttestationMechanism attestationMechanism = null;
+                await RetryOperationHelper
+                    .RetryOperationsAsync(
+                        async () =>
+                        {
+                            attestationMechanism = await provisioningServiceClient.GetEnrollmentGroupAttestationAsync(enrollmentGroup.EnrollmentGroupId);
+                        },
+                        s_provisioningServiceRetryPolicy,
+                        s_retryableExceptions,
+                        Logger,
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                if (attestationMechanism == null)
+                {
+                    throw new ArgumentException($"The attestation mechanism for enrollment with group Id {enrollmentGroup.EnrollmentGroupId} could not retrieved, exiting test.");
+                }
+
+                // Note that tpm is not a supported attestation type for group enrollments
+                if (attestationType == AttestationMechanismType.SymmetricKey)
+                {
+                    attestationMechanism.Type.Should().Be(AttestationMechanismType.SymmetricKey);
+
+                    var symmetricKeyAttestation = (SymmetricKeyAttestation)attestationMechanism.GetAttestation();
+                    symmetricKeyAttestation.PrimaryKey.Should().Be(((SymmetricKeyAttestation)enrollmentGroup.Attestation).PrimaryKey);
+                    symmetricKeyAttestation.SecondaryKey.Should().Be(((SymmetricKeyAttestation)enrollmentGroup.Attestation).SecondaryKey);
+                }
+                else if (attestationType == AttestationMechanismType.X509)
+                {
+                    attestationMechanism.Type.Should().Be(AttestationMechanismType.X509);
+
+                    var x509Attestation = (X509Attestation)attestationMechanism.GetAttestation();
+                    x509Attestation.GetPrimaryX509CertificateInfo().SHA1Thumbprint
+                        .Should()
+                        .Be(((X509Attestation)enrollmentGroup.Attestation).GetPrimaryX509CertificateInfo().SHA1Thumbprint);
+                    x509Attestation.GetSecondaryX509CertificateInfo().SHA1Thumbprint
+                        .Should()
+                        .Be(((X509Attestation)enrollmentGroup.Attestation).GetSecondaryX509CertificateInfo().SHA1Thumbprint);
+                }
             }
-
-            // Note that tpm is not a supported attestation type for group enrollments
-            if (attestationType == AttestationMechanismType.SymmetricKey)
+            finally
             {
-                attestationMechanism.Type.Should().Be(AttestationMechanismType.SymmetricKey);
-
-                var symmetricKeyAttestation = (SymmetricKeyAttestation)attestationMechanism.GetAttestation();
-                symmetricKeyAttestation.PrimaryKey.Should().Be(((SymmetricKeyAttestation)enrollmentGroup.Attestation).PrimaryKey);
-                symmetricKeyAttestation.SecondaryKey.Should().Be(((SymmetricKeyAttestation)enrollmentGroup.Attestation).SecondaryKey);
-            }
-            else if (attestationType == AttestationMechanismType.X509)
-            {
-                attestationMechanism.Type.Should().Be(AttestationMechanismType.X509);
-
-                var x509Attestation = (X509Attestation)attestationMechanism.GetAttestation();
-                x509Attestation.GetPrimaryX509CertificateInfo().SHA1Thumbprint
-                    .Should()
-                    .Be(((X509Attestation)enrollmentGroup.Attestation).GetPrimaryX509CertificateInfo().SHA1Thumbprint);
-                x509Attestation.GetSecondaryX509CertificateInfo().SHA1Thumbprint
-                    .Should()
-                    .Be(((X509Attestation)enrollmentGroup.Attestation).GetSecondaryX509CertificateInfo().SHA1Thumbprint);
+                await DeleteCreatedEnrollmentAsync(EnrollmentType.Group, null, enrollmentGroup.EnrollmentGroupId, Logger);
             }
         }
 
@@ -325,43 +340,47 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     iotHubsToProvisionTo,
                     null,
                     Logger).ConfigureAwait(false);
-
-            IndividualEnrollment individualEnrollmentResult = null;
-            await RetryOperationHelper
-                .RetryOperationsAsync(
-                    async () =>
-                    {
-                        individualEnrollmentResult = await provisioningServiceClient.GetIndividualEnrollmentAsync(individualEnrollment.RegistrationId).ConfigureAwait(false);
-                    },
-                    s_provisioningServiceRetryPolicy,
-                    s_retryableExceptions,
-                    Logger,
-                    CancellationToken.None)
-                .ConfigureAwait(false);
-
-            if (individualEnrollmentResult == null)
+            try
             {
-                throw new ArgumentException($"The individual enrollment with registration Id {individualEnrollment.RegistrationId} could not retrieved, exiting test.");
+                IndividualEnrollment individualEnrollmentResult = null;
+                await RetryOperationHelper
+                    .RetryOperationsAsync(
+                        async () =>
+                        {
+                            individualEnrollmentResult = await provisioningServiceClient.GetIndividualEnrollmentAsync(individualEnrollment.RegistrationId).ConfigureAwait(false);
+                        },
+                        s_provisioningServiceRetryPolicy,
+                        s_retryableExceptions,
+                        Logger,
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                if (individualEnrollmentResult == null)
+                {
+                    throw new ArgumentException($"The individual enrollment with registration Id {individualEnrollment.RegistrationId} could not retrieved, exiting test.");
+                }
+
+                Assert.AreEqual(individualEnrollmentResult.ProvisioningStatus, ProvisioningStatus.Enabled);
+
+                if (reprovisionPolicy != null)
+                {
+                    Assert.AreEqual(reprovisionPolicy.UpdateHubAssignment, individualEnrollmentResult.ReprovisionPolicy.UpdateHubAssignment);
+                    Assert.AreEqual(reprovisionPolicy.MigrateDeviceData, individualEnrollmentResult.ReprovisionPolicy.MigrateDeviceData);
+                }
+
+                if (customAllocationDefinition != null)
+                {
+                    Assert.AreEqual(customAllocationDefinition.WebhookUrl, individualEnrollmentResult.CustomAllocationDefinition.WebhookUrl);
+                    Assert.AreEqual(customAllocationDefinition.ApiVersion, individualEnrollmentResult.CustomAllocationDefinition.ApiVersion);
+                }
+
+                //allocation policy is never null
+                Assert.AreEqual(allocationPolicy, individualEnrollmentResult.AllocationPolicy);
             }
-
-            Assert.AreEqual(individualEnrollmentResult.ProvisioningStatus, ProvisioningStatus.Enabled);
-
-            if (reprovisionPolicy != null)
+            finally
             {
-                Assert.AreEqual(reprovisionPolicy.UpdateHubAssignment, individualEnrollmentResult.ReprovisionPolicy.UpdateHubAssignment);
-                Assert.AreEqual(reprovisionPolicy.MigrateDeviceData, individualEnrollmentResult.ReprovisionPolicy.MigrateDeviceData);
+                await DeleteCreatedEnrollmentAsync(EnrollmentType.Individual, individualEnrollment.RegistrationId, null, Logger);
             }
-
-            if (customAllocationDefinition != null)
-            {
-                Assert.AreEqual(customAllocationDefinition.WebhookUrl, individualEnrollmentResult.CustomAllocationDefinition.WebhookUrl);
-                Assert.AreEqual(customAllocationDefinition.ApiVersion, individualEnrollmentResult.CustomAllocationDefinition.ApiVersion);
-            }
-
-            //allocation policy is never null
-            Assert.AreEqual(allocationPolicy, individualEnrollmentResult.AllocationPolicy);
-
-            await DeleteCreatedEnrollmentAsync(EnrollmentType.Individual, individualEnrollment.RegistrationId, null, Logger);
         }
 
         public async Task ProvisioningServiceClient_GroupEnrollments_Create_Ok(string proxyServerAddress, AttestationMechanismType attestationType)
@@ -392,41 +411,46 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         Logger)
                     .ConfigureAwait(false);
 
-                EnrollmentGroup enrollmentGroupResult = null;
-                await RetryOperationHelper
-                    .RetryOperationsAsync(
-                        async () =>
-                        {
-                            enrollmentGroupResult = await provisioningServiceClient.GetEnrollmentGroupAsync(enrollmentGroup.EnrollmentGroupId).ConfigureAwait(false);
-                        },
-                        s_provisioningServiceRetryPolicy,
-                        s_retryableExceptions,
-                        Logger,
-                        CancellationToken.None)
-                    .ConfigureAwait(false);
-
-                if (enrollmentGroupResult == null)
+                try
                 {
-                    throw new ArgumentException($"The enrollment group with group Id {enrollmentGroup.EnrollmentGroupId} could not retrieved, exiting test.");
+                    EnrollmentGroup enrollmentGroupResult = null;
+                    await RetryOperationHelper
+                        .RetryOperationsAsync(
+                            async () =>
+                            {
+                                enrollmentGroupResult = await provisioningServiceClient.GetEnrollmentGroupAsync(enrollmentGroup.EnrollmentGroupId).ConfigureAwait(false);
+                            },
+                            s_provisioningServiceRetryPolicy,
+                            s_retryableExceptions,
+                            Logger,
+                            CancellationToken.None)
+                        .ConfigureAwait(false);
+
+                    if (enrollmentGroupResult == null)
+                    {
+                        throw new ArgumentException($"The enrollment group with group Id {enrollmentGroup.EnrollmentGroupId} could not retrieved, exiting test.");
+                    }
+
+                    Assert.AreEqual(enrollmentGroupResult.ProvisioningStatus, ProvisioningStatus.Enabled);
+
+                    if (reprovisionPolicy != null)
+                    {
+                        Assert.AreEqual(reprovisionPolicy.MigrateDeviceData, enrollmentGroupResult.ReprovisionPolicy.MigrateDeviceData);
+                        Assert.AreEqual(reprovisionPolicy.UpdateHubAssignment, enrollmentGroupResult.ReprovisionPolicy.UpdateHubAssignment);
+                    }
+
+                    if (customAllocationDefinition != null)
+                    {
+                        Assert.AreEqual(customAllocationDefinition.WebhookUrl, enrollmentGroupResult.CustomAllocationDefinition.WebhookUrl);
+                        Assert.AreEqual(customAllocationDefinition.ApiVersion, enrollmentGroupResult.CustomAllocationDefinition.ApiVersion);
+                    }
+
+                    Assert.AreEqual(allocationPolicy, enrollmentGroup.AllocationPolicy);
                 }
-
-                Assert.AreEqual(enrollmentGroupResult.ProvisioningStatus, ProvisioningStatus.Enabled);
-
-                if (reprovisionPolicy != null)
+                finally
                 {
-                    Assert.AreEqual(reprovisionPolicy.MigrateDeviceData, enrollmentGroupResult.ReprovisionPolicy.MigrateDeviceData);
-                    Assert.AreEqual(reprovisionPolicy.UpdateHubAssignment, enrollmentGroupResult.ReprovisionPolicy.UpdateHubAssignment);
+                    await DeleteCreatedEnrollmentAsync(EnrollmentType.Group, "", enrollmentGroup.EnrollmentGroupId, Logger).ConfigureAwait(false);
                 }
-
-                if (customAllocationDefinition != null)
-                {
-                    Assert.AreEqual(customAllocationDefinition.WebhookUrl, enrollmentGroupResult.CustomAllocationDefinition.WebhookUrl);
-                    Assert.AreEqual(customAllocationDefinition.ApiVersion, enrollmentGroupResult.CustomAllocationDefinition.ApiVersion);
-                }
-
-                Assert.AreEqual(allocationPolicy, enrollmentGroup.AllocationPolicy);
-
-                await DeleteCreatedEnrollmentAsync(EnrollmentType.Group, "", enrollmentGroup.EnrollmentGroupId, Logger).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
Some tests never deleted them and some tests only deleted them if the test passed up to that point

```csharp
enrollment serviceClient.CreateEnrollmentGroup(...);

try
{
    // test code
}
finally
{
     serviceClient.DeleteEnrollment(enrollment); // with retry, ignores thrown exceptions
}
```