### PR TITLE
Flaky test fix and wait on some fault injection durations

### DIFF
--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                 deviceClient.Dispose();
                 await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
 
-                if (FaultShouldDisconnect(faultType))
+                if (!FaultShouldDisconnect(faultType))
                 {
                     faultInjectionDuration.Stop();
 

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -227,6 +227,18 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
 
                 deviceClient.Dispose();
                 await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
+
+                if (FaultShouldDisconnect(faultType))
+                {
+                    faultInjectionDuration.Stop();
+
+                    TimeSpan timeToFinishFaultInjection = faultDuration.Subtract(faultInjectionDuration.Elapsed);
+                    if (timeToFinishFaultInjection > TimeSpan.Zero)
+                    {
+                        logger.Trace($"{nameof(FaultInjection)}: Waiting {timeToFinishFaultInjection} to ensure that FaultInjection duration passed.");
+                        await Task.Delay(timeToFinishFaultInjection).ConfigureAwait(false);
+                    }
+                }
             }
         }
 

--- a/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                 deviceClients.ForEach(x => x.Dispose());
                 await Task.WhenAll(testDevices.Select(x => x.RemoveDeviceAsync())).ConfigureAwait(false);
 
-                if (FaultInjection.FaultShouldDisconnect(faultType))
+                if (!FaultInjection.FaultShouldDisconnect(faultType))
                 {
                     faultInjectionDuration.Stop();
 

--- a/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
@@ -179,6 +179,18 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                 testDeviceCallbackHandlers.ForEach(x => x.Dispose());
                 deviceClients.ForEach(x => x.Dispose());
                 await Task.WhenAll(testDevices.Select(x => x.RemoveDeviceAsync())).ConfigureAwait(false);
+
+                if (FaultInjection.FaultShouldDisconnect(faultType))
+                {
+                    faultInjectionDuration.Stop();
+
+                    TimeSpan timeToFinishFaultInjection = faultDuration.Subtract(faultInjectionDuration.Elapsed);
+                    if (timeToFinishFaultInjection > TimeSpan.Zero)
+                    {
+                        logger.Trace($"{nameof(FaultInjection)}: Waiting {timeToFinishFaultInjection} to ensure that FaultInjection duration passed.");
+                        await Task.Delay(timeToFinishFaultInjection).ConfigureAwait(false);
+                    }
+                }
             }
         }
     }

--- a/e2e/test/iothub/service/RegistryManagerE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryManagerE2ETests.cs
@@ -112,7 +112,14 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             try
             {
-                Device actual = await registryManager.GetDeviceAsync(deviceId).ConfigureAwait(false);
+                Device actual = null;
+                do
+                {
+                    // allow some time for the device registry to update the cache
+                    await Task.Delay(50).ConfigureAwait(false);
+                    actual = await registryManager.GetDeviceAsync(deviceId).ConfigureAwait(false);
+                } while (actual == null);
+
                 actual.Should().NotBeNull($"Got null in GET on device {deviceId} to check IotEdge property.");
                 actual.Capabilities.IotEdge.Should().BeTrue();
             }

--- a/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
+++ b/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
@@ -348,7 +348,8 @@ namespace Microsoft.Azure.Devices.Client.Test
             // arrange
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
             var contextMock = Substitute.For<PipelineContext>();
-            contextMock.ConnectionStatusChangesHandler = new ConnectionStatusChangesHandler(delegate (ConnectionStatus status, ConnectionStatusChangeReason reason) { });
+            contextMock.ConnectionStatusChangesHandler = new ConnectionStatusChangesHandler(
+                delegate (ConnectionStatus status, ConnectionStatusChangeReason reason) { });
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             var retryPolicy = new TestRetryPolicy();
@@ -356,7 +357,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             int innerHandlerCallCounter = 0;
 
-            innerHandlerMock.OpenAsync(Arg.Any<CancellationToken>()).Returns(t =>
+            innerHandlerMock.OpenAsync(CancellationToken.None).Returns(t =>
                {
                    innerHandlerCallCounter++;
                    throw new IotHubCommunicationException();


### PR DESCRIPTION
TBH I don't love NSubstitute as a mocking framework. All too often I see a runtime error (that doesn't reproduce consistently) about not being able to match a type.

> Test method Microsoft.Azure.Devices.Client.Test.RetryDelegatingHandlerTests.RetrySetRetryPolicyVerifyInternalsSuccess threw exception:
NSubstitute.Exceptions.AmbiguousArgumentsException: Cannot determine argument specifications to use.
Please use specifications for all arguments of the same type.

In this case, we can simply pass the parameter that will be passed rather than use a filter.