### PR TITLE
Tags property on twin should just be a dictionary

### DIFF
--- a/SDK v2 migration guide.md
+++ b/SDK v2 migration guide.md
@@ -180,6 +180,7 @@ but users are still encouraged to migrate to version 2 when they have the chance
 - `JobProperties` properties that hold Azure Storage SAS URIs are now of type `System.Uri` instead of `string`.
 - `JobProperties` has been split into several classes with only the necessary properties for the specified operation.
   - See `ExportJobProperties`, `ImportJobProperties`, and `IotHubJobResponse`.
+- Twin.Tags is now of type `IDictionary<string, object>`.
 
 #### Notable additions
 
@@ -306,6 +307,7 @@ but users are still encouraged to migrate to version 2 when they have the chance
 
 - Query methods (like for individual and group enrollments) now take a query string (and optionally a page size parameter), and the `Query` result no longer requires disposing.
 - ETag fields on the classes `IndividualEnrollment`, `EnrollmentGroup`, and `DeviceRegistrationState` are now taken as the `Azure.ETag` type instead of strings.
+- Twin.Tags is now of type `IDictionary<string, object>`.
 
 ### Security provider client
 

--- a/e2e/test/iothub/service/BulkOperationsE2ETests.cs
+++ b/e2e/test/iothub/service/BulkOperationsE2ETests.cs
@@ -28,8 +28,6 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
 
             Twin twin = await serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
-
-            twin.Tags = new TwinCollection();
             twin.Tags[tagName] = tagValue;
 
             BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<Twin> { twin }, false).ConfigureAwait(false);
@@ -39,7 +37,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             Assert.AreEqual(twin.DeviceId, twinUpd.DeviceId, "Device ID changed");
             Assert.IsNotNull(twinUpd.Tags, "Twin.Tags is null");
-            Assert.IsTrue(twinUpd.Tags.Contains(tagName), "Twin doesn't contain the tag");
+            Assert.IsTrue(twinUpd.Tags.ContainsKey(tagName), "Twin doesn't contain the tag");
             Assert.AreEqual((string)twin.Tags[tagName], (string)twinUpd.Tags[tagName], "Tag value changed");
         }
 
@@ -63,7 +61,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             Assert.AreEqual(twin.DeviceId, twinUpd.DeviceId, "Device ID changed");
             Assert.IsNotNull(twinUpd.Tags, "Twin.Tags is null");
-            Assert.IsTrue(twinUpd.Tags.Contains(tagName), "Twin doesn't contain the tag");
+            Assert.IsTrue(twinUpd.Tags.ContainsKey(tagName), "Twin doesn't contain the tag");
             Assert.AreEqual((string)twin.Tags[tagName], (string)twinUpd.Tags[tagName], "Tag value changed");
         }
 
@@ -78,8 +76,6 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
 
             Twin twin = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
-
-            twin.Tags = new TwinCollection();
             twin.Tags[tagName] = tagValue;
 
             BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<Twin> { twin }, false).ConfigureAwait(false);
@@ -90,7 +86,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             Assert.AreEqual(twin.DeviceId, twinUpd.DeviceId, "Device ID changed");
             Assert.AreEqual(twin.ModuleId, twinUpd.ModuleId, "Module ID changed");
             Assert.IsNotNull(twinUpd.Tags, "Twin.Tags is null");
-            Assert.IsTrue(twinUpd.Tags.Contains(tagName), "Twin doesn't contain the tag");
+            Assert.IsTrue(twinUpd.Tags.ContainsKey(tagName), "Twin doesn't contain the tag");
             Assert.AreEqual((string)twin.Tags[tagName], (string)twinUpd.Tags[tagName], "Tag value changed");
         }
 
@@ -118,7 +114,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             Assert.AreEqual(twin.DeviceId, twinUpd.DeviceId, "Device ID changed");
             Assert.AreEqual(twin.ModuleId, twinUpd.ModuleId, "Module ID changed");
             Assert.IsNotNull(twinUpd.Tags, "Twin.Tags is null");
-            Assert.IsTrue(twinUpd.Tags.Contains(tagName), "Twin doesn't contain the tag");
+            Assert.IsTrue(twinUpd.Tags.ContainsKey(tagName), "Twin doesn't contain the tag");
             Assert.AreEqual((string)twin.Tags[tagName], (string)twinUpd.Tags[tagName], "Tag value changed");
         }
 

--- a/e2e/test/iothub/service/IoTHubServiceProxyE2ETests.cs
+++ b/e2e/test/iothub/service/IoTHubServiceProxyE2ETests.cs
@@ -79,9 +79,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             var twin = new Twin(JobDeviceId)
             {
-                Tags = new TwinCollection(),
+                Tags = { { JobTestTagName, JobDeviceId } },
             };
