### PR TITLE
Disambiguate twin classes from hub and dps service clients

### DIFF
--- a/SDK v2 migration guide.md
+++ b/SDK v2 migration guide.md
@@ -80,10 +80,14 @@ but users are still encouraged to migrate to version 2 when they have the chance
 | Version 1 API | Equivalent version 2 API |
 |:---|:---|
 | `DeviceClient` | `IotHubDeviceClient` |
-| `DeviceClient.SendTelemetryAsync(...)` | `IotHubDeviceClient.SendTelemetryAsync(...)` |
-| `DeviceClient.SendTelemetryBatchAsync(...)` | `IotHubDeviceClient.SendTelemetryBatchAsync(...)` |
-| `DeviceClient.SetConnectionStatusChangesHandler(...)` | `DeviceClient.ConnectionStatusChangeCallback` |
-| `DeviceClient.SetReceiveMessageHandlerAsync(...)` | `DeviceClient.SetIncomingMessageCallbackAsync(...)` |
+| `DeviceClient.SendEventAsync(...)` | `IotHubDeviceClient.SendTelemetryAsync(...)` |
+| `DeviceClient.SendEventBatchAsync(...)` | `IotHubDeviceClient.SendTelemetryBatchAsync(...)` |
+| `DeviceClient.SetConnectionStatusChangesHandler(...)` | `IotHubDeviceClient.ConnectionStatusChangeCallback` |
+| `DeviceClient.SetReceiveMessageHandlerAsync(...)` | `IotHubDeviceClient.SetIncomingMessageCallbackAsync(...)` |
+| `DeviceClient.GetTwinAsync(...)` | `IotHubDeviceClient.GetTwinPropertiesAsync(...)` |
+| `Twin` | `TwinProperties` |
+| `Twin.Properties.Desired` | `TwinProperties.Desired` |
+| `Twin.Properties.Reported` | `TwinProperties.Reported` |
 | `MessageResponse` | `MessageAcknowledgement` |
 | `Message` | `TelemetryMessage`, `IncomingMessage` |
 | `DeviceClient.SetRetryPolicy(...)` | `IotHubClientOptions.RetryPolicy` |
@@ -168,6 +172,7 @@ but users are still encouraged to migrate to version 2 when they have the chance
 | `AuthenticationType` | `ClientAuthenticationType` |
 | `DeviceConnectionState` | `ClientConnectionState` |
 | `DeviceStatus` | `ClientStatus` |
+| `DeviceCapabilities` | `ClientCapabilities` |
 | `RegistryManager.CreateQuery(...)` | `IotHubServiceClient.Query.CreateAsync<T>(...)` |
 | `RegistryManager.AddConfigurationAsync(...)` | `IotHubServiceClient.Configurations.CreateAsync(...)` |
 | `RegistryManager.GetConfigurationsAsync(int maxCount)`| `IotHubServiceClient.Configurations.GetAsync(int maxCount)` |
@@ -311,6 +316,7 @@ but users are still encouraged to migrate to version 2 when they have the chance
 | `TwinCollectionArray.GetLastUpdatedOn()` | `ProvisioningTwinPropertyArray.GetLastUpdatedOnUtc()` |
 | `Metadata` | `ProvisioningTwinMetadata` |
 | `Metadata.LastUpdatedOn` | `ProvisioningTwinMetadata.LastUpdatedOnUtc` |
+| `DeviceCapabilities` | `ProvisioningClientCapabilities` |
 | `X509Attestation.CreateFromCAReferences(...)` | `X509Attestation.CreateFromCaReferences(...)` |
 | `X509Attestation.CAReferences` | `X509Attestation.CaReferences` |
 | `X509CAReferences` | `X509CaReferences` |

--- a/SDK v2 migration guide.md
+++ b/SDK v2 migration guide.md
@@ -154,12 +154,20 @@ but users are still encouraged to migrate to version 2 when they have the chance
 | `Module.LastActivityTime` | `Module.LastActiveOnUtc` |
 | `RegistryManager.GetTwinAsync(...)` | `IotHubServiceClient.Twins.GetAsync(...)` |
 | `RegistryManager.UpdateTwinAsync(...)` | `IotHubServiceClient.Twins.UpdateAsync(...)` |
-| `Twin.StatusUpdatedOn` | `Twin.StatusUpdatedOnUtc` |
-| `Twin.LastActivityOn` | `Twin.LastActiveOnUtc` |
-| `TwinCollection.GetLastUpdatedOn()` | `TwinCollection.GetLastUpdatedOnUtc()` |
-| `TwinCollectionArray.GetLastUpdatedOn()` | `TwinCollectionArray.GetLastUpdatedOnUtc()` |
-| `TwinCollectionValue.GetLastUpdatedOn()` | `TwinCollectionValue.GetLastUpdatedOnUtc()` |
-| `Metadata.LastUpdatedOn` | `TwinMetadata.LastUpdatedOnUtc` |
+| `Twin` | `ClientTwin` |
+| `Twin.StatusUpdatedOn` | `ClientTwin.StatusUpdatedOnUtc` |
+| `Twin.LastActivityOn` | `ClientTwin.LastActiveOnUtc` |
+| `TwinCollection` | `ClientTwinProperties` |
+| `TwinCollection.GetLastUpdatedOn()` | `ClientTwinProperties.GetLastUpdatedOnUtc()` |
+| `TwinCollectionValue` | `ClientTwinPropertyValue` |
+| `TwinCollectionValue.GetLastUpdatedOn()` | `ClientTwinPropertyValue.GetLastUpdatedOnUtc()` |
+| `TwinCollectionArray` | `ClientTwinPropertyArray` |
+| `TwinCollectionArray.GetLastUpdatedOn()` | `ClientTwinPropertiesArray.GetLastUpdatedOnUtc()` |
+| `Metadata` | `ClientTwinMetadata` |
+| `Metadata.LastUpdatedOn` | `ClientTwinMetadata.LastUpdatedOnUtc` |
+| `AuthenticationType` | `ClientAuthenticationType` |
+| `DeviceConnectionState` | `ClientConnectionState` |
+| `DeviceStatus` | `ClientStatus` |
 | `RegistryManager.CreateQuery(...)` | `IotHubServiceClient.Query.CreateAsync<T>(...)` |
 | `RegistryManager.AddConfigurationAsync(...)` | `IotHubServiceClient.Configurations.CreateAsync(...)` |
 | `RegistryManager.GetConfigurationsAsync(int maxCount)`| `IotHubServiceClient.Configurations.GetAsync(int maxCount)` |
@@ -292,17 +300,22 @@ but users are still encouraged to migrate to version 2 when they have the chance
 | `EnrollmentGroup.LastUpdatedDateTimeUtc` | `EnrollmentGroup.LastUpdatedOnUtc` |
 | `IndividualEnrollment.CreatedDateTimeUtc` | `IndividualEnrollment.CreatedOnUtc` |
 | `IndividualEnrollment.LastUpdatedDateTimeUtc` | `IndividualEnrollment.LastUpdatedOnUtc` |
-| `Twin.StatusUpdatedOn` | `Twin.StatusUpdatedOnUtc` |
-| `Twin.LastActivityOn` | `Twin.LastActiveOnUtc` |
+| `Twin` | `ProvisioningTwin` |
+| `Twin.StatusUpdatedOn` | `ProvisioningTwin.StatusUpdatedOnUtc` |
+| `Twin.LastActivityOn` | `ProvisioningTwin.LastActiveOnUtc` |
+| `TwinCollection` | `ProvisioningTwinProperties` |
+| `TwinCollection.GetLastUpdatedOn()` | `ProvisioningTwinProperties.GetLastUpdatedOnUtc()` |
+| `TwinCollectionValue` | `ProvisioningTwinPropertyValue` |
+| `TwinCollectionValue.GetLastUpdatedOn()` | `ProvisioningTwinPropertyValue.GetLastUpdatedOnUtc()` |
+| `TwinCollectionArray` | `ProvisioningTwinPropertyArray` |
+| `TwinCollectionArray.GetLastUpdatedOn()` | `ProvisioningTwinPropertyArray.GetLastUpdatedOnUtc()` |
+| `Metadata` | `ProvisioningTwinMetadata` |
+| `Metadata.LastUpdatedOn` | `ProvisioningTwinMetadata.LastUpdatedOnUtc` |
 | `X509Attestation.CreateFromCAReferences(...)` | `X509Attestation.CreateFromCaReferences(...)` |
 | `X509Attestation.CAReferences` | `X509Attestation.CaReferences` |
 | `X509CAReferences` | `X509CaReferences` |
 | `X509CertificateInfo.SHA1Thumbprint` | `X509CertificateInfo.Sha1Thumbprint` |
 | `X509CertificateInfo.SHA256Thumbprint` | `X509CertificateInfo.Sha256Thumbprint` |
-| `TwinCollection.GetLastUpdatedOn()` | `TwinCollection.GetLastUpdatedOnUtc()` |
-| `TwinCollectionArray.GetLastUpdatedOn()` | `TwinCollectionArray.GetLastUpdatedOnUtc()` |
-| `TwinCollectionValue.GetLastUpdatedOn()` | `TwinCollectionValue.GetLastUpdatedOnUtc()` |
-| `Metadata.LastUpdatedOn` | `TwinMetadata.LastUpdatedOnUtc` |
 
 #### Other notable breaking changes
 

--- a/e2e/test/helpers/TestDevice.cs
+++ b/e2e/test/helpers/TestDevice.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
         private X509Certificate2 _authCertificate;
 
-        private TestDevice(Device device, Client.IAuthenticationMethod authenticationMethod)
+        private TestDevice(Device device, IAuthenticationMethod authenticationMethod)
         {
             Device = device;
             AuthenticationMethod = authenticationMethod;
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
             VerboseTestLogger.WriteLine($"{nameof(GetTestDeviceAsync)}: Creating device {deviceName} with type {type}.");
 
-            Client.IAuthenticationMethod auth = null;
+            IAuthenticationMethod auth = null;
 
             var requestDevice = new Device(deviceName);
             X509Certificate2 authCertificate = null;

--- a/e2e/test/helpers/templates/PoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/PoolingOverAmqp.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
             // Arrange
             // Initialize the test device client instances
             // Set the device client connection status change handler
-            VerboseTestLogger.WriteLine($"{nameof(PoolingOverAmqp)} Initializing Device Clients for multiplexing test");
+            VerboseTestLogger.WriteLine($"{nameof(PoolingOverAmqp)} Initializing device clients for multiplexing test");
             for (int i = 0; i < devicesCount; i++)
             {
                 // Initialize the test device client instances

--- a/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                     async (r, d) =>
                     {
                         Device device = await r.Devices.GetAsync(d).ConfigureAwait(false);
-                        device.Status = DeviceStatus.Disabled;
+                        device.Status = ClientStatus.Disabled;
                         await r.Devices.SetAsync(device).ConfigureAwait(false);
                     })
                 .ConfigureAwait(false);
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 async (r, d) =>
                 {
                     Device device = await r.Devices.GetAsync(d).ConfigureAwait(false);
-                    device.Status = DeviceStatus.Disabled;
+                    device.Status = ClientStatus.Disabled;
                     await r.Devices.SetAsync(device).ConfigureAwait(false);
                 })
                 .ConfigureAwait(false);
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // Receiving the module twin should succeed right now.
             VerboseTestLogger.WriteLine($"{nameof(IotHubDeviceClient_Gives_ConnectionStatus_Disconnected_ChangeReason_DeviceDisabled_Base)}: DeviceClient GetTwinAsync.");
-            ClientTwin twin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+            Client.ClientTwin twin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
             Assert.IsNotNull(twin);
 
             // Delete/disable the device in IoT hub. This should trigger the ConnectionStatusChangeHandler.
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // Receiving the module twin should succeed right now.
             VerboseTestLogger.WriteLine($"{nameof(IotHubModuleClient_Gives_ConnectionStatus_Disconnected_ChangeReason_DeviceDisabled_Base)}: ModuleClient GetTwinAsync.");
-            ClientTwin twin = await moduleClient.GetTwinAsync().ConfigureAwait(false);
+            Client.ClientTwin twin = await moduleClient.GetTwinAsync().ConfigureAwait(false);
             Assert.IsNotNull(twin);
 
             // Delete/disable the device in IoT hub.

--- a/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // Receiving the module twin should succeed right now.
             VerboseTestLogger.WriteLine($"{nameof(IotHubDeviceClient_Gives_ConnectionStatus_Disconnected_ChangeReason_DeviceDisabled_Base)}: DeviceClient GetTwinAsync.");
-            Twin twin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+            TwinProperties twin = await deviceClient.GetTwinPropertiesAsync().ConfigureAwait(false);
             Assert.IsNotNull(twin);
 
             // Delete/disable the device in IoT hub. This should trigger the ConnectionStatusChangeHandler.
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // Receiving the module twin should succeed right now.
             VerboseTestLogger.WriteLine($"{nameof(IotHubModuleClient_Gives_ConnectionStatus_Disconnected_ChangeReason_DeviceDisabled_Base)}: ModuleClient GetTwinAsync.");
-            Twin twin = await moduleClient.GetTwinAsync().ConfigureAwait(false);
+            TwinProperties twin = await moduleClient.GetTwinPropertiesAsync().ConfigureAwait(false);
             Assert.IsNotNull(twin);
 
             // Delete/disable the device in IoT hub.

--- a/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // Receiving the module twin should succeed right now.
             VerboseTestLogger.WriteLine($"{nameof(IotHubDeviceClient_Gives_ConnectionStatus_Disconnected_ChangeReason_DeviceDisabled_Base)}: DeviceClient GetTwinAsync.");
-            Client.ClientTwin twin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+            Twin twin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
             Assert.IsNotNull(twin);
 
             // Delete/disable the device in IoT hub. This should trigger the ConnectionStatusChangeHandler.
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             // Receiving the module twin should succeed right now.
             VerboseTestLogger.WriteLine($"{nameof(IotHubModuleClient_Gives_ConnectionStatus_Disconnected_ChangeReason_DeviceDisabled_Base)}: ModuleClient GetTwinAsync.");
-            Client.ClientTwin twin = await moduleClient.GetTwinAsync().ConfigureAwait(false);
+            Twin twin = await moduleClient.GetTwinAsync().ConfigureAwait(false);
             Assert.IsNotNull(twin);
 
             // Delete/disable the device in IoT hub.

--- a/e2e/test/iothub/SasCredentialAuthenticationTests.cs
+++ b/e2e/test/iothub/SasCredentialAuthenticationTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             string jobId = "JOBSAMPLE" + Guid.NewGuid().ToString();
             string jobDeviceId = "JobsSample_Device";
             string query = $"DeviceId IN ['{jobDeviceId}']";
-            var twin = new Twin(jobDeviceId);
+            var twin = new ClientTwin(jobDeviceId);
 
             try
             {

--- a/e2e/test/iothub/TokenCredentialAuthenticationTests.cs
+++ b/e2e/test/iothub/TokenCredentialAuthenticationTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             string jobId = "JOBSAMPLE" + Guid.NewGuid().ToString();
             string jobDeviceId = "JobsSample_Device";
             string query = $"DeviceId IN ['{jobDeviceId}']";
-            var twin = new Twin(jobDeviceId);
+            var twin = new ClientTwin(jobDeviceId);
 
             try
             {

--- a/e2e/test/iothub/service/BulkOperationsE2ETests.cs
+++ b/e2e/test/iothub/service/BulkOperationsE2ETests.cs
@@ -27,13 +27,13 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
 
-            Twin twin = await serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
+            ClientTwin twin = await serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
             twin.Tags[tagName] = tagValue;
 
-            BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<Twin> { twin }, false).ConfigureAwait(false);
+            BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<ClientTwin> { twin }, false).ConfigureAwait(false);
             Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{ResultErrorsToString(result)}");
 
-            Twin twinUpd = await serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
+            ClientTwin twinUpd = await serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
 
             Assert.AreEqual(twin.DeviceId, twinUpd.DeviceId, "Device ID changed");
             Assert.IsNotNull(twinUpd.Tags, "Twin.Tags is null");
@@ -51,13 +51,13 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
 
-            var twin = new Twin(testDevice.Id);
+            var twin = new ClientTwin(testDevice.Id);
             twin.Tags[tagName] = tagValue;
 
-            BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<Twin> { twin }, false).ConfigureAwait(false);
+            BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<ClientTwin> { twin }, false).ConfigureAwait(false);
             Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{ResultErrorsToString(result)}");
 
-            Twin twinUpd = await serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
+            ClientTwin twinUpd = await serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
 
             Assert.AreEqual(twin.DeviceId, twinUpd.DeviceId, "Device ID changed");
             Assert.IsNotNull(twinUpd.Tags, "Twin.Tags is null");
@@ -75,13 +75,13 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix).ConfigureAwait(false);
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
 
-            Twin twin = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
+            ClientTwin twin = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
             twin.Tags[tagName] = tagValue;
 
-            BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<Twin> { twin }, false).ConfigureAwait(false);
+            BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<ClientTwin> { twin }, false).ConfigureAwait(false);
             Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{ResultErrorsToString(result)}");
 
-            Twin twinUpd = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
+            ClientTwin twinUpd = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
 
             Assert.AreEqual(twin.DeviceId, twinUpd.DeviceId, "Device ID changed");
             Assert.AreEqual(twin.ModuleId, twinUpd.ModuleId, "Module ID changed");
@@ -100,16 +100,16 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix).ConfigureAwait(false);
 
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            var twin = new Twin(testModule.DeviceId)
+            var twin = new ClientTwin(testModule.DeviceId)
             {
                 ModuleId = testModule.Id
             };
             twin.Tags[tagName] = tagValue;
 
-            BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<Twin> { twin }, false).ConfigureAwait(false);
+            BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<ClientTwin> { twin }, false).ConfigureAwait(false);
             Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{ResultErrorsToString(result)}");
 
-            Twin twinUpd = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
+            ClientTwin twinUpd = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
 
             Assert.AreEqual(twin.DeviceId, twinUpd.DeviceId, "Device ID changed");
             Assert.AreEqual(twin.ModuleId, twinUpd.ModuleId, "Module ID changed");

--- a/e2e/test/iothub/service/ExportDevicesTests.cs
+++ b/e2e/test/iothub/service/ExportDevicesTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                     new Device(edgeId1)
                     {
                         Authentication = new AuthenticationMechanism { Type = ClientAuthenticationType.Sas },
-                        Capabilities = new DeviceCapabilities { IsIotEdge = true },
+                        Capabilities = new ClientCapabilities { IsIotEdge = true },
                     })
                     .ConfigureAwait(false);
 
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                     new Device(edgeId2)
                     {
                         Authentication = new AuthenticationMechanism { Type = ClientAuthenticationType.Sas },
-                        Capabilities = new DeviceCapabilities { IsIotEdge = true },
+                        Capabilities = new ClientCapabilities { IsIotEdge = true },
                         ParentScopes = { edge1.Scope },
                     })
                     .ConfigureAwait(false);

--- a/e2e/test/iothub/service/ExportDevicesTests.cs
+++ b/e2e/test/iothub/service/ExportDevicesTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 Device edge1 = await serviceClient.Devices.CreateAsync(
                     new Device(edgeId1)
                     {
-                        Authentication = new AuthenticationMechanism { Type = AuthenticationType.Sas },
+                        Authentication = new AuthenticationMechanism { Type = ClientAuthenticationType.Sas },
                         Capabilities = new DeviceCapabilities { IsIotEdge = true },
                     })
                     .ConfigureAwait(false);
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 Device edge2 = await serviceClient.Devices.CreateAsync(
                     new Device(edgeId2)
                     {
-                        Authentication = new AuthenticationMechanism { Type = AuthenticationType.Sas },
+                        Authentication = new AuthenticationMechanism { Type = ClientAuthenticationType.Sas },
                         Capabilities = new DeviceCapabilities { IsIotEdge = true },
                         ParentScopes = { edge1.Scope },
                     })
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 Device device = await serviceClient.Devices.CreateAsync(
                     new Device(deviceId)
                     {
-                        Authentication = new AuthenticationMechanism { Type = AuthenticationType.Sas },
+                        Authentication = new AuthenticationMechanism { Type = ClientAuthenticationType.Sas },
                         Scope = edge1.Scope,
                     })
                     .ConfigureAwait(false);

--- a/e2e/test/iothub/service/ImportDevicesTests.cs
+++ b/e2e/test/iothub/service/ImportDevicesTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                         new ExportImportDevice(
                             new Device(deviceId)
                             {
-                                Authentication = new AuthenticationMechanism { Type = AuthenticationType.Sas }
+                                Authentication = new AuthenticationMechanism { Type = ClientAuthenticationType.Sas }
                             },
                             ImportMode.Create),
                     });

--- a/e2e/test/iothub/service/IoTHubCertificateValidationE2ETest.cs
+++ b/e2e/test/iothub/service/IoTHubCertificateValidationE2ETest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         {
             using var sc = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionStringInvalidServiceCertificate);
             var exception = await Assert.ThrowsExceptionAsync<IotHubServiceException>(
-                () => sc.Query.CreateAsync<Twin>("select * from devices")).ConfigureAwait(false);
+                () => sc.Query.CreateAsync<ClientTwin>("select * from devices")).ConfigureAwait(false);
 
 #if NET472
             Assert.IsInstanceOfType(exception.InnerException.InnerException.InnerException, typeof(AuthenticationException));
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             var exception = await Assert.ThrowsExceptionAsync<IotHubServiceException>(
                 () => sc.ScheduledJobs.ScheduleTwinUpdateAsync(
                     "DeviceId IN ['testDevice']",
-                    new Twin(),
+                    new ClientTwin(),
                     DateTimeOffset.UtcNow,
                     ScheduledTwinUpdateOptions))
                 .ConfigureAwait(false);

--- a/e2e/test/iothub/service/IoTHubServiceProxyE2ETests.cs
+++ b/e2e/test/iothub/service/IoTHubServiceProxyE2ETests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             };
             using var sc = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString, options);
 
-            var twin = new Twin(JobDeviceId)
+            var twin = new ClientTwin(JobDeviceId)
             {
                 Tags = { { JobTestTagName, JobDeviceId } },
             };

--- a/e2e/test/iothub/service/PnpServiceTests.cs
+++ b/e2e/test/iothub/service/PnpServiceTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             // Get device twin.
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            Twin twin = await serviceClient.Twins.GetAsync(testDevice.Device.Id).ConfigureAwait(false);
+            ClientTwin twin = await serviceClient.Twins.GetAsync(testDevice.Device.Id).ConfigureAwait(false);
 
             // Assert
             twin.ModelId.Should().Be(TestModelId, "because the device was created as plug and play");
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             // Get device twin.
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            Twin twin = await serviceClient.Twins.GetAsync(testDevice.Device.Id).ConfigureAwait(false);
+            ClientTwin twin = await serviceClient.Twins.GetAsync(testDevice.Device.Id).ConfigureAwait(false);
 
             // Assert
             twin.ModelId.Should().Be(TestModelId, "because the device was created as plug and play");
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             // Get module twin.
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            Twin twin = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
+            ClientTwin twin = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
 
             // Assert
             twin.ModelId.Should().Be(TestModelId, "because the module was created as plug and play");

--- a/e2e/test/iothub/service/QueryClientE2ETests.cs
+++ b/e2e/test/iothub/service/QueryClientE2ETests.cs
@@ -45,16 +45,16 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             await WaitForDevicesToBeQueryableAsync(serviceClient.Query, queryText, 2);
 
-            QueryResponse<Twin> queryResponse = await serviceClient.Query.CreateAsync<Twin>(queryText);
+            QueryResponse<ClientTwin> queryResponse = await serviceClient.Query.CreateAsync<ClientTwin>(queryText);
 
             // assert
 
             (await queryResponse.MoveNextAsync()).Should().BeTrue("Should have at least one page of jobs.");
-            Twin firstQueriedTwin = queryResponse.Current;
+            ClientTwin firstQueriedTwin = queryResponse.Current;
 
             firstQueriedTwin.DeviceId.Should().BeOneOf(testDevice1.Id, testDevice2.Id);
             (await queryResponse.MoveNextAsync()).Should().BeTrue();
-            Twin secondQueriedTwin = queryResponse.Current;
+            ClientTwin secondQueriedTwin = queryResponse.Current;
             secondQueriedTwin.DeviceId.Should().BeOneOf(testDevice1.Id, testDevice2.Id);
             secondQueriedTwin.DeviceId.Should().NotBe(firstQueriedTwin.DeviceId);
             (await queryResponse.MoveNextAsync()).Should().BeFalse();
@@ -81,12 +81,12 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             await WaitForDevicesToBeQueryableAsync(serviceClient.Query, queryText, 3);
 
-            QueryResponse<Twin> queryResponse = await serviceClient.Query.CreateAsync<Twin>(queryText, firstPageOptions);
+            QueryResponse<ClientTwin> queryResponse = await serviceClient.Query.CreateAsync<ClientTwin>(queryText, firstPageOptions);
 
             // assert
 
             queryResponse.CurrentPage.Count().Should().Be(1);
-            Twin firstQueriedTwin = queryResponse.CurrentPage.First();
+            ClientTwin firstQueriedTwin = queryResponse.CurrentPage.First();
             firstQueriedTwin.DeviceId.Should().BeOneOf(testDevice1.Id, testDevice2.Id, testDevice3.Id);
 
             // consume the first page of results so the next MoveNextAsync gets a new page
@@ -99,14 +99,14 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             (await queryResponse.MoveNextAsync(secondPageOptions)).Should().BeTrue();
             queryResponse.CurrentPage.Count().Should().Be(2);
