### PR TITLE
Build and upload only Device SDK nuget packages

### DIFF
--- a/vsts/build-test-nuget.yml
+++ b/vsts/build-test-nuget.yml
@@ -33,7 +33,7 @@ jobs:
         displayName: 'Copy nuget package files to the artifacts folder'
         inputs:
           SourceFolder: '$(Build.SourcesDirectory)/bin/pkg'
-          Contents: '**/*.*nupkg'
+          Contents: '**/Microsoft.Azure.Devices.*.*nupkg'
           TargetFolder: '$(Build.ArtifactStagingDirectory)/nuget'
         condition: always()
 


### PR DESCRIPTION
Updated package upload filter for the build process
- Build and upload only Device SDK nuget packages
- skip samples nuget packages on upload processes