### PR TITLE
Allow users to provide a client web socket instance for AMQP DPS device client

### DIFF
--- a/SDK v2 migration guide.md
+++ b/SDK v2 migration guide.md
@@ -166,6 +166,11 @@ to migrate to version 2.x when they have the chance. For more details on LTS rel
 - The previous way of providing transport level settings (`ProvisioningTransportHandler`) has been replaced with `ProvisioningClientTransportSettings`.
 - TPM support removed. The library used for TPM operations is broken on Linux and support for it is being shutdown. We'll reconsider how to support HSM.
 
+#### Notable additions
+- Added support for setting a client web socket instance in the client options so that users can have better control over AMQP web socket connections.
+- Added support for setting the web socket level keep alive interval for AMQP web socket connections.
+- Added support for setting the remote certificate validation callback for AMQP TCP connections.
+
 ### DPS service client
 
 | Version 1.x API | Equivalent version 2.x API |

--- a/provisioning/device/src/TransportSettings/ProvisioningClientAmqpSettings.cs
+++ b/provisioning/device/src/TransportSettings/ProvisioningClientAmqpSettings.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                 Proxy = Proxy,
                 SslProtocols = SslProtocols,
                 IdleTimeout = IdleTimeout,
+                ClientWebSocket = ClientWebSocket,
+                WebSocketKeepAlive = WebSocketKeepAlive,
             };
         }
     }

--- a/provisioning/device/src/TransportSettings/ProvisioningClientAmqpSettings.cs
+++ b/provisioning/device/src/TransportSettings/ProvisioningClientAmqpSettings.cs
@@ -43,10 +43,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// This option is ignored for TCP connections.
         /// <para>
         /// If not provided, a client web socket instance will be created for you based on the other
-        /// settings provided in this class.
+        /// settings provided in this class. If provided, all other web socket level options set in this
+        /// class will be ignored (WebSocketKeepAlive, proxy, and x509 certificates, for example).
         /// </para>
         /// </remarks>
-        public ClientWebSocket ClientWebSocket { get; set; } = new ClientWebSocket();
+        public ClientWebSocket ClientWebSocket { get; set; }
 
         /// <summary>
         /// A keep-alive for the transport layer in sending ping/pong control frames when using web sockets.

--- a/provisioning/device/src/TransportSettings/ProvisioningClientAmqpSettings.cs
+++ b/provisioning/device/src/TransportSettings/ProvisioningClientAmqpSettings.cs
@@ -41,6 +41,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// </summary>
         /// <remarks>
         /// This option is ignored for TCP connections.
+        /// <para>
+        /// If not provided, a client web socket instance will be created for you based on the other
+        /// settings provided in this class.
+        /// </para>
         /// </remarks>
         public ClientWebSocket ClientWebSocket { get; set; } = new ClientWebSocket();
 

--- a/provisioning/device/src/TransportSettings/ProvisioningClientAmqpSettings.cs
+++ b/provisioning/device/src/TransportSettings/ProvisioningClientAmqpSettings.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Net.Security;
+using System.Net.WebSockets;
 
 namespace Microsoft.Azure.Devices.Provisioning.Client
 {
@@ -35,6 +35,20 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// </para>
         /// </remarks>
         public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromMinutes(2);
+
+        /// <summary>
+        /// The client web socket to use when communicating over web sockets.
+        /// </summary>
+        /// <remarks>
+        /// This option is ignored for TCP connections.
+        /// </remarks>
+        public ClientWebSocket ClientWebSocket { get; set; } = new ClientWebSocket();
+
+        /// <summary>
+        /// A keep-alive for the transport layer in sending ping/pong control frames when using web sockets.
+        /// </summary>
+        /// <seealso href="https://docs.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.keepaliveinterval"/>
+        public TimeSpan? WebSocketKeepAlive { get; set; }
 
         internal override ProvisioningClientTransportSettings Clone()
         {

--- a/provisioning/device/src/TransportSettings/ProvisioningClientTransportSettings.cs
+++ b/provisioning/device/src/TransportSettings/ProvisioningClientTransportSettings.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Net;
 using System.Net.Security;
+using System.Net.WebSockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 
@@ -67,7 +68,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// If incorrectly implemented, your device may fail to connect to IoT hub and/or be open to security vulnerabilities.
         /// <para>
         /// This feature is only applicable for HTTP, MQTT over TCP, MQTT over web socket, AMQP
-        /// over TCP. AMQP web socket communication does not support this feature.
+        /// over TCP. AMQP web socket communication does not support this feature. For users who want
+        /// this support over AMQP websocket, you must instead provide a <see cref="ClientWebSocket"/>
+        /// instance with the desired callback set.
         /// </para>
         /// </remarks>
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; } = DefaultRemoteCertificateValidation;

--- a/provisioning/device/src/TransportSettings/ProvisioningClientTransportSettings.cs
+++ b/provisioning/device/src/TransportSettings/ProvisioningClientTransportSettings.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// This feature is only applicable for HTTP, MQTT over TCP, MQTT over web socket, AMQP
         /// over TCP. AMQP web socket communication does not support this feature. For users who want
         /// this support over AMQP websocket, you must instead provide a <see cref="ClientWebSocket"/>
-        /// instance with the desired callback set.
+        /// instance with the desired callback and other websocket options (eg. proxy, keep-alive etc.) set.
         /// </para>
         /// </remarks>
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; } = DefaultRemoteCertificateValidation;

