### PR TITLE
Multiple fixes for the hub exception, dps exception, and e2e tests

### DIFF
--- a/e2e/test/helpers/TestDevice.cs
+++ b/e2e/test/helpers/TestDevice.cs
@@ -122,11 +122,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                         device = await serviceClient.Devices.GetAsync(requestDevice.Id).ConfigureAwait(false);
                         if (device is null)
                         {
-                            throw new IotHubServiceException($"Created device {requestDevice.Id} not yet gettable from IoT hub.")
-                            {
-                                StatusCode = HttpStatusCode.NotFound,
-                                ErrorCode = IotHubServiceErrorCode.DeviceNotFound,
-                            };
+                            throw new IotHubServiceException(
+                                $"Created device {requestDevice.Id} not yet gettable from IoT hub.",
+                                HttpStatusCode.NotFound,
+                                IotHubServiceErrorCode.DeviceNotFound);
                         }
                     },
                     s_exponentialBackoffRetryStrategy,

--- a/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
@@ -44,7 +44,6 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             //assert
             var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
             error.And.ErrorCode.Should().Be(IotHubClientErrorCode.DeviceNotFound);
             error.And.IsTransient.Should().BeFalse();
         }
@@ -70,7 +69,6 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // assert
             var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
             error.And.ErrorCode.Should().Be(IotHubClientErrorCode.Unauthorized);
             error.And.IsTransient.Should().BeFalse();
         }

--- a/e2e/test/iothub/FileUploadE2ETests.cs
+++ b/e2e/test/iothub/FileUploadE2ETests.cs
@@ -156,7 +156,6 @@ namespace Microsoft.Azure.Devices.E2ETests
 
                     // assert
                     var error = await act.Should().ThrowAsync<IotHubClientException>();
-                    error.And.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
                     error.And.ErrorCode.Should().Be(IotHubClientErrorCode.ServerError);
                     error.And.IsTransient.Should().BeTrue();
                 }

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -172,7 +172,6 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // assert
             var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
             error.And.ErrorCode.Should().Be(IotHubClientErrorCode.Unauthorized);
             error.And.IsTransient.Should().BeFalse();
         }
@@ -195,7 +194,6 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // assert
             var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
             error.And.ErrorCode.Should().Be(IotHubClientErrorCode.Unauthorized);
             error.And.IsTransient.Should().BeFalse();
         }
@@ -218,7 +216,6 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // assert
             var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
             error.And.ErrorCode.Should().Be(IotHubClientErrorCode.Unauthorized);
             error.And.IsTransient.Should().BeFalse();
         }
@@ -241,7 +238,6 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // assert
             var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
             error.And.ErrorCode.Should().Be(IotHubClientErrorCode.Unauthorized);
             error.And.IsTransient.Should().BeFalse();
         }

--- a/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
@@ -206,7 +206,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             // assert
             var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.StatusCode.Should().Be((HttpStatusCode)429);
             error.And.ErrorCode.Should().Be(IotHubClientErrorCode.Throttled);
             error.And.IsTransient.Should().BeTrue();
         }
@@ -229,7 +228,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             // assert
             var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.StatusCode.Should().Be((HttpStatusCode)429);
             error.And.ErrorCode.Should().Be(IotHubClientErrorCode.Throttled);
             error.And.IsTransient.Should().BeTrue();
         }
@@ -251,7 +249,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             // assert
             var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.StatusCode.Should().Be(HttpStatusCode.Forbidden);
             error.And.ErrorCode.Should().Be(IotHubClientErrorCode.DeviceMaximumQueueDepthExceeded);
             error.And.IsTransient.Should().BeFalse();
         }
@@ -273,7 +270,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             // assert
             var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.StatusCode.Should().Be(HttpStatusCode.Forbidden);
             error.And.ErrorCode.Should().Be(IotHubClientErrorCode.DeviceMaximumQueueDepthExceeded);
             error.And.IsTransient.Should().BeFalse();
         }
@@ -294,7 +290,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             // assert
             var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
             error.And.ErrorCode.Should().Be(IotHubClientErrorCode.Unauthorized);
             error.And.IsTransient.Should().BeFalse();
         }
@@ -315,7 +310,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             // assert
             var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
             error.And.ErrorCode.Should().Be(IotHubClientErrorCode.Unauthorized);
             error.And.IsTransient.Should().BeFalse();
         }

