### PR TITLE
Suppress warning about using pre-release packages in samples projects

### DIFF
--- a/iothub/device/samples/getting started/FileUploadSample/FileUploadSample.csproj
+++ b/iothub/device/samples/getting started/FileUploadSample/FileUploadSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/device/samples/getting started/MessageReceiveSample/MessageReceiveSample.csproj
+++ b/iothub/device/samples/getting started/MessageReceiveSample/MessageReceiveSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/device/samples/getting started/MethodSample/MethodSample.csproj
+++ b/iothub/device/samples/getting started/MethodSample/MethodSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+    
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/device/samples/getting started/SimulatedDevice/SimulatedDevice.csproj
+++ b/iothub/device/samples/getting started/SimulatedDevice/SimulatedDevice.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/device/samples/getting started/SimulatedDeviceWithCommand/SimulatedDeviceWithCommand.csproj
+++ b/iothub/device/samples/getting started/SimulatedDeviceWithCommand/SimulatedDeviceWithCommand.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/device/samples/getting started/TwinSample/TwinSample.csproj
+++ b/iothub/device/samples/getting started/TwinSample/TwinSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/device/samples/how to guides/DeviceReconnectionSample/DeviceReconnectionSample.csproj
+++ b/iothub/device/samples/how to guides/DeviceReconnectionSample/DeviceReconnectionSample.csproj
@@ -5,6 +5,12 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <RootNamespace>Microsoft.Azure.Devices.Client.Samples</RootNamespace>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/device/samples/how to guides/X509DeviceCertWithChainSample/X509DeviceCertWithChainSample.csproj
+++ b/iothub/device/samples/how to guides/X509DeviceCertWithChainSample/X509DeviceCertWithChainSample.csproj
@@ -3,7 +3,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-	<LangVersion>9.0</LangVersion>
+	  <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/device/samples/solutions/PnpDeviceSamples/PnpConvention/PnpHelpers.csproj
+++ b/iothub/device/samples/solutions/PnpDeviceSamples/PnpConvention/PnpHelpers.csproj
@@ -5,6 +5,12 @@
     <IsTestProject>True</IsTestProject>
     <LangVersion>9.0</LangVersion>
     <IsTestProject>False</IsTestProject>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/device/samples/solutions/PnpDeviceSamples/TemperatureController/TemperatureController.csproj
+++ b/iothub/device/samples/solutions/PnpDeviceSamples/TemperatureController/TemperatureController.csproj
@@ -5,6 +5,12 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <RootDir>$(MSBuildProjectDirectory)\..\..\..\..\..</RootDir>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/device/samples/solutions/PnpDeviceSamples/Thermostat/Thermostat.csproj
+++ b/iothub/device/samples/solutions/PnpDeviceSamples/Thermostat/Thermostat.csproj
@@ -6,6 +6,12 @@
     <LangVersion>9.0</LangVersion>
     <RootDir>$(MSBuildProjectDirectory)\..\..\..\..\..</RootDir>
     <RootNamespace>Microsoft.Azure.Devices.Client.Samples</RootNamespace>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/getting started/EdgeDeploymentSample/EdgeDeploymentSample.csproj
