### PR TITLE
Allow users to set a remote certificate validation callback for the IoT hub service client

### DIFF
--- a/iothub/service/src/Amqp/AmqpConnectionHandler.cs
+++ b/iothub/service/src/Amqp/AmqpConnectionHandler.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Globalization;
-using System.Net;
 using System.Net.Security;
-using System.Net.WebSockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -120,7 +118,7 @@ namespace Microsoft.Azure.Devices.Amqp
                     {
                         TargetHost = _credential.HostName,
                         Certificate = null,
-                        CertificateValidationCallback = OnRemoteCertificateValidation
+                        CertificateValidationCallback = _options.RemoteCertificateValidationCallback,
                     };
 
                     amqpTransportInitiator = new AmqpTransportInitiator(amqpSettings, tlsTranpsortSettings);
@@ -250,15 +248,6 @@ namespace Microsoft.Azure.Devices.Amqp
                 Logging.Info(s_amqpVersion_1_0_0, nameof(CreateAmqpSettings));
 
             return amqpSettings;
-        }
-
-        private static bool OnRemoteCertificateValidation(
-            object sender,
-            X509Certificate certificate,
-            X509Chain chain,
-            SslPolicyErrors sslPolicyErrors)
-        {
-            return sslPolicyErrors == SslPolicyErrors.None;
         }
 
         /// <inheritdoc/>

--- a/iothub/service/src/Http/HttpClientFactory.cs
+++ b/iothub/service/src/Http/HttpClientFactory.cs
@@ -61,6 +61,10 @@ namespace Microsoft.Azure.Devices
             {
                 SslProtocols = options.SslProtocols,
                 CheckCertificateRevocationList = options.CertificateRevocationCheck,
+                ServerCertificateCustomValidationCallback = (httpRequest, certificate, chain, policyErrors) =>
+                {
+                    return options.RemoteCertificateValidationCallback.Invoke(httpRequest, certificate, chain, policyErrors);
+                },
             };
 #pragma warning restore CA2000 // Dispose objects before losing scope
 

--- a/iothub/service/src/IotHubServiceClientOptions.cs
+++ b/iothub/service/src/IotHubServiceClientOptions.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Security;
 using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Azure.Devices
 {
@@ -101,5 +103,28 @@ namespace Microsoft.Azure.Devices
         /// </para>
         /// </remarks>
         public TimeSpan AmqpConnectionKeepAlive { get; set; } = TimeSpan.FromMinutes(2);
+
+        /// <summary>
+        /// A callback for remote certificate validation.
+        /// </summary>
+        /// <remarks>
+        /// If incorrectly implemented, your device may fail to connect to IoT Hub and/or be open to security vulnerabilities.
+        /// <para>
+        /// This feature is only applicable for HTTP connections and for AMQP TCP connections. AMQP web socket communication
+        /// does not support this feature.
+        /// </para>
+        /// </remarks>
+        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; } = DefaultRemoteCertificateValidation;
+
+        // The default remote certificate validation callback. It returns false if any SSL level exceptions occurred
+        // during the handshake.
+        private static bool DefaultRemoteCertificateValidation(
+            object sender,
+            X509Certificate certificate,
+            X509Chain chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            return sslPolicyErrors == SslPolicyErrors.None;
+        }
     }
 }

--- a/iothub/service/src/IotHubServiceClientOptions.cs
+++ b/iothub/service/src/IotHubServiceClientOptions.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Devices
         /// A callback for remote certificate validation.
         /// </summary>
         /// <remarks>
-        /// If incorrectly implemented, your device may fail to connect to IoT Hub and/or be open to security vulnerabilities.
+        /// If incorrectly implemented, your device may fail to connect to IoT hub and/or be open to security vulnerabilities.
         /// <para>
         /// This feature is only applicable for HTTP connections and for AMQP TCP connections. AMQP web socket communication
         /// does not support this feature.


### PR DESCRIPTION
currently supported over HTTP and AMQP TCP. Will add AMQP WS support later