### PR TITLE
Consolidate "C#" and ".NET" used interchangeably to reference our SDK

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We monitor the Github issues section specifically for bugs found with our SDK, h
 
 # File a bug (code or documentation)
 That is definitely something we want to hear about. Please open an issue on github, we'll address it as fast as possible. Typically here's the information we're going to ask for to get started:
-- What SDK are you using (Node, C, C#, Python, Java?)
+- What SDK are you using (Node, C, .NET, Python, Java?)
 - What version of the SDK?
 - Do you have a snippet of code that would help us reproduce the bug?
 - Do you have logs showing what's happening?
@@ -23,7 +23,7 @@ That is definitely something we want to hear about. Please open an issue on gith
 * Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
 * Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
 * Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
-* Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub. This is the repo for C# only. Use the respective repo for (C, Java, .NET, Node.js, Python).
+* Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub. This is the repo for .NET only. Use the respective repo for (C, Java, .NET, Node.js, Python).
 
 ## Contribute documentation
 
@@ -78,7 +78,7 @@ sure your plans and ours are in sync :) Just open an issue on github and tag it 
         3. Run the E2E test suite and ensure that all the tests pass successfully. You can also test against the [CI script](https://github.com/Azure/azure-iot-sdk-csharp/blob/main/jenkins/windows_csharp.cmd) that is used in our gated build system.
 
     e) Samples:
