### PR TITLE
Create IoT hub devices within samples

### DIFF
--- a/iothub/device/samples/getting started/FileUploadSample/FileUploadSample.cs
+++ b/iothub/device/samples/getting started/FileUploadSample/FileUploadSample.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             const string filePath = "TestPayload.txt";
 
             using var fileStreamSource = new FileStream(filePath, FileMode.Open);
-            var fileName = Path.GetFileName(fileStreamSource.Name);
+            string fileName = Path.GetFileName(fileStreamSource.Name);
 
             Console.WriteLine($"Uploading file {fileName}");
 

--- a/iothub/device/samples/getting started/FileUploadSample/FileUploadSample.csproj
+++ b/iothub/device/samples/getting started/FileUploadSample/FileUploadSample.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\service\src\Microsoft.Azure.Devices.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="TestPayload.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/iothub/device/samples/getting started/FileUploadSample/Parameters.cs
+++ b/iothub/device/samples/getting started/FileUploadSample/Parameters.cs
@@ -9,10 +9,17 @@ namespace Microsoft.Azure.Devices.Client.Samples
     {
         [Option(
             'c',
-            "PrimaryConnectionString",
-            Required = true,
+            "DeviceConnectionString",
+            Required = false,
             HelpText = "The primary connection string for the device to simulate.")]
-        public string PrimaryConnectionString { get; set; }
+        public string DeviceConnectionString { get; set; }
+
+        [Option(
+            'p',
+            "HubConnectionString",
+            Required = false,
+            HelpText = "The primary connection string for the device to simulate.")]
+        public string HubConnectionString { get; set; }
 
         [Option(
             't',

--- a/iothub/device/samples/getting started/FileUploadSample/Program.cs
+++ b/iothub/device/samples/getting started/FileUploadSample/Program.cs
@@ -55,7 +55,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
                 string deviceId = $"FileUploadSample_{Guid.NewGuid()}";
                 var tempDevice = new Device(deviceId);
-                devicesToDelete.Add(tempDevice);
 
                 await registryManager.AddDeviceAsync(tempDevice);
                 using var deviceClient = DeviceClient.CreateFromConnectionString(

--- a/iothub/service/samples/getting started/EdgeDeploymentSample/Program.cs
+++ b/iothub/service/samples/getting started/EdgeDeploymentSample/Program.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Samples
                 Environment.Exit(1);
             }
 
-            using RegistryManager registryManager = RegistryManager.CreateFromConnectionString(parameters.HubConnectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(parameters.HubConnectionString);
 
             var sample = new EdgeDeploymentSample(registryManager);
             await sample.RunSampleAsync();


### PR DESCRIPTION
Our device samples currently rely on existing devices in an IoT hub to run. This can lead to cluttering and possible frustration for users who don't expect to already need an existing device to run our code. This change creates the option for creating a device within the sample, and then running it normally.