+++ b/iothub/service/samples/getting started/EdgeDeploymentSample/EdgeDeploymentSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/getting started/FileUploadNotificationReceiverSample/FileUploadNotificationReceiverSample.csproj
+++ b/iothub/service/samples/getting started/FileUploadNotificationReceiverSample/FileUploadNotificationReceiverSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/getting started/InvokeDeviceMethod/InvokeDeviceMethod.csproj
+++ b/iothub/service/samples/getting started/InvokeDeviceMethod/InvokeDeviceMethod.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/getting started/JobsSample/JobsSample.csproj
+++ b/iothub/service/samples/getting started/JobsSample/JobsSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/getting started/ReadD2cMessages/ReadD2cMessages.csproj
+++ b/iothub/service/samples/getting started/ReadD2cMessages/ReadD2cMessages.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/getting started/ServiceClientSample/ServiceClientSample.csproj
+++ b/iothub/service/samples/getting started/ServiceClientSample/ServiceClientSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/how to guides/AutomaticDeviceManagementSample/AutomaticDeviceManagementSample.csproj
+++ b/iothub/service/samples/how to guides/AutomaticDeviceManagementSample/AutomaticDeviceManagementSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/how to guides/AzureSasCredentialAuthenticationSample/AzureSasCredentialAuthenticationSample.csproj
+++ b/iothub/service/samples/how to guides/AzureSasCredentialAuthenticationSample/AzureSasCredentialAuthenticationSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/how to guides/CleanupDevicesSample/CleanupDevicesSample.csproj
+++ b/iothub/service/samples/how to guides/CleanupDevicesSample/CleanupDevicesSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/how to guides/ImportExportDevicesSample/ImportExportDevicesSample.csproj
+++ b/iothub/service/samples/how to guides/ImportExportDevicesSample/ImportExportDevicesSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/how to guides/ImportExportDevicesWithManagedIdentitySample/ImportExportDevicesWithManagedIdentitySample.csproj
+++ b/iothub/service/samples/how to guides/ImportExportDevicesWithManagedIdentitySample/ImportExportDevicesWithManagedIdentitySample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/how to guides/RegistryManagerSample/RegistryManagerSample.csproj
+++ b/iothub/service/samples/how to guides/RegistryManagerSample/RegistryManagerSample.csproj
@@ -5,6 +5,12 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <RootNamespace>Microsoft.Azure.Devices.Samples</RootNamespace>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/how to guides/RoleBasedAuthenticationSample/RoleBasedAuthenticationSample.csproj
+++ b/iothub/service/samples/how to guides/RoleBasedAuthenticationSample/RoleBasedAuthenticationSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/solutions/DigitalTwinClientSamples/TemperatureController/TemperatureController.csproj
+++ b/iothub/service/samples/solutions/DigitalTwinClientSamples/TemperatureController/TemperatureController.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/solutions/DigitalTwinClientSamples/Thermostat/Thermostat.csproj
+++ b/iothub/service/samples/solutions/DigitalTwinClientSamples/Thermostat/Thermostat.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/solutions/PnpServiceSamples/TemperatureController/TemperatureController.csproj
+++ b/iothub/service/samples/solutions/PnpServiceSamples/TemperatureController/TemperatureController.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iothub/service/samples/solutions/PnpServiceSamples/Thermostat/Thermostat.csproj
+++ b/iothub/service/samples/solutions/PnpServiceSamples/Thermostat/Thermostat.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/provisioning/device/samples/Getting Started/X509Sample/X509Sample.csproj
+++ b/provisioning/device/samples/Getting Started/X509Sample/X509Sample.csproj
@@ -5,6 +5,12 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <RootNamespace>Microsoft.Azure.Devices.Provisioning.Client.Samples</RootNamespace>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/provisioning/device/samples/How To/SymmetricKeySample/SymmetricKeySample.csproj
+++ b/provisioning/device/samples/How To/SymmetricKeySample/SymmetricKeySample.csproj
@@ -5,6 +5,12 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <RootNamespace>Microsoft.Azure.Devices.Provisioning.Client.Samples</RootNamespace>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />

--- a/provisioning/service/samples/Getting Started/CleanupEnrollmentsSample/CleanupEnrollmentsSample.csproj
+++ b/provisioning/service/samples/Getting Started/CleanupEnrollmentsSample/CleanupEnrollmentsSample.csproj
@@ -5,6 +5,12 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <RootNamespace>Microsoft.Azure.Devices.Provisioning.Service.Samples</RootNamespace>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/provisioning/service/samples/Getting Started/EnrollmentGroupX509Sample/EnrollmentGroupX509Sample.csproj
+++ b/provisioning/service/samples/Getting Started/EnrollmentGroupX509Sample/EnrollmentGroupX509Sample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/provisioning/service/samples/Getting Started/IndividualEnrollmentTpmSample/IndividualEnrollmentTpmSample.csproj
+++ b/provisioning/service/samples/Getting Started/IndividualEnrollmentTpmSample/IndividualEnrollmentTpmSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/provisioning/service/samples/Getting Started/IndividualEnrollmentX509Sample/IndividualEnrollmentX509Sample.csproj
+++ b/provisioning/service/samples/Getting Started/IndividualEnrollmentX509Sample/IndividualEnrollmentX509Sample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/provisioning/service/samples/How To/BulkOperationSample/BulkOperationSample.csproj
+++ b/provisioning/service/samples/How To/BulkOperationSample/BulkOperationSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/provisioning/service/samples/How To/GroupCertificateVerificationSample/GroupCertificateVerificationSample.csproj
+++ b/provisioning/service/samples/How To/GroupCertificateVerificationSample/GroupCertificateVerificationSample.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+
+    <!--
+    Warning for using pre-release nugets can be ignored since this sample 
+    can't target a main release yet.
+    -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We can remove this once the samples point to a main release version