-    Add relevant samples to the [Azure IoT Samples for C# Repo](https://github.com/Azure-Samples/azure-iot-samples-csharp). Make sure to add a supporting readme file demonstrating the steps to run the sample.
+    Add relevant samples to the respective sample directory, such as [Azure IoT hub device samples for .NET](https://github.com/Azure/azure-iot-sdk-csharp/tree/main/iothub/device/samples). Make sure to add a supporting readme file demonstrating the steps to run the sample.
     
     f) Documentation:
     To make sure that the API documentation can be generated from our code, we follow the following format for class and method signatures:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-Thank you for helping us improve the Azure IoT C# SDK!
+Thank you for helping us improve the Azure IoT .NET SDK!
 
 Need support?
 - Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.

--- a/build.ps1
+++ b/build.ps1
@@ -266,7 +266,7 @@ try
         $env:AZURE_IOT_LOCALPACKAGES = ""
         
         # SDK binaries
-        BuildProject . "Azure IoT C# SDK Solution"
+        BuildProject . "Azure IoT .NET SDK Solution"
 
         # Samples
         # TODO: BuildProject <path> "<desc>"

--- a/doc/devguide.md
+++ b/doc/devguide.md
@@ -2,12 +2,12 @@
 
 ## 1. Dev machine prerequisites
 
-Before starting development on the Azure IoT SDK for C# you will need to install a few frameworks and tools. Please follow the instructions within [devbox_setup](devbox_setup.md).
+Before starting development on the Azure IoT SDK for .NET you will need to install a few frameworks and tools. Please follow the instructions within [devbox_setup](devbox_setup.md).
 
 ## 2. Design Guidelines and Coding Style
 
 ### Design
-We are following the [Azure SDK design specification for C#](https://azuresdkspecs.z5.web.core.windows.net/DotNetSpec.html). To preserve backward compatibility, existing code will not change to follow these rules.
+We are following the [Azure SDK design specification for .NET](https://azuresdkspecs.z5.web.core.windows.net/DotNetSpec.html). To preserve backward compatibility, existing code will not change to follow these rules.
 
 #### Using [`IDisposable`](https://docs.microsoft.com/en-us/dotnet/api/system.idisposable?view=net-5.0#implementing-idisposable) types:
 - If the sdk implements `class A` that owns an `IDisposable` resource `X`, then `A` should also be `IDisposable`. In that case, resource `X` can be safely disposed when `class A` is disposed.
@@ -70,9 +70,9 @@ Please see `build -h` for instructions on how to set up a local NuGet source and
 
 ### /doc
 
-Contains development instructions for building and changing the Azure IoT SDK for C#.
+Contains development instructions for building and changing the Azure IoT SDK for .NET.
 
-If you would like to develop an application using the Azure IoT SDK for C# (using pre-built binaries), please follow the dev-guide here: https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-sdks 
+If you would like to develop an application using the Azure IoT SDK for .NET (using pre-built binaries), please follow the dev-guide here: https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-sdks 
 
 ### Package architecture
 ![packages](https://www.plantuml.com/plantuml/png/0/jLLRRi8m4Fn7oXtyNv4J80G2LLMbI2tG0xZs9bWuSLYlaTAAkpSXK48W9PJWtvsTcNtO7bdYI2xMNi_hQGY9aM6eeYKngH04APCKePIB5O-01KgWiIOaV_pb4FmfR9G0wy-N746omU3PQ0au7B9lhxTjaLbBOVaHcblBve05OA8L97G85UU9JRHniZ1QSfIXdTWnVGQHieHPm9DS7Mi4iuyf2mqoMPgeniQEJCn9YPAyp8zp3nTbNisdFRMuRLUt_uPcespUNfL4_hxOncPKmMUD-TKzujyTO7OIQ-LfpzdaeeITbLk514Ow3Hrqv8gLAhR1rksQ2-I9JGtce7YT_cEPc-Y2DL67T2z4zxkRWt2eAFCNQLmZszCrtTX-VtZb7MZCFOpr7efBQz8Pt-4YTaPOczfVl1SAkrbajxYF5jcjysD4JhQopH16aCZy-_e1 "packages")

--- a/e2e/test/prerequisites/readme.md
+++ b/e2e/test/prerequisites/readme.md
@@ -1,5 +1,5 @@
 
-# Azure IoT C# end-to-end test prerequisites
+# Azure IoT .NET end-to-end test prerequisites
 
 The E2E tests require some Azure resources to be set up and configured. Running the [e2eTestsSetup.ps1](https://github.com/Azure/azure-iot-sdk-csharp/blob/main/e2e/test/prerequisites/E2ETestsSetup/e2eTestsSetup.ps1) powershell script is a convenient way of getting all the resources setup with the required configuration.
 

--- a/iothub/device/devdoc/amqpstack.md
+++ b/iothub/device/devdoc/amqpstack.md
@@ -18,7 +18,7 @@ The `AmqpTransportHandler` is always the last element of the transport pipeline,
 
 By default, each `DeviceClient`/`ModuleClient` will use a separate TCP/WSS non-pooled connection.
 
-The Azure IoT Device SDK for C# supports high performance scenarios such as [Azure IoT Protocol Gateway](https://github.com/Azure/azure-iot-protocol-gateway) and [Azure IoT Edge](https://github.com/Azure/iotedge). For this, the following features are available:
+The Azure IoT Device SDK for .NET supports high performance scenarios such as [Azure IoT Protocol Gateway](https://github.com/Azure/azure-iot-protocol-gateway) and [Azure IoT Edge](https://github.com/Azure/iotedge). For this, the following features are available:
 - Multiplexing allows multiple IoT identities (devices or modules) to share a single TCP/TLS connection.
 - Connection pooling allows the SDK to automatically load-balance multiple clients on a small number of TCP/TLS connections.
 

--- a/iothub/service/samples/getting started/ReadD2cMessages/README.md
+++ b/iothub/service/samples/getting started/ReadD2cMessages/README.md
@@ -4,7 +4,7 @@ This sample demonstrates how to use the Azure Event Hubs client library for .NET
 
 ## Prerequisites
 
-The .NET SDK 3.1 is recommended. You can download the .NET Core SDK for multiple platforms from [.NET](https://www.microsoft.com/net/download/all). You can verify the current version of C# on your development machine using 'dotnet --version'.
+The .NET SDK 3.1 is recommended. You can download the .NET Core SDK for multiple platforms from [.NET](https://www.microsoft.com/net/download/all). You can verify the current version on your development machine using 'dotnet --version'.
 
 > Note: the Event Hubs client 5.2 does not work with .NET 5.0.
 

--- a/iothub/service/samples/readme.md
+++ b/iothub/service/samples/readme.md
@@ -1,4 +1,4 @@
-## Service samples for Azure IoT Service SDK for C#
+## Service samples for Azure IoT Service SDK for .NET
 
 This folder contains simple samples showing how to use the various features of Microsoft Azure IoT Hub service to build backend applications in .NET. 
 

--- a/readme.md
+++ b/readme.md
@@ -12,11 +12,11 @@ If you need any help migrating your code to try out the new 2.X.X clients, pleas
 
 This repository contains the following:
 
-- **Microsoft Azure IoT Hub device SDK for C#** to connect client devices to Azure IoT Hub with .NET.
-- **Microsoft Azure IoT Hub service SDK for C#** to manage your IoT Hub service instance from a back-end .NET application.
-- **Microsoft Azure Provisioning device SDK for C#** to provision devices to Azure IoT Hub with .NET.
-- **Microsoft Azure Provisioning service SDK for C#** to manage your Provisioning service instance from a back-end .NET application.
-- **Microsoft Azure IoT Devices Authentication Providers for C#** to provide authentication classes for provisioning devices and connecting to IoT hub.
+- **Microsoft Azure IoT Hub device SDK for .NET** to connect client devices to Azure IoT Hub with .NET.
+- **Microsoft Azure IoT Hub service SDK for .NET** to manage your IoT Hub service instance from a back-end .NET application.
+- **Microsoft Azure Provisioning device SDK for .NET** to provision devices to Azure IoT Hub with .NET.
+- **Microsoft Azure Provisioning service SDK for .NET** to manage your Provisioning service instance from a back-end .NET application.
+- **Microsoft Azure IoT Devices Authentication Providers for .NET** to provide authentication classes for provisioning devices and connecting to IoT hub.
 
 ## Critical Upcoming Change Notice
 
@@ -89,7 +89,7 @@ Samples for each of these categories are further separated into three sub-catego
 If you are looking for a good device sample to get started with, please see the [device reconnection sample](https://github.com/Azure/azure-iot-sdk-csharp/tree/main/iothub/device/samples/how%20to%20guides/DeviceReconnectionSample).
 It shows how to connect a device, handle disconnect events, cases to handle when making calls, and when to re-initialize the `DeviceClient`.
 
-## Contribute to the Azure IoT C# SDK
+## Contribute to the Azure IoT .NET SDK
 
 If you would like to build or change the SDK source code, please follow the [devguide](doc/devguide.md).
 


### PR DESCRIPTION
Updated to consistently refer to it as .NET SDK