### PR TITLE
Turn SDK log collection off by default

### DIFF
--- a/e2e/test/E2EMsTestBase.cs
+++ b/e2e/test/E2EMsTestBase.cs
@@ -33,10 +33,25 @@ namespace Microsoft.Azure.Devices.E2ETests
         // The test timeout for e2e tests that involve testing token refresh
         protected const int TokenRefreshTestTimeoutMilliseconds = 20 * 60 * 1000; // 20 minutes
 
+        private const string CollectSdkLogsEnvVar = "COLLECT_SDK_LOGS";
+        public static readonly bool s_collectSdkLogs;
+
+        static E2EMsTestBase()
+        {
+            if (bool.TryParse(Environment.GetEnvironmentVariable(CollectSdkLogsEnvVar), out bool collectSdkLogs))
+            {
+                s_collectSdkLogs = collectSdkLogs;
+            }
+        }
+
         [TestInitialize]
         public void TestInitialize()
         {
-            _listener = new ConsoleEventListener();
+            VerboseTestLogger.WriteLine($"SDK logs collection is '{s_collectSdkLogs}' based on environment variable '{CollectSdkLogsEnvVar}'.");
+            if (s_collectSdkLogs)
+            {
+                _listener = new ConsoleEventListener();
+            }
         }
 
         [TestCleanup]
@@ -57,7 +72,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             if (disposing)
             {
-                _listener.Dispose();
+                _listener?.Dispose();
             }
         }
     }


### PR DESCRIPTION
Same, but for `main`.