-            twin.Tags[JobTestTagName] = JobDeviceId;
 
             int tryCount = 0;
 

--- a/e2e/test/iothub/service/RegistryE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryE2ETests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
             var twin = new Twin(deviceId)
             {
-                Tags = new TwinCollection(@"{ companyId: 1234 }"),
+                Tags = { { "companyId", 1234 } },
             };
 
             var iotEdgeDevice = new Device(deviceId)

--- a/iothub/service/samples/getting started/JobsSample/JobsSample.cs
+++ b/iothub/service/samples/getting started/JobsSample/JobsSample.cs
@@ -33,10 +33,8 @@ namespace Microsoft.Azure.Devices.Samples.JobsSample
 
             var twin = new Twin(DeviceId)
             {
-                Tags = new TwinCollection()
+                Tags = { { TestTagName, TestTagValue } },
             };
-            twin.Tags[TestTagName] = TestTagValue;
-
 
             // *************************************** Schedule twin job ***************************************
             // Prepare to catch Throttling exception if more than 1 job is already running.

--- a/iothub/service/src/Registry/DevicesClient.cs
+++ b/iothub/service/src/Registry/DevicesClient.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Azure.Devices
                             ReportedProperties = twin.Properties.Reported,
                         }
                     }
-                }; ;
+                };
 
                 return await BulkDeviceOperationAsync(exportImportDeviceList, cancellationToken).ConfigureAwait(false);
             }

--- a/iothub/service/src/Registry/Models/ExportImportDevice.cs
+++ b/iothub/service/src/Registry/Models/ExportImportDevice.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using Azure;
 using Azure.Core.Serialization;
 using Newtonsoft.Json;
@@ -146,7 +148,7 @@ namespace Microsoft.Azure.Devices
         /// The JSON document read and written by the solution back end. The tags are not visible to device apps.
         /// </summary>
         [JsonProperty(PropertyName = "tags", NullValueHandling = NullValueHandling.Ignore)]
-        public TwinCollection Tags { get; set; }
+        public IDictionary<string, object> Tags { get; internal set; } = new Dictionary<string, object>();
 
         /// <summary>
         /// The desired and reported properties for the device or module.

--- a/iothub/service/src/Twin/Models/Twin.cs
+++ b/iothub/service/src/Twin/Models/Twin.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Gets and sets the twin tags.
         /// </summary>
-        public TwinCollection Tags { get; set; } = new();
+        public IDictionary<string, object> Tags { get; protected internal set; } = new Dictionary<string, object>();
 
         /// <summary>
         /// Gets and sets the twin properties.

--- a/iothub/service/src/Twin/Models/TwinJsonConverter.cs
+++ b/iothub/service/src/Twin/Models/TwinJsonConverter.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Azure.Devices
                         {
                             throw new InvalidOperationException("Tags Json not a Dictionary.");
                         }
-                        twin.Tags = new TwinCollection(JToken.ReadFrom(reader) as JObject);
+                        twin.Tags = serializer.Deserialize<Dictionary<string, object>>(reader);
                         break;
 
                     case PropertiesJsonTag:

--- a/provisioning/service/src/Twin/Twin.cs
+++ b/provisioning/service/src/Twin/Twin.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </summary>
         public Twin()
         {
-            Tags = new TwinCollection();
             Properties = new TwinProperties();
         }
 
@@ -40,7 +39,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="twinProperties"></param>
         public Twin(TwinProperties twinProperties)
         {
-            Tags = new TwinCollection();
             Properties = twinProperties;
         }
 
@@ -64,9 +62,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         public string ModuleId { get; set; }
 
         /// <summary>
-        /// Gets and sets the  twin tags.
+        /// Gets and sets the twin tags.
         /// </summary>
-        public TwinCollection Tags { get; set; }
+        public IDictionary<string, object> Tags { get; internal set; } = new Dictionary<string, object>();
 
         /// <summary>
         /// Gets and sets the twin properties.

--- a/provisioning/service/src/Twin/TwinJsonConverter.cs
+++ b/provisioning/service/src/Twin/TwinJsonConverter.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                         {
                             throw new InvalidOperationException("Tags Json not a Dictionary.");
                         }
-                        twin.Tags = new TwinCollection(JToken.ReadFrom(reader) as JObject);
+                        twin.Tags = serializer.Deserialize<Dictionary<string, object>>(reader);
                         break;
 
                     case PropertiesJsonTag:


### PR DESCRIPTION
If you edit a device's twin's tags in the portal, they show up in the twin document as a simple object with key/value pairs where you can't have 2 entries with the same key. IOW, it is just a dictionary. We don't need all the other stuff that comes with a TwinCollection, like metadata.