-            IEnumerator<Twin> secondPageEnumerator = queryResponse.CurrentPage.GetEnumerator();
+            IEnumerator<ClientTwin> secondPageEnumerator = queryResponse.CurrentPage.GetEnumerator();
             secondPageEnumerator.MoveNext().Should().BeTrue();
-            Twin secondQueriedTwin = secondPageEnumerator.Current;
+            ClientTwin secondQueriedTwin = secondPageEnumerator.Current;
             secondQueriedTwin.DeviceId.Should().BeOneOf(testDevice1.Id, testDevice2.Id, testDevice3.Id);
             secondQueriedTwin.DeviceId.Should().NotBe(firstQueriedTwin.DeviceId);
 
             secondPageEnumerator.MoveNext().Should().BeTrue();
-            Twin thirdQueriedTwin = secondPageEnumerator.Current;
+            ClientTwin thirdQueriedTwin = secondPageEnumerator.Current;
             thirdQueriedTwin.DeviceId.Should().BeOneOf(testDevice1.Id, testDevice2.Id, testDevice3.Id);
             thirdQueriedTwin.DeviceId.Should().NotBe(firstQueriedTwin.DeviceId);
             thirdQueriedTwin.DeviceId.Should().NotBe(secondQueriedTwin.DeviceId);
@@ -138,13 +138,13 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             await WaitForDevicesToBeQueryableAsync(serviceClient.Query, queryText, 3);
 
-            QueryResponse<Twin> twinQuery = await serviceClient.Query.CreateAsync<Twin>(queryText, queryOptions);
+            QueryResponse<ClientTwin> twinQuery = await serviceClient.Query.CreateAsync<ClientTwin>(queryText, queryOptions);
 
             // assert
             List<string> returnedTwinDeviceIds = new();
             while (await twinQuery.MoveNextAsync())
             {
-                Twin queriedTwin = twinQuery.Current;
+                ClientTwin queriedTwin = twinQuery.Current;
                 returnedTwinDeviceIds.Add(queriedTwin.DeviceId);
             }
 
@@ -177,13 +177,13 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             await WaitForDevicesToBeQueryableAsync(serviceClient.Query, queryText, 3);
 
-            QueryResponse<Twin> twinQuery = await serviceClient.Query.CreateAsync<Twin>(queryText, queryOptions);
+            QueryResponse<ClientTwin> twinQuery = await serviceClient.Query.CreateAsync<ClientTwin>(queryText, queryOptions);
 
             // assert
             List<string> returnedTwinDeviceIds = new();
             while (await twinQuery.MoveNextAsync())
             {
-                Twin queriedTwin = twinQuery.Current;
+                ClientTwin queriedTwin = twinQuery.Current;
                 returnedTwinDeviceIds.Add(queriedTwin.DeviceId);
             }
 
@@ -275,11 +275,11 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             // so keep executing the query until both devices are returned in the results or until a timeout.
             using var cancellationTokenSource = new CancellationTokenSource(_queryableDelayTimeout);
             CancellationToken cancellationToken = cancellationTokenSource.Token;
-            QueryResponse<Twin> queryResponse = await queryClient.CreateAsync<Twin>(query);
+            QueryResponse<ClientTwin> queryResponse = await queryClient.CreateAsync<ClientTwin>(query);
             while (queryResponse.CurrentPage.Count() < expectedCount)
             {
                 await Task.Delay(100).ConfigureAwait(false);
-                queryResponse = await queryClient.CreateAsync<Twin>(query);
+                queryResponse = await queryClient.CreateAsync<ClientTwin>(query);
                 cancellationToken.ThrowIfCancellationRequested(); // timed out waiting for the devices to become queryable
             }
         }
@@ -320,7 +320,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
         private static async Task ScheduleJobToBeQueriedAsync(ScheduledJobsClient jobsClient, string deviceId)
         {
-            var twinUpdate = new Twin();
+            var twinUpdate = new ClientTwin();
             twinUpdate.Properties.Desired["key"] = "value";
 
             try

--- a/e2e/test/iothub/service/RegistryE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryE2ETests.cs
@@ -70,14 +70,14 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 // Create a top-level edge device.
                 var edgeDevice1 = new Device(edgeId1)
                 {
-                    Capabilities = new DeviceCapabilities { IsIotEdge = true }
+                    Capabilities = new ClientCapabilities { IsIotEdge = true }
                 };
                 edgeDevice1 = await serviceClient.Devices.CreateAsync(edgeDevice1).ConfigureAwait(false);
 
                 // Create a second-level edge device with edge 1 as the parent.
                 var edgeDevice2 = new Device(edgeId2)
                 {
-                    Capabilities = new DeviceCapabilities { IsIotEdge = true },
+                    Capabilities = new ClientCapabilities { IsIotEdge = true },
                     ParentScopes = { edgeDevice1.Scope },
                 };
                 edgeDevice2 = await serviceClient.Devices.CreateAsync(edgeDevice2).ConfigureAwait(false);
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             var iotEdgeDevice = new Device(deviceId)
             {
-                Capabilities = new DeviceCapabilities { IsIotEdge = true }
+                Capabilities = new ClientCapabilities { IsIotEdge = true }
             };
 
             await serviceClient.Devices.CreateWithTwinAsync(iotEdgeDevice, twin).ConfigureAwait(false);

--- a/e2e/test/iothub/service/RegistryE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryE2ETests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             string deviceId = _idPrefix + Guid.NewGuid();
 
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            var twin = new Twin(deviceId)
+            var twin = new ClientTwin(deviceId)
             {
                 Tags = { { "companyId", 1234 } },
             };
@@ -255,9 +255,9 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             try
             {
                 await serviceClient.Devices.CreateAsync(device1).ConfigureAwait(false);
-                Twin twin1 = await serviceClient.Twins.GetAsync(device1.Id).ConfigureAwait(false);
+                ClientTwin twin1 = await serviceClient.Twins.GetAsync(device1.Id).ConfigureAwait(false);
                 await serviceClient.Devices.CreateAsync(device2).ConfigureAwait(false);
-                Twin twin2 = await serviceClient.Twins.GetAsync(device2.Id).ConfigureAwait(false);
+                ClientTwin twin2 = await serviceClient.Twins.GetAsync(device2.Id).ConfigureAwait(false);
 
                 // act
 
@@ -479,7 +479,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             try
             {
                 // Get the module twin
-                Twin moduleTwin = await serviceClient.Twins.GetAsync(module.DeviceId, module.Id).ConfigureAwait(false);
+                ClientTwin moduleTwin = await serviceClient.Twins.GetAsync(module.DeviceId, module.Id).ConfigureAwait(false);
 
                 moduleTwin.ModuleId.Should().BeEquivalentTo(module.Id, "ModuleId on the Twin should match that of the module identity.");
 
@@ -488,7 +488,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 string propValue = "userA";
                 moduleTwin.Properties.Desired[propName] = propValue;
 
-                Twin updatedModuleTwin = await serviceClient.Twins.UpdateAsync(module.DeviceId, module.Id, moduleTwin).ConfigureAwait(false);
+                ClientTwin updatedModuleTwin = await serviceClient.Twins.UpdateAsync(module.DeviceId, module.Id, moduleTwin).ConfigureAwait(false);
 
                 Assert.IsNotNull(updatedModuleTwin.Properties.Desired[propName]);
                 Assert.AreEqual(propValue, (string)updatedModuleTwin.Properties.Desired[propName]);
@@ -533,7 +533,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             {
                 ETag oldEtag = device.ETag;
 
-                device.Status = DeviceStatus.Disabled;
+                device.Status = ClientStatus.Disabled;
 
                 // Update the device once so that the last ETag falls out of date.
                 device = await serviceClient.Devices.SetAsync(device).ConfigureAwait(false);
@@ -556,7 +556,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 .NotThrow<IotHubServiceException>("Did not expect test to throw a precondition failed exception since 'onlyIfUnchanged' was set to false");
 
                 // set the 'onlyIfUnchanged' flag to true to check that, with an up-to-date ETag, the request performs without exception.
-                device.Status = DeviceStatus.Enabled;
+                device.Status = ClientStatus.Enabled;
                 FluentActions
                 .Invoking(async () => { device = await serviceClient.Devices.SetAsync(device, true).ConfigureAwait(false); })
                 .Should()
@@ -587,7 +587,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             {
                 ETag oldEtag = device.ETag;
 
-                device.Status = DeviceStatus.Disabled;
+                device.Status = ClientStatus.Disabled;
 
                 // Update the device once so that the last ETag falls out of date.
                 device = await serviceClient.Devices.SetAsync(device).ConfigureAwait(false);
@@ -675,7 +675,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
                 // set the 'onlyIfUnchanged' flag to true to check that, with an up-to-date ETag, the request performs without exception.
                 module.ManagedBy = "";
-                device.Status = DeviceStatus.Enabled;
+                device.Status = ClientStatus.Enabled;
                 FluentActions
                 .Invoking(async () => { await serviceClient.Modules.SetAsync(module, true).ConfigureAwait(false); })
                 .Should()

--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -448,8 +448,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             long newTwinVersion = await deviceClient.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
 
             // Validate the updated twin from the device-client
-           Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
-            bool propertyFound = deviceTwin.ReportedByClient.TryGetValue(propName, out T actual);
+           TwinProperties deviceTwin = await deviceClient.GetTwinPropertiesAsync().ConfigureAwait(false);
+            bool propertyFound = deviceTwin.Reported.TryGetValue(propName, out T actual);
             propertyFound.Should().BeTrue();
             // We don't support nested deserialization yet, so we'll need to serialize the response and compare them.
             JsonConvert.SerializeObject(actual).Should().Be(JsonConvert.SerializeObject(propValue));
@@ -502,8 +502,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
             // Validate the updated twin from the device-client
             // Validate the updated twin from the device-client
-            Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
-            bool propertyFound = deviceTwin.RequestsFromService.TryGetValue(propName, out T actual);
+            TwinProperties deviceTwin = await deviceClient.GetTwinPropertiesAsync().ConfigureAwait(false);
+            bool propertyFound = deviceTwin.Desired.TryGetValue(propName, out T actual);
             propertyFound.Should().BeTrue();
             // We don't support nested deserialization yet, so we'll need to serialize the response and compare them.
             JsonConvert.SerializeObject(actual).Should().Be(JsonConvert.SerializeObject(propValue));
@@ -616,8 +616,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                 updateReceivedTask).ConfigureAwait(false);
 
             // Validate the updated twin from the device-client
-            Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
-            bool propertyFound = deviceTwin.RequestsFromService.TryGetValue(propName, out T actual);
+            TwinProperties deviceTwin = await deviceClient.GetTwinPropertiesAsync().ConfigureAwait(false);
+            bool propertyFound = deviceTwin.Desired.TryGetValue(propName, out T actual);
             propertyFound.Should().BeTrue();
             // We don't support nested deserialization yet, so we'll need to serialize the response and compare them.
             JsonConvert.SerializeObject(actual).Should().Be(JsonConvert.SerializeObject(propValue));
@@ -645,8 +645,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             await _serviceClient.Twins.UpdateAsync(testDevice.Id, twinPatch).ConfigureAwait(false);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
-            Client.Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
-            bool propertyFound = deviceTwin.RequestsFromService.TryGetValue(propName, out string actual);
+            Client.TwinProperties deviceTwin = await deviceClient.GetTwinPropertiesAsync().ConfigureAwait(false);
+            bool propertyFound = deviceTwin.Desired.TryGetValue(propName, out string actual);
             propertyFound.Should().BeTrue();
             actual.Should().Be(propValue);
 

--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -442,13 +442,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
             VerboseTestLogger.WriteLine($"{nameof(Twin_DeviceSetsReportedPropertyAndGetsItBackAsync)}: name={propName}, value={propValue}");
 
-            var props = new ReportedPropertyCollection();
+            var props = new ReportedProperties();
             props[propName] = propValue;
             await deviceClient.OpenAsync().ConfigureAwait(false);
             long newTwinVersion = await deviceClient.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
 
             // Validate the updated twin from the device-client
-            Client.ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+           Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
             bool propertyFound = deviceTwin.ReportedByClient.TryGetValue(propName, out T actual);
             propertyFound.Should().BeTrue();
             // We don't support nested deserialization yet, so we'll need to serialize the response and compare them.
@@ -502,7 +502,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
             // Validate the updated twin from the device-client
             // Validate the updated twin from the device-client
-            Client.ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+            Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
             bool propertyFound = deviceTwin.RequestsFromService.TryGetValue(propName, out T actual);
             propertyFound.Should().BeTrue();
             // We don't support nested deserialization yet, so we'll need to serialize the response and compare them.
@@ -616,7 +616,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                 updateReceivedTask).ConfigureAwait(false);
 
             // Validate the updated twin from the device-client
-            Client.ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+            Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
             bool propertyFound = deviceTwin.RequestsFromService.TryGetValue(propName, out T actual);
             propertyFound.Should().BeTrue();
             // We don't support nested deserialization yet, so we'll need to serialize the response and compare them.
@@ -645,7 +645,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             await _serviceClient.Twins.UpdateAsync(testDevice.Id, twinPatch).ConfigureAwait(false);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
-            Client.ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+            Client.Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
             bool propertyFound = deviceTwin.RequestsFromService.TryGetValue(propName, out string actual);
             propertyFound.Should().BeTrue();
             actual.Should().Be(propValue);
@@ -663,7 +663,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             using var deviceClient = new IotHubDeviceClient(testDevice.ConnectionString, options);
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
-            var patch = new ReportedPropertyCollection();
+            var patch = new ReportedProperties();
             patch[propName] = propValue;
             await deviceClient.UpdateReportedPropertiesAsync(patch).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);
@@ -687,7 +687,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
             await deviceClient
                 .UpdateReportedPropertiesAsync(
-                    new ReportedPropertyCollection
+                    new ReportedProperties
                     {
                         [propName1] = null
                     })
@@ -697,7 +697,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
             await deviceClient
                 .UpdateReportedPropertiesAsync(
-                    new ReportedPropertyCollection
+                    new ReportedProperties
                     {
                         [propName1] = new Dictionary<string, object>
                         {
@@ -713,7 +713,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
             await deviceClient
                 .UpdateReportedPropertiesAsync(
-                    new ReportedPropertyCollection
+                    new ReportedProperties
                     {
                         [propName1] = new Dictionary<string, object>
                         {

--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -448,14 +448,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             long newTwinVersion = await deviceClient.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
 
             // Validate the updated twin from the device-client
-            ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+            Client.ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
             bool propertyFound = deviceTwin.ReportedByClient.TryGetValue(propName, out T actual);
             propertyFound.Should().BeTrue();
             // We don't support nested deserialization yet, so we'll need to serialize the response and compare them.
             JsonConvert.SerializeObject(actual).Should().Be(JsonConvert.SerializeObject(propValue));
 
             // Validate the updated twin from the service-client
-            Twin completeTwin = await _serviceClient.Twins.GetAsync(deviceId).ConfigureAwait(false);
+            ClientTwin completeTwin = await _serviceClient.Twins.GetAsync(deviceId).ConfigureAwait(false);
             object actualProp = completeTwin.Properties.Reported[propName];
             JsonConvert.SerializeObject(actualProp).Should().Be(JsonConvert.SerializeObject(propValue));
             completeTwin.Properties.Reported.Version.Should().Be(newTwinVersion);
@@ -502,14 +502,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
             // Validate the updated twin from the device-client
             // Validate the updated twin from the device-client
-            ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+            Client.ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
             bool propertyFound = deviceTwin.RequestsFromService.TryGetValue(propName, out T actual);
             propertyFound.Should().BeTrue();
             // We don't support nested deserialization yet, so we'll need to serialize the response and compare them.
             JsonConvert.SerializeObject(actual).Should().Be(JsonConvert.SerializeObject(propValue));
 
             // Validate the updated twin from the service-client
-            Twin completeTwin = await _serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
+            ClientTwin completeTwin = await _serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
             dynamic actualProp = completeTwin.Properties.Desired[propName];
             Assert.AreEqual(JsonConvert.SerializeObject(actualProp), JsonConvert.SerializeObject(propValue));
 
@@ -553,7 +553,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
         public static async Task RegistryManagerUpdateDesiredPropertyAsync(string deviceId, string propName, object propValue)
         {
-            var twinPatch = new Twin();
+            var twinPatch = new ClientTwin();
             twinPatch.Properties.Desired[propName] = propValue;
 
             await _serviceClient.Twins.UpdateAsync(deviceId, twinPatch).ConfigureAwait(false);
@@ -616,14 +616,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                 updateReceivedTask).ConfigureAwait(false);
 
             // Validate the updated twin from the device-client
-            ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+            Client.ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
             bool propertyFound = deviceTwin.RequestsFromService.TryGetValue(propName, out T actual);
             propertyFound.Should().BeTrue();
             // We don't support nested deserialization yet, so we'll need to serialize the response and compare them.
             JsonConvert.SerializeObject(actual).Should().Be(JsonConvert.SerializeObject(propValue));
 
             // Validate the updated twin from the service-client
-            Twin completeTwin = await _serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
+            ClientTwin completeTwin = await _serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
             object actualProp = completeTwin.Properties.Desired[propName];
             JsonConvert.SerializeObject(actualProp).Should().Be(JsonConvert.SerializeObject(propValue));
 
@@ -640,12 +640,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             var options = new IotHubClientOptions(transportSettings);
             using var deviceClient = new IotHubDeviceClient(testDevice.ConnectionString, options);
 
-            var twinPatch = new Twin();
+            var twinPatch = new ClientTwin();
             twinPatch.Properties.Desired[propName] = propValue;
             await _serviceClient.Twins.UpdateAsync(testDevice.Id, twinPatch).ConfigureAwait(false);
 
             await deviceClient.OpenAsync().ConfigureAwait(false);
-            ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+            Client.ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
             bool propertyFound = deviceTwin.RequestsFromService.TryGetValue(propName, out string actual);
             propertyFound.Should().BeTrue();
             actual.Should().Be(propValue);
@@ -668,7 +668,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             await deviceClient.UpdateReportedPropertiesAsync(patch).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);
 
-            Twin serviceTwin = await _serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
+            ClientTwin serviceTwin = await _serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
             Assert.AreEqual<string>(serviceTwin.Properties.Reported[propName].ToString(), propValue);
 
             VerboseTestLogger.WriteLine("verified " + serviceTwin.Properties.Reported[propName].ToString() + "=" + propValue);
@@ -692,7 +692,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
                         [propName1] = null
                     })
                 .ConfigureAwait(false);
-            Twin serviceTwin = await _serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
+            ClientTwin serviceTwin = await _serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
             Assert.IsFalse(serviceTwin.Properties.Reported.Contains(propName1));
 
             await deviceClient
@@ -742,7 +742,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             string propName = Guid.NewGuid().ToString();
             string propValue = Guid.NewGuid().ToString();
 
-            Twin twin = await _serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
+            ClientTwin twin = await _serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
             ETag oldEtag = twin.ETag;
 
             twin.Properties.Desired[propName] = propValue;

--- a/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
+++ b/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
                 await deviceClient.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
 
-                ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+                Client.ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
                 deviceTwin.Should().NotBeNull();
                 deviceTwin.ReportedByClient.Should().NotBeNull();
                 deviceTwin.ReportedByClient.TryGetValue(propName, out string actualValue).Should().BeTrue();
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
         {
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
 
-            var twinPatch = new Twin();
+            var twinPatch = new ClientTwin();
             twinPatch.Properties.Desired[propName] = propValue;
 
             await serviceClient.Twins.UpdateAsync(deviceId, twinPatch).ConfigureAwait(false);
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             using var cts = new CancellationTokenSource(FaultInjection.RecoveryTime);
 
             string propName = Guid.NewGuid().ToString();
-            var props = new TwinCollection();
+            var props = new ClientTwinProperties();
 
             // Configure the callback and start accepting twin changes.
             async Task InitOperationAsync(IotHubDeviceClient deviceClient, TestDevice testDevice)

--- a/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
+++ b/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
@@ -240,13 +240,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
                 await deviceClient.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
 
-                Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+                TwinProperties deviceTwin = await deviceClient.GetTwinPropertiesAsync().ConfigureAwait(false);
                 deviceTwin.Should().NotBeNull();
-                deviceTwin.ReportedByClient.Should().NotBeNull();
-                deviceTwin.ReportedByClient.TryGetValue(propName, out string actualValue).Should().BeTrue();
+                deviceTwin.Reported.Should().NotBeNull();
+                deviceTwin.Reported.TryGetValue(propName, out string actualValue).Should().BeTrue();
                 actualValue.Should().Be(propValue);
-                deviceTwin.ReportedByClient[propName].Should().NotBeNull();
-                deviceTwin.ReportedByClient[propName].Should().BeEquivalentTo(propValue);
+                deviceTwin.Reported[propName].Should().NotBeNull();
+                deviceTwin.Reported[propName].Should().BeEquivalentTo(propValue);
             }
 
             await FaultInjection

--- a/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
+++ b/e2e/test/iothub/twin/TwinFaultInjectionTests.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             string proxyAddress = null)
         {
             string propName = Guid.NewGuid().ToString();
-            var props = new ReportedPropertyCollection();
+            var props = new ReportedProperties();
 
             async Task InitAsync(IotHubDeviceClient deviceClient, TestDevice testDevice)
             {
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
                 await deviceClient.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
 
-                Client.ClientTwin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
+                Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
                 deviceTwin.Should().NotBeNull();
                 deviceTwin.ReportedByClient.Should().NotBeNull();
                 deviceTwin.ReportedByClient.TryGetValue(propName, out string actualValue).Should().BeTrue();

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -592,7 +591,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             AttestationMechanismType attestationType,
             EnrollmentType? enrollmentType,
             bool setCustomProxy,
-            Devices.Provisioning.Service.ProvisioningDeviceCapabilities capabilities,
+            ProvisioningDeviceCapabilities capabilities,
             string proxyServerAddress = null)
         {
             //Default reprovisioning settings: Hashed allocation, no reprovision policy, hub names, or custom allocation policy
@@ -620,7 +619,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             AllocationPolicy allocationPolicy,
             CustomAllocationDefinition customAllocationDefinition,
             IList<string> iothubs,
-            Devices.Provisioning.Service.ProvisioningDeviceCapabilities deviceCapabilities,
+            ProvisioningDeviceCapabilities deviceCapabilities,
             string proxyServerAddress = null)
         {
             string groupId = null;
@@ -662,7 +661,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             using var cts = new CancellationTokenSource(PassingTimeoutMiliseconds);
 
             DeviceRegistrationResult result = null;
-            Client.IAuthenticationMethod authMethod = null;
+            IAuthenticationMethod authMethod = null;
 
             VerboseTestLogger.WriteLine($"ProvisioningDeviceClient RegisterAsync for group {groupId} . . . ");
 
@@ -686,7 +685,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     }
                 }
 
-                ValidateDeviceRegistrationResult(false, result);
+                ProvisioningE2ETests.ValidateDeviceRegistrationResult(false, result);
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
                 // The certificate instance referenced in the ClientAuthenticationWithX509Certificate instance is common for all tests in this class. It is disposed during class cleanup.
@@ -873,7 +872,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         /// </summary
         private async Task ConfirmRegisteredDeviceWorksAsync(
             DeviceRegistrationResult result,
-            Client.IAuthenticationMethod auth,
+            IAuthenticationMethod auth,
             IotHubClientTransportSettings transportSettings,
             bool sendReportedPropertiesUpdate)
         {
@@ -888,8 +887,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             if (sendReportedPropertiesUpdate)
             {
                 VerboseTestLogger.WriteLine("DeviceClient updating desired properties.");
-                Client.ClientTwin twin = await iotClient.GetTwinAsync().ConfigureAwait(false);
-                var propertiesToReport = new ReportedPropertyCollection
+                Twin twin = await iotClient.GetTwinAsync().ConfigureAwait(false);
+                var propertiesToReport = new ReportedProperties
                 {
                     [new Guid().ToString()] = new Guid().ToString(),
                 };
@@ -902,8 +901,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
         private static async Task ConfirmExpectedDeviceCapabilitiesAsync(
             DeviceRegistrationResult result,
-            Client.IAuthenticationMethod auth,
-            Devices.Provisioning.Service.ProvisioningDeviceCapabilities capabilities)
+            IAuthenticationMethod auth,
+            ProvisioningDeviceCapabilities capabilities)
         {
             if (capabilities != null && capabilities.IotEdge)
             {
@@ -923,7 +922,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             AllocationPolicy allocationPolicy,
             CustomAllocationDefinition customAllocationDefinition,
             IList<string> iothubs,
-            Devices.Provisioning.Service.ProvisioningDeviceCapabilities capabilities = null)
+            ProvisioningDeviceCapabilities capabilities = null)
         {
             VerboseTestLogger.WriteLine($"{nameof(CreateAuthProviderFromNameAsync)}({attestationType})");
 
@@ -1051,7 +1050,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             throw new NotSupportedException($"Unknown attestation type: '{attestationType}'.");
         }
 
-        private Client.IAuthenticationMethod CreateAuthenticationMethodFromAuthProvider(
+        private IAuthenticationMethod CreateAuthenticationMethodFromAuthProvider(
             AuthenticationProvider provisioningAuth,
             string deviceId)
         {
@@ -1078,7 +1077,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         /// <summary>
         /// Assert that the device registration result has not errors, and that it was assigned to a hub and has a device id
         /// </summary>
-        private void ValidateDeviceRegistrationResult(bool validatePayload, DeviceRegistrationResult result)
+        private static void ValidateDeviceRegistrationResult(bool validatePayload, DeviceRegistrationResult result)
         {
             Assert.IsNotNull(result);
             VerboseTestLogger.WriteLine($"{result.Status} (Error Code: {result.ErrorCode}; Error Message: {result.ErrorMessage})");

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -373,7 +373,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     AttestationMechanismType.SymmetricKey,
                     EnrollmentType.Individual,
                     false,
-                    new Devices.Provisioning.Service.DeviceCapabilities() { IotEdge = true })
+                    new Devices.Provisioning.Service.ProvisioningDeviceCapabilities() { IotEdge = true })
                 .ConfigureAwait(false);
         }
 
@@ -386,7 +386,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     AttestationMechanismType.SymmetricKey,
                     EnrollmentType.Group,
                     false,
-                    new Devices.Provisioning.Service.DeviceCapabilities() { IotEdge = true })
+                    new Devices.Provisioning.Service.ProvisioningDeviceCapabilities() { IotEdge = true })
                 .ConfigureAwait(false);
         }
 
@@ -399,7 +399,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     AttestationMechanismType.SymmetricKey,
                     EnrollmentType.Individual,
                     false,
-                    new Devices.Provisioning.Service.DeviceCapabilities() { IotEdge = false })
+                    new Devices.Provisioning.Service.ProvisioningDeviceCapabilities() { IotEdge = false })
                 .ConfigureAwait(false);
         }
 