--- a/e2e/test/iothub/service/IoTHubCertificateValidationE2ETest.cs
+++ b/e2e/test/iothub/service/IoTHubCertificateValidationE2ETest.cs
@@ -58,7 +58,9 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             using var service = new IotHubServiceClient(
                 TestConfiguration.IotHub.ConnectionStringInvalidServiceCertificate, options);
             var testMessage = new Message();
+            await service.Messages.OpenAsync().ConfigureAwait(false);
             await service.Messages.SendAsync("testDevice1", testMessage).ConfigureAwait(false);
+            await service.Messages.CloseAsync().ConfigureAwait(false);
         }
 
         [LoggedTestMethod]
@@ -131,6 +133,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                     TestConfiguration.IotHub.DeviceConnectionStringInvalidServiceCertificate,
                     new IotHubClientOptions(transportSettings));
             var testMessage = new OutgoingMessage();
+            await deviceClient.OpenAsync().ConfigureAwait(false);
             await deviceClient.SendEventAsync(testMessage).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);
         }

--- a/e2e/test/iothub/service/RegistryE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryE2ETests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
         [LoggedTestMethod]
         [Timeout(TestTimeoutMilliseconds)]
-        public async Task DevicesClient_AddDevices2Async_Works()
+        public async Task DevicesClient_AddDevicesAsync_Works()
         {
             // arrange
 
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
         [LoggedTestMethod]
         [Timeout(TestTimeoutMilliseconds)]
-        public async Task DevicesClient_UpdateDevices2Async_Works()
+        public async Task DevicesClient_UpdateDevicesAsync_Works()
         {
             // arrange
 
@@ -232,7 +232,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
         [LoggedTestMethod]
         [Timeout(TestTimeoutMilliseconds)]
-        public async Task RegistryManager_UpdateTwins2Async_Works()
+        public async Task RegistryManager_UpdateTwinsAsync_Works()
         {
             // arrange
 
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
         [LoggedTestMethod]
         [Timeout(TestTimeoutMilliseconds)]
-        public async Task DevicesClient_RemoveDevices2Async_Works()
+        public async Task DevicesClient_RemoveDevicesAsync_Works()
         {
             // arrange
 
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 error1.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
                 error1.And.ErrorCode.Should().Be(IotHubServiceErrorCode.DeviceNotFound);
 
-                Func<Task> act2 = async () => await serviceClient.Devices.GetAsync(device1.Id).ConfigureAwait(false);
+                Func<Task> act2 = async () => await serviceClient.Devices.GetAsync(device2.Id).ConfigureAwait(false);
 
                 var error2 = await act2.Should().ThrowAsync<IotHubServiceException>("Expected the request to fail with a \"not found\" error");
                 error2.And.StatusCode.Should().Be(HttpStatusCode.NotFound);

--- a/iothub/device/src/Exceptions/IotHubClientException.cs
+++ b/iothub/device/src/Exceptions/IotHubClientException.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.Client
         [NonSerialized]
         private const string TrackingIdValueSerializationStoreName = "IotHubClientException-TrackingId";
 
-        private static readonly HashSet<IotHubClientErrorCode> transientErrorCodes = new()
+        private static readonly HashSet<IotHubClientErrorCode> s_transientErrorCodes = new()
         {
             IotHubClientErrorCode.QuotaExceeded,
             IotHubClientErrorCode.ServerError,
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Client
         // the hub service, so it is not always possible to obtain the HTTP status code and a specific error code.
         // With a best effort match, we map the error codes here to what the hub service exception has, and then match 
         // an appropriate HTTP status code for each of them via the dictionary below.
-        private static readonly Dictionary<IotHubClientErrorCode, HttpStatusCode> httpStatusCodes = new()
+        private static readonly Dictionary<IotHubClientErrorCode, HttpStatusCode> s_httpStatusCodes = new()
         {
             { IotHubClientErrorCode.Ok, HttpStatusCode.OK },
             { IotHubClientErrorCode.DeviceMaximumQueueDepthExceeded, HttpStatusCode.Forbidden },
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Devices.Client
             IsTransient = DetermineIfTransient(errorCode);
             TrackingId = trackingId;
             ErrorCode = errorCode;
-            StatusCode = httpStatusCodes.TryGetValue(errorCode, out HttpStatusCode value) 
+            StatusCode = s_httpStatusCodes.TryGetValue(errorCode, out HttpStatusCode value) 
                 ? value
                 : 0;
         }
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Devices.Client
         {
             IsTransient = DetermineIfTransient(errorCode);
             ErrorCode = errorCode;
-            StatusCode = httpStatusCodes.TryGetValue(errorCode, out HttpStatusCode value)
+            StatusCode = s_httpStatusCodes.TryGetValue(errorCode, out HttpStatusCode value)
                 ? value
                 : 0;
         }
@@ -180,12 +180,12 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Indicates if the error is transient and should be retried.
         /// </summary>
-        public bool IsTransient { get; private set; }
+        public bool IsTransient { get; }
 
         /// <summary>
         /// The service returned tracking Id associated with this particular error.
         /// </summary>
-        public string TrackingId { get; set; }
+        public string TrackingId { get; internal set; }
 
         /// <summary>
         /// The HTTP status code.
@@ -193,12 +193,12 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// This property is not actually obtained from the response but mapped from the property <see cref="ErrorCode"/> with the best effort match.
         /// </remarks>
-        public HttpStatusCode StatusCode { get; private set; }
+        public HttpStatusCode StatusCode { get; }
 
         /// <summary>
         /// The specific error code.
         /// </summary>
-        public IotHubClientErrorCode ErrorCode { get; internal set; }
+        public IotHubClientErrorCode ErrorCode { get; }
 
         /// <summary>
         /// Sets the <see cref="SerializationInfo"/> with information about the exception.
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.Devices.Client
 
         private bool DetermineIfTransient(IotHubClientErrorCode errorCode)
         {
-            return transientErrorCodes.Contains(errorCode);
+            return s_transientErrorCodes.Contains(errorCode);
         }
     }
 }

--- a/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
+++ b/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var contextMock = Substitute.For<PipelineContext>();
             contextMock.ConnectionStatusChangeHandler = (connectionInfo) => { };
             var nextHandlerMock = Substitute.For<IDelegatingHandler>();
-            nextHandlerMock.OpenAsync(Arg.Any<CancellationToken>()).Returns(t => throw new IotHubClientException() { ErrorCode = IotHubClientErrorCode.DeviceNotFound });
+            nextHandlerMock.OpenAsync(Arg.Any<CancellationToken>()).Returns(t => throw new IotHubClientException(IotHubClientErrorCode.DeviceNotFound));
 
             ConnectionStatusInfo connectionStatusInfo = new ConnectionStatusInfo();
             Action<ConnectionStatusInfo> statusChangeHandler = (c) =>

--- a/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
+++ b/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
@@ -344,7 +344,6 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // act and assert
             var exception = await sut.OpenAsync(CancellationToken.None).ExpectedAsync<IotHubClientException>().ConfigureAwait(false);
-            exception.StatusCode.Should().Be(HttpStatusCode.RequestTimeout);
             exception.ErrorCode.Should().Be(IotHubClientErrorCode.NetworkErrors);
             nextHandlerCallCounter.Should().Be(2);
             retryPolicy.Counter.Should().Be(2);
@@ -353,7 +352,6 @@ namespace Microsoft.Azure.Devices.Client.Test
             sut.SetRetryPolicy(noretry);
 
             exception = await sut.OpenAsync(CancellationToken.None).ExpectedAsync<IotHubClientException>().ConfigureAwait(false);
-            exception.StatusCode.Should().Be(HttpStatusCode.RequestTimeout);
             exception.ErrorCode.Should().Be(IotHubClientErrorCode.NetworkErrors);
             nextHandlerCallCounter.Should().Be(3);
             retryPolicy.Counter.Should().Be(2);
@@ -367,7 +365,6 @@ namespace Microsoft.Azure.Devices.Client.Test
             {
                 Counter++;
                 lastException.Should().BeOfType(typeof(IotHubClientException));
-                ((IotHubClientException)lastException).StatusCode.Should().Be(HttpStatusCode.RequestTimeout);
                 ((IotHubClientException)lastException).ErrorCode.Should().Be(IotHubClientErrorCode.NetworkErrors);
 
                 retryInterval = TimeSpan.MinValue;

--- a/iothub/service/src/Exceptions/IotHubServiceException.cs
+++ b/iothub/service/src/Exceptions/IotHubServiceException.cs
@@ -53,23 +53,23 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Indicates if the error is transient and should be retried.
         /// </summary>
-        public bool IsTransient { get; set; }
+        public bool IsTransient { get; }
 
         /// <summary>
         /// The service returned tracking Id associated with this particular error.
         /// </summary>
-        public string TrackingId { get; set; }
+        public string TrackingId { get; internal set; }
 
         /// <summary>
         /// The status code returned back in the IoT hub service response.
         /// </summary>
-        public HttpStatusCode StatusCode { get; set; }
+        public HttpStatusCode StatusCode { get; }
 
         /// <summary>
         /// The specific error code in the IoT hub service response, if available.
         /// </summary>
         /// <seealso href="https://docs.microsoft.com/rest/api/iothub/common-error-codes"/>.
-        public IotHubServiceErrorCode ErrorCode { get; set; }
+        public IotHubServiceErrorCode ErrorCode { get; }
 
         /// <summary>
         /// Sets the <see cref="SerializationInfo"/> with information about the exception.

--- a/iothub/service/src/Exceptions/IotHubServiceException.cs
+++ b/iothub/service/src/Exceptions/IotHubServiceException.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// The service returned tracking Id associated with this particular error.
         /// </summary>
-        public string TrackingId { get; internal set; }
+        public string TrackingId { get; protected internal set; }
 
         /// <summary>
         /// The status code returned back in the IoT hub service response.
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Devices
             info.AddValue(TrackingIdSerializationStoreName, TrackingId);
         }
 
-        private bool DetermineIfTransient(HttpStatusCode statusCode, IotHubServiceErrorCode errorCode)
+        private static bool DetermineIfTransient(HttpStatusCode statusCode, IotHubServiceErrorCode errorCode)
         {
             switch (errorCode)
             {

--- a/provisioning/device/src/DeviceProvisioningClientException.cs
+++ b/provisioning/device/src/DeviceProvisioningClientException.cs
@@ -71,22 +71,22 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// <summary>
         /// If true, the error is transient and the application should retry at a later time.
         /// </summary>
-        public bool IsTransient { get; private set; }
+        public bool IsTransient { get; }
 
         /// <summary>
         /// Service reported tracking Id. Use this when reporting a service issue.
         /// </summary>
-        public string TrackingId { get; set; }
+        public string TrackingId { get; }
 
         /// <summary>
         /// The 3-digit HTTP status code returned by Device Provisioning Service.
         /// </summary>
-        public HttpStatusCode StatusCode { get; private set; }
+        public HttpStatusCode StatusCode { get; }
 
         /// <summary>
         /// The specific 6-digit error code in the DPS response, if available.
         /// </summary>
-        public int ErrorCode { get; private set; }
+        public int ErrorCode { get; }
 
         /// <summary>
         /// Sets the <see cref="SerializationInfo"/> with information about the exception.

--- a/provisioning/device/src/DeviceProvisioningClientException.cs
+++ b/provisioning/device/src/DeviceProvisioningClientException.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
             info.AddValue(IsTransientValueSerializationStoreName, IsTransient);
         }
 
-        private bool DetermineIfTransient(HttpStatusCode statusCode)
+        private static bool DetermineIfTransient(HttpStatusCode statusCode)
         {
             return statusCode >= HttpStatusCode.InternalServerError
                 || statusCode == HttpStatusCode.RequestTimeout

--- a/provisioning/service/src/Exceptions/DeviceProvisioningServiceException.cs
+++ b/provisioning/service/src/Exceptions/DeviceProvisioningServiceException.cs
@@ -100,22 +100,22 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <summary>
         /// True if the error is transient.
         /// </summary>
-        public bool IsTransient { get; private set; }
+        public bool IsTransient { get; }
 
         /// <summary>
         /// Service reported tracking Id. Use this when reporting a service issue.
         /// </summary>
-        public string TrackingId { get; private set; }
+        public string TrackingId { get; }
 
         /// <summary>
         /// The 3-digit HTTP status code returned by Device Provisioning Service.
         /// </summary>
-        public HttpStatusCode StatusCode { get; private set; }
+        public HttpStatusCode StatusCode { get; }
 
         /// <summary>
         /// The specific 6-digit error code in the DPS response, if available.
         /// </summary>
-        public int ErrorCode { get; private set; }
+        public int ErrorCode { get; }
 
         /// <summary>
         /// The HTTP headers.

--- a/provisioning/service/src/Exceptions/DeviceProvisioningServiceException.cs
+++ b/provisioning/service/src/Exceptions/DeviceProvisioningServiceException.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </remarks>
         public IDictionary<string, string> Fields { get; private set; } = new Dictionary<string, string>();
 
-        private bool DetermineIfTransient(HttpStatusCode statusCode)
+        private static bool DetermineIfTransient(HttpStatusCode statusCode)
         {
             return statusCode >= HttpStatusCode.InternalServerError || statusCode == HttpStatusCode.RequestTimeout || (int)statusCode == 429;
         }


### PR DESCRIPTION
What's notable in this PR is that we remove the property `StatusCode` from `IotHubClientException` as per our v2 meeting. 