--- a/provisioning/device/src/Transports/Amqp/AmqpClientConnection.cs
+++ b/provisioning/device/src/Transports/Amqp/AmqpClientConnection.cs
@@ -209,7 +209,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
         private async Task<ClientWebSocket> CreateClientWebSocketAsync(Uri websocketUri, IWebProxy webProxy, CancellationToken cancellationToken)
         {
-            var websocket = new ClientWebSocket();
+            var websocket = _clientSettings?.ClientWebSocket ?? new ClientWebSocket();
+
+            if (_clientSettings.WebSocketKeepAlive.HasValue)
+            {
+                websocket.Options.KeepAliveInterval = _clientSettings.WebSocketKeepAlive.Value;
+            }
+
             // Set SubProtocol to AMQPWSB10
             websocket.Options.AddSubProtocol(Amqpwsb10);
 

--- a/provisioning/device/src/Transports/Amqp/AmqpClientConnection.cs
+++ b/provisioning/device/src/Transports/Amqp/AmqpClientConnection.cs
@@ -200,16 +200,24 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                 Host = _host,
                 Port = WebSocketPort
             };
-            ClientWebSocket websocket = await CreateClientWebSocketAsync(webSocketUriBuilder.Uri, proxy, cancellationToken).ConfigureAwait(false);
-            return new ClientWebSocketTransport(
-                websocket,
-                null,
-                null);
+
+            ClientWebSocket websocket = CreateClientWebSocket(proxy);
+
+            await websocket.ConnectAsync(webSocketUriBuilder.Uri, cancellationToken).ConfigureAwait(false);
+
+            return new ClientWebSocketTransport(websocket, null, null);
         }
 
-        private async Task<ClientWebSocket> CreateClientWebSocketAsync(Uri websocketUri, IWebProxy webProxy, CancellationToken cancellationToken)
+        private ClientWebSocket CreateClientWebSocket(IWebProxy webProxy)
         {
-            var websocket = _clientSettings?.ClientWebSocket ?? new ClientWebSocket();
+            // Just return the user-supplied client websocket if they provided one.
+            if (_clientSettings?.ClientWebSocket != null)
+            {
+                return _clientSettings.ClientWebSocket;
+            }
+
+            // Otherwise we'll create the client web socket for them.
+            var websocket = new ClientWebSocket();
 
             if (_clientSettings.WebSocketKeepAlive.HasValue)
             {
@@ -218,7 +226,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
             // Set SubProtocol to AMQPWSB10
             websocket.Options.AddSubProtocol(Amqpwsb10);
-
             websocket.Options.SetBuffer(BufferSize, BufferSize);
 
             //Check if we're configured to use a proxy server
@@ -229,22 +236,20 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                     // Configure proxy server
                     websocket.Options.Proxy = webProxy;
                     if (Logging.IsEnabled)
-                        Logging.Info(this, $"{nameof(CreateClientWebSocketAsync)} Setting ClientWebSocket.Options.Proxy");
+                        Logging.Info(this, $"{nameof(CreateClientWebSocket)} Setting ClientWebSocket.Options.Proxy");
                 }
             }
             catch (PlatformNotSupportedException)
             {
                 // .NET Core 2.0 doesn't support WebProxy configuration - ignore this setting.
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"{nameof(CreateClientWebSocketAsync)} PlatformNotSupportedException thrown as .NET Core 2.0 doesn't support proxy");
+                    Logging.Error(this, $"{nameof(CreateClientWebSocket)} PlatformNotSupportedException thrown as .NET Core 2.0 doesn't support proxy");
             }
 
             if (TransportSettings.Certificate != null)
             {
                 websocket.Options.ClientCertificates.Add(TransportSettings.Certificate);
             }
-
-            await websocket.ConnectAsync(websocketUri, cancellationToken).ConfigureAwait(false);
 
             return websocket;
         }

--- a/provisioning/device/src/Transports/Http/ProvisioningTransportHandlerHttp.cs
+++ b/provisioning/device/src/Transports/Http/ProvisioningTransportHandlerHttp.cs
@@ -100,11 +100,15 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                     // When revisiting TLS12 work for DPS, we should figure out why. Perhaps the service needs to support it.
 
                     SslProtocols = _settings.SslProtocols,
-                    ServerCertificateCustomValidationCallback = (httpRequest, certificate, chain, policyErrors) =>
+                };
+
+                if (_settings.RemoteCertificateValidationCallback != null)
+                {
+                    httpClientHandler.ServerCertificateCustomValidationCallback = (httpRequest, certificate, chain, policyErrors) =>
                     {
                         return _settings.RemoteCertificateValidationCallback.Invoke(httpRequest, certificate, chain, policyErrors);
-                    },
-                };
+                    };
+                }
 
                 if (_settings.Proxy != null)
                 {


### PR DESCRIPTION
This allows users to set the remote certificate validation callback as long as they target a .NET version that supports that feature.

Also add the web socket idle timeout option back into the AMQP options bundle