@@ -412,7 +412,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     AttestationMechanismType.SymmetricKey,
                     EnrollmentType.Group,
                     false,
-                    new Devices.Provisioning.Service.DeviceCapabilities() { IotEdge = false })
+                    new Devices.Provisioning.Service.ProvisioningDeviceCapabilities() { IotEdge = false })
                 .ConfigureAwait(false);
         }
 
@@ -592,7 +592,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             AttestationMechanismType attestationType,
             EnrollmentType? enrollmentType,
             bool setCustomProxy,
-            Devices.Provisioning.Service.DeviceCapabilities capabilities,
+            Devices.Provisioning.Service.ProvisioningDeviceCapabilities capabilities,
             string proxyServerAddress = null)
         {
             //Default reprovisioning settings: Hashed allocation, no reprovision policy, hub names, or custom allocation policy
@@ -620,7 +620,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             AllocationPolicy allocationPolicy,
             CustomAllocationDefinition customAllocationDefinition,
             IList<string> iothubs,
-            Devices.Provisioning.Service.DeviceCapabilities deviceCapabilities,
+            Devices.Provisioning.Service.ProvisioningDeviceCapabilities deviceCapabilities,
             string proxyServerAddress = null)
         {
             string groupId = null;
@@ -888,7 +888,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             if (sendReportedPropertiesUpdate)
             {
                 VerboseTestLogger.WriteLine("DeviceClient updating desired properties.");
-                ClientTwin twin = await iotClient.GetTwinAsync().ConfigureAwait(false);
+                Client.ClientTwin twin = await iotClient.GetTwinAsync().ConfigureAwait(false);
                 var propertiesToReport = new ReportedPropertyCollection
                 {
                     [new Guid().ToString()] = new Guid().ToString(),
@@ -903,7 +903,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         private static async Task ConfirmExpectedDeviceCapabilitiesAsync(
             DeviceRegistrationResult result,
             Client.IAuthenticationMethod auth,
-            Devices.Provisioning.Service.DeviceCapabilities capabilities)
+            Devices.Provisioning.Service.ProvisioningDeviceCapabilities capabilities)
         {
             if (capabilities != null && capabilities.IotEdge)
             {
@@ -923,7 +923,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             AllocationPolicy allocationPolicy,
             CustomAllocationDefinition customAllocationDefinition,
             IList<string> iothubs,
-            Devices.Provisioning.Service.DeviceCapabilities capabilities = null)
+            Devices.Provisioning.Service.ProvisioningDeviceCapabilities capabilities = null)
         {
             VerboseTestLogger.WriteLine($"{nameof(CreateAuthProviderFromNameAsync)}({attestationType})");
 

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     AttestationMechanismType.SymmetricKey,
                     EnrollmentType.Individual,
                     false,
-                    new Devices.Provisioning.Service.ProvisioningDeviceCapabilities() { IotEdge = true })
+                    new Devices.Provisioning.Service.ProvisioningClientCapabilities() { IotEdge = true })
                 .ConfigureAwait(false);
         }
 
@@ -385,7 +385,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     AttestationMechanismType.SymmetricKey,
                     EnrollmentType.Group,
                     false,
-                    new Devices.Provisioning.Service.ProvisioningDeviceCapabilities() { IotEdge = true })
+                    new Devices.Provisioning.Service.ProvisioningClientCapabilities() { IotEdge = true })
                 .ConfigureAwait(false);
         }
 
@@ -398,7 +398,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     AttestationMechanismType.SymmetricKey,
                     EnrollmentType.Individual,
                     false,
-                    new Devices.Provisioning.Service.ProvisioningDeviceCapabilities() { IotEdge = false })
+                    new Devices.Provisioning.Service.ProvisioningClientCapabilities() { IotEdge = false })
                 .ConfigureAwait(false);
         }
 
@@ -411,7 +411,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     AttestationMechanismType.SymmetricKey,
                     EnrollmentType.Group,
                     false,
-                    new Devices.Provisioning.Service.ProvisioningDeviceCapabilities() { IotEdge = false })
+                    new Devices.Provisioning.Service.ProvisioningClientCapabilities() { IotEdge = false })
                 .ConfigureAwait(false);
         }
 
@@ -591,7 +591,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             AttestationMechanismType attestationType,
             EnrollmentType? enrollmentType,
             bool setCustomProxy,
-            ProvisioningDeviceCapabilities capabilities,
+            ProvisioningClientCapabilities capabilities,
             string proxyServerAddress = null)
         {
             //Default reprovisioning settings: Hashed allocation, no reprovision policy, hub names, or custom allocation policy
@@ -619,7 +619,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             AllocationPolicy allocationPolicy,
             CustomAllocationDefinition customAllocationDefinition,
             IList<string> iothubs,
-            ProvisioningDeviceCapabilities deviceCapabilities,
+            ProvisioningClientCapabilities deviceCapabilities,
             string proxyServerAddress = null)
         {
             string groupId = null;
@@ -887,7 +887,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             if (sendReportedPropertiesUpdate)
             {
                 VerboseTestLogger.WriteLine("DeviceClient updating desired properties.");
-                Twin twin = await iotClient.GetTwinAsync().ConfigureAwait(false);
+                TwinProperties twin = await iotClient.GetTwinPropertiesAsync().ConfigureAwait(false);
                 var propertiesToReport = new ReportedProperties
                 {
                     [new Guid().ToString()] = new Guid().ToString(),
@@ -902,7 +902,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         private static async Task ConfirmExpectedDeviceCapabilitiesAsync(
             DeviceRegistrationResult result,
             IAuthenticationMethod auth,
-            ProvisioningDeviceCapabilities capabilities)
+            ProvisioningClientCapabilities capabilities)
         {
             if (capabilities != null && capabilities.IotEdge)
             {
@@ -922,7 +922,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             AllocationPolicy allocationPolicy,
             CustomAllocationDefinition customAllocationDefinition,
             IList<string> iothubs,
-            ProvisioningDeviceCapabilities capabilities = null)
+            ProvisioningClientCapabilities capabilities = null)
         {
             VerboseTestLogger.WriteLine($"{nameof(CreateAuthProviderFromNameAsync)}({attestationType})");
 

--- a/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
@@ -447,7 +447,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             AllocationPolicy allocationPolicy,
             CustomAllocationDefinition customAllocationDefinition,
             IList<string> iotHubsToProvisionTo,
-            Devices.Provisioning.Service.DeviceCapabilities capabilities)
+            Devices.Provisioning.Service.ProvisioningDeviceCapabilities capabilities)
         {
             Attestation attestation;
             IndividualEnrollment individualEnrollment;
@@ -506,7 +506,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             AllocationPolicy allocationPolicy,
             CustomAllocationDefinition customAllocationDefinition,
             IList<string> iothubs,
-            Devices.Provisioning.Service.DeviceCapabilities capabilities)
+            Devices.Provisioning.Service.ProvisioningDeviceCapabilities capabilities)
         {
             Attestation attestation;
 

--- a/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
@@ -447,7 +447,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             AllocationPolicy allocationPolicy,
             CustomAllocationDefinition customAllocationDefinition,
             IList<string> iotHubsToProvisionTo,
-            Devices.Provisioning.Service.ProvisioningDeviceCapabilities capabilities)
+            Devices.Provisioning.Service.ProvisioningClientCapabilities capabilities)
         {
             Attestation attestation;
             IndividualEnrollment individualEnrollment;
@@ -506,7 +506,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             AllocationPolicy allocationPolicy,
             CustomAllocationDefinition customAllocationDefinition,
             IList<string> iothubs,
-            Devices.Provisioning.Service.ProvisioningDeviceCapabilities capabilities)
+            Devices.Provisioning.Service.ProvisioningClientCapabilities capabilities)
         {
             Attestation attestation;
 

--- a/iothub/device/samples/getting started/TwinSample/TwinSample.cs
+++ b/iothub/device/samples/getting started/TwinSample/TwinSample.cs
@@ -34,14 +34,14 @@ namespace Microsoft.Azure.Devices.Client.Samples
             await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(OnDesiredPropertyChangedAsync);
 
             Console.WriteLine("Retrieving twin...");
-            ClientTwin twin = await _deviceClient.GetTwinAsync();
+            Twin twin = await _deviceClient.GetTwinAsync();
 
             Console.WriteLine("\tInitial twin value received:");
             Console.WriteLine($"\tDesired properties: {twin.RequestsFromService.GetSerializedString()}");
             Console.WriteLine($"\tReported properties: {twin.ReportedByClient.GetSerializedString()}");
 
             Console.WriteLine("Sending sample start time as reported property");
-            var reportedProperties = new ReportedPropertyCollection
+            var reportedProperties = new ReportedProperties
             {
                 ["DateTimeLastAppLaunch"] = DateTime.UtcNow
             };
@@ -62,9 +62,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
             await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(null);
         }
 
