### PR TITLE
Turn SDK log capturing off by default for E2E tests

### DIFF
--- a/e2e/test/E2EMsTestBase.cs
+++ b/e2e/test/E2EMsTestBase.cs
@@ -31,11 +31,26 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         // The test timeout for e2e tests that involve testing token refresh
         protected const int TokenRefreshTestTimeoutMilliseconds = 20 * 60 * 1000; // 20 minutes
+        
+        private const string CollectSdkLogsEnvVar = "COLLECT_SDK_LOGS";
+        public static readonly bool CollectSdkLogs;
+
+        static E2EMsTestBase()
+        {
+            if (bool.TryParse(Environment.GetEnvironmentVariable(CollectSdkLogsEnvVar), out bool collectSdkLogs))
+            {
+                CollectSdkLogs = collectSdkLogs;
+            }
+        }
 
         [TestInitialize]
         public void TestInitialize()
         {
-            _listener = new ConsoleEventListener();
+            VerboseTestLogger.WriteLine($"SDK logs collection is '{CollectSdkLogs}' based on environment variable '{CollectSdkLogsEnvVar}'.");
+            if (CollectSdkLogs)
+            {
+                _listener = new ConsoleEventListener();
+            }
         }
 
         [TestCleanup]
@@ -56,7 +71,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             if (disposing)
             {
-                _listener.Dispose();
+                _listener?.Dispose();
             }
         }
     }


### PR DESCRIPTION
SDK logs are nice but the tests that run concurrently put logs into each other's console output. As the logs come at a significant cost to running E2E tests in a pipeline and given that the logs aren't exclusive to each test, I'm turning collection off by default.

To turn them on, set an environment variable of `COLLECT_SDK_LOGS` to `true`.