-        private async Task OnDesiredPropertyChangedAsync(DesiredPropertyCollection desiredProperties)
+        private async Task OnDesiredPropertyChangedAsync(DesiredProperties desiredProperties)
         {
-            var reportedProperties = new ReportedPropertyCollection();
+            var reportedProperties = new ReportedProperties();
 
             Console.WriteLine("\tDesired properties requested:");
             Console.WriteLine($"\t{desiredProperties.GetSerializedString()}");

--- a/iothub/device/samples/getting started/TwinSample/TwinSample.cs
+++ b/iothub/device/samples/getting started/TwinSample/TwinSample.cs
@@ -34,11 +34,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
             await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(OnDesiredPropertyChangedAsync);
 
             Console.WriteLine("Retrieving twin...");
-            Twin twin = await _deviceClient.GetTwinAsync();
+            TwinProperties twin = await _deviceClient.GetTwinPropertiesAsync();
 
             Console.WriteLine("\tInitial twin value received:");
-            Console.WriteLine($"\tDesired properties: {twin.RequestsFromService.GetSerializedString()}");
-            Console.WriteLine($"\tReported properties: {twin.ReportedByClient.GetSerializedString()}");
+            Console.WriteLine($"\tDesired properties: {twin.Desired.GetSerializedString()}");
+            Console.WriteLine($"\tReported properties: {twin.Reported.GetSerializedString()}");
 
             Console.WriteLine("Sending sample start time as reported property");
             var reportedProperties = new ReportedProperties

--- a/iothub/device/samples/how to guides/DeviceReconnectionSample/DeviceReconnectionSample.cs
+++ b/iothub/device/samples/how to guides/DeviceReconnectionSample/DeviceReconnectionSample.cs
@@ -197,10 +197,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         private async Task GetTwinAndDetectChangesAsync(CancellationToken cancellationToken)
         {
-            Twin twin = await s_deviceClient.GetTwinAsync(s_appCancellation.Token);
-            _logger.LogInformation($"Device retrieving twin values: {twin.RequestsFromService.GetSerializedString()}");
+            TwinProperties twin = await s_deviceClient.GetTwinPropertiesAsync(s_appCancellation.Token);
+            _logger.LogInformation($"Device retrieving twin values: {twin.Desired.GetSerializedString()}");
 
-            DesiredProperties desiredProperties = twin.RequestsFromService;
+            DesiredProperties desiredProperties = twin.Desired;
             long serverDesiredPropertyVersion = desiredProperties.Version;
 
             // Check if the desired property version is outdated on the local side.

--- a/iothub/device/samples/how to guides/DeviceReconnectionSample/DeviceReconnectionSample.cs
+++ b/iothub/device/samples/how to guides/DeviceReconnectionSample/DeviceReconnectionSample.cs
@@ -197,10 +197,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         private async Task GetTwinAndDetectChangesAsync(CancellationToken cancellationToken)
         {
-            ClientTwin twin = await s_deviceClient.GetTwinAsync(s_appCancellation.Token);
+            Twin twin = await s_deviceClient.GetTwinAsync(s_appCancellation.Token);
             _logger.LogInformation($"Device retrieving twin values: {twin.RequestsFromService.GetSerializedString()}");
 
-            DesiredPropertyCollection desiredProperties = twin.RequestsFromService;
+            DesiredProperties desiredProperties = twin.RequestsFromService;
             long serverDesiredPropertyVersion = desiredProperties.Version;
 
             // Check if the desired property version is outdated on the local side.
@@ -211,13 +211,13 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
         }
 
-        private async Task HandleTwinUpdateNotificationsAsync(DesiredPropertyCollection twinUpdateRequest)
+        private async Task HandleTwinUpdateNotificationsAsync(DesiredProperties twinUpdateRequest)
         {
             CancellationToken cancellationToken = s_appCancellation.Token;
 
             if (!cancellationToken.IsCancellationRequested)
             {
-                var reportedProperties = new ReportedPropertyCollection();
+                var reportedProperties = new ReportedProperties();
 
                 _logger.LogInformation($"Twin property update requested: \n{twinUpdateRequest.GetSerializedString()}");
 

--- a/iothub/device/samples/solutions/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iothub/device/samples/solutions/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -147,10 +147,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         private async Task GetWritablePropertiesAndHandleChangesAsync()
         {
-            Twin twin = await _deviceClient.GetTwinAsync();
-            _logger.LogInformation($"Device retrieving twin values on CONNECT: {twin.RequestsFromService.GetSerializedString()}");
+            TwinProperties twin = await _deviceClient.GetTwinPropertiesAsync();
+            _logger.LogInformation($"Device retrieving twin values on CONNECT: {twin.Desired.GetSerializedString()}");
 
-            DesiredProperties desiredProperties = twin.RequestsFromService;
+            DesiredProperties desiredProperties = twin.Desired;
             long serverWritablePropertiesVersion = desiredProperties.Version;
 
             // Check if the writable property version is outdated on the local side.
@@ -453,9 +453,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         private async Task CheckEmptyPropertiesAsync(string componentName, CancellationToken cancellationToken)
         {
-            Twin twin = await _deviceClient.GetTwinAsync(cancellationToken);
-            DesiredProperties desiredProperties = twin.RequestsFromService;
-            ReportedProperties reportedProperties = twin.ReportedByClient;
+            TwinProperties twin = await _deviceClient.GetTwinPropertiesAsync(cancellationToken);
+            DesiredProperties desiredProperties = twin.Desired;
+            ReportedProperties reportedProperties = twin.Reported;
 
             // Check if the device properties (both writable and reported) for the current component are empty.
             if (!desiredProperties.TryGetValue(componentName, out object _) && !reportedProperties.TryGetValue(componentName, out object _))

--- a/iothub/device/samples/solutions/PnpDeviceSamples/Thermostat/ThermostatSample.cs
+++ b/iothub/device/samples/solutions/PnpDeviceSamples/Thermostat/ThermostatSample.cs
@@ -115,10 +115,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         private async Task GetWritablePropertiesAndHandleChangesAsync()
         {
-            Twin twin = await _deviceClient.GetTwinAsync();
-            _logger.LogInformation($"Device retrieving twin values on CONNECT: {twin.RequestsFromService.GetSerializedString()}");
+            TwinProperties twin = await _deviceClient.GetTwinPropertiesAsync();
+            _logger.LogInformation($"Device retrieving twin values on CONNECT: {twin.Desired.GetSerializedString()}");
 
-            DesiredProperties desiredProperties = twin.RequestsFromService;
+            DesiredProperties desiredProperties = twin.Desired;
             long serverWritablePropertiesVersion = desiredProperties.Version;
 
             // Check if the writable property version is outdated on the local side.
@@ -294,9 +294,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         private async Task CheckEmptyPropertiesAsync(CancellationToken cancellationToken)
         {
-            Twin twin = await _deviceClient.GetTwinAsync(cancellationToken);
-            DesiredProperties desiredProperties = twin.RequestsFromService;
-            ReportedProperties reportedProperties = twin.ReportedByClient;
+            TwinProperties twin = await _deviceClient.GetTwinPropertiesAsync(cancellationToken);
+            DesiredProperties desiredProperties = twin.Desired;
+            ReportedProperties reportedProperties = twin.Reported;
 
             // Check if the device properties (both writable and reported) are empty.
             if (!desiredProperties.TryGetValue(TargetTemperatureProperty, out object _) && !reportedProperties.TryGetValue(TargetTemperatureProperty, out object _))

--- a/iothub/device/samples/solutions/PnpDeviceSamples/Thermostat/ThermostatSample.cs
+++ b/iothub/device/samples/solutions/PnpDeviceSamples/Thermostat/ThermostatSample.cs
@@ -115,10 +115,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         private async Task GetWritablePropertiesAndHandleChangesAsync()
         {
-            ClientTwin twin = await _deviceClient.GetTwinAsync();
+            Twin twin = await _deviceClient.GetTwinAsync();
             _logger.LogInformation($"Device retrieving twin values on CONNECT: {twin.RequestsFromService.GetSerializedString()}");
 
-            DesiredPropertyCollection desiredProperties = twin.RequestsFromService;
+            DesiredProperties desiredProperties = twin.RequestsFromService;
             long serverWritablePropertiesVersion = desiredProperties.Version;
 
             // Check if the writable property version is outdated on the local side.
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         // The desired property update callback, which receives the target temperature as a desired property update,
         // and updates the current temperature value over telemetry and reported property update.
-        private async Task TargetTemperatureUpdateCallbackAsync(DesiredPropertyCollection desiredProperties)
+        private async Task TargetTemperatureUpdateCallbackAsync(DesiredProperties desiredProperties)
         {
             bool targetTempUpdateReceived = desiredProperties.TryGetValue(TargetTemperatureProperty, out double targetTemperature);
             if (targetTempUpdateReceived)
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
                 s_localWritablePropertiesVersion = desiredProperties.Version;
 
-                var reportedPropertyPending = new ReportedPropertyCollection
+                var reportedPropertyPending = new ReportedProperties
                 {
                     {
                         TargetTemperatureProperty,
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                     await Task.Delay(6 * 1000);
                 }
 
-                var reportedProperty = new ReportedPropertyCollection
+                var reportedProperty = new ReportedProperties
                 {
                     {
                         TargetTemperatureProperty,
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         {
             const string propertyName = "maxTempSinceLastReboot";
 
-            var reportedProperties = new ReportedPropertyCollection
+            var reportedProperties = new ReportedProperties
             {
                 [propertyName] = _maxTemp
             };
@@ -294,9 +294,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         private async Task CheckEmptyPropertiesAsync(CancellationToken cancellationToken)
         {
-            ClientTwin twin = await _deviceClient.GetTwinAsync(cancellationToken);
-            DesiredPropertyCollection desiredProperties = twin.RequestsFromService;
-            ReportedPropertyCollection reportedProperties = twin.ReportedByClient;
+            Twin twin = await _deviceClient.GetTwinAsync(cancellationToken);
+            DesiredProperties desiredProperties = twin.RequestsFromService;
+            ReportedProperties reportedProperties = twin.ReportedByClient;
 
             // Check if the device properties (both writable and reported) are empty.
             if (!desiredProperties.TryGetValue(TargetTemperatureProperty, out object _) && !reportedProperties.TryGetValue(TargetTemperatureProperty, out object _))
@@ -309,7 +309,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         {
             // If the device properties are empty, report the default value with ACK(ac=203, av=0) as part of the PnP convention.
             // "DefaultPropertyValue" is set from the device when the desired property is not set via the hub.
-            var reportedProperty = new ReportedPropertyCollection
+            var reportedProperty = new ReportedProperties
             {
                 {
                     propertyName,

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -282,16 +282,19 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// Retrieve the twin properties for the current client. The client instance must be opened already.
+        /// Retrieve the twin properties for the current client.
         /// </summary>
         /// <remarks>
+        /// The client instance must be opened already.
+        /// <para>
         /// This API gives you the client's view of the twin. For more information on twins in IoT hub, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins"/>.
+        /// </para>
         /// </remarks>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
         /// <returns>The twin object for the current client.</returns>
-        public async Task<Twin> GetTwinAsync(CancellationToken cancellationToken = default)
+        public async Task<TwinProperties> GetTwinPropertiesAsync(CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.Client
         // Twin property update request callback information
         private bool _twinPatchSubscribedWithService;
 
-        private Func<DesiredPropertyCollection, Task> _desiredPropertyUpdateCallback;
+        private Func<DesiredProperties, Task> _desiredPropertyUpdateCallback;
 
         private protected readonly IotHubClientOptions _clientOptions;
 
@@ -291,7 +291,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
         /// <returns>The twin object for the current client.</returns>
-        public async Task<ClientTwin> GetTwinAsync(CancellationToken cancellationToken = default)
+        public async Task<Twin> GetTwinAsync(CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -305,7 +305,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <returns>The new version of the updated twin if the update was successful.</returns>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        public async Task<long> UpdateReportedPropertiesAsync(ReportedPropertyCollection reportedProperties, CancellationToken cancellationToken = default)
+        public async Task<long> UpdateReportedPropertiesAsync(ReportedProperties reportedProperties, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(reportedProperties, nameof(reportedProperties));
             cancellationToken.ThrowIfCancellationRequested();
@@ -329,7 +329,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
         public async Task SetDesiredPropertyUpdateCallbackAsync(
-            Func<DesiredPropertyCollection, Task> callback,
+            Func<DesiredProperties, Task> callback,
             CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
@@ -476,7 +476,7 @@ namespace Microsoft.Azure.Devices.Client
             }
         }
 
-        internal void OnDesiredStatePatchReceived(DesiredPropertyCollection patch)
+        internal void OnDesiredStatePatchReceived(DesiredProperties patch)
         {
             if (_desiredPropertyUpdateCallback == null)
             {

--- a/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
@@ -126,13 +126,13 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return NextHandler?.DisableTwinPatchAsync(cancellationToken) ?? Task.CompletedTask;
         }
 
-        public virtual Task<ClientTwin> GetTwinAsync(CancellationToken cancellationToken)
+        public virtual Task<Twin> GetTwinAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
-            return NextHandler?.GetTwinAsync(cancellationToken) ?? Task.FromResult((ClientTwin)null);
+            return NextHandler?.GetTwinAsync(cancellationToken) ?? Task.FromResult((Twin)null);
         }
 
-        public virtual Task<long> UpdateReportedPropertiesAsync(ReportedPropertyCollection reportedProperties, CancellationToken cancellationToken)
+        public virtual Task<long> UpdateReportedPropertiesAsync(ReportedProperties reportedProperties, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
             return NextHandler?.UpdateReportedPropertiesAsync(reportedProperties, cancellationToken) ?? Task.FromResult(0L);

--- a/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
@@ -126,10 +126,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return NextHandler?.DisableTwinPatchAsync(cancellationToken) ?? Task.CompletedTask;
         }
 
-        public virtual Task<Twin> GetTwinAsync(CancellationToken cancellationToken)
+        public virtual Task<TwinProperties> GetTwinAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
-            return NextHandler?.GetTwinAsync(cancellationToken) ?? Task.FromResult((Twin)null);
+            return NextHandler?.GetTwinAsync(cancellationToken) ?? Task.FromResult((TwinProperties)null);
         }
 
         public virtual Task<long> UpdateReportedPropertiesAsync(ReportedProperties reportedProperties, CancellationToken cancellationToken)

--- a/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return ExecuteWithErrorHandlingAsync(() => base.DisableTwinPatchAsync(cancellationToken));
         }
 
-        public override Task<Twin> GetTwinAsync(CancellationToken cancellationToken)
+        public override Task<TwinProperties> GetTwinAsync(CancellationToken cancellationToken)
         {
             return ExecuteWithErrorHandlingAsync(() => base.GetTwinAsync(cancellationToken));
         }

--- a/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
@@ -68,12 +68,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return ExecuteWithErrorHandlingAsync(() => base.DisableTwinPatchAsync(cancellationToken));
         }
 
-        public override Task<ClientTwin> GetTwinAsync(CancellationToken cancellationToken)
+        public override Task<Twin> GetTwinAsync(CancellationToken cancellationToken)
         {
             return ExecuteWithErrorHandlingAsync(() => base.GetTwinAsync(cancellationToken));
         }
 
-        public override Task<long> UpdateReportedPropertiesAsync(ReportedPropertyCollection reportedProperties, CancellationToken cancellationToken)
+        public override Task<long> UpdateReportedPropertiesAsync(ReportedProperties reportedProperties, CancellationToken cancellationToken)
         {
             return ExecuteWithErrorHandlingAsync(() => base.UpdateReportedPropertiesAsync(reportedProperties, cancellationToken));
         }

--- a/iothub/device/src/Pipeline/IDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/IDelegatingHandler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Devices.Client
         Task SendMethodResponseAsync(DirectMethodResponse methodResponse, CancellationToken cancellationToken);
 
         // Twin.
-        Task<Twin> GetTwinAsync(CancellationToken cancellationToken);
+        Task<TwinProperties> GetTwinAsync(CancellationToken cancellationToken);
 
         Task<long> UpdateReportedPropertiesAsync(ReportedProperties reportedProperties, CancellationToken cancellationToken);
 

--- a/iothub/device/src/Pipeline/IDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/IDelegatingHandler.cs
@@ -36,9 +36,9 @@ namespace Microsoft.Azure.Devices.Client
         Task SendMethodResponseAsync(DirectMethodResponse methodResponse, CancellationToken cancellationToken);
 
         // Twin.
-        Task<ClientTwin> GetTwinAsync(CancellationToken cancellationToken);
+        Task<Twin> GetTwinAsync(CancellationToken cancellationToken);
 
-        Task<long> UpdateReportedPropertiesAsync(ReportedPropertyCollection reportedProperties, CancellationToken cancellationToken);
+        Task<long> UpdateReportedPropertiesAsync(ReportedProperties reportedProperties, CancellationToken cancellationToken);
 
         Task EnableTwinPatchAsync(CancellationToken cancellationToken);
 

--- a/iothub/device/src/Pipeline/PipelineContext.cs
+++ b/iothub/device/src/Pipeline/PipelineContext.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.Client
 
         internal Action<ConnectionStatusInfo> ConnectionStatusChangeHandler { get; set; }
 
-        internal Action<DesiredPropertyCollection> DesiredPropertyUpdateCallback { get; set; }
+        internal Action<DesiredProperties> DesiredPropertyUpdateCallback { get; set; }
 
         internal Func<DirectMethodRequest, Task> MethodCallback { get; set; }
 

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
-        public override async Task<Twin> GetTwinAsync(CancellationToken cancellationToken)
+        public override async Task<TwinProperties> GetTwinAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, cancellationToken, nameof(GetTwinAsync));

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
-        public override async Task<ClientTwin> GetTwinAsync(CancellationToken cancellationToken)
+        public override async Task<Twin> GetTwinAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, cancellationToken, nameof(GetTwinAsync));
@@ -355,7 +355,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
-        public override async Task<long> UpdateReportedPropertiesAsync(ReportedPropertyCollection reportedProperties, CancellationToken cancellationToken)
+        public override async Task<long> UpdateReportedPropertiesAsync(ReportedProperties reportedProperties, CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, reportedProperties, cancellationToken, nameof(UpdateReportedPropertiesAsync));

--- a/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
         }
 
-        public override async Task<Twin> GetTwinAsync(CancellationToken cancellationToken)
+        public override async Task<TwinProperties> GetTwinAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, cancellationToken, nameof(GetTwinAsync));
@@ -368,7 +368,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                         PayloadConvention = _payloadConvention,
                     };
 
-                    return new Twin(twinDesiredProperties, twinReportedProperties);
+                    return new TwinProperties(twinDesiredProperties, twinReportedProperties);
                 }
                 catch (JsonReaderException ex)
                 {

--- a/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
     internal class AmqpTransportHandler : TransportHandler
     {
         protected AmqpUnit _amqpUnit;
-        private readonly Action<DesiredPropertyCollection> _onDesiredStatePatchListener;
+        private readonly Action<DesiredProperties> _onDesiredStatePatchListener;
         private readonly object _lock = new();
         private readonly ConcurrentDictionary<string, TaskCompletionSource<AmqpMessage>> _twinResponseCompletions = new();
         private readonly ConcurrentDictionary<string, DateTimeOffset> _twinResponseTimeouts = new();
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
         }
 
-        public override async Task<ClientTwin> GetTwinAsync(CancellationToken cancellationToken)
+        public override async Task<Twin> GetTwinAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, cancellationToken, nameof(GetTwinAsync));
@@ -356,19 +356,19 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                 {
                     // The response here is deserialized into an SDK-defined type based on service-defined NewtonSoft.Json-based json property name.
                     // For this reason, we use NewtonSoft Json serializer for this deserialization.
-                    ClientTwinProperties clientTwinProperties = JsonConvert.DeserializeObject<ClientTwinProperties>(body);
+                    TwinDocument clientTwinProperties = JsonConvert.DeserializeObject<TwinDocument>(body);
 
-                    var twinDesiredProperties = new DesiredPropertyCollection(clientTwinProperties.Desired)
+                    var twinDesiredProperties = new DesiredProperties(clientTwinProperties.Desired)
                     {
                         PayloadConvention = _payloadConvention,
                     };
 
-                    var twinReportedProperties = new ReportedPropertyCollection(clientTwinProperties.Reported, true)
+                    var twinReportedProperties = new ReportedProperties(clientTwinProperties.Reported, true)
                     {
                         PayloadConvention = _payloadConvention,
                     };
 
-                    return new ClientTwin(twinDesiredProperties, twinReportedProperties);
+                    return new Twin(twinDesiredProperties, twinReportedProperties);
                 }
                 catch (JsonReaderException ex)
                 {
@@ -385,7 +385,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
         }
 
-        public override async Task<long> UpdateReportedPropertiesAsync(ReportedPropertyCollection reportedProperties, CancellationToken cancellationToken)
+        public override async Task<long> UpdateReportedPropertiesAsync(ReportedProperties reportedProperties, CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, reportedProperties, cancellationToken, nameof(UpdateReportedPropertiesAsync));
@@ -414,7 +414,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         private async Task<AmqpMessage> RoundTripTwinMessageAsync(
             AmqpTwinMessageType amqpTwinMessageType,
-            ReportedPropertyCollection reportedProperties,
+            ReportedProperties reportedProperties,
             CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
@@ -463,7 +463,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                 string responseBody = reader.ReadToEnd();
 
                 Dictionary<string, object> desiredPropertyPatchDictionary = _payloadConvention.PayloadSerializer.DeserializeToType<Dictionary<string, object>>(responseBody);
-                var desiredPropertyPatch = new DesiredPropertyCollection(desiredPropertyPatchDictionary)
+                var desiredPropertyPatch = new DesiredProperties(desiredPropertyPatchDictionary)
                 {
                     PayloadConvention = _payloadConvention,
                 };

--- a/iothub/device/src/Transport/Amqp/AmqpUnit.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnit.cs
@@ -880,7 +880,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
         internal async Task SendTwinMessageAsync(
             AmqpTwinMessageType amqpTwinMessageType,
             string correlationId,
-            ReportedPropertyCollection reportedProperties,
+            ReportedProperties reportedProperties,
             CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotSendingLink.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotSendingLink.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
 
         internal async Task<AmqpIotOutcome> SendTwinPatchMessageAsync(
             string correlationId,
-            ReportedPropertyCollection reportedProperties,
+            ReportedProperties reportedProperties,
             CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)

--- a/iothub/device/src/Transport/Mqtt/GetTwinResponse.cs
+++ b/iothub/device/src/Transport/Mqtt/GetTwinResponse.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         /// <remarks>
         /// This value is null if the get twin request failed.
         /// </remarks>
-        internal Twin Twin { get; set; }
+        internal TwinProperties Twin { get; set; }
 
         /// <summary>
         /// The error message if the request failed.

--- a/iothub/device/src/Transport/Mqtt/GetTwinResponse.cs
+++ b/iothub/device/src/Transport/Mqtt/GetTwinResponse.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         /// <remarks>
         /// This value is null if the get twin request failed.
         /// </remarks>
-        internal ClientTwin Twin { get; set; }
+        internal Twin Twin { get; set; }
 
         /// <summary>
         /// The error message if the request failed.

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -547,7 +547,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
         }
 
-        public override async Task<Twin> GetTwinAsync(CancellationToken cancellationToken)
+        public override async Task<TwinProperties> GetTwinAsync(CancellationToken cancellationToken)
         {
             if (!_isSubscribedToTwinResponses)
             {
@@ -1006,7 +1006,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                             var getTwinResponse = new GetTwinResponse
                             {
                                 Status = status,
-                                Twin = new Twin(twinDesiredProperties, twinReportedProperties),
+                                Twin = new TwinProperties(twinDesiredProperties, twinReportedProperties),
                             };
 
                             getTwinCompletion.TrySetResult(getTwinResponse);

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         private readonly MqttQualityOfServiceLevel _receivingQualityOfService;
 
         private readonly Func<DirectMethodRequest, Task> _methodListener;
-        private readonly Action<DesiredPropertyCollection> _onDesiredStatePatchListener;
+        private readonly Action<DesiredProperties> _onDesiredStatePatchListener;
         private readonly Func<IncomingMessage, Task<MessageAcknowledgement>> _messageReceivedListener;
 
         private readonly ConcurrentDictionary<string, TaskCompletionSource<GetTwinResponse>> _getTwinResponseCompletions = new();
@@ -547,7 +547,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
         }
 
-        public override async Task<ClientTwin> GetTwinAsync(CancellationToken cancellationToken)
+        public override async Task<Twin> GetTwinAsync(CancellationToken cancellationToken)
         {
             if (!_isSubscribedToTwinResponses)
             {
@@ -621,7 +621,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
         }
 
-        public override async Task<long> UpdateReportedPropertiesAsync(ReportedPropertyCollection reportedProperties, CancellationToken cancellationToken)
+        public override async Task<long> UpdateReportedPropertiesAsync(ReportedProperties reportedProperties, CancellationToken cancellationToken)
         {
             if (!_isSubscribedToTwinResponses)
             {
@@ -947,7 +947,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             string patch = _payloadConvention.PayloadEncoder.ContentEncoding.GetString(receivedEventArgs.ApplicationMessage.Payload);
             Dictionary<string, object> desiredPropertyPatchDictionary = _payloadConvention.PayloadSerializer.DeserializeToType<Dictionary<string, object>>(patch);
-            var desiredPropertyPatch = new DesiredPropertyCollection(desiredPropertyPatchDictionary)
+            var desiredPropertyPatch = new DesiredProperties(desiredPropertyPatchDictionary)
             {
                 PayloadConvention = _payloadConvention,
             };
@@ -986,19 +986,19 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                             // Use the encoder that has been agreed to between the client and service to decode the byte[] reasponse
                             // The response is deserialized into an SDK-defined type based on service-defined NewtonSoft.Json-based json property name.
                             // For this reason, we use NewtonSoft Json serializer for this deserialization.
-                            ClientTwinProperties clientTwinProperties = JsonConvert
-                                .DeserializeObject<ClientTwinProperties>(
+                            TwinDocument clientTwinProperties = JsonConvert
+                                .DeserializeObject<TwinDocument>(
                                     _payloadConvention
                                     .PayloadEncoder
                                     .ContentEncoding
                                     .GetString(payloadBytes));
 
-                            var twinDesiredProperties = new DesiredPropertyCollection(clientTwinProperties.Desired)
+                            var twinDesiredProperties = new DesiredProperties(clientTwinProperties.Desired)
                             {
                                 PayloadConvention = _payloadConvention,
                             };
 
-                            var twinReportedProperties = new ReportedPropertyCollection(clientTwinProperties.Reported, true)
+                            var twinReportedProperties = new ReportedProperties(clientTwinProperties.Reported, true)
                             {
                                 PayloadConvention = _payloadConvention,
                             };
@@ -1006,7 +1006,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                             var getTwinResponse = new GetTwinResponse
                             {
                                 Status = status,
-                                Twin = new ClientTwin(twinDesiredProperties, twinReportedProperties),
+                                Twin = new Twin(twinDesiredProperties, twinReportedProperties),
                             };
 
                             getTwinCompletion.TrySetResult(getTwinResponse);

--- a/iothub/device/src/Twin/DesiredProperties.cs
+++ b/iothub/device/src/Twin/DesiredProperties.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Devices.Client
     /// <summary>
     /// The collection of desired property update requests received from service.
     /// </summary>
-    public class DesiredPropertyCollection : PropertyCollection
+    public class DesiredProperties : PropertyCollection
     {
         /// <summary>
         /// Creates an instance of this class.
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// This class can be inherited from and set by unit tests for mocking purposes.
         /// </remarks>
-        protected internal DesiredPropertyCollection(Dictionary<string, object> desiredProperties)
+        protected internal DesiredProperties(Dictionary<string, object> desiredProperties)
             : base(desiredProperties, true)
         {
         }

--- a/iothub/device/src/Twin/PropertyCollection.cs
+++ b/iothub/device/src/Twin/PropertyCollection.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Azure.Devices.Client
     /// The collection of twin properties.
     /// </summary>
     /// <remarks>
-    /// This abstract class is inherited by <see cref="ReportedPropertyCollection"/> to represent the collection of twin properties reported by the client.
-    /// This abstract class is inherited by <see cref="DesiredPropertyCollection"/> to represent the collection of desired property update requests received from service.
+    /// This abstract class is inherited by <see cref="ReportedProperties"/> to represent the collection of twin properties reported by the client.
+    /// This abstract class is inherited by <see cref="DesiredProperties"/> to represent the collection of desired property update requests received from service.
     /// </remarks>
     public abstract class PropertyCollection : IEnumerable<KeyValuePair<string, object>>
     {

--- a/iothub/device/src/Twin/ReportedProperties.cs
+++ b/iothub/device/src/Twin/ReportedProperties.cs
@@ -9,12 +9,12 @@ namespace Microsoft.Azure.Devices.Client
     /// <summary>
     /// The collection of twin properties reported by the client.
     /// </summary>
-    public class ReportedPropertyCollection : PropertyCollection
+    public class ReportedProperties : PropertyCollection
     {
         /// <summary>
         /// Initializes a new instance of this class.
         /// </summary>
-        public ReportedPropertyCollection()
+        public ReportedProperties()
             : this(new Dictionary<string, object>(), false)
         {
         }
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// This class can be inherited from and set by unit tests for mocking purposes.
         /// </remarks>
-        protected internal ReportedPropertyCollection(Dictionary<string, object> reportedProperties, bool responseFromService)
+        protected internal ReportedProperties(Dictionary<string, object> reportedProperties, bool responseFromService)
             : base(reportedProperties, responseFromService)
         {
         }

--- a/iothub/device/src/Twin/Twin.cs
+++ b/iothub/device/src/Twin/Twin.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Devices.Client
     /// <summary>
     /// A container for client properties retrieved from the service.
     /// </summary>
-    public class ClientTwin
+    public class Twin
     {
         /// <summary>
         /// Creates an instance of this class.
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// This class can be inherited from and set by unit tests for mocking purposes.
         /// </remarks>
-        protected internal ClientTwin(DesiredPropertyCollection requestsFromService, ReportedPropertyCollection reportedByClient)
+        protected internal Twin(DesiredProperties requestsFromService, ReportedProperties reportedByClient)
         {
             RequestsFromService = requestsFromService;
             ReportedByClient = reportedByClient;
@@ -23,11 +23,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// The collection of desired property update requests received from service.
         /// </summary>
-        public DesiredPropertyCollection RequestsFromService { get; }
+        public DesiredProperties RequestsFromService { get; }
 
         /// <summary>
         /// The collection of twin properties reported by the client.
         /// </summary>
-        public ReportedPropertyCollection ReportedByClient { get; }
+        public ReportedProperties ReportedByClient { get; }
     }
 }

--- a/iothub/device/src/Twin/TwinDocument.cs
+++ b/iothub/device/src/Twin/TwinDocument.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices.Client
     /// This class uses NewtonSoft.Json for the top-level property deserialization
     /// since the property names are known and defined by service contract.
     /// </summary>
-    internal class ClientTwinProperties
+    internal class TwinDocument
     {
         [JsonProperty(PropertyName = "desired", DefaultValueHandling = DefaultValueHandling.Ignore)]
         internal Dictionary<string, object> Desired { get; set; }

--- a/iothub/device/src/Twin/TwinProperties.cs
+++ b/iothub/device/src/Twin/TwinProperties.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Devices.Client
     /// <summary>
     /// A container for client properties retrieved from the service.
     /// </summary>
-    public class Twin
+    public class TwinProperties
     {
         /// <summary>
         /// Creates an instance of this class.
@@ -14,20 +14,20 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// This class can be inherited from and set by unit tests for mocking purposes.
         /// </remarks>
-        protected internal Twin(DesiredProperties requestsFromService, ReportedProperties reportedByClient)
+        protected internal TwinProperties(DesiredProperties requestsFromService, ReportedProperties reportedByClient)
         {
-            RequestsFromService = requestsFromService;
-            ReportedByClient = reportedByClient;
+            Desired = requestsFromService;
+            Reported = reportedByClient;
         }
 
         /// <summary>
         /// The collection of desired property update requests received from service.
         /// </summary>
-        public DesiredProperties RequestsFromService { get; }
+        public DesiredProperties Desired { get; }
 
         /// <summary>
         /// The collection of twin properties reported by the client.
         /// </summary>
-        public ReportedProperties ReportedByClient { get; }
+        public ReportedProperties Reported { get; }
     }
 }

--- a/iothub/device/tests/DeviceClientTwinApiTests.cs
+++ b/iothub/device/tests/DeviceClientTwinApiTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             var client = new IotHubDeviceClient(fakeConnectionString);
             client.InnerHandler = innerHandler;
-            Func<DesiredPropertyCollection, Task> myCallback = (p) => Task.CompletedTask;
+            Func<DesiredProperties, Task> myCallback = (p) => Task.CompletedTask;
 
             // act
             await client.SetDesiredPropertyUpdateCallbackAsync(myCallback).ConfigureAwait(false);
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             var client = new IotHubDeviceClient(fakeConnectionString);
             client.InnerHandler = innerHandler;
-            Func<DesiredPropertyCollection, Task> myCallback = (p) => Task.CompletedTask;
+            Func<DesiredProperties, Task> myCallback = (p) => Task.CompletedTask;
 
             // act
             await client.SetDesiredPropertyUpdateCallbackAsync(myCallback).ConfigureAwait(false);
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             var client = new IotHubDeviceClient(fakeConnectionString);
             client.InnerHandler = innerHandler;
-            Func<DesiredPropertyCollection, Task> myCallback = (p) => Task.CompletedTask;
+            Func<DesiredProperties, Task> myCallback = (p) => Task.CompletedTask;
 
             // act
             await client.SetDesiredPropertyUpdateCallbackAsync(myCallback).ConfigureAwait(false);
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             var client = new IotHubDeviceClient(fakeConnectionString);
             client.InnerHandler = innerHandler;
-            var props = new ReportedPropertyCollection();
+            var props = new ReportedProperties();
 
             // act
             await client.UpdateReportedPropertiesAsync(props).ConfigureAwait(false);
@@ -129,14 +129,14 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandler = Substitute.For<IDelegatingHandler>();
             var client = new IotHubDeviceClient(fakeConnectionString);
             client.InnerHandler = innerHandler;
-            var myPatch = new DesiredPropertyCollection(new Dictionary<string, object> { { "key", "value" }, { "$version", 1 } })
+            var myPatch = new DesiredProperties(new Dictionary<string, object> { { "key", "value" }, { "$version", 1 } })
             {
                 PayloadConvention = DefaultPayloadConvention.Instance,
             };
 
             int callCount = 0;
-            DesiredPropertyCollection receivedPatch = null;
-            Func<DesiredPropertyCollection, Task> myCallback = (p) =>
+            DesiredProperties receivedPatch = null;
+            Func<DesiredProperties, Task> myCallback = (p) =>
             {
                 callCount++;
                 receivedPatch = p;

--- a/iothub/device/tests/DeviceClientTwinApiTests.cs
+++ b/iothub/device/tests/DeviceClientTwinApiTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             client.InnerHandler = innerHandler;
 
             // act
-            await client.GetTwinAsync().ConfigureAwait(false);
+            await client.GetTwinPropertiesAsync().ConfigureAwait(false);
 
             // assert
             await innerHandler.

--- a/iothub/device/tests/IotHubDeviceClientTests.cs
+++ b/iothub/device/tests/IotHubDeviceClientTests.cs
@@ -1254,7 +1254,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             // We will setup the main handler which can be either MQTT or AMQP or HTTP handler to throw
             // a cancellation token expiry exception (OperationCancelledException) to ensure that we mimic when a token expires.
             mainProtocolHandler
-                .When(x => x.UpdateReportedPropertiesAsync(Arg.Any<ReportedPropertyCollection>(), Arg.Any<CancellationToken>()))
+                .When(x => x.UpdateReportedPropertiesAsync(Arg.Any<ReportedProperties>(), Arg.Any<CancellationToken>()))
                 .Do(x => { throw new OperationCanceledException(); });
 
             ErrorDelegatingHandler errorHandler = new ErrorDelegatingHandler(null, mainProtocolHandler);
@@ -1268,7 +1268,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             using var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            Func<Task> act = async () => await deviceClient.UpdateReportedPropertiesAsync(new ReportedPropertyCollection(), cts.Token);
+            Func<Task> act = async () => await deviceClient.UpdateReportedPropertiesAsync(new ReportedProperties(), cts.Token);
 
             // assert
             act.Should().Throw<OperationCanceledException>();

--- a/iothub/device/tests/IotHubDeviceClientTests.cs
+++ b/iothub/device/tests/IotHubDeviceClientTests.cs
@@ -1299,7 +1299,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             using var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            Func<Task> act = async () => await deviceClient.GetTwinAsync(cts.Token);
+            Func<Task> act = async () => await deviceClient.GetTwinPropertiesAsync(cts.Token);
 
             // assert
             act.Should().Throw<OperationCanceledException>();

--- a/iothub/service/samples/getting started/EdgeDeploymentSample/EdgeDeploymentSample.cs
+++ b/iothub/service/samples/getting started/EdgeDeploymentSample/EdgeDeploymentSample.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.Samples
                 foreach (Device device in edgeDevices)
                 {
                     Console.WriteLine($"Created edge device {device.Id}");
-                    Twin twin = await _serviceClient.Twins.GetAsync(device.Id);
+                    ClientTwin twin = await _serviceClient.Twins.GetAsync(device.Id);
                     Console.WriteLine($"\tTwin is {JsonSerializer.Serialize(twin)}");
 
                     twin.Tags[conditionPropertyName] = conditionPropertyValue;

--- a/iothub/service/samples/getting started/EdgeDeploymentSample/EdgeDeploymentSample.cs
+++ b/iothub/service/samples/getting started/EdgeDeploymentSample/EdgeDeploymentSample.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Devices.Samples
                 string deviceName = $"{deviceIdPrefix}_{i:D8}-{Guid.NewGuid()}";
                 var device = new Device(deviceName)
                 {
-                    Capabilities = new DeviceCapabilities
+                    Capabilities = new ClientCapabilities
                     {
                         IsIotEdge = true,
                     }

--- a/iothub/service/samples/getting started/JobsSample/JobsSample.cs
+++ b/iothub/service/samples/getting started/JobsSample/JobsSample.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.Samples.JobsSample
             //   IoT hub query language in additional detail.
             string query = $"DeviceId IN ['{DeviceId}']";
 
-            var twin = new Twin(DeviceId)
+            var twin = new ClientTwin(DeviceId)
             {
                 Tags = { { TestTagName, TestTagValue } },
             };

--- a/iothub/service/samples/how to guides/ImportExportDevicesSample/ImportExportDevicesSample.cs
+++ b/iothub/service/samples/how to guides/ImportExportDevicesSample/ImportExportDevicesSample.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Devices.Samples
                 var deviceToAdd = new ExportImportDevice
                 {
                     Id = deviceName,
-                    Status = DeviceStatus.Enabled,
+                    Status = ClientStatus.Enabled,
                     Authentication = new AuthenticationMechanism
                     {
                         SymmetricKey = new SymmetricKey

--- a/iothub/service/samples/how to guides/RegistryManagerSample/RegistryManagerSample.cs
+++ b/iothub/service/samples/how to guides/RegistryManagerSample/RegistryManagerSample.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Samples
             string edgeParentId = GenerateDeviceId();
             var edgeParent = new Device(edgeParentId)
             {
-                Capabilities = new DeviceCapabilities
+                Capabilities = new ClientCapabilities
                 {
                     // To create an edge device, this must be set to true
                     IsIotEdge = true,
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices.Samples
             string nestedEdgeId = GenerateDeviceId();
             var nestedEdge = new Device(nestedEdgeId)
             {
-                Capabilities = new DeviceCapabilities
+                Capabilities = new ClientCapabilities
                 {
                     IsIotEdge = true,
                 },

--- a/iothub/service/samples/how to guides/RegistryManagerSample/RegistryManagerSample.cs
+++ b/iothub/service/samples/how to guides/RegistryManagerSample/RegistryManagerSample.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Devices.Samples
             {
                 Authentication = new AuthenticationMechanism
                 {
-                    Type = AuthenticationType.SelfSigned,
+                    Type = ClientAuthenticationType.SelfSigned,
                     X509Thumbprint = new X509Thumbprint
                     {
                         PrimaryThumbprint = _parameters.PrimaryThumbprint,
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices.Samples
             {
                 Authentication = new AuthenticationMechanism
                 {
-                    Type = AuthenticationType.CertificateAuthority,
+                    Type = ClientAuthenticationType.CertificateAuthority,
                 },
             };
 
@@ -158,11 +158,11 @@ namespace Microsoft.Azure.Devices.Samples
             string queryText = $"SELECT * FROM devices WHERE STARTSWITH(id, '{_parameters.DevicePrefix}')";
             Console.WriteLine($"Using query text of: {queryText}");
 
-            QueryResponse<Twin> query = await _client.Query.CreateAsync<Twin>(queryText);
+            QueryResponse<ClientTwin> query = await _client.Query.CreateAsync<ClientTwin>(queryText);
 
             while (await query.MoveNextAsync())
             {
-                Twin twin = query.Current;
+                ClientTwin twin = query.Current;
                 Console.WriteLine($"{twin.DeviceId}");
                 Console.WriteLine($"\tIs edge: {twin.Capabilities.IsIotEdge}");
                 if (!string.IsNullOrWhiteSpace(twin.DeviceScope))
@@ -180,10 +180,10 @@ namespace Microsoft.Azure.Devices.Samples
         {
             Console.WriteLine("\n=== Updating a desired property value ===\n");
 
-            Twin twin = await _client.Twins.GetAsync(deviceId);
+            ClientTwin twin = await _client.Twins.GetAsync(deviceId);
 
             // Set a desired value for a property the device supports, with the corresponding data type
-            var patch = new Twin(twin.DeviceId)
+            var patch = new ClientTwin(twin.DeviceId)
             {
                 ETag = twin.ETag,
             };

--- a/iothub/service/samples/solutions/PnpServiceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iothub/service/samples/solutions/PnpServiceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.Samples
         public async Task RunSampleAsync()
         {
             // Get and print the device twin
-            Twin twin = await GetAndPrintDeviceTwinAsync();
+            ClientTwin twin = await GetAndPrintDeviceTwinAsync();
             _logger.LogDebug($"Model Id of {_deviceId} is: {twin.ModelId}");
 
             // Update the targetTemperature property on the thermostat1 component
@@ -43,11 +43,11 @@ namespace Microsoft.Azure.Devices.Samples
             await InvokeRebootCommandAsync();
         }
 
-        private async Task<Twin> GetAndPrintDeviceTwinAsync()
+        private async Task<ClientTwin> GetAndPrintDeviceTwinAsync()
         {
             _logger.LogDebug($"Get the {_deviceId} device twin.");
 
-            Twin twin = await _serviceClient.Twins.GetAsync(_deviceId);
+            ClientTwin twin = await _serviceClient.Twins.GetAsync(_deviceId);
             _logger.LogDebug($"{_deviceId} twin: \n{JsonConvert.SerializeObject(twin, Formatting.Indented)}");
 
             return twin;
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Devices.Samples
             var twinPatch = CreatePropertyPatch(targetTemperaturePropertyName, desiredTargetTemperature, Thermostat1Component);
             _logger.LogDebug($"Updating the {targetTemperaturePropertyName} property under component {Thermostat1Component} on the {_deviceId} device twin to { desiredTargetTemperature}.");
 
-            Twin currentTwin = await _serviceClient.Twins.GetAsync(_deviceId);
+            ClientTwin currentTwin = await _serviceClient.Twins.GetAsync(_deviceId);
             twinPatch.ETag = currentTwin.ETag;
             await _serviceClient.Twins.UpdateAsync(_deviceId, twinPatch, true);
 
@@ -136,9 +136,9 @@ namespace Microsoft.Azure.Devices.Samples
          *      }
          *  }
          */
-        private static Twin CreatePropertyPatch(string propertyName, object propertyValue, string componentName)
+        private static ClientTwin CreatePropertyPatch(string propertyName, object propertyValue, string componentName)
         {
-            var twinPatch = new Twin();
+            var twinPatch = new ClientTwin();
             twinPatch.Properties.Desired[componentName] = new
             {
                 __t = "c"

--- a/iothub/service/samples/solutions/PnpServiceSamples/Thermostat/ThermostatSample.cs
+++ b/iothub/service/samples/solutions/PnpServiceSamples/Thermostat/ThermostatSample.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.Samples
         public async Task RunSampleAsync()
         {
             // Get and print the device twin
-            Twin deviceTwin = await GetAndPrintDeviceTwinAsync();
+            ClientTwin deviceTwin = await GetAndPrintDeviceTwinAsync();
             _logger.LogDebug($"The {_deviceId} device twin has a model with ID {deviceTwin.ModelId}.");
 
             // Update the targetTemperature property of the device twin
@@ -35,11 +35,11 @@ namespace Microsoft.Azure.Devices.Samples
             await InvokeGetMaxMinReportCommandAsync();
         }
 
-        private async Task<Twin> GetAndPrintDeviceTwinAsync()
+        private async Task<ClientTwin> GetAndPrintDeviceTwinAsync()
         {
             _logger.LogDebug($"Get the {_deviceId} device twin.");
 
-            Twin twin = await _serviceClient.Twins.GetAsync(_deviceId);
+            ClientTwin twin = await _serviceClient.Twins.GetAsync(_deviceId);
             _logger.LogDebug($"{_deviceId} twin: \n{JsonConvert.SerializeObject(twin, Formatting.Indented)}");
 
             return twin;
@@ -48,13 +48,13 @@ namespace Microsoft.Azure.Devices.Samples
         private async Task UpdateTargetTemperaturePropertyAsync()
         {
             const string targetTemperaturePropertyName = "targetTemperature";
-            Twin twin = await _serviceClient.Twins.GetAsync(_deviceId);
+            ClientTwin twin = await _serviceClient.Twins.GetAsync(_deviceId);
 
             // Choose a random value to assign to the targetTemperature property
             int desiredTargetTemperature = s_random.Next(0, 100);
 
             // Update the twin
-            var twinPatch = new Twin
+            var twinPatch = new ClientTwin
             {
                 ETag = twin.ETag,
             };

--- a/iothub/service/src/Exceptions/IotHubServiceErrorCode.cs
+++ b/iothub/service/src/Exceptions/IotHubServiceErrorCode.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Devices
         ArgumentNull = 400005,
 
         /// <summary>
-        /// Returned by the service if a JSON object provided by this library cannot be parsed, for instance, if the JSON provided for <see cref="TwinsClient.UpdateAsync(string, Twin, bool, System.Threading.CancellationToken)"/> is invalid.
+        /// Returned by the service if a JSON object provided by this library cannot be parsed, for instance, if the JSON provided for <see cref="TwinsClient.UpdateAsync(string, ClientTwin, bool, System.Threading.CancellationToken)"/> is invalid.
         /// </summary>
         IotHubFormatError = 400006,
 

--- a/iothub/service/src/Jobs/Models/JobRequest.cs
+++ b/iothub/service/src/Jobs/Models/JobRequest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices
         /// Required if the job type is update twin.
         /// </remarks>
         [JsonProperty(PropertyName = "updateTwin")]
-        internal Twin UpdateTwin { get; set; }
+        internal ClientTwin UpdateTwin { get; set; }
 
         /// <summary>
         /// Condition for device query to get devices to execute the job on.

--- a/iothub/service/src/Jobs/Models/TwinScheduledJob.cs
+++ b/iothub/service/src/Jobs/Models/TwinScheduledJob.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices
         /// Creates an instance of this class for twin scheduled job.
         /// </summary>
         /// <param name="updateTwin">The update twin tags and desired properties.</param>
-        protected internal TwinScheduledJob(Twin updateTwin)
+        protected internal TwinScheduledJob(ClientTwin updateTwin)
         {
             JobType = JobType.ScheduleUpdateTwin;
             UpdateTwin = updateTwin;
@@ -33,6 +33,6 @@ namespace Microsoft.Azure.Devices
         /// The update twin tags and desired properties.
         /// </summary>
         [JsonProperty(PropertyName = "updateTwin", NullValueHandling = NullValueHandling.Ignore)]
-        public Twin UpdateTwin { get; }
+        public ClientTwin UpdateTwin { get; }
     }
 }

--- a/iothub/service/src/Jobs/ScheduledJobsClient.cs
+++ b/iothub/service/src/Jobs/ScheduledJobsClient.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.Devices
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
         public virtual async Task<TwinScheduledJob> ScheduleTwinUpdateAsync(
             string queryCondition,
-            Twin twin,
+            ClientTwin twin,
             DateTimeOffset startOnUtc,
             ScheduledJobsOptions scheduledJobsOptions = default,
             CancellationToken cancellationToken = default)

--- a/iothub/service/src/Query/QueryClient.cs
+++ b/iothub/service/src/Query/QueryClient.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Devices
         /// <param name="cancellationToken">Task cancellation token.</param>
         /// <typeparam name="T">
         /// The type to deserialize the set of items into. For example, when running a query like "SELECT * FROM devices",
-        /// this type should be <see cref="Twin"/>. When running a query like "SELECT * FROM devices.jobs", this type should be
+        /// this type should be <see cref="ClientTwin"/>. When running a query like "SELECT * FROM devices.jobs", this type should be
         /// <see cref="ScheduledJob"/>.
         /// </typeparam>
         /// <returns>An iterable set of the queried items.</returns>

--- a/iothub/service/src/Query/QueryResponse.cs
+++ b/iothub/service/src/Query/QueryResponse.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices
     /// </summary>
     /// <typeparam name="T">
     /// The type of the queried items. For instance, when using a query such as "SELECT * FROM devices",
-    /// this type should be type <see cref="Twin"/>. When using a query such as "SELECT * FROM devices.jobs",
+    /// this type should be type <see cref="ClientTwin"/>. When using a query such as "SELECT * FROM devices.jobs",
     /// this type should be type <see cref="ScheduledJob"/>.
     /// </typeparam>
     public class QueryResponse<T>

--- a/iothub/service/src/Registry/DevicesClient.cs
+++ b/iothub/service/src/Registry/DevicesClient.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided cancellation token has requested cancellation.</exception>
-        public virtual async Task<BulkRegistryOperationResult> CreateWithTwinAsync(Device device, Twin twin, CancellationToken cancellationToken = default)
+        public virtual async Task<BulkRegistryOperationResult> CreateWithTwinAsync(Device device, ClientTwin twin, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Creating device with twin: {device?.Id}", nameof(CreateWithTwinAsync));

--- a/iothub/service/src/Registry/Models/AuthenticationMechanism.cs
+++ b/iothub/service/src/Registry/Models/AuthenticationMechanism.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices
         {
             SymmetricKey = new SymmetricKey();
             X509Thumbprint = new X509Thumbprint();
-            Type = AuthenticationType.Sas;
+            Type = ClientAuthenticationType.Sas;
         }
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Devices
                 _symmetricKey = value;
                 if (value != null)
                 {
-                    Type = AuthenticationType.Sas;
+                    Type = ClientAuthenticationType.Sas;
                 }
             }
         }
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices
                 _x509Thumbprint = value;
                 if (value != null)
                 {
-                    Type = AuthenticationType.SelfSigned;
+                    Type = ClientAuthenticationType.SelfSigned;
                 }
             }
         }
@@ -61,8 +61,8 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Gets or sets the authentication type.
         /// </summary>
-        [DefaultValue(AuthenticationType.Sas)]
+        [DefaultValue(ClientAuthenticationType.Sas)]
         [JsonProperty(PropertyName = "type", DefaultValueHandling = DefaultValueHandling.Populate)]
-        public AuthenticationType Type { get; set; }
+        public ClientAuthenticationType Type { get; set; }
     }
 }

--- a/iothub/service/src/Registry/Models/Device.cs
+++ b/iothub/service/src/Registry/Models/Device.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Devices
         ///  Capabilities that are enabled one the device.
         /// </summary>
         [JsonProperty(PropertyName = "capabilities", NullValueHandling = NullValueHandling.Ignore)]
-        public virtual DeviceCapabilities Capabilities { get; set; }
+        public virtual ClientCapabilities Capabilities { get; set; }
 
         /// <summary>
         /// The scope of the device. For edge devices, this is auto-generated and immutable. For leaf devices, set this to create child/parent

--- a/iothub/service/src/Registry/Models/Device.cs
+++ b/iothub/service/src/Registry/Models/Device.cs
@@ -59,14 +59,14 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         [JsonProperty(PropertyName = "connectionState")]
         [JsonConverter(typeof(StringEnumConverter))]
-        public DeviceConnectionState ConnectionState { get; internal set; }
+        public ClientConnectionState ConnectionState { get; internal set; }
 
         /// <summary>
         /// Device's status.
         /// </summary>
         [JsonProperty(PropertyName = "status")]
         [JsonConverter(typeof(StringEnumConverter))]
-        public DeviceStatus Status { get; set; }
+        public ClientStatus Status { get; set; }
 
         /// <summary>
         /// Reason, if any, for the device to be in specified status.

--- a/iothub/service/src/Registry/Models/ExportImportDevice.cs
+++ b/iothub/service/src/Registry/Models/ExportImportDevice.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices
             /// desired porperty values are JSON objects, up-to 4KB in length.
             /// </remarks>
             [JsonProperty(PropertyName = "desired", NullValueHandling = NullValueHandling.Ignore)]
-            public TwinCollection DesiredProperties { get; set; }
+            public ClientTwinProperties DesiredProperties { get; set; }
 
             /// <summary>
             /// The collection of reported property key-value pairs.
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices
             /// reported property values are JSON objects, up-to 4KB in length.
             /// </remarks>
             [JsonProperty(PropertyName = "reported", NullValueHandling = NullValueHandling.Ignore)]
-            public TwinCollection ReportedProperties { get; set; }
+            public ClientTwinProperties ReportedProperties { get; set; }
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.Devices
         /// If disabled, it cannot connect to the service.
         /// </remarks>
         [JsonProperty(PropertyName = "status", Required = Required.Always)]
-        public DeviceStatus Status { get; set; }
+        public ClientStatus Status { get; set; }
 
         /// <summary>
         /// The 128 character-long string that stores the reason for the device identity status.

--- a/iothub/service/src/Registry/Models/ExportImportDevice.cs
+++ b/iothub/service/src/Registry/Models/ExportImportDevice.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Devices
         /// Status of capabilities enabled on the device or module.
         /// </summary>
         [JsonProperty(PropertyName = "capabilities", NullValueHandling = NullValueHandling.Ignore)]
-        public DeviceCapabilities Capabilities { get; set; }
+        public ClientCapabilities Capabilities { get; set; }
 
         /// <summary>
         /// The scope of the device. For edge devices, this is auto-generated and immutable. For leaf

--- a/iothub/service/src/Registry/Models/Module.cs
+++ b/iothub/service/src/Registry/Models/Module.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         [JsonProperty(PropertyName = "connectionState")]
         [JsonConverter(typeof(StringEnumConverter))]
-        public DeviceConnectionState ConnectionState { get; internal set; }
+        public ClientConnectionState ConnectionState { get; internal set; }
 
         /// <summary>
         /// Time when the connection state was last updated.

--- a/iothub/service/src/Twin/Models/ClientAuthenticationType.cs
+++ b/iothub/service/src/Twin/Models/ClientAuthenticationType.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices
     /// Used to specify the authentication type used by a device.
     /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
-    public enum AuthenticationType
+    public enum ClientAuthenticationType
     {
         /// <summary>
         /// Shared access key.

--- a/iothub/service/src/Twin/Models/ClientCapabilities.cs
+++ b/iothub/service/src/Twin/Models/ClientCapabilities.cs
@@ -3,17 +3,17 @@
 
 using Newtonsoft.Json;
 
-namespace Microsoft.Azure.Devices.Provisioning.Service
+namespace Microsoft.Azure.Devices
 {
     /// <summary>
     /// Status of capabilities enabled on the device.
     /// </summary>
-    public class ProvisioningDeviceCapabilities
+    public class ClientCapabilities
     {
         /// <summary>
-        /// IoT Edge capability.
+        /// Indicates if the device is an IoT Edge device.
         /// </summary>
         [JsonProperty(PropertyName = "iotEdge")]
-        public bool IotEdge { get; set; }
+        public bool IsIotEdge { get; set; }
     }
 }

--- a/iothub/service/src/Twin/Models/ClientConnectionState.cs
+++ b/iothub/service/src/Twin/Models/ClientConnectionState.cs
@@ -4,9 +4,9 @@
 namespace Microsoft.Azure.Devices
 {
     /// <summary>
-    /// Specifies the different connection states of a device.
+    /// Specifies the different connection states of a device or module.
     /// </summary>
-    public enum DeviceConnectionState
+    public enum ClientConnectionState
     {
         /// <summary>
         /// Represents a device in the disconnected state.

--- a/iothub/service/src/Twin/Models/ClientStatus.cs
+++ b/iothub/service/src/Twin/Models/ClientStatus.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices
     /// Specifies the different states of a device.
     /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
-    public enum DeviceStatus
+    public enum ClientStatus
     {
         /// <summary>
         /// Indicates that a device is enabled.

--- a/iothub/service/src/Twin/Models/ClientTwin.cs
+++ b/iothub/service/src/Twin/Models/ClientTwin.cs
@@ -14,19 +14,19 @@ namespace Microsoft.Azure.Devices
     /// <summary>
     /// Properties of a device stored on the service.
     /// </summary>
-    [JsonConverter(typeof(TwinJsonConverter))]
-    public class Twin
+    [JsonConverter(typeof(ClientTwinJsonConverter))]
+    public class ClientTwin
     {
         /// <summary>
         /// Creates an instance of this class.
         /// </summary>
-        public Twin() { }
+        public ClientTwin() { }
 
         /// <summary>
         /// Creates an instance of this class.
         /// </summary>
         /// <param name="deviceId">The unique Id of the device to which the twin belongs.</param>
-        public Twin(string deviceId)
+        public ClientTwin(string deviceId)
         {
             DeviceId = deviceId;
         }
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices
         /// Creates an instance of this class.
         /// </summary>
         /// <param name="twinProperties">Properties of the twin.</param>
-        public Twin(TwinProperties twinProperties)
+        public ClientTwin(ClientTwinDocument twinProperties)
         {
             Properties = twinProperties ?? new();
         }
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Gets and sets the twin properties.
         /// </summary>
-        public TwinProperties Properties { get; set; } = new();
+        public ClientTwinDocument Properties { get; set; } = new();
 
         /// <summary>
         /// Gets the twin configuration properties.
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         [DefaultValue(null)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public DeviceStatus? Status { get; internal set; }
+        public ClientStatus? Status { get; internal set; }
 
         /// <summary>
         /// Reason, if any, for the corresponding device to be in specified status.
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices
         [DefaultValue(null)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(StringEnumConverter))]
-        public DeviceConnectionState? ConnectionState { get; internal set; }
+        public ClientConnectionState? ConnectionState { get; internal set; }
 
         /// <summary>
         /// Time when the corresponding device was last active.
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         [DefaultValue(null)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public AuthenticationType? AuthenticationType { get; internal set; }
+        public ClientAuthenticationType? AuthenticationType { get; internal set; }
 
         /// <summary>
         /// Corresponding device's X509 thumbprint.

--- a/iothub/service/src/Twin/Models/ClientTwin.cs
+++ b/iothub/service/src/Twin/Models/ClientTwin.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json.Converters;
 namespace Microsoft.Azure.Devices
 {
     /// <summary>
-    /// Properties of a device stored on the service.
+    /// Properties of a device or module stored on the service.
     /// </summary>
     [JsonConverter(typeof(ClientTwinJsonConverter))]
     public class ClientTwin
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices
         public string DeviceId { get; set; }
 
         /// <summary>
-        /// The DTDL model Id of the device.
+        /// The DTDL model Id of the device or module.
         /// </summary>
         /// <remarks>
         /// The value will be null for a non-pnp device.
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices
         /// <remarks>
         /// Twin capabilities are read only.
         /// </remarks>
-        public DeviceCapabilities Capabilities { get; internal set; }
+        public ClientCapabilities Capabilities { get; internal set; }
 
         /// <summary>
         /// Twin's ETag.

--- a/iothub/service/src/Twin/Models/ClientTwinDocument.cs
+++ b/iothub/service/src/Twin/Models/ClientTwinDocument.cs
@@ -8,18 +8,18 @@ namespace Microsoft.Azure.Devices
     /// <summary>
     /// Represents twin properties.
     /// </summary>
-    public class TwinProperties
+    public class ClientTwinDocument
     {
         /// <summary>
         /// Gets and sets the twin desired properties.
         /// </summary>
         [JsonProperty(PropertyName = "desired", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public TwinCollection Desired { get; set; } = new();
+        public ClientTwinProperties Desired { get; set; } = new();
 
         /// <summary>
         /// Gets and sets the twin reported properties.
         /// </summary>
         [JsonProperty(PropertyName = "reported", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public TwinCollection Reported { get; set; } = new();
+        public ClientTwinProperties Reported { get; set; } = new();
     }
 }

--- a/iothub/service/src/Twin/Models/ClientTwinJsonConverter.cs
+++ b/iothub/service/src/Twin/Models/ClientTwinJsonConverter.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.Devices
 
                     case CapabilitiesJsonTag:
                         Dictionary<string, object> capabilitiesDictionary = serializer.Deserialize<Dictionary<string, object>>(reader);
-                        twin.Capabilities = new DeviceCapabilities
+                        twin.Capabilities = new ClientCapabilities
                         {
                             IsIotEdge = capabilitiesDictionary.ContainsKey(IotEdgeName) && (bool)capabilitiesDictionary[IotEdgeName]
                         };

--- a/iothub/service/src/Twin/Models/ClientTwinJsonConverter.cs
+++ b/iothub/service/src/Twin/Models/ClientTwinJsonConverter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices
     /// <summary>
     /// Converts a twin to JSON.
     /// </summary>
-    public sealed class TwinJsonConverter : JsonConverter
+    internal sealed class ClientTwinJsonConverter : JsonConverter
     {
         private const string DeviceIdJsonTag = "deviceId";
         private const string ModuleIdJsonTag = "moduleId";
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Devices
         /// Converts twin to its equivalent JSON representation.
         /// </summary>
         /// <param name="writer">the JSON writer.</param>
-        /// <param name="value">the <see cref="Twin"/> to convert.</param>
+        /// <param name="value">the <see cref="ClientTwin"/> to convert.</param>
         /// <param name="serializer">the JSON serializer.</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices
                 throw new ArgumentNullException(nameof(serializer));
             }
 
-            var twin = value as Twin;
+            var twin = value as ClientTwin;
 
             if (twin == null)
             {
@@ -161,13 +161,13 @@ namespace Microsoft.Azure.Devices
                 if (twin.Properties.Desired != null)
                 {
                     writer.WritePropertyName(DesiredPropertiesJsonTag);
-                    serializer.Serialize(writer, twin.Properties.Desired, typeof(TwinCollection));
+                    serializer.Serialize(writer, twin.Properties.Desired, typeof(ClientTwinProperties));
                 }
 
                 if (twin.Properties.Reported != null)
                 {
                     writer.WritePropertyName(ReportedPropertiesJsonTag);
-                    serializer.Serialize(writer, twin.Properties.Reported, typeof(TwinCollection));
+                    serializer.Serialize(writer, twin.Properties.Reported, typeof(ClientTwinProperties));
                 }
 
                 writer.WriteEndObject();
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <summary>
-        /// Converts JSON to its equivalent <see cref="Twin"/> representation.
+        /// Converts JSON to its equivalent <see cref="ClientTwin"/> representation.
         /// </summary>
         /// <param name="reader">the JSON reader.</param>
         /// <param name="objectType">object type</param>
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.Devices
                 throw new ArgumentNullException(nameof(serializer));
             }
 
-            var twin = new Twin();
+            var twin = new ClientTwin();
 
             if (reader.TokenType != JsonToken.StartObject)
             {
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.Devices
 
                     case StatusTag:
                         string status = reader.Value as string;
-                        twin.Status = status?[0] == '\"' ? JsonConvert.DeserializeObject<DeviceStatus>(status) : serializer.Deserialize<DeviceStatus>(reader);
+                        twin.Status = status?[0] == '\"' ? JsonConvert.DeserializeObject<ClientStatus>(status) : serializer.Deserialize<ClientStatus>(reader);
                         break;
 
                     case StatusReasonTag:
@@ -292,8 +292,8 @@ namespace Microsoft.Azure.Devices
                     case ConnectionStateTag:
                         string connectionState = reader.Value as string;
                         twin.ConnectionState = connectionState?[0] == '\"'
-                            ? JsonConvert.DeserializeObject<DeviceConnectionState>(connectionState)
-                            : serializer.Deserialize<DeviceConnectionState>(reader);
+                            ? JsonConvert.DeserializeObject<ClientConnectionState>(connectionState)
+                            : serializer.Deserialize<ClientConnectionState>(reader);
                         break;
 
                     case LastActivityTimeTag:
@@ -307,8 +307,8 @@ namespace Microsoft.Azure.Devices
                     case AuthenticationTypeTag:
                         string authenticationType = reader.Value as string;
                         twin.AuthenticationType = authenticationType?[0] == '\"'
-                            ? JsonConvert.DeserializeObject<AuthenticationType>(authenticationType)
-                            : serializer.Deserialize<AuthenticationType>(reader);
+                            ? JsonConvert.DeserializeObject<ClientAuthenticationType>(authenticationType)
+                            : serializer.Deserialize<ClientAuthenticationType>(reader);
                         break;
 
                     case X509ThumbprintTag:
@@ -346,7 +346,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Value indicating whether this TwinJsonConverter can write JSON
         /// </summary>
-        public override bool CanConvert(Type objectType) => typeof(Twin).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+        public override bool CanConvert(Type objectType) => typeof(ClientTwin).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
 
         private static Dictionary<string, object> GetTagsForTwin(JsonReader reader)
         {
@@ -401,7 +401,7 @@ namespace Microsoft.Azure.Devices
                 : null;
         }
 
-        private static void PopulatePropertiesForTwin(Twin twin, JsonReader reader)
+        private static void PopulatePropertiesForTwin(ClientTwin twin, JsonReader reader)
         {
             if (twin == null)
             {
@@ -428,11 +428,11 @@ namespace Microsoft.Azure.Devices
                 switch (propertyName)
                 {
                     case DesiredPropertiesJsonTag:
-                        twin.Properties.Desired = new TwinCollection(JToken.ReadFrom(reader) as JObject);
+                        twin.Properties.Desired = new ClientTwinProperties(JToken.ReadFrom(reader) as JObject);
                         break;
 
                     case ReportedPropertiesJsonTag:
-                        twin.Properties.Reported = new TwinCollection(JToken.ReadFrom(reader) as JObject);
+                        twin.Properties.Reported = new ClientTwinProperties(JToken.ReadFrom(reader) as JObject);
                         break;
 
                     default:

--- a/iothub/service/src/Twin/Models/ClientTwinMetadata.cs
+++ b/iothub/service/src/Twin/Models/ClientTwinMetadata.cs
@@ -6,16 +6,16 @@ using System;
 namespace Microsoft.Azure.Devices
 {
     /// <summary>
-    /// Metadata for properties in <see cref="TwinCollection"/>.
+    /// Metadata for properties in <see cref="ClientTwinProperties"/>.
     /// </summary>
-    public sealed class TwinMetadata
+    public sealed class ClientTwinMetadata
     {
         /// <summary>
         /// Initializes an instance of this class.
         /// </summary>
         /// <param name="lastUpdatedOnUtc">When a property was last updated.</param>
         /// <param name="lastUpdatedVersion">The version of the property when last updated.</param>
-        public TwinMetadata(DateTimeOffset lastUpdatedOnUtc, long? lastUpdatedVersion)
+        public ClientTwinMetadata(DateTimeOffset lastUpdatedOnUtc, long? lastUpdatedVersion)
         {
             LastUpdatedOnUtc = lastUpdatedOnUtc;
             LastUpdatedVersion = lastUpdatedVersion;

--- a/iothub/service/src/Twin/Models/ClientTwinPropertiesJsonConverter.cs
+++ b/iothub/service/src/Twin/Models/ClientTwinPropertiesJsonConverter.cs
@@ -2,16 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Devices.Provisioning.Service
+namespace Microsoft.Azure.Devices
 {
-    [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses",
-        Justification = "CodeAnalysis limitation: TwinCollectionJsonConverter is actually used by TwinCollection")]
-    internal class TwinCollectionJsonConverter : JsonConverter
+    internal class ClientTwinPropertiesJsonConverter : JsonConverter
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
@@ -21,8 +18,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 return;
             }
 
-            var properties = value as TwinCollection;
-            if (properties == null)
+            if (value is not ClientTwinProperties properties)
             {
                 throw new InvalidOperationException("Object passed is not of type TwinCollection.");
             }
@@ -30,12 +26,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             serializer.Serialize(writer, properties.JObject);
         }
 
-        public override bool CanConvert(Type objectType) => typeof(TwinCollection).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+        public override bool CanConvert(Type objectType) => typeof(ClientTwinProperties).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            return new TwinCollection(JToken.ReadFrom(reader) as JObject);
+            return new ClientTwinProperties(JToken.ReadFrom(reader) as JObject);
         }
     }
 }
-

--- a/iothub/service/src/Twin/Models/ClientTwinPropertyArray.cs
+++ b/iothub/service/src/Twin/Models/ClientTwinPropertyArray.cs
@@ -2,34 +2,28 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.CSharp.RuntimeBinder;
 using Newtonsoft.Json.Linq;
-using static Microsoft.Azure.Devices.Provisioning.Service.TwinCollection;
+using static Microsoft.Azure.Devices.ClientTwinProperties;
 
-namespace Microsoft.Azure.Devices.Provisioning.Service
+namespace Microsoft.Azure.Devices
 {
     /// <summary>
-    /// Represents a property value in a <see cref="TwinCollection"/>.
+    /// Represents a property array in a <see cref="ClientTwinProperties"/>.
     /// </summary>
-    [SuppressMessage("Microsoft.Design", "CA1710:IdentifiersShouldHaveCorrectSuffix",
-        Justification = "Public API cannot change name.")]
-    [SuppressMessage("Microsoft.Design", "CA1036:OverrideMethodsOnComparableTypes",
-        Justification = "Uses default JValue comparison, equality and hashing implementations.")]
-    public class TwinCollectionValue : JValue
+    public class ClientTwinPropertyArray : JArray
     {
         private readonly JObject _metadata;
 
-        internal TwinCollectionValue(JValue jValue, JObject metadata)
-            : base(jValue)
+        internal ClientTwinPropertyArray(JArray jArray, JObject metadata)
+            : base(jArray)
         {
-            _metadata = metadata;
+            _metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
         }
 
         /// <summary>
         /// Gets the value for the given property name.
         /// </summary>
-        /// <param name="propertyName">Property Name to lookup.</param>
+        /// <param name="propertyName">Property name to look up.</param>
         /// <returns>Property value, if present.</returns>
         /// <exception cref="InvalidOperationException">When the specified <paramref name="propertyName"/> does not exist in the collection.</exception>
         public dynamic this[string propertyName]
@@ -41,22 +35,22 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                     MetadataName => GetMetadata(),
                     LastUpdatedName => GetLastUpdatedOnUtc(),
                     LastUpdatedVersionName => GetLastUpdatedVersion(),
-                    _ => throw new InvalidOperationException($"{nameof(TwinCollectionValue)} does not contain a definition for '{propertyName}'."),
+                    _ => throw new InvalidOperationException($"{nameof(ClientTwinPropertyArray)} does not contain a definition for '{propertyName}'."),
                 };
             }
         }
 
         /// <summary>
-        /// Gets the Metadata for this property.
+        /// Gets the metadata for this property.
         /// </summary>
         /// <returns>Metadata instance representing the metadata for this property.</returns>
-        public TwinMetadata GetMetadata()
+        public ClientTwinMetadata GetMetadata()
         {
-            return new TwinMetadata(GetLastUpdatedOnUtc(), GetLastUpdatedVersion());
+            return new ClientTwinMetadata(GetLastUpdatedOnUtc(), GetLastUpdatedVersion());
         }
 
         /// <summary>
-        /// Gets the time when this property was last updated.
+        /// Gets the last updated time for this property.
         /// </summary>
         public DateTimeOffset GetLastUpdatedOnUtc()
         {
@@ -67,13 +61,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 return lastUpdatedOnUtc;
             }
 
-            return DateTimeOffset.MinValue;
+            return default;
         }
 
         /// <summary>
-        /// Gets the LastUpdatedVersion for this property.
+        /// Gets the last updated version for this property.
         /// </summary>
-        /// <returns>LastUpdatdVersion if present, null otherwise.</returns>
+        /// <returns>Last updated version if present, null otherwise.</returns>
         public long? GetLastUpdatedVersion()
         {
             return (long?)_metadata?[LastUpdatedVersionName];

--- a/iothub/service/src/Twin/Models/ClientTwinPropertyValue.cs
+++ b/iothub/service/src/Twin/Models/ClientTwinPropertyValue.cs
@@ -3,21 +3,21 @@
 
 using System;
 using Newtonsoft.Json.Linq;
-using static Microsoft.Azure.Devices.TwinCollection;
+using static Microsoft.Azure.Devices.ClientTwinProperties;
 
 namespace Microsoft.Azure.Devices
 {
     /// <summary>
-    /// Represents a property array in a <see cref="TwinCollection"/>.
+    /// Represents a property value in a <see cref="ClientTwinProperties"/>.
     /// </summary>
-    public class TwinCollectionArray : JArray
+    public class ClientTwinPropertyValue : JValue
     {
         private readonly JObject _metadata;
 
-        internal TwinCollectionArray(JArray jArray, JObject metadata)
-            : base(jArray)
+        internal ClientTwinPropertyValue(JValue jValue, JObject metadata)
+            : base(jValue)
         {
-            _metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
+            _metadata = metadata;
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices
                     MetadataName => GetMetadata(),
                     LastUpdatedName => GetLastUpdatedOnUtc(),
                     LastUpdatedVersionName => GetLastUpdatedVersion(),
-                    _ => throw new InvalidOperationException($"{nameof(TwinCollectionArray)} does not contain a definition for '{propertyName}'."),
+                    _ => throw new InvalidOperationException($"{nameof(ClientTwinPropertyValue)} does not contain a definition for '{propertyName}'."),
                 };
             }
         }
@@ -44,13 +44,13 @@ namespace Microsoft.Azure.Devices
         /// Gets the metadata for this property.
         /// </summary>
         /// <returns>Metadata instance representing the metadata for this property.</returns>
-        public TwinMetadata GetMetadata()
+        public ClientTwinMetadata GetMetadata()
         {
-            return new TwinMetadata(GetLastUpdatedOnUtc(), GetLastUpdatedVersion());
+            return new ClientTwinMetadata(GetLastUpdatedOnUtc(), GetLastUpdatedVersion());
         }
 
         /// <summary>
-        /// Gets the last updated time for this property.
+        /// Gets the time when this property was last updated in UTC.
         /// </summary>
         public DateTimeOffset GetLastUpdatedOnUtc()
         {

--- a/iothub/service/src/Twin/TwinsClient.cs
+++ b/iothub/service/src/Twin/TwinsClient.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> GetAsync(string deviceId, CancellationToken cancellationToken = default)
+        public virtual async Task<ClientTwin> GetAsync(string deviceId, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Getting device twin: {deviceId}", nameof(GetAsync));
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices
                 using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Get, GetTwinUri(deviceId), _credentialProvider);
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.OK, response).ConfigureAwait(false);
-                return await HttpMessageHelper.DeserializeResponseAsync<Twin>(response).ConfigureAwait(false);
+                return await HttpMessageHelper.DeserializeResponseAsync<ClientTwin>(response).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> GetAsync(string deviceId, string moduleId, CancellationToken cancellationToken = default)
+        public virtual async Task<ClientTwin> GetAsync(string deviceId, string moduleId, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Getting device module twin: {deviceId}/{moduleId}", nameof(GetAsync));
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Devices
                     _credentialProvider);
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.OK, response).ConfigureAwait(false);
-                return await HttpMessageHelper.DeserializeResponseAsync<Twin>(response).ConfigureAwait(false);
+                return await HttpMessageHelper.DeserializeResponseAsync<ClientTwin>(response).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> UpdateAsync(string deviceId, Twin twinPatch, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<ClientTwin> UpdateAsync(string deviceId, ClientTwin twinPatch, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
             Argument.AssertNotNull(twinPatch, nameof(twinPatch));
@@ -214,10 +214,10 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> UpdateAsync(
+        public virtual async Task<ClientTwin> UpdateAsync(
             string deviceId,
             string moduleId,
-            Twin twinPatch,
+            ClientTwin twinPatch,
             bool onlyIfUnchanged = false,
             CancellationToken cancellationToken = default)
         {
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Update the mutable fields for a list of module twins previously created within the system.
         /// </summary>
-        /// <param name="twins">List of <see cref="Twin"/>s with updated fields.</param>
+        /// <param name="twins">List of <see cref="ClientTwin"/>s with updated fields.</param>
         /// <param name="onlyIfUnchanged">
         /// If false, this operation will be performed even if the provided device identity has
         /// an out of date ETag. If true, the operation will throw a <see cref="IotHubServiceException"/> with <see cref="IotHubServiceErrorCode.PreconditionFailed"/>
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<BulkRegistryOperationResult> UpdateAsync(IEnumerable<Twin> twins, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<BulkRegistryOperationResult> UpdateAsync(IEnumerable<ClientTwin> twins, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, "Updating twins", nameof(UpdateAsync));
@@ -320,7 +320,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> ReplaceAsync(string deviceId, Twin newTwin, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<ClientTwin> ReplaceAsync(string deviceId, ClientTwin newTwin, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
             Argument.AssertNotNull(newTwin, nameof(newTwin));
@@ -355,7 +355,7 @@ namespace Microsoft.Azure.Devices
         /// certificate validation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
-        public virtual async Task<Twin> ReplaceAsync(string deviceId, string moduleId, Twin newTwin, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<ClientTwin> ReplaceAsync(string deviceId, string moduleId, ClientTwin newTwin, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
             Argument.AssertNotNullOrWhiteSpace(moduleId, nameof(moduleId));
@@ -364,9 +364,9 @@ namespace Microsoft.Azure.Devices
             return await UpdateInternalAsync(deviceId, moduleId, newTwin, newTwin.ETag, true, onlyIfUnchanged, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<Twin> UpdateInternalAsync(
+        private async Task<ClientTwin> UpdateInternalAsync(
             string deviceId,
-            Twin twin,
+            ClientTwin twin,
             ETag etag,
             bool isReplace,
             bool onlyIfUnchanged = false,
@@ -389,7 +389,7 @@ namespace Microsoft.Azure.Devices
                 HttpMessageHelper.ConditionallyInsertETag(request, etag, onlyIfUnchanged);
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.OK, response).ConfigureAwait(false);
-                return await HttpMessageHelper.DeserializeResponseAsync<Twin>(response).ConfigureAwait(false);
+                return await HttpMessageHelper.DeserializeResponseAsync<ClientTwin>(response).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -404,10 +404,10 @@ namespace Microsoft.Azure.Devices
             }
         }
 
-        private async Task<Twin> UpdateInternalAsync(
+        private async Task<ClientTwin> UpdateInternalAsync(
             string deviceId,
             string moduleId,
-            Twin twin,
+            ClientTwin twin,
             ETag etag,
             bool isReplace,
             bool onlyIfUnchanged = false,
@@ -431,7 +431,7 @@ namespace Microsoft.Azure.Devices
                 HttpMessageHelper.ConditionallyInsertETag(request, etag, onlyIfUnchanged);
                 HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.OK, response).ConfigureAwait(false);
-                return await HttpMessageHelper.DeserializeResponseAsync<Twin>(response).ConfigureAwait(false);
+                return await HttpMessageHelper.DeserializeResponseAsync<ClientTwin>(response).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -446,14 +446,14 @@ namespace Microsoft.Azure.Devices
             }
         }
 
-        private static IEnumerable<ExportImportDevice> GenerateExportImportDeviceListForTwinBulkOperations(IEnumerable<Twin> twins, ImportMode importMode)
+        private static IEnumerable<ExportImportDevice> GenerateExportImportDeviceListForTwinBulkOperations(IEnumerable<ClientTwin> twins, ImportMode importMode)
         {
             Debug.Assert(twins != null);
             Debug.Assert(twins.Any());
 
             var exportImportDeviceList = new List<ExportImportDevice>(twins.Count());
 
-            foreach (Twin twin in twins)
+            foreach (ClientTwin twin in twins)
             {
                 if (twin == null)
                 {

--- a/iothub/service/tests/DeviceAuthenticationTests.cs
+++ b/iothub/service/tests/DeviceAuthenticationTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Api.Test
         {
             var deviceGoodAuthConfig = new Device("123")
             {
-                ConnectionState = DeviceConnectionState.Connected,
+                ConnectionState = ClientConnectionState.Connected,
                 Authentication = new AuthenticationMechanism()
                 {
                     SymmetricKey = new SymmetricKey()
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Devices.Api.Test
         {
             var deviceGoodAuthConfig = new Device("123")
             {
-                ConnectionState = DeviceConnectionState.Connected,
+                ConnectionState = ClientConnectionState.Connected,
                 Authentication = new AuthenticationMechanism()
                 {
                     SymmetricKey = null,
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Devices.Api.Test
         {
             var deviceGoodAuthConfig = new Device("123")
             {
-                ConnectionState = DeviceConnectionState.Connected,
+                ConnectionState = ClientConnectionState.Connected,
                 Authentication = new AuthenticationMechanism()
                 {
                     SymmetricKey = null,
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.Devices.Api.Test
         {
             var deviceGoodAuthConfig = new Device("123")
             {
-                ConnectionState = DeviceConnectionState.Connected,
+                ConnectionState = ClientConnectionState.Connected,
                 Authentication = new AuthenticationMechanism()
                 {
                     SymmetricKey = null,
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Devices.Api.Test
         {
             var deviceGoodAuthConfig = new Device("123")
             {
-                ConnectionState = DeviceConnectionState.Connected,
+                ConnectionState = ClientConnectionState.Connected,
                 Authentication = new AuthenticationMechanism()
                 {
                     SymmetricKey = new SymmetricKey()
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.Devices.Api.Test
         {
             var deviceBadAuthConfig = new Device("123")
             {
-                ConnectionState = DeviceConnectionState.Connected,
+                ConnectionState = ClientConnectionState.Connected,
                 Authentication = new AuthenticationMechanism()
                 {
                     SymmetricKey = null,
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.Devices.Api.Test
         {
             var deviceBadAuthConfig = new Device("123")
             {
-                ConnectionState = DeviceConnectionState.Connected,
+                ConnectionState = ClientConnectionState.Connected,
                 Authentication = new AuthenticationMechanism()
                 {
                     SymmetricKey = null,
@@ -253,10 +253,10 @@ namespace Microsoft.Azure.Devices.Api.Test
         {
             var deviceBadThumbprint = new Device("123")
             {
-                ConnectionState = DeviceConnectionState.Connected,
+                ConnectionState = ClientConnectionState.Connected,
                 Authentication = new AuthenticationMechanism
                 {
-                    Type = AuthenticationType.CertificateAuthority,
+                    Type = ClientAuthenticationType.CertificateAuthority,
                     SymmetricKey = null,
                     X509Thumbprint = null
                 }

--- a/iothub/service/tests/Registry/DevicesTests.cs
+++ b/iothub/service/tests/Registry/DevicesTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.Tests
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
-            var deviceToReturn = new Device(DeviceId) { ConnectionState = DeviceConnectionState.Connected };
+            var deviceToReturn = new Device(DeviceId) { ConnectionState = ClientConnectionState.Connected };
             var mockHttpResponse = new HttpResponseMessage();
             mockHttpResponse.Content = HttpMessageHelper.SerializePayload(deviceToReturn);
             mockHttpResponse.StatusCode = HttpStatusCode.OK;
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Devices.Tests
         [TestMethod]
         public async Task RegisterDeviceAsyncTest()
         {
-            var deviceToReturn = new Device("123") { ConnectionState = DeviceConnectionState.Connected };
+            var deviceToReturn = new Device("123") { ConnectionState = ClientConnectionState.Connected };
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
@@ -92,8 +92,8 @@ namespace Microsoft.Azure.Devices.Tests
         [ExpectedException(typeof(InvalidOperationException))]
         public async Task RegisterDevicesAsyncWithETagsSetTest()
         {
-            var goodDevice = new Device("123") { ConnectionState = DeviceConnectionState.Connected };
-            var badDevice = new Device("234") { ConnectionState = DeviceConnectionState.Connected, ETag = new("234") };
+            var goodDevice = new Device("123") { ConnectionState = ClientConnectionState.Connected };
+            var badDevice = new Device("234") { ConnectionState = ClientConnectionState.Connected, ETag = new("234") };
 
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             var mockHttpRequestFactory = new Mock<HttpRequestMessageFactory>();
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Devices.Tests
         [ExpectedException(typeof(InvalidOperationException))]
         public async Task RegisterDevicesAsyncWithNullDeviceTest()
         {
-            var goodDevice = new Device("123") { ConnectionState = DeviceConnectionState.Connected };
+            var goodDevice = new Device("123") { ConnectionState = ClientConnectionState.Connected };
             Device badDevice = null;
 
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Devices.Tests
         [TestMethod]
         public async Task UpdateDeviceAsyncTest()
         {
-            var deviceToReturn = new Device("123") { ConnectionState = DeviceConnectionState.Connected, ETag = new ETag("123") };
+            var deviceToReturn = new Device("123") { ConnectionState = ClientConnectionState.Connected, ETag = new ETag("123") };
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.Devices.Tests
         [ExpectedException(typeof(InvalidOperationException))]
         public async Task UpdateDevicesAsyncWithNullDeviceTest()
         {
-            var goodDevice = new Device("123") { ConnectionState = DeviceConnectionState.Connected, ETag = new ETag("234") };
+            var goodDevice = new Device("123") { ConnectionState = ClientConnectionState.Connected, ETag = new ETag("234") };
             Device badDevice = null;
 
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
@@ -204,8 +204,8 @@ namespace Microsoft.Azure.Devices.Tests
         [TestMethod]
         public async Task UpdateDevicesAsyncForceUpdateTest()
         {
-            var goodDevice1 = new Device("123") { ConnectionState = DeviceConnectionState.Connected };
-            var goodDevice2 = new Device("234") { ConnectionState = DeviceConnectionState.Connected };
+            var goodDevice1 = new Device("123") { ConnectionState = ClientConnectionState.Connected };
+            var goodDevice2 = new Device("234") { ConnectionState = ClientConnectionState.Connected };
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
@@ -223,8 +223,8 @@ namespace Microsoft.Azure.Devices.Tests
         [TestMethod]
         public async Task UpdateDevicesAsyncForceUpdateFalseTest()
         {
-            var goodDevice1 = new Device("123") { ConnectionState = DeviceConnectionState.Connected, ETag = new ETag("234") };
-            var goodDevice2 = new Device("234") { ConnectionState = DeviceConnectionState.Connected, ETag = new ETag("123") };
+            var goodDevice1 = new Device("123") { ConnectionState = ClientConnectionState.Connected, ETag = new ETag("234") };
+            var goodDevice2 = new Device("234") { ConnectionState = ClientConnectionState.Connected, ETag = new ETag("123") };
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
@@ -257,7 +257,7 @@ namespace Microsoft.Azure.Devices.Tests
         [ExpectedException(typeof(InvalidOperationException))]
         public async Task DeleteDevicesAsyncWithNullDeviceTest()
         {
-            var goodDevice = new Device("123") { ConnectionState = DeviceConnectionState.Connected, ETag = new ETag("234") };
+            var goodDevice = new Device("123") { ConnectionState = ClientConnectionState.Connected, ETag = new ETag("234") };
             Device badDevice = null;
 
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
@@ -287,8 +287,8 @@ namespace Microsoft.Azure.Devices.Tests
         [TestMethod]
         public async Task DeleteDevicesAsyncForceDeleteTest()
         {
-            var goodDevice1 = new Device("123") { ConnectionState = DeviceConnectionState.Connected };
-            var goodDevice2 = new Device("234") { ConnectionState = DeviceConnectionState.Connected };
+            var goodDevice1 = new Device("123") { ConnectionState = ClientConnectionState.Connected };
+            var goodDevice2 = new Device("234") { ConnectionState = ClientConnectionState.Connected };
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
@@ -308,8 +308,8 @@ namespace Microsoft.Azure.Devices.Tests
         [ExpectedException(typeof(ArgumentException))]
         public async Task DeleteDevicesAsyncForceDeleteFalseMissingETagTest()
         {
-            var badDevice1 = new Device("123") { ConnectionState = DeviceConnectionState.Connected };
-            var badDevice2 = new Device("234") { ConnectionState = DeviceConnectionState.Connected };
+            var badDevice1 = new Device("123") { ConnectionState = ClientConnectionState.Connected };
+            var badDevice2 = new Device("234") { ConnectionState = ClientConnectionState.Connected };
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new Mock<HttpRequestMessageFactory>();
@@ -326,8 +326,8 @@ namespace Microsoft.Azure.Devices.Tests
         [TestMethod]
         public async Task DeleteDevicesAsyncForceDeleteFalseTest()
         {
-            var goodDevice1 = new Device("123") { ConnectionState = DeviceConnectionState.Connected, ETag = new ETag("234") };
-            var goodDevice2 = new Device("234") { ConnectionState = DeviceConnectionState.Connected, ETag = new ETag("123") };
+            var goodDevice1 = new Device("123") { ConnectionState = ClientConnectionState.Connected, ETag = new ETag("234") };
+            var goodDevice2 = new Device("234") { ConnectionState = ClientConnectionState.Connected, ETag = new ETag("123") };
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
@@ -346,8 +346,8 @@ namespace Microsoft.Azure.Devices.Tests
         [ExpectedException(typeof(InvalidOperationException))]
         public async Task UpdateTwinsAsyncWithInvalidDeviceIdTest()
         {
-            var goodTwin = new Twin("123");
-            var badTwin = new Twin("/badTwin");
+            var goodTwin = new ClientTwin("123");
+            var badTwin = new ClientTwin("/badTwin");
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
@@ -357,7 +357,7 @@ namespace Microsoft.Azure.Devices.Tests
             mockHttpClient.Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockHttpResponse);
 
             var Twin = new TwinsClient(HostName, mockCredentialProvider.Object, mockHttpClient.Object, mockHttpRequestFactory);
-            await Twin.UpdateAsync(new List<Twin>() { goodTwin, badTwin }, true).ConfigureAwait(false);
+            await Twin.UpdateAsync(new List<ClientTwin>() { goodTwin, badTwin }, true).ConfigureAwait(false);
             Assert.Fail("UpdateTwins API did not throw exception when bad deviceid was used.");
         }
 
@@ -365,8 +365,8 @@ namespace Microsoft.Azure.Devices.Tests
         [ExpectedException(typeof(InvalidOperationException))]
         public async Task UpdateTwinsAsyncWithETagMissingTest()
         {
-            var goodTwin = new Twin("123") { ETag = new ETag("234") };
-            var badTwin = new Twin("234");
+            var goodTwin = new ClientTwin("123") { ETag = new ETag("234") };
+            var badTwin = new ClientTwin("234");
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
@@ -376,7 +376,7 @@ namespace Microsoft.Azure.Devices.Tests
             mockHttpClient.Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockHttpResponse);
 
             var Twin = new TwinsClient(HostName, mockCredentialProvider.Object, mockHttpClient.Object, mockHttpRequestFactory);
-            await Twin.UpdateAsync(new List<Twin>() { goodTwin, badTwin }, true).ConfigureAwait(false);
+            await Twin.UpdateAsync(new List<ClientTwin>() { goodTwin, badTwin }, true).ConfigureAwait(false);
             Assert.Fail("UpdateTwins API did not throw exception when ETag was null.");
         }
 
@@ -384,8 +384,8 @@ namespace Microsoft.Azure.Devices.Tests
         [ExpectedException(typeof(InvalidOperationException))]
         public async Task UpdateTwinsAsyncWithNullTwinTest()
         {
-            var goodTwin = new Twin("123") { ETag = new ETag("234") };
-            Twin badTwin = null;
+            var goodTwin = new ClientTwin("123") { ETag = new ETag("234") };
+            ClientTwin badTwin = null;
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
@@ -394,7 +394,7 @@ namespace Microsoft.Azure.Devices.Tests
             var mockHttpClient = new Mock<HttpClient>();
 
             var Twin = new TwinsClient(HostName, mockCredentialProvider.Object, mockHttpClient.Object, mockHttpRequestFactory);
-            await Twin.UpdateAsync(new List<Twin>() { goodTwin, badTwin }, true).ConfigureAwait(false);
+            await Twin.UpdateAsync(new List<ClientTwin>() { goodTwin, badTwin }, true).ConfigureAwait(false);
             Assert.Fail("UpdateTwins API did not throw exception when Null twin was used.");
         }
 
@@ -403,7 +403,7 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task UpdateTwinsAsyncWithNullTwinListTest()
         {
             var serviceClient = new IotHubServiceClient(validMockConnectionString);
-            await serviceClient.Twins.UpdateAsync(new List<Twin>()).ConfigureAwait(false);
+            await serviceClient.Twins.UpdateAsync(new List<ClientTwin>()).ConfigureAwait(false);
             Assert.Fail("UpdateTwins API did not throw exception when Null twin list was used.");
         }
 
@@ -411,8 +411,8 @@ namespace Microsoft.Azure.Devices.Tests
         [ExpectedException(typeof(InvalidOperationException))]
         public async Task UpdateTwinsAsyncWithDeviceIdNullTest()
         {
-            var goodTwin = new Twin("123") { ETag = new ETag("234") };
-            var badTwin = new Twin();
+            var goodTwin = new ClientTwin("123") { ETag = new ETag("234") };
+            var badTwin = new ClientTwin();
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
@@ -422,15 +422,15 @@ namespace Microsoft.Azure.Devices.Tests
             mockHttpClient.Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockHttpResponse);
 
             var Twin = new TwinsClient(HostName, mockCredentialProvider.Object, mockHttpClient.Object, mockHttpRequestFactory);
-            await Twin.UpdateAsync(new List<Twin>() { goodTwin, badTwin }, true).ConfigureAwait(false);
+            await Twin.UpdateAsync(new List<ClientTwin>() { goodTwin, badTwin }, true).ConfigureAwait(false);
             Assert.Fail("UpdateTwins API did not throw exception when deviceId was null.");
         }
 
         [TestMethod]
         public async Task UpdateTwinsAsyncForceUpdateTest()
         {
-            var goodTwin1 = new Twin("123");
-            var goodTwin2 = new Twin("234");
+            var goodTwin1 = new ClientTwin("123");
+            var goodTwin2 = new ClientTwin("234");
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
@@ -441,15 +441,15 @@ namespace Microsoft.Azure.Devices.Tests
             mockHttpClient.Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockHttpResponse);
 
             var Twin = new TwinsClient(HostName, mockCredentialProvider.Object, mockHttpClient.Object, mockHttpRequestFactory);
-            await Twin.UpdateAsync(new List<Twin>() { goodTwin1, goodTwin2 }, false, CancellationToken.None).ConfigureAwait(false);
+            await Twin.UpdateAsync(new List<ClientTwin>() { goodTwin1, goodTwin2 }, false, CancellationToken.None).ConfigureAwait(false);
         }
 
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
         public async Task UpdateTwinsAsyncForceUpdateMissingETagTest()
         {
-            var badTwin1 = new Twin("123");
-            var badTwin2 = new Twin("234");
+            var badTwin1 = new ClientTwin("123");
+            var badTwin2 = new ClientTwin("234");
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
@@ -459,14 +459,14 @@ namespace Microsoft.Azure.Devices.Tests
             mockHttpClient.Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockHttpResponse);
 
             var Twin = new TwinsClient(HostName, mockCredentialProvider.Object, mockHttpClient.Object, mockHttpRequestFactory);
-            await Twin.UpdateAsync(new List<Twin>() { badTwin1, badTwin2 }, true, CancellationToken.None).ConfigureAwait(false);
+            await Twin.UpdateAsync(new List<ClientTwin>() { badTwin1, badTwin2 }, true, CancellationToken.None).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task UpdateTwinsAsyncForceUpdateFalseTest()
         {
-            var goodTwin1 = new Twin("123") { ETag = new ETag("234") };
-            var goodTwin2 = new Twin("234") { ETag = new ETag("234") };
+            var goodTwin1 = new ClientTwin("123") { ETag = new ETag("234") };
+            var goodTwin2 = new ClientTwin("234") { ETag = new ETag("234") };
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider.Setup(getCredential => getCredential.GetAuthorizationHeader()).Returns(validMockAuthenticationHeaderValue);
             var mockHttpRequestFactory = new HttpRequestMessageFactory(HttpUri, "");
@@ -477,13 +477,13 @@ namespace Microsoft.Azure.Devices.Tests
             mockHttpClient.Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockHttpResponse);
 
             var Twin = new TwinsClient(HostName, mockCredentialProvider.Object, mockHttpClient.Object, mockHttpRequestFactory);
-            await Twin.UpdateAsync(new List<Twin>() { goodTwin1, goodTwin2 }, true, CancellationToken.None).ConfigureAwait(false);
+            await Twin.UpdateAsync(new List<ClientTwin>() { goodTwin1, goodTwin2 }, true, CancellationToken.None).ConfigureAwait(false);
         }
 
         [TestMethod]
         public void Twin_ParentScopes_NotNull()
         {
-            var twin = new Twin();
+            var twin = new ClientTwin();
             twin.ParentScopes.Should().NotBeNull("To prevent NREs because a property was unexecptedly null, it should have a default list instance assigned.");
             twin.ParentScopes.Should().BeEmpty("The default list instance should be empty.");
         }

--- a/iothub/service/tests/SerializationTests.cs
+++ b/iothub/service/tests/SerializationTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.Tests
  ""lastActivityTime"": ""2018-06-29T21:17:08.7759733"",
 }";
 
-            JsonConvert.DeserializeObject<Twin>(jsonString);
+            JsonConvert.DeserializeObject<ClientTwin>(jsonString);
         }
 
         [TestMethod]

--- a/provisioning/service/samples/Getting Started/IndividualEnrollmentTpmSample/IndividualEnrollmentTpmSample.cs
+++ b/provisioning/service/samples/Getting Started/IndividualEnrollmentTpmSample/IndividualEnrollmentTpmSample.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Samples
         private readonly string _deviceId;
 
         private const ProvisioningStatus OptionalProvisioningStatus = ProvisioningStatus.Enabled;
-        private readonly ProvisioningDeviceCapabilities _optionalEdgeCapabilityEnabled = new() { IotEdge = true };
-        private readonly ProvisioningDeviceCapabilities _optionalEdgeCapabilityDisabled = new() { IotEdge = false };
+        private readonly ProvisioningClientCapabilities _optionalEdgeCapabilityEnabled = new() { IotEdge = true };
+        private readonly ProvisioningClientCapabilities _optionalEdgeCapabilityDisabled = new() { IotEdge = false };
 
         private readonly ProvisioningServiceClient _provisioningServiceClient;
 

--- a/provisioning/service/samples/Getting Started/IndividualEnrollmentTpmSample/IndividualEnrollmentTpmSample.cs
+++ b/provisioning/service/samples/Getting Started/IndividualEnrollmentTpmSample/IndividualEnrollmentTpmSample.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Samples
         private readonly string _deviceId;
 
         private const ProvisioningStatus OptionalProvisioningStatus = ProvisioningStatus.Enabled;
-        private readonly DeviceCapabilities _optionalEdgeCapabilityEnabled = new() { IotEdge = true };
-        private readonly DeviceCapabilities _optionalEdgeCapabilityDisabled = new() { IotEdge = false };
+        private readonly ProvisioningDeviceCapabilities _optionalEdgeCapabilityEnabled = new() { IotEdge = true };
+        private readonly ProvisioningDeviceCapabilities _optionalEdgeCapabilityDisabled = new() { IotEdge = false };
 
         private readonly ProvisioningServiceClient _provisioningServiceClient;
 
@@ -68,9 +68,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Samples
                 DeviceId = _deviceId,
                 ProvisioningStatus = OptionalProvisioningStatus,
                 Capabilities = _optionalEdgeCapabilityEnabled,
-                InitialTwinState = new TwinState(
+                InitialTwinState = new ProvisioningTwinState(
                     tags: null,
-                    desiredProperties: new TwinCollection
+                    desiredProperties: new ProvisioningTwinProperties
                     {
                         ["Brand"] = "Contoso",
                         ["Model"] = "SSC4",

--- a/provisioning/service/samples/Getting Started/IndividualEnrollmentX509Sample/IndividualEnrollmentX509Sample.cs
+++ b/provisioning/service/samples/Getting Started/IndividualEnrollmentX509Sample/IndividualEnrollmentX509Sample.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Samples
         private readonly string _deviceId;
 
         private const ProvisioningStatus OptionalProvisioningStatus = ProvisioningStatus.Enabled;
-        private readonly DeviceCapabilities _optionalEdgeCapabilityEnabled = new() { IotEdge = true };
-        private readonly DeviceCapabilities _optionalEdgeCapabilityDisabled = new() { IotEdge = false };
+        private readonly ProvisioningDeviceCapabilities _optionalEdgeCapabilityEnabled = new() { IotEdge = true };
+        private readonly ProvisioningDeviceCapabilities _optionalEdgeCapabilityDisabled = new() { IotEdge = false };
 
         public IndividualEnrollmentX509Sample(ProvisioningServiceClient provisioningServiceClient, X509Certificate2 issuerCertificate, string deviceId, string registrationId)
         {
@@ -66,9 +66,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Samples
                 DeviceId = _deviceId,
                 ProvisioningStatus = OptionalProvisioningStatus,
                 Capabilities = _optionalEdgeCapabilityEnabled,
-                InitialTwinState = new TwinState(
+                InitialTwinState = new ProvisioningTwinState(
                     tags: null,
-                    desiredProperties: new TwinCollection
+                    desiredProperties: new ProvisioningTwinProperties
                     {
                         ["Brand"] = "Contoso",
                         ["Model"] = "SSC4",

--- a/provisioning/service/samples/Getting Started/IndividualEnrollmentX509Sample/IndividualEnrollmentX509Sample.cs
+++ b/provisioning/service/samples/Getting Started/IndividualEnrollmentX509Sample/IndividualEnrollmentX509Sample.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Samples
         private readonly string _deviceId;
 
         private const ProvisioningStatus OptionalProvisioningStatus = ProvisioningStatus.Enabled;
-        private readonly ProvisioningDeviceCapabilities _optionalEdgeCapabilityEnabled = new() { IotEdge = true };
-        private readonly ProvisioningDeviceCapabilities _optionalEdgeCapabilityDisabled = new() { IotEdge = false };
+        private readonly ProvisioningClientCapabilities _optionalEdgeCapabilityEnabled = new() { IotEdge = true };
+        private readonly ProvisioningClientCapabilities _optionalEdgeCapabilityDisabled = new() { IotEdge = false };
 
         public IndividualEnrollmentX509Sample(ProvisioningServiceClient provisioningServiceClient, X509Certificate2 issuerCertificate, string deviceId, string registrationId)
         {

--- a/provisioning/service/src/Models/EnrollmentGroup.cs
+++ b/provisioning/service/src/Models/EnrollmentGroup.cs
@@ -130,12 +130,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             string enrollmentGroupId,
             AttestationMechanism attestation,
             string iotHubHostName,
-            TwinState initialTwinState,
+            ProvisioningTwinState initialTwinState,
             ProvisioningStatus? provisioningStatus,
             DateTimeOffset createdOnUtc,
             DateTimeOffset lastUpdatedOnUtc,
             ETag eTag,
-            DeviceCapabilities capabilities)
+            ProvisioningDeviceCapabilities capabilities)
         {
             if (attestation == null)
             {
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Initial twin state.
         /// </summary>
         [JsonProperty(PropertyName = "initialTwin", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public TwinState InitialTwinState { get; set; }
+        public ProvisioningTwinState InitialTwinState { get; set; }
 
         /// <summary>
         /// The provisioning status.
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Capabilities of the device.
         /// </summary>
         [JsonProperty(PropertyName = "capabilities", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public DeviceCapabilities Capabilities { get; set; }
+        public ProvisioningDeviceCapabilities Capabilities { get; set; }
 
         /// <summary>
         /// The behavior when a device is re-provisioned to an IoT hub.

--- a/provisioning/service/src/Models/EnrollmentGroup.cs
+++ b/provisioning/service/src/Models/EnrollmentGroup.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             DateTimeOffset createdOnUtc,
             DateTimeOffset lastUpdatedOnUtc,
             ETag eTag,
-            ProvisioningDeviceCapabilities capabilities)
+            ProvisioningClientCapabilities capabilities)
         {
             if (attestation == null)
             {
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Capabilities of the device.
         /// </summary>
         [JsonProperty(PropertyName = "capabilities", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public ProvisioningDeviceCapabilities Capabilities { get; set; }
+        public ProvisioningClientCapabilities Capabilities { get; set; }
 
         /// <summary>
         /// The behavior when a device is re-provisioned to an IoT hub.

--- a/provisioning/service/src/Models/IndividualEnrollment.cs
+++ b/provisioning/service/src/Models/IndividualEnrollment.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             DateTimeOffset createdOnUtc,
             DateTimeOffset lastUpdatedOnUtc,
             ETag eTag,
-            ProvisioningDeviceCapabilities capabilities)
+            ProvisioningClientCapabilities capabilities)
         {
             if (attestation == null)
             {
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Capabilities of the device.
         /// </summary>
         [JsonProperty(PropertyName = "capabilities", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public ProvisioningDeviceCapabilities Capabilities { get; set; }
+        public ProvisioningClientCapabilities Capabilities { get; set; }
 
         /// <summary>
         /// The behavior when a device is re-provisioned to an IoT hub.

--- a/provisioning/service/src/Models/IndividualEnrollment.cs
+++ b/provisioning/service/src/Models/IndividualEnrollment.cs
@@ -69,12 +69,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             AttestationMechanism attestation,
             string deviceId,
             string iotHubHostName,
-            TwinState initialTwinState,
+            ProvisioningTwinState initialTwinState,
             ProvisioningStatus? provisioningStatus,
             DateTimeOffset createdOnUtc,
             DateTimeOffset lastUpdatedOnUtc,
             ETag eTag,
-            DeviceCapabilities capabilities)
+            ProvisioningDeviceCapabilities capabilities)
         {
             if (attestation == null)
             {
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Initial twin state.
         /// </summary>
         [JsonProperty(PropertyName = "initialTwin", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public TwinState InitialTwinState { get; set; }
+        public ProvisioningTwinState InitialTwinState { get; set; }
 
         /// <summary>
         /// The provisioning status.
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Capabilities of the device.
         /// </summary>
         [JsonProperty(PropertyName = "capabilities", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public DeviceCapabilities Capabilities { get; set; }
+        public ProvisioningDeviceCapabilities Capabilities { get; set; }
 
         /// <summary>
         /// The behavior when a device is re-provisioned to an IoT hub.

--- a/provisioning/service/src/Twin/ProvisioningClientCapabilities.cs
+++ b/provisioning/service/src/Twin/ProvisioningClientCapabilities.cs
@@ -3,17 +3,17 @@
 
 using Newtonsoft.Json;
 
-namespace Microsoft.Azure.Devices
+namespace Microsoft.Azure.Devices.Provisioning.Service
 {
     /// <summary>
     /// Status of capabilities enabled on the device.
     /// </summary>
-    public class DeviceCapabilities
+    public class ProvisioningClientCapabilities
     {
         /// <summary>
-        /// Indicates if the device is an IoT Edge device.
+        /// IoT Edge capability.
         /// </summary>
         [JsonProperty(PropertyName = "iotEdge")]
-        public bool IsIotEdge { get; set; }
+        public bool IotEdge { get; set; }
     }
 }

--- a/provisioning/service/src/Twin/ProvisioningDeviceCapabilities.cs
+++ b/provisioning/service/src/Twin/ProvisioningDeviceCapabilities.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// <summary>
     /// Status of capabilities enabled on the device.
     /// </summary>
-    public class DeviceCapabilities
+    public class ProvisioningDeviceCapabilities
     {
         /// <summary>
         /// IoT Edge capability.

--- a/provisioning/service/src/Twin/ProvisioningTwinDocument.cs
+++ b/provisioning/service/src/Twin/ProvisioningTwinDocument.cs
@@ -6,20 +6,20 @@ using Newtonsoft.Json;
 namespace Microsoft.Azure.Devices.Provisioning.Service
 {
     /// <summary>
-    /// Represents properties on a device twin.
+    /// Represents the different collections of properties on a client twin.
     /// </summary>
-    public class TwinProperties
+    public class ProvisioningTwinDocument
     {
         /// <summary>
         /// Gets and sets the twin desired properties.
         /// </summary>
         [JsonProperty(PropertyName = "desired", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public TwinCollection Desired { get; set; } = new();
+        public ProvisioningTwinProperties Desired { get; set; } = new();
 
         /// <summary>
         /// Gets and sets the twin reported properties.
         /// </summary>
         [JsonProperty(PropertyName = "reported", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public TwinCollection Reported { get; set; } = new();
+        public ProvisioningTwinProperties Reported { get; set; } = new();
     }
 }

--- a/provisioning/service/src/Twin/ProvisioningTwinMetadata.cs
+++ b/provisioning/service/src/Twin/ProvisioningTwinMetadata.cs
@@ -6,16 +6,16 @@ using System;
 namespace Microsoft.Azure.Devices.Provisioning.Service
 {
     /// <summary>
-    /// Metadata for properties in a <see cref="TwinCollection"/>.
+    /// Metadata for properties in a <see cref="ProvisioningTwinProperties"/>.
     /// </summary>
-    public sealed class TwinMetadata
+    public sealed class ProvisioningTwinMetadata
     {
         /// <summary>
         /// Creates an instance of this class.
         /// </summary>
         /// <param name="lastUpdatedOn">When the property was last updated.</param>
         /// <param name="lastUpdatedVersion">The version of the property when updated.</param>
-        public TwinMetadata(DateTimeOffset lastUpdatedOn, long? lastUpdatedVersion)
+        public ProvisioningTwinMetadata(DateTimeOffset lastUpdatedOn, long? lastUpdatedVersion)
         {
             LastUpdatedOnUtc = lastUpdatedOn;
             LastUpdatedVersion = lastUpdatedVersion;

--- a/provisioning/service/src/Twin/ProvisioningTwinProperties.cs
+++ b/provisioning/service/src/Twin/ProvisioningTwinProperties.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -13,12 +12,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// <summary>
     /// Represents a collection of properties for device twin.
     /// </summary>
-    [SuppressMessage(
-        "Microsoft.Design",
-        "CA1010:CollectionsShouldImplementGenericInterface",
-        Justification = "Public API: this was not designed to be a generic collection.")]
-    [JsonConverter(typeof(TwinCollectionJsonConverter))]
-    public class TwinCollection : IEnumerable
+    [JsonConverter(typeof(ProvisioningTwinPropertiesJsonConverter))]
+    public class ProvisioningTwinProperties : IEnumerable
     {
         internal const string MetadataName = "$metadata";
         internal const string LastUpdatedName = "$lastUpdated";
@@ -30,7 +25,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Creates an instance of this class.
         /// Shouldn't use this constructor since _metadata is null and calling GetLastUpdated can result in NullReferenceException.
         /// </summary>
-        public TwinCollection()
+        public ProvisioningTwinProperties()
             : this((JObject)null)
         {
         }
@@ -39,7 +34,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Creates an instance of this class using a JSON fragment as the body.
         /// </summary>
         /// <param name="twinJson">JSON fragment containing the twin data.</param>
-        public TwinCollection(string twinJson)
+        public ProvisioningTwinProperties(string twinJson)
             : this(JObject.Parse(twinJson))
         {
         }
@@ -49,7 +44,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </summary>
         /// <param name="twinJson">JSON fragment containing the twin data.</param>
         /// <param name="metadataJson">JSON fragment containing the metadata.</param>
-        public TwinCollection(string twinJson, string metadataJson)
+        public ProvisioningTwinProperties(string twinJson, string metadataJson)
             : this(JObject.Parse(twinJson), JObject.Parse(metadataJson))
         {
         }
@@ -58,7 +53,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Creates an instance of this class using a JSON fragment as the body.
         /// </summary>
         /// <param name="twinJson">JSON fragment containing the twin data.</param>
-        internal TwinCollection(JObject twinJson)
+        internal ProvisioningTwinProperties(JObject twinJson)
         {
             JObject = twinJson ?? new JObject();
 
@@ -73,7 +68,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </summary>
         /// <param name="twinJson">JSON fragment containing the twin data.</param>
         /// <param name="metadataJson">JSON fragment containing the metadata.</param>
-        public TwinCollection(JObject twinJson, JObject metadataJson)
+        public ProvisioningTwinProperties(JObject twinJson, JObject metadataJson)
         {
             JObject = twinJson ?? new JObject();
             _metadata = metadataJson;
@@ -157,9 +152,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Gets the Metadata for this property.
         /// </summary>
         /// <returns>Metadata instance representing the metadata for this property.</returns>
-        public TwinMetadata GetMetadata()
+        public ProvisioningTwinMetadata GetMetadata()
         {
-            return new TwinMetadata(GetLastUpdatedOnUtc(), GetLastUpdatedVersion());
+            return new ProvisioningTwinMetadata(GetLastUpdatedOnUtc(), GetLastUpdatedVersion());
         }
 
         /// <summary>
@@ -217,15 +212,15 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="result">The value to return from the property collection.</param>
         /// <returns>
         /// A <see cref="JToken"/> as an <see cref="object"/> if the metadata is not present; otherwise it will return a
-        /// <see cref="TwinCollection"/>, a <see cref="TwinCollectionArray"/> or a <see cref="TwinCollectionValue"/>.
+        /// <see cref="ProvisioningTwinProperties"/>, a <see cref="ProvisioningTwinPropertiesArray"/> or a <see cref="ProvisioningTwinPropertyValue"/>.
         /// </returns>
         /// <remarks>
-        /// If this method is used with a <see cref="TwinCollection"/> returned from a DeviceClient it will always return a
-        /// <see cref="JToken"/>. However, if you are using this method with a <see cref="TwinCollection"/> returned from a
+        /// If this method is used with a <see cref="ProvisioningTwinProperties"/> returned from a DeviceClient it will always return a
+        /// <see cref="JToken"/>. However, if you are using this method with a <see cref="ProvisioningTwinProperties"/> returned from a
         /// RegistryManager client, it will return the corresponding type depending on what is stored in the properties collection.
         ///
-        /// For example a <see cref="List{T}"/> would return a <see cref="TwinCollectionArray"/>, with the metadata intact, when used with
-        /// a <see cref="TwinCollection"/> returned from a `IotHubServiceClient`.`TwinsClient`. If you need this method to always return a
+        /// For example a <see cref="List{T}"/> would return a <see cref="ProvisioningTwinPropertiesArray"/>, with the metadata intact, when used with
+        /// a <see cref="ProvisioningTwinProperties"/> returned from a `IotHubServiceClient`.`TwinsClient`. If you need this method to always return a
         /// <see cref="JToken"/> please see the <see cref="ClearMetadata"/> method for more information.
         /// </remarks>
         private bool TryGetMemberInternal(string propertyName, out object result)
@@ -240,15 +235,15 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             {
                 if (value is JValue jsonValue)
                 {
-                    result = new TwinCollectionValue(jsonValue, (JObject)_metadata[propertyName]);
+                    result = new ProvisioningTwinPropertyValue(jsonValue, (JObject)_metadata[propertyName]);
                 }
                 else if (value is JArray jsonArray)
                 {
-                    result = new TwinCollectionArray(jsonArray, (JObject)_metadata[propertyName]);
+                    result = new ProvisioningTwinPropertiesArray(jsonArray, (JObject)_metadata[propertyName]);
                 }
                 else
                 {
-                    result = new TwinCollection(value as JObject, (JObject)_metadata[propertyName]);
+                    result = new ProvisioningTwinProperties(value as JObject, (JObject)_metadata[propertyName]);
                 }
             }
             else

--- a/provisioning/service/src/Twin/ProvisioningTwinPropertiesArray.cs
+++ b/provisioning/service/src/Twin/ProvisioningTwinPropertiesArray.cs
@@ -3,28 +3,28 @@
 
 using System;
 using Newtonsoft.Json.Linq;
-using static Microsoft.Azure.Devices.TwinCollection;
+using static Microsoft.Azure.Devices.Provisioning.Service.ProvisioningTwinProperties;
 
-namespace Microsoft.Azure.Devices
+namespace Microsoft.Azure.Devices.Provisioning.Service
 {
     /// <summary>
-    /// Represents a property value in a <see cref="TwinCollection"/>.
+    /// Represents a property array in a <see cref="ProvisioningTwinProperties"/>.
     /// </summary>
-    public class TwinCollectionValue : JValue
+    public class ProvisioningTwinPropertiesArray : JArray
     {
         private readonly JObject _metadata;
 
-        internal TwinCollectionValue(JValue jValue, JObject metadata)
-            : base(jValue)
+        internal ProvisioningTwinPropertiesArray(JArray jArray, JObject metadata)
+            : base(jArray)
         {
-            _metadata = metadata;
+            _metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
         }
 
         /// <summary>
         /// Gets the value for the given property name.
         /// </summary>
-        /// <param name="propertyName">Property name to look up.</param>
-        /// <returns>Property value, if present.</returns>
+        /// <param name="propertyName">Property Name to lookup.</param>
+        /// <returns>Property value, if present</returns>
         /// <exception cref="InvalidOperationException">When the specified <paramref name="propertyName"/> does not exist in the collection.</exception>
         public dynamic this[string propertyName]
         {
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices
                     MetadataName => GetMetadata(),
                     LastUpdatedName => GetLastUpdatedOnUtc(),
                     LastUpdatedVersionName => GetLastUpdatedVersion(),
-                    _ => throw new InvalidOperationException($"{nameof(TwinCollectionValue)} does not contain a definition for '{propertyName}'."),
+                    _ => throw new InvalidOperationException($"{nameof(ProvisioningTwinPropertiesArray)} does not contain a definition for '{propertyName}'."),
                 };
             }
         }
@@ -44,9 +44,9 @@ namespace Microsoft.Azure.Devices
         /// Gets the metadata for this property.
         /// </summary>
         /// <returns>Metadata instance representing the metadata for this property.</returns>
-        public TwinMetadata GetMetadata()
+        public ProvisioningTwinMetadata GetMetadata()
         {
-            return new TwinMetadata(GetLastUpdatedOnUtc(), GetLastUpdatedVersion());
+            return new ProvisioningTwinMetadata(GetLastUpdatedOnUtc(), GetLastUpdatedVersion());
         }
 
         /// <summary>

--- a/provisioning/service/src/Twin/ProvisioningTwinPropertiesJsonConverter.cs
+++ b/provisioning/service/src/Twin/ProvisioningTwinPropertiesJsonConverter.cs
@@ -6,9 +6,9 @@ using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Devices
+namespace Microsoft.Azure.Devices.Provisioning.Service
 {
-    internal class TwinCollectionJsonConverter : JsonConverter
+    internal class ProvisioningTwinPropertiesJsonConverter : JsonConverter
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
@@ -18,7 +18,8 @@ namespace Microsoft.Azure.Devices
                 return;
             }
 
-            if (value is not TwinCollection properties)
+            var properties = value as ProvisioningTwinProperties;
+            if (properties == null)
             {
                 throw new InvalidOperationException("Object passed is not of type TwinCollection.");
             }
@@ -26,11 +27,12 @@ namespace Microsoft.Azure.Devices
             serializer.Serialize(writer, properties.JObject);
         }
 
-        public override bool CanConvert(Type objectType) => typeof(TwinCollection).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+        public override bool CanConvert(Type objectType) => typeof(ProvisioningTwinProperties).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            return new TwinCollection(JToken.ReadFrom(reader) as JObject);
+            return new ProvisioningTwinProperties(JToken.ReadFrom(reader) as JObject);
         }
     }
 }
+

--- a/provisioning/service/src/Twin/ProvisioningTwinPropertyValue.cs
+++ b/provisioning/service/src/Twin/ProvisioningTwinPropertyValue.cs
@@ -3,28 +3,28 @@
 
 using System;
 using Newtonsoft.Json.Linq;
-using static Microsoft.Azure.Devices.Provisioning.Service.TwinCollection;
+using static Microsoft.Azure.Devices.Provisioning.Service.ProvisioningTwinProperties;
 
 namespace Microsoft.Azure.Devices.Provisioning.Service
 {
     /// <summary>
-    /// Represents a property array in a <see cref="TwinCollection"/>.
+    /// Represents a property value in a <see cref="ProvisioningTwinProperties"/>.
     /// </summary>
-    public class TwinCollectionArray : JArray
+    public class ProvisioningTwinPropertyValue : JValue
     {
         private readonly JObject _metadata;
 
-        internal TwinCollectionArray(JArray jArray, JObject metadata)
-            : base(jArray)
+        internal ProvisioningTwinPropertyValue(JValue jValue, JObject metadata)
+            : base(jValue)
         {
-            _metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
+            _metadata = metadata;
         }
 
         /// <summary>
         /// Gets the value for the given property name.
         /// </summary>
         /// <param name="propertyName">Property Name to lookup.</param>
-        /// <returns>Property value, if present</returns>
+        /// <returns>Property value, if present.</returns>
         /// <exception cref="InvalidOperationException">When the specified <paramref name="propertyName"/> does not exist in the collection.</exception>
         public dynamic this[string propertyName]
         {
@@ -35,22 +35,22 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                     MetadataName => GetMetadata(),
                     LastUpdatedName => GetLastUpdatedOnUtc(),
                     LastUpdatedVersionName => GetLastUpdatedVersion(),
-                    _ => throw new InvalidOperationException($"{nameof(TwinCollectionArray)} does not contain a definition for '{propertyName}'."),
+                    _ => throw new InvalidOperationException($"{nameof(ProvisioningTwinPropertyValue)} does not contain a definition for '{propertyName}'."),
                 };
             }
         }
 
         /// <summary>
-        /// Gets the metadata for this property.
+        /// Gets the Metadata for this property.
         /// </summary>
         /// <returns>Metadata instance representing the metadata for this property.</returns>
-        public TwinMetadata GetMetadata()
+        public ProvisioningTwinMetadata GetMetadata()
         {
-            return new TwinMetadata(GetLastUpdatedOnUtc(), GetLastUpdatedVersion());
+            return new ProvisioningTwinMetadata(GetLastUpdatedOnUtc(), GetLastUpdatedVersion());
         }
 
         /// <summary>
-        /// Gets the time when this property was last updated in UTC.
+        /// Gets the time when this property was last updated.
         /// </summary>
         public DateTimeOffset GetLastUpdatedOnUtc()
         {
@@ -61,13 +61,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 return lastUpdatedOnUtc;
             }
 
-            return default;
+            return DateTimeOffset.MinValue;
         }
 
         /// <summary>
-        /// Gets the last updated version for this property.
+        /// Gets the LastUpdatedVersion for this property.
         /// </summary>
-        /// <returns>Last updated version if present, null otherwise.</returns>
+        /// <returns>LastUpdatdVersion if present, null otherwise.</returns>
         public long? GetLastUpdatedVersion()
         {
             return (long?)_metadata?[LastUpdatedVersionName];

--- a/provisioning/service/src/Twin/ProvisioningTwinState.cs
+++ b/provisioning/service/src/Twin/ProvisioningTwinState.cs
@@ -1,38 +1,27 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Provisioning.Service
 {
     /// <summary>
-    /// Representation of a single Twin initial state for the Device Provisioning Service.
+    /// Representation of a single twin initial state.
     /// </summary>
     /// <remarks>
-    /// The TwinState can contain one <see cref="ProvisioningTwinProperties"/> of Tags, and one
-    /// <see cref="ProvisioningTwinProperties"/> of properties.desired.
-    ///
     /// Each entity in the collections can contain a associated <see cref="ProvisioningTwinMetadata"/>.
     ///
     /// These metadata are provided by the Service and contains information about the last
-    ///     updated date time, and version.
+    /// updated date time, and version.
     /// </remarks>
     /// <example>
-    /// For instance, the following is a valid TwinState, represented as <c>initialTwin</c> in the rest API.
+    /// For instance, the following is a valid twin state, represented as <c>initialTwin</c> in the rest API.
     /// <code>
     /// {
     ///     "initialTwin": {
     ///         "tags":{
     ///             "SpeedUnity":"MPH",
-    ///             "$metadata":{
-    ///                 "$lastUpdated":"2017-09-21T02:07:44.238Z",
-    ///                 "$lastUpdatedVersion":4,
-    ///                 "SpeedUnity":{
-    ///                     "$lastUpdated":"2017-09-21T02:07:44.238Z",
-    ///                     "$lastUpdatedVersion":4
-    ///                 }
-    ///             },
-    ///             "$version":4
     ///         }
     ///         "properties":{
     ///             "desired": {
@@ -69,7 +58,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         private ProvisioningTwinDocument _properties;
 
         /// <summary>
-        /// Creates an instance of TwinState.
+        /// Creates an instance of this class.
         /// </summary>
         /// <remarks>
         /// This constructor creates an instance of the TwinState with the provided twin collection tags and desired properties.
@@ -81,7 +70,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         ///     "initialTwin": {
         ///         "tags":{
         ///             "SpeedUnity":"MPH",
-        ///             "$version":4
         ///         }
         ///         "properties":{
         ///             "desired":{
@@ -98,14 +86,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </example>
         /// <param name="tags">The twin collection with the initial tags state. It can be null.</param>
         /// <param name="desiredProperties">The twin collection with the initial desired properties. It can be null.</param>
-        public ProvisioningTwinState(ProvisioningTwinProperties tags, ProvisioningTwinProperties desiredProperties)
+        public ProvisioningTwinState(IDictionary<string, object> tags, ProvisioningTwinProperties desiredProperties)
         {
             Tags = tags;
             DesiredProperties = desiredProperties;
         }
 
         [JsonConstructor]
-        private ProvisioningTwinState(ProvisioningTwinProperties tags, ProvisioningTwinDocument properties)
+        private ProvisioningTwinState(IDictionary<string, object> tags, ProvisioningTwinDocument properties)
         {
             Tags = tags;
             DesiredProperties = properties?.Desired;
@@ -115,7 +103,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Getter and setter the for tags.
         /// </summary>
         [JsonProperty(PropertyName = "tags", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public ProvisioningTwinProperties Tags { get; set; }
+        public IDictionary<string, object> Tags { get; set; }
 
         /// <summary>
         /// Getter and setter the desired properties.

--- a/provisioning/service/src/Twin/ProvisioningTwinState.cs
+++ b/provisioning/service/src/Twin/ProvisioningTwinState.cs
@@ -9,10 +9,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// Representation of a single Twin initial state for the Device Provisioning Service.
     /// </summary>
     /// <remarks>
-    /// The TwinState can contain one <see cref="TwinCollection"/> of Tags, and one
-    /// <see cref="TwinCollection"/> of properties.desired.
+    /// The TwinState can contain one <see cref="ProvisioningTwinProperties"/> of Tags, and one
+    /// <see cref="ProvisioningTwinProperties"/> of properties.desired.
     ///
-    /// Each entity in the collections can contain a associated <see cref="TwinMetadata"/>.
+    /// Each entity in the collections can contain a associated <see cref="ProvisioningTwinMetadata"/>.
     ///
     /// These metadata are provided by the Service and contains information about the last
     ///     updated date time, and version.
@@ -63,10 +63,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// }
     /// </code>
     /// </example>
-    public class TwinState
+    public class ProvisioningTwinState
     {
         [JsonProperty(PropertyName = "properties", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        private TwinProperties _properties;
+        private ProvisioningTwinDocument _properties;
 
         /// <summary>
         /// Creates an instance of TwinState.
@@ -98,14 +98,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </example>
         /// <param name="tags">The twin collection with the initial tags state. It can be null.</param>
         /// <param name="desiredProperties">The twin collection with the initial desired properties. It can be null.</param>
-        public TwinState(TwinCollection tags, TwinCollection desiredProperties)
+        public ProvisioningTwinState(ProvisioningTwinProperties tags, ProvisioningTwinProperties desiredProperties)
         {
             Tags = tags;
             DesiredProperties = desiredProperties;
         }
 
         [JsonConstructor]
-        private TwinState(TwinCollection tags, TwinProperties properties)
+        private ProvisioningTwinState(ProvisioningTwinProperties tags, ProvisioningTwinDocument properties)
         {
             Tags = tags;
             DesiredProperties = properties?.Desired;
@@ -115,19 +115,19 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Getter and setter the for tags.
         /// </summary>
         [JsonProperty(PropertyName = "tags", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public TwinCollection Tags { get; set; }
+        public ProvisioningTwinProperties Tags { get; set; }
 
         /// <summary>
         /// Getter and setter the desired properties.
         /// </summary>
         [JsonIgnore]
-        public TwinCollection DesiredProperties
+        public ProvisioningTwinProperties DesiredProperties
         {
             get => _properties?.Desired;
 
             set => _properties = value == null
                 ? null
-                : new TwinProperties
+                : new ProvisioningTwinDocument
                     {
                         Desired = value,
                         Reported = null,

--- a/provisioning/service/tests/Config/IndividualEnrollmentTests.cs
+++ b/provisioning/service/tests/Config/IndividualEnrollmentTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         private const string SampleLastUpdatedDateTimeUTCString = "2017-11-14T12:34:18.321Z";
         private readonly DateTime _sampleLastUpdatedDateTimeUTC = new(2017, 11, 14, 12, 34, 18, 321, DateTimeKind.Utc);
         private static ETag SampleEtag = new ETag("00000000-0000-0000-0000-00000000000");
-        private readonly DeviceCapabilities _sampleEdgeCapabilityTrue = new() { IotEdge = true };
-        private readonly DeviceCapabilities _sampleEdgeCapabilityFalse = new() { IotEdge = false };
+        private readonly ProvisioningDeviceCapabilities _sampleEdgeCapabilityTrue = new() { IotEdge = true };
+        private readonly ProvisioningDeviceCapabilities _sampleEdgeCapabilityFalse = new() { IotEdge = false };
 
         private const string SampleEndorsementKey =
             "AToAAQALAAMAsgAgg3GXZ0SEs/gakMyNRqXXJP1S124GUgtk8qHaGzMUaaoABgCAAEMAEAgAAAAAAAEAxsj" +

--- a/provisioning/service/tests/Config/IndividualEnrollmentTests.cs
+++ b/provisioning/service/tests/Config/IndividualEnrollmentTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         private const string SampleLastUpdatedDateTimeUTCString = "2017-11-14T12:34:18.321Z";
         private readonly DateTime _sampleLastUpdatedDateTimeUTC = new(2017, 11, 14, 12, 34, 18, 321, DateTimeKind.Utc);
         private static ETag SampleEtag = new ETag("00000000-0000-0000-0000-00000000000");
-        private readonly ProvisioningDeviceCapabilities _sampleEdgeCapabilityTrue = new() { IotEdge = true };
-        private readonly ProvisioningDeviceCapabilities _sampleEdgeCapabilityFalse = new() { IotEdge = false };
+        private readonly ProvisioningClientCapabilities _sampleEdgeCapabilityTrue = new() { IotEdge = true };
+        private readonly ProvisioningClientCapabilities _sampleEdgeCapabilityFalse = new() { IotEdge = false };
 
         private const string SampleEndorsementKey =
             "AToAAQALAAMAsgAgg3GXZ0SEs/gakMyNRqXXJP1S124GUgtk8qHaGzMUaaoABgCAAEMAEAgAAAAAAAEAxsj" +

--- a/provisioning/service/tests/Config/TwinStateTests.cs
+++ b/provisioning/service/tests/Config/TwinStateTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 
@@ -10,13 +11,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
     [TestCategory("Unit")]
     public class TwinStateTests
     {
-        private ProvisioningTwinProperties SampleTags = new ProvisioningTwinProperties
+        private readonly Dictionary<string, object> _sampleTags = new()
         {
-            ["SpeedUnity"] = "MPH",
-            ["ConsumeUnity"] = "MPG",
+            { "SpeedUnity", "MPH" },
+            { "ConsumeUnity", "MPG" },
         };
 
-        private ProvisioningTwinProperties SampleDesiredProperties = new ProvisioningTwinProperties
+        private readonly ProvisioningTwinProperties _sampleDesiredProperties = new ProvisioningTwinProperties
         {
             ["Brand"] = "NiceCar",
             ["Model"] = "SNC4",
@@ -60,14 +61,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
             "  }" +
             "}";
 
-        /* SRS_TWIN_STATE_21_001: [The constructor shall store the provided tags and desiredProperties.] */
-        /* SRS_TWIN_STATE_21_002: [If the _properties is null, the get.DesiredProperties shall return null.] */
-        /* SRS_TWIN_STATE_21_004: [If the value is null, the set.DesiredProperties shall set _properties as null.] */
         [TestMethod]
         public void TwinStateSucceedOnNull()
         {
             // arrange
-            ProvisioningTwinProperties tags = null;
+            Dictionary<string, object> tags = null;
             ProvisioningTwinProperties desiredProperties = null;
 
             // act
@@ -82,7 +80,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TwinStateSucceedOnTagsWitoutDesiredProperties()
         {
             // arrange
-            ProvisioningTwinProperties tags = SampleTags;
+            Dictionary<string, object> tags = _sampleTags;
             ProvisioningTwinProperties desiredProperties = null;
 
             // act
@@ -93,15 +91,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
             Assert.IsNull(initialTwin.DesiredProperties);
         }
 
-        /* SRS_TWIN_STATE_21_003: [The get.DesiredProperties shall return the content of _properties.Desired.] */
-        /* SRS_TWIN_STATE_21_005: [The set.DesiredProperties shall convert the provided value in a 
-                                    TwinPropertyes.Desired and store it as _properties.] */
         [TestMethod]
         public void TwinStateSucceedOnDesiredPropertiesWitoutTags()
         {
             // arrange
-            ProvisioningTwinProperties tags = null;
-            ProvisioningTwinProperties desiredProperties = SampleDesiredProperties;
+            Dictionary<string, object> tags = null;
+            ProvisioningTwinProperties desiredProperties = _sampleDesiredProperties;
 
             // act
             var initialTwin = new ProvisioningTwinState(tags, desiredProperties);
@@ -115,8 +110,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TwinStateSucceedOnDesiredPropertiesAndTags()
         {
             // arrange
-            ProvisioningTwinProperties tags = SampleTags;
-            ProvisioningTwinProperties desiredProperties = SampleDesiredProperties;
+            Dictionary<string, object> tags = _sampleTags;
+            ProvisioningTwinProperties desiredProperties = _sampleDesiredProperties;
 
             // act
             var initialTwin = new ProvisioningTwinState(tags, desiredProperties);
@@ -130,7 +125,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TwinStateSucceedOnTagsToJson()
         {
             // arrange
-            ProvisioningTwinProperties tags = SampleTags;
+            Dictionary<string, object> tags = _sampleTags;
             ProvisioningTwinProperties desiredProperties = null;
             var initialTwin = new ProvisioningTwinState(tags, desiredProperties);
 
@@ -145,8 +140,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TwinStateSucceedOnDesiredPropertiesToJson()
         {
             // arrange
-            ProvisioningTwinProperties tags = null;
-            ProvisioningTwinProperties desiredProperties = SampleDesiredProperties;
+            Dictionary<string, object> tags = null;
+            ProvisioningTwinProperties desiredProperties = _sampleDesiredProperties;
             var initialTwin = new ProvisioningTwinState(tags, desiredProperties);
 
             // act
@@ -160,8 +155,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TwinStateSucceedOnToJson()
         {
             // arrange
-            ProvisioningTwinProperties tags = SampleTags;
-            ProvisioningTwinProperties desiredProperties = SampleDesiredProperties;
+            Dictionary<string, object> tags = _sampleTags;
+            ProvisioningTwinProperties desiredProperties = _sampleDesiredProperties;
             var initialTwin = new ProvisioningTwinState(tags, desiredProperties);
 
             // act
@@ -174,10 +169,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         [TestMethod]
         public void TwinStateSucceedOnFromJson()
         {
-            // arrange
-            ProvisioningTwinProperties tags = SampleTags;
-            ProvisioningTwinProperties desiredProperties = SampleDesiredProperties;
-
             // act
             ProvisioningTwinState initialTwin = JsonConvert.DeserializeObject<ProvisioningTwinState>(FullInitialTwinJSON);
 

--- a/provisioning/service/tests/Config/TwinStateTests.cs
+++ b/provisioning/service/tests/Config/TwinStateTests.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
     [TestCategory("Unit")]
     public class TwinStateTests
     {
-        private TwinCollection SampleTags = new TwinCollection
+        private ProvisioningTwinProperties SampleTags = new ProvisioningTwinProperties
         {
             ["SpeedUnity"] = "MPH",
             ["ConsumeUnity"] = "MPG",
         };
 
-        private TwinCollection SampleDesiredProperties = new TwinCollection
+        private ProvisioningTwinProperties SampleDesiredProperties = new ProvisioningTwinProperties
         {
             ["Brand"] = "NiceCar",
             ["Model"] = "SNC4",
@@ -67,11 +67,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TwinStateSucceedOnNull()
         {
             // arrange
-            TwinCollection tags = null;
-            TwinCollection desiredProperties = null;
+            ProvisioningTwinProperties tags = null;
+            ProvisioningTwinProperties desiredProperties = null;
 
             // act
-            var initialTwin = new TwinState(tags, desiredProperties);
+            var initialTwin = new ProvisioningTwinState(tags, desiredProperties);
 
             // assert
             Assert.IsNull(initialTwin.Tags);
@@ -82,11 +82,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TwinStateSucceedOnTagsWitoutDesiredProperties()
         {
             // arrange
-            TwinCollection tags = SampleTags;
-            TwinCollection desiredProperties = null;
+            ProvisioningTwinProperties tags = SampleTags;
+            ProvisioningTwinProperties desiredProperties = null;
 
             // act
-            var initialTwin = new TwinState(tags, desiredProperties);
+            var initialTwin = new ProvisioningTwinState(tags, desiredProperties);
 
             // assert
             Assert.AreEqual(tags, initialTwin.Tags);
@@ -100,11 +100,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TwinStateSucceedOnDesiredPropertiesWitoutTags()
         {
             // arrange
-            TwinCollection tags = null;
-            TwinCollection desiredProperties = SampleDesiredProperties;
+            ProvisioningTwinProperties tags = null;
+            ProvisioningTwinProperties desiredProperties = SampleDesiredProperties;
 
             // act
-            var initialTwin = new TwinState(tags, desiredProperties);
+            var initialTwin = new ProvisioningTwinState(tags, desiredProperties);
 
             // assert
             Assert.IsNull(initialTwin.Tags);
@@ -115,11 +115,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TwinStateSucceedOnDesiredPropertiesAndTags()
         {
             // arrange
-            TwinCollection tags = SampleTags;
-            TwinCollection desiredProperties = SampleDesiredProperties;
+            ProvisioningTwinProperties tags = SampleTags;
+            ProvisioningTwinProperties desiredProperties = SampleDesiredProperties;
 
             // act
-            var initialTwin = new TwinState(tags, desiredProperties);
+            var initialTwin = new ProvisioningTwinState(tags, desiredProperties);
 
             // assert
             Assert.AreEqual(tags, initialTwin.Tags);
@@ -130,9 +130,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TwinStateSucceedOnTagsToJson()
         {
             // arrange
-            TwinCollection tags = SampleTags;
-            TwinCollection desiredProperties = null;
-            var initialTwin = new TwinState(tags, desiredProperties);
+            ProvisioningTwinProperties tags = SampleTags;
+            ProvisioningTwinProperties desiredProperties = null;
+            var initialTwin = new ProvisioningTwinState(tags, desiredProperties);
 
             // act
             string jsonResult = JsonConvert.SerializeObject(initialTwin);
@@ -145,9 +145,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TwinStateSucceedOnDesiredPropertiesToJson()
         {
             // arrange
-            TwinCollection tags = null;
-            TwinCollection desiredProperties = SampleDesiredProperties;
-            var initialTwin = new TwinState(tags, desiredProperties);
+            ProvisioningTwinProperties tags = null;
+            ProvisioningTwinProperties desiredProperties = SampleDesiredProperties;
+            var initialTwin = new ProvisioningTwinState(tags, desiredProperties);
 
             // act
             string jsonResult = JsonConvert.SerializeObject(initialTwin);
@@ -160,9 +160,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TwinStateSucceedOnToJson()
         {
             // arrange
-            TwinCollection tags = SampleTags;
-            TwinCollection desiredProperties = SampleDesiredProperties;
-            var initialTwin = new TwinState(tags, desiredProperties);
+            ProvisioningTwinProperties tags = SampleTags;
+            ProvisioningTwinProperties desiredProperties = SampleDesiredProperties;
+            var initialTwin = new ProvisioningTwinState(tags, desiredProperties);
 
             // act
             string jsonResult = JsonConvert.SerializeObject(initialTwin);
@@ -175,11 +175,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void TwinStateSucceedOnFromJson()
         {
             // arrange
-            TwinCollection tags = SampleTags;
-            TwinCollection desiredProperties = SampleDesiredProperties;
+            ProvisioningTwinProperties tags = SampleTags;
+            ProvisioningTwinProperties desiredProperties = SampleDesiredProperties;
 
             // act
-            TwinState initialTwin = JsonConvert.DeserializeObject<TwinState>(FullInitialTwinJSON);
+            ProvisioningTwinState initialTwin = JsonConvert.DeserializeObject<ProvisioningTwinState>(FullInitialTwinJSON);
 
             // assert
             TestAssert.AreEqualJson(FullInitialTwinJSON, JsonConvert.SerializeObject(initialTwin));


### PR DESCRIPTION
Especially for customers that use our SDK clients together in the same file, we prefer to avoid naming conflicts that they otherwise have to disambiguate by using the full namespace (or aliasing types).

For this reason, I've renamed most twin types in hub service client to be `ClientTwin*` and in dps service client to be `ProvisioningTwin*`.

I also took a look at the other type names and resolved some wrongness (like DeviceStatus when it also applies to modules, so renamed to ClientStatus).

The other change was TwinCollection and TwinProperties. I spent more time on this than anything. The user doesn't really interact with the TwinCollection type except off of the Twin class. It contains the Desired and Reported properties. So, I renamed that to ClientTwinDocument, which isn't a great name but not one the user should ever use directly. That freed up the TwinProperties name for what was TwinCollection, so it is now ClientTwinProperties. The other related types followed suit, so ClientTwinPropertyValue and ClientTwinPropertyArray.

Finally, the hub device client has some small number of classes for twin. I renamed it from ClientTwin to just Twin.

Thoughts?