### PR TITLE
Rename DPS exception types

### DIFF
--- a/SDK v2 migration guide.md
+++ b/SDK v2 migration guide.md
@@ -171,6 +171,7 @@ Find a client you currently use below, read the table of API name changes and us
 | `Message.ExpiryTimeUtc` | `TelemetryMessage.ExpiresOnUtc`, `IncomingMessage.ExpiresOnUtc` | See³ |
 | `MethodRequest` | `DirectMethodRequest` | Use full name of the operation type.⁴ |
 | `MethodResponse` | `DirectMethodResponse` | See⁴ |
+| `IotHubException` | `IotHubClientException` | Specify the exception is for Hub device and module client only. |
 
 #### ModuleClient
 
@@ -275,6 +276,7 @@ What was a loose affiliation of separate clients is now a consolidated client wi
 | `CloudToDeviceMethodResult` | `DirectMethodClientResponse` | See² |
 | `ServiceClient.GetFeedbackReceiver(...)` | `IotHubServiceClient.MessageFeedback.MessageFeedbackProcessor` | |
 | `ServiceClient.GetFileNotificationReceiver()` | `IotHubServiceClient.FileUploadNotifications.FileUploadNotificationProcessor` | |
+| `IotHubException` | `IotHubServiceException` | Specify the exception is for Hub service client only. |
 
 #### JobClient
 
@@ -331,6 +333,7 @@ What was a loose affiliation of separate clients is now a consolidated client wi
 | `ProvisioningRegistrationAdditionalData` | `RegistrationRequestPayload`| |
 | `DeviceRegistrationResult.CreatedDateTimeUtc` | `DeviceRegistrationResult.CreatedOnUtc` | Conforming to the naming guidelines by the Azure SDK team, where DateTime/Offset types have an "On" suffix (and "Utc" suffix when explicitly in UTC).¹ |
 | `DeviceRegistrationResult.LastUpdatedDateTimeUtc` | `DeviceRegistrationResult.LastUpdatedOnUtc` | See¹ |
+| `ProvisioningTransportException` | `ProvisioningClientException` | |
 
 ### DPS service client
 
@@ -383,6 +386,7 @@ What was a loose affiliation of separate clients is now a consolidated client wi
 | `X509CAReferences` | `X509CaReferences` | See³ |
 | `X509CertificateInfo.SHA1Thumbprint` | `X509CertificateInfo.Sha1Thumbprint` | See³ |
 | `X509CertificateInfo.SHA256Thumbprint` | `X509CertificateInfo.Sha256Thumbprint` | See³ |
+| `ProvisioningServiceClientException` | `ProvisioningServiceException` | |
 
 ### Security provider client
 

--- a/SDK v2 migration guide.md
+++ b/SDK v2 migration guide.md
@@ -92,7 +92,7 @@ The v2 strategy can be grouped into 3 categories.
     - The exception message is meant for human readable expanation.
     - Inner exceptions may offer more insight and are worth logging out.
     - `TrackingId` is for uniquely identifying specific operations and are useful in sharing with IoT hub support to assist them in more quickly identifying errors that may have been logged by the service.
-  - `DeviceProvisioningClientException` for provisioning device client and `DeviceProvisioningServiceException` for provisioning service client for exceptions arising from communication attempts with DPS.
+  - `ProvisioningClientException` for provisioning device client and `ProvisioningServiceException` for provisioning service client for exceptions arising from communication attempts with DPS.
     > As with the IoT hub exceptions, primarily observe the `IsTransient` and `ErrorCode` properties.
     > Other properties may be valuable for logging or debugging.
 

--- a/e2e/test/helpers/ProvisioningServiceRetryPolicy.cs
+++ b/e2e/test/helpers/ProvisioningServiceRetryPolicy.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             retryInterval = TimeSpan.Zero;
 
             if (currentRetryCount > MaxRetryCount
-                || lastException is not DeviceProvisioningServiceException)
+                || lastException is not ProvisioningServiceException)
             {
                 return false;
             }
 
-            if (lastException is DeviceProvisioningServiceException provisioningException)
+            if (lastException is ProvisioningServiceException provisioningException)
             {
                 if (!provisioningException.IsTransient)
                 {

--- a/e2e/test/provisioning/ProvisioningCertificateValidationE2ETest.cs
+++ b/e2e/test/provisioning/ProvisioningCertificateValidationE2ETest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
             Func<Task> act = async () => await q.NextAsync();
 
-            var error = await act.Should().ThrowAsync<DeviceProvisioningServiceException>().ConfigureAwait(false);
+            var error = await act.Should().ThrowAsync<ProvisioningServiceException>().ConfigureAwait(false);
 #if NET472
                 Assert.IsInstanceOfType(error.And.InnerException.InnerException.InnerException, typeof(AuthenticationException));
 #else
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             var clientOptions = new ProvisioningClientOptions(new ProvisioningClientAmqpSettings(ProvisioningClientTransportProtocol.Tcp));
             Func<Task> act = async () => await TestInvalidServiceCertificate(clientOptions);
 
-            var error = await act.Should().ThrowAsync<DeviceProvisioningClientException>().ConfigureAwait(false);
+            var error = await act.Should().ThrowAsync<ProvisioningClientException>().ConfigureAwait(false);
             Assert.IsInstanceOfType(error.And.InnerException, typeof(AuthenticationException));
         }
 
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             var clientOptions = new ProvisioningClientOptions(new ProvisioningClientMqttSettings(ProvisioningClientTransportProtocol.Tcp));
             Func<Task> act = async () => await TestInvalidServiceCertificate(clientOptions);
 
-            var error = await act.Should().ThrowAsync<DeviceProvisioningClientException>().ConfigureAwait(false);
+            var error = await act.Should().ThrowAsync<ProvisioningClientException>().ConfigureAwait(false);
             if (error.And.InnerException == null)
             {
                 Assert.AreEqual("MQTT Protocol Exception: Channel closed.", error.And.Message);
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             var clientOptions = new ProvisioningClientOptions(new ProvisioningClientAmqpSettings(ProvisioningClientTransportProtocol.WebSocket));
             Func<Task> act = async () => await TestInvalidServiceCertificate(clientOptions);
 
-            var error = await act.Should().ThrowAsync<DeviceProvisioningClientException>().ConfigureAwait(false);
+            var error = await act.Should().ThrowAsync<ProvisioningClientException>().ConfigureAwait(false);
             Assert.IsInstanceOfType(error.And.InnerException.InnerException.InnerException, typeof(AuthenticationException));
         }
 
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             var clientOptions = new ProvisioningClientOptions(new ProvisioningClientMqttSettings(ProvisioningClientTransportProtocol.WebSocket));
             Func<Task> act = async () => await TestInvalidServiceCertificate(clientOptions);
 
-            var error = await act.Should().ThrowAsync<DeviceProvisioningClientException>().ConfigureAwait(false);
+            var error = await act.Should().ThrowAsync<ProvisioningClientException>().ConfigureAwait(false);
             Assert.IsInstanceOfType(error.And.InnerException.InnerException.InnerException, typeof(AuthenticationException));
         }
 

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -675,9 +675,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         result = await provClient.RegisterAsync(cts.Token).ConfigureAwait(false);
                         break;
                     }
-                    // Catching all DeviceProvisioningClientException as the status code is not the same for Mqtt, Amqp and Http.
+                    // Catching all ProvisioningClientException as the status code is not the same for Mqtt, Amqp and Http.
                     // It should be safe to retry on any non-transient exception just for E2E tests as we have concurrency issues.
-                    catch (DeviceProvisioningClientException ex) when (++tryCount < MaxTryCount)
+                    catch (ProvisioningClientException ex) when (++tryCount < MaxTryCount)
                     {
                         VerboseTestLogger.WriteLine($"ProvisioningDeviceClient RegisterAsync failed because: {ex.Message}");
                         await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
@@ -753,7 +753,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
                 using var cts = new CancellationTokenSource(FailingTimeoutMiliseconds);
                 Func<Task> act = async () => await provClient.RegisterAsync(cts.Token);
-                var exception = await act.Should().ThrowAsync<DeviceProvisioningClientException>().ConfigureAwait(false);
+                var exception = await act.Should().ThrowAsync<ProvisioningClientException>().ConfigureAwait(false);
                 VerboseTestLogger.WriteLine($"Exception: {exception}");
             }
             finally
@@ -815,7 +815,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                 VerboseTestLogger.WriteLine("ProvisioningDeviceClient RegisterAsync . . . ");
 
                 Func<Task> act = async () => await provClient.RegisterAsync(cts.Token);
-                var exception = await act.Should().ThrowAsync<DeviceProvisioningClientException>().ConfigureAwait(false);
+                var exception = await act.Should().ThrowAsync<ProvisioningClientException>().ConfigureAwait(false);
 
                 VerboseTestLogger.WriteLine($"Exception: {exception}");
             }

--- a/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningServiceClientE2ETests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             Func<Task> act = async () => await provisioningServiceClient.IndividualEnrollments.GetAsync("invalid-registration-id").ConfigureAwait(false);
 
             // assert
-            var error = await act.Should().ThrowAsync<DeviceProvisioningServiceException>();
+            var error = await act.Should().ThrowAsync<ProvisioningServiceException>();
             error.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
             error.And.ErrorCode.Should().Be(404201);
             error.And.IsTransient.Should().BeFalse();
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
             Func<Task> act = async () => await provisioningServiceClient.EnrollmentGroups.GetAsync("invalid-registration-id").ConfigureAwait(false);
 
             // assert
-            var error = await act.Should().ThrowAsync<DeviceProvisioningServiceException>();
+            var error = await act.Should().ThrowAsync<ProvisioningServiceException>();
             error.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
             error.And.ErrorCode.Should().Be(404204);
             error.And.IsTransient.Should().BeFalse();

--- a/iothub/device/samples/solutions/PnpDeviceSamples/TemperatureController/Program.cs
+++ b/iothub/device/samples/solutions/PnpDeviceSamples/TemperatureController/Program.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 // cancellation timeout of 4 minutes: https://github.com/Azure/azure-iot-sdk-csharp/blob/64f6e9f24371bc40ab3ec7a8b8accbfb537f0fe1/iothub/device/src/InternalClient.cs#L1922
                 await deviceClient.CloseAsync(CancellationToken.None);
             }
-            catch (Exception ex) when (ex is OperationCanceledException || ex is DeviceProvisioningClientException)
+            catch (Exception ex) when (ex is OperationCanceledException || ex is ProvisioningClientException)
             {
                 // User canceled the operation. Nothing to do here.
             }

--- a/provisioning/device/src/ProvisioningClientException.cs
+++ b/provisioning/device/src/ProvisioningClientException.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Net;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Azure.Devices.Provisioning.Client
@@ -10,16 +9,16 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
     /// <summary>
     /// The exception that is thrown when an error occurs during device provisioning client operation.
     /// </summary>
-    public class DeviceProvisioningClientException : Exception
+    public class ProvisioningClientException : Exception
     {
-        private const string IsTransientValueSerializationStoreName = "DeviceProvisioningClientException-IsTransient";
+        private const string IsTransientValueSerializationStoreName = "ProvisioningClientException-IsTransient";
 
         /// <summary>
         /// Creates a new instance of this class.
         /// </summary>
         /// <param name="message">The exception message.</param>
         /// <param name="isTransient">True if the error is transient.</param>
-        protected internal DeviceProvisioningClientException(string message, bool isTransient)
+        protected internal ProvisioningClientException(string message, bool isTransient)
             : this(message, null, isTransient)
         {
         }
@@ -30,7 +29,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// <param name="message">The exception message.</param>
         /// <param name="isTransient">True if the error is transient.</param>
         /// <param name="innerException">The inner exception.</param>
-        protected internal DeviceProvisioningClientException(string message, Exception innerException, bool isTransient)
+        protected internal ProvisioningClientException(string message, Exception innerException, bool isTransient)
             : base(message, innerException)
         {
             IsTransient = isTransient;
@@ -44,7 +43,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// <param name="isTransient">If the error is transient and the application should retry at a later time.</param>
         /// <param name="errorCode">The specific 6-digit error code in the DPS response, if available.</param>
         /// <param name="trackingId">Service reported tracking Id.</param>
-        protected internal DeviceProvisioningClientException(string message, Exception innerException, bool isTransient, int errorCode, string trackingId)
+        protected internal ProvisioningClientException(string message, Exception innerException, bool isTransient, int errorCode, string trackingId)
             : base(message, innerException)
         {
             IsTransient = isTransient;
@@ -57,7 +56,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// </summary>
         /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
-        protected internal DeviceProvisioningClientException(SerializationInfo info, StreamingContext context)
+        protected internal ProvisioningClientException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             if (info != null)

--- a/provisioning/device/src/Transports/Amqp/ProvisioningTransportHandlerAmqp.cs
+++ b/provisioning/device/src/Transports/Amqp/ProvisioningTransportHandlerAmqp.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                                 linkedCancellationToken.Token)
                             .ConfigureAwait(false);
                     }
-                    catch (DeviceProvisioningClientException e) when (e.IsTransient)
+                    catch (ProvisioningClientException e) when (e.IsTransient)
                     {
                         operation.RetryAfter = _retryAfter;
                     }
@@ -187,17 +187,17 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                 // Deliberately not including the caught exception as this exception's inner exception because
                 // if the user sees an OperationCancelledException in the thrown exception, they may think they cancelled
                 // the operation even though they didn't.
-                throw new DeviceProvisioningClientException($"AMQP connection was lost during provisioning.", true);
+                throw new ProvisioningClientException($"AMQP connection was lost during provisioning.", true);
 
                 // If it was the user's cancellation token that requested cancellation, then this catch block
                 // won't execute and the OperationCanceledException will be thrown as expected.
             }
-            catch (Exception ex) when (ex is not DeviceProvisioningClientException)
+            catch (Exception ex) when (ex is not ProvisioningClientException)
             {
                 if (Logging.IsEnabled)
                     Logging.Error(this, $"{nameof(ProvisioningTransportHandlerAmqp)} threw exception {ex}", nameof(RegisterAsync));
 
-                throw new DeviceProvisioningClientException($"AMQP transport exception", ex, true);
+                throw new ProvisioningClientException($"AMQP transport exception", ex, true);
             }
             finally
             {
@@ -327,7 +327,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                         _retryAfter = errorDetails.RetryAfter;
                     }
 
-                    throw new DeviceProvisioningClientException(
+                    throw new ProvisioningClientException(
                         rejected.Error.Description,
                         null,
                         isTransient,
@@ -343,7 +343,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                                 $"Parsing error: {ex}. Server response: {rejected.Error.Description}",
                             nameof(RegisterAsync));
 
-                    throw new DeviceProvisioningClientException(
+                    throw new ProvisioningClientException(
                         $"AMQP transport exception: malformed server error message: '{rejected.Error.Description}'",
                         ex,
                         false);

--- a/provisioning/device/src/Transports/Mqtt/ProvisioningTransportHandlerMqtt.cs
+++ b/provisioning/device/src/Transports/Mqtt/ProvisioningTransportHandlerMqtt.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    throw new DeviceProvisioningClientException("Failed to open the MQTT connection.", ex, true);
+                    throw new ProvisioningClientException("Failed to open the MQTT connection.", ex, true);
                 }
 
                 currentStatus = "subscribing to registration responses";
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                 // Deliberately not including the caught exception as this exception's inner exception because
                 // if the user sees an OperationCancelledException in the thrown exception, they may think they cancelled
                 // the operation even though they didn't.
-                throw new DeviceProvisioningClientException($"MQTT connection was lost while {currentStatus}.", _connectionLossCause, true);
+                throw new ProvisioningClientException($"MQTT connection was lost while {currentStatus}.", _connectionLossCause, true);
 
                 // If it was the user's cancellation token that requested cancellation, then this catch block
                 // won't execute and the OperationCanceledException will be thrown as expected.
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
             {
                 // MQTTNet throws MqttCommunicationTimedOutException instead of OperationCanceledException
                 // when the cancellation token requests cancellation.
-                throw new DeviceProvisioningClientException("Timed out while provisioning.", ex, true);
+                throw new ProvisioningClientException("Timed out while provisioning.", ex, true);
             }
             catch (MqttCommunicationTimedOutException ex) when (cancellationToken.IsCancellationRequested)
             {
@@ -199,19 +199,19 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
                 if (subscribeResults?.Items == null)
                 {
-                    throw new DeviceProvisioningClientException($"Failed to subscribe to topic '{SubscribeFilter}'.", true);
+                    throw new ProvisioningClientException($"Failed to subscribe to topic '{SubscribeFilter}'.", true);
                 }
 
                 MqttClientSubscribeResultItem subscribeResult = subscribeResults.Items.FirstOrDefault();
 
                 if (!subscribeResult.TopicFilter.Topic.Equals(SubscribeFilter))
                 {
-                    throw new DeviceProvisioningClientException($"Received unexpected subscription to topic '{subscribeResult.TopicFilter.Topic}'.", true);
+                    throw new ProvisioningClientException($"Received unexpected subscription to topic '{subscribeResult.TopicFilter.Topic}'.", true);
                 }
             }
-            catch (Exception ex) when (ex is not DeviceProvisioningClientException && ex is not OperationCanceledException)
+            catch (Exception ex) when (ex is not ProvisioningClientException && ex is not OperationCanceledException)
             {
-                throw new DeviceProvisioningClientException("Failed to subscribe to the registrations response topic.", ex, true);
+                throw new ProvisioningClientException("Failed to subscribe to the registrations response topic.", ex, true);
             }
         }
 
@@ -240,12 +240,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
                 if (publishResult.ReasonCode != MqttClientPublishReasonCode.Success)
                 {
-                    throw new DeviceProvisioningClientException($"Failed to publish the MQTT packet for message with reason code '{publishResult.ReasonCode}'.", true);
+                    throw new ProvisioningClientException($"Failed to publish the MQTT packet for message with reason code '{publishResult.ReasonCode}'.", true);
                 }
             }
-            catch (Exception ex) when (ex is not DeviceProvisioningClientException && ex is not OperationCanceledException)
+            catch (Exception ex) when (ex is not ProvisioningClientException && ex is not OperationCanceledException)
             {
-                throw new DeviceProvisioningClientException("Failed to send the initial registration request.", ex, true);
+                throw new ProvisioningClientException("Failed to send the initial registration request.", ex, true);
             }
 
             if (Logging.IsEnabled)
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
             if (registrationStatus.Status != RegistrationOperationStatus.OperationStatusAssigning)
             {
-                throw new DeviceProvisioningClientException($"Failed to provision. Service responded with status {registrationStatus.Status}.", true);
+                throw new ProvisioningClientException($"Failed to provision. Service responded with status {registrationStatus.Status}.", true);
             }
 
             return registrationStatus;
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
                 if (publishResult.ReasonCode != MqttClientPublishReasonCode.Success)
                 {
-                    throw new DeviceProvisioningClientException($"Failed to publish the MQTT registration message with reason code '{publishResult.ReasonCode}'.", true);
+                    throw new ProvisioningClientException($"Failed to publish the MQTT registration message with reason code '{publishResult.ReasonCode}'.", true);
                 }
 
                 RegistrationOperationStatus currentStatus = await GetTaskCompletionSourceResultAsync(

--- a/provisioning/service/src/DeviceRegistrationsClient.cs
+++ b/provisioning/service/src/DeviceRegistrationsClient.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <returns>The <see cref="DeviceRegistrationState"/> with the content of the DeviceRegistrationState in the Provisioning Device Service.</returns>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="registrationId"/> is null.</exception>
         /// <exception cref="ArgumentException">If the provided <paramref name="registrationId"/> is empty or white space.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">
+        /// <exception cref="ProvisioningServiceException">
         /// If the service was not able to retrieve the registration state for the provided <paramref name="registrationId"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="registrationId"/> is null.</exception>
         /// <exception cref="ArgumentException">If the provided <paramref name="registrationId"/> is empty or white space.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">
+        /// <exception cref="ProvisioningServiceException">
         /// If the service was not able to delete the registration state for the provided <paramref name="registrationId"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="deviceRegistrationState">The device registration to delete.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="deviceRegistrationState"/> is null.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">
+        /// <exception cref="ProvisioningServiceException">
         /// When the service wasn't able to delete the registration status.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>

--- a/provisioning/service/src/EnrollmentGroupsClient.cs
+++ b/provisioning/service/src/EnrollmentGroupsClient.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The created or updated enrollment group.</returns>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="enrollmentGroup"/> is null.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">
+        /// <exception cref="ProvisioningServiceException">
         /// If the service was not able to create or update the enrollment.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <returns>The retrieved enrollment group.</returns>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="enrollmentGroupId"/> is null.</exception>
         /// <exception cref="ArgumentException">If the provided <paramref name="enrollmentGroupId"/> is empty or white space.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">
+        /// <exception cref="ProvisioningServiceException">
         /// If the service was not able to retrieve the enrollment group information for the provided <paramref name="enrollmentGroupId"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="enrollmentGroupId"/> is null.</exception>
         /// <exception cref="ArgumentException">If the provided <paramref name="enrollmentGroupId"/> is empty or white space.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">
+        /// <exception cref="ProvisioningServiceException">
         /// If the service was not able to delete the enrollment group information for the provided <paramref name="enrollmentGroupId"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="enrollmentGroup">The <see cref="EnrollmentGroup"/> that identifies the enrollmentGroup. It cannot be null.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="enrollmentGroup"/> is null.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">
+        /// <exception cref="ProvisioningServiceException">
         /// If the service was not able to delete the enrollment group information for the provided <paramref name="enrollmentGroup"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <returns>An object with the result of each operation.</returns>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="enrollmentGroups"/> is null.</exception>
         /// <exception cref="ArgumentException">If the provided <paramref name="enrollmentGroups"/> is an empty collection.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">
+        /// <exception cref="ProvisioningServiceException">
         /// If the client failed to send the request or service was not able to execute the bulk operation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <returns>The attestation mechanism of the enrollment group.</returns>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="enrollmentGroupId"/> is null.</exception>
         /// <exception cref="ArgumentException">If the provided <paramref name="enrollmentGroupId"/> is empty or white space.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">
+        /// <exception cref="ProvisioningServiceException">
         /// If the service was not able to retrieve the enrollment group attestation information for the provided <paramref name="enrollmentGroupId"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>

--- a/provisioning/service/src/Http/ContractApiHttp.cs
+++ b/provisioning/service/src/Http/ContractApiHttp.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="cancellationToken">the task cancellation Token.</param>
         /// <returns>The <see cref="ContractApiResponse"/> with the HTTP response.</returns>
         /// <exception cref="OperationCanceledException">If the cancellation was requested.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">If there is an error in the HTTP communication
+        /// <exception cref="ProvisioningServiceException">If there is an error in the HTTP communication
         /// between client and service or the service answers the request with error status.</exception>
         public async Task<ContractApiResponse> RequestAsync(
             HttpMethod httpMethod,
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                     using HttpResponseMessage httpResponse = await _httpClientObj.SendAsync(msg, cancellationToken).ConfigureAwait(false);
                     if (httpResponse == null)
                     {
-                        throw new DeviceProvisioningServiceException(
+                        throw new ProvisioningServiceException(
                             $"The response message was null when executing operation {httpMethod}.", isTransient: true);
                     }
 
@@ -155,22 +155,22 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                     ReadOnlyCollection<Exception> innerExceptions = ex.Flatten().InnerExceptions;
                     if (innerExceptions.Any(e => e is TimeoutException))
                     {
-                        throw new DeviceProvisioningServiceException(ex.Message, ex, true);
+                        throw new ProvisioningServiceException(ex.Message, ex, true);
                     }
 
                     throw;
                 }
                 catch (TimeoutException ex)
                 {
-                    throw new DeviceProvisioningServiceException(ex.Message, HttpStatusCode.RequestTimeout, ex);
+                    throw new ProvisioningServiceException(ex.Message, HttpStatusCode.RequestTimeout, ex);
                 }
                 catch (IOException ex)
                 {
-                    throw new DeviceProvisioningServiceException(ex.Message, ex, true);
+                    throw new ProvisioningServiceException(ex.Message, ex, true);
                 }
                 catch (HttpRequestException ex)
                 {
-                    throw new DeviceProvisioningServiceException(ex.Message, ex, true);
+                    throw new ProvisioningServiceException(ex.Message, ex, true);
                 }
                 catch (TaskCanceledException ex)
                 {
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                         throw new OperationCanceledException(ex.Message, ex);
                     }
 
-                    throw new DeviceProvisioningServiceException($"The {httpMethod} operation timed out.", HttpStatusCode.RequestTimeout, ex);
+                    throw new ProvisioningServiceException($"The {httpMethod} operation timed out.", HttpStatusCode.RequestTimeout, ex);
                 }
             }
 
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         {
             if (response.Body == null)
             {
-                throw new DeviceProvisioningServiceException(response.ErrorMessage, response.StatusCode, response.Fields);
+                throw new ProvisioningServiceException(response.ErrorMessage, response.StatusCode, response.Fields);
             }
 
             // Both 200 and 204 indicate a successful operation, so there is no reason to parse the body for an error code
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
 
                     if (response.StatusCode >= HttpStatusCode.Ambiguous)
                     {
-                        throw new DeviceProvisioningServiceException(
+                        throw new ProvisioningServiceException(
                             $"{response.ErrorMessage}:{response.Body}",
                             response.StatusCode,
                             responseBody.ErrorCode,
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 }
                 catch (JsonException jex)
                 {
-                    throw new DeviceProvisioningServiceException(
+                    throw new ProvisioningServiceException(
                         $"Fail to deserialize the received response body: {response.Body}",
                         jex,
                         false);

--- a/provisioning/service/src/IndividualEnrollmentsClient.cs
+++ b/provisioning/service/src/IndividualEnrollmentsClient.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The created or updated individual enrollment.</returns>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="individualEnrollment"/> is null.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">If the service was not able to create or update the enrollment.</exception>
+        /// <exception cref="ProvisioningServiceException">If the service was not able to create or update the enrollment.</exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
         public async Task<IndividualEnrollment> CreateOrUpdateAsync(IndividualEnrollment individualEnrollment, CancellationToken cancellationToken = default)
         {
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <returns>The retrieved enrollment.</returns>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="registrationId"/> is null.</exception>
         /// <exception cref="ArgumentException">If the provided <paramref name="registrationId"/> is empty or white space.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">If the service was not able to get the enrollment.</exception>
+        /// <exception cref="ProvisioningServiceException">If the service was not able to get the enrollment.</exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
         public async Task<IndividualEnrollment> GetAsync(string registrationId, CancellationToken cancellationToken = default)
         {
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="registrationId"/> is null.</exception>
         /// <exception cref="ArgumentException">If the provided <paramref name="registrationId"/> is empty or white space.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">
+        /// <exception cref="ProvisioningServiceException">
         /// If the client failed to send the request or service was not able to execute the operation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="individualEnrollment">The individual enrollment to delete.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="individualEnrollment"/> is null.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">
+        /// <exception cref="ProvisioningServiceException">
         /// If the client failed to send the request or service was not able to execute the operation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <returns>An object with the result of each operation.</returns>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="individualEnrollments"/> is null.</exception>
         /// <exception cref="ArgumentException">If the provided <paramref name="individualEnrollments"/> is an empty collection.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">
+        /// <exception cref="ProvisioningServiceException">
         /// If the client failed to send the request or service was not able to execute the bulk operation.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>
@@ -233,7 +233,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <returns>The <see cref="AttestationMechanism"/> of the individual enrollment associated with the provided <paramref name="registrationId"/>.</returns>
         /// <exception cref="ArgumentNullException">If the provided <paramref name="registrationId"/> is null.</exception>
         /// <exception cref="ArgumentException">If the provided <paramref name="registrationId"/> is empty or white space.</exception>
-        /// <exception cref="DeviceProvisioningServiceException">
+        /// <exception cref="ProvisioningServiceException">
         /// If the service was not able to retrieve the individual enrollment attestation information for the provided <paramref name="registrationId"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided <paramref name="cancellationToken"/> has requested cancellation.</exception>

--- a/provisioning/service/src/Models/AttestationMechanism.cs
+++ b/provisioning/service/src/Models/AttestationMechanism.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 case AttestationMechanismType.X509:
                     if (x509 == null)
                     {
-                        throw new DeviceProvisioningServiceException("Invalid X509 attestation mechanism.", HttpStatusCode.BadRequest);
+                        throw new ProvisioningServiceException("Invalid X509 attestation mechanism.", HttpStatusCode.BadRequest);
                     }
 
                     X509 = x509;
@@ -74,14 +74,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 case AttestationMechanismType.Tpm:
                     if (tpm == null)
                     {
-                        throw new DeviceProvisioningServiceException("Invalid TPM attestation mechanism.", HttpStatusCode.BadRequest);
+                        throw new ProvisioningServiceException("Invalid TPM attestation mechanism.", HttpStatusCode.BadRequest);
                     }
 
                     Tpm = tpm;
                     break;
 
                 default:
-                    throw new DeviceProvisioningServiceException("Unknown attestation mechanism.", HttpStatusCode.BadRequest);
+                    throw new ProvisioningServiceException("Unknown attestation mechanism.", HttpStatusCode.BadRequest);
             }
         }
 
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 AttestationMechanismType.SymmetricKey => _symmetricKey,
                 AttestationMechanismType.Tpm => _tpm,
                 AttestationMechanismType.None => s_none,
-                _ => throw new DeviceProvisioningServiceException("Unknown attestation type", HttpStatusCode.BadRequest),
+                _ => throw new ProvisioningServiceException("Unknown attestation type", HttpStatusCode.BadRequest),
             };
         }
 

--- a/provisioning/service/src/Models/EnrollmentGroup.cs
+++ b/provisioning/service/src/Models/EnrollmentGroup.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         {
             if (attestation == null)
             {
-                throw new DeviceProvisioningServiceException("Service responded with an enrollment without attestation.", HttpStatusCode.BadRequest);
+                throw new ProvisioningServiceException("Service responded with an enrollment without attestation.", HttpStatusCode.BadRequest);
             }
 
             EnrollmentGroupId = enrollmentGroupId;

--- a/provisioning/service/src/Models/IndividualEnrollment.cs
+++ b/provisioning/service/src/Models/IndividualEnrollment.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         {
             if (attestation == null)
             {
-                throw new DeviceProvisioningServiceException("Service responded with an enrollment without attestation.", HttpStatusCode.BadRequest);
+                throw new ProvisioningServiceException("Service responded with an enrollment without attestation.", HttpStatusCode.BadRequest);
             }
 
             RegistrationId = registrationId;

--- a/provisioning/service/src/Models/X509CertificateInfo.cs
+++ b/provisioning/service/src/Models/X509CertificateInfo.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 || notAfterUtc == null
                 || version == null)
             {
-                throw new DeviceProvisioningServiceException("DateTime cannot be null", HttpStatusCode.BadRequest);
+                throw new ProvisioningServiceException("DateTime cannot be null", HttpStatusCode.BadRequest);
             }
 
             SubjectName = subjectName;

--- a/provisioning/service/src/Models/X509Certificates.cs
+++ b/provisioning/service/src/Models/X509Certificates.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         [JsonConstructor]
         private X509Certificates(X509CertificateWithInfo primary, X509CertificateWithInfo secondary = null)
         {
-            Primary = primary ?? throw new DeviceProvisioningServiceException("Primary certificate cannot be null.", HttpStatusCode.BadRequest);
+            Primary = primary ?? throw new ProvisioningServiceException("Primary certificate cannot be null.", HttpStatusCode.BadRequest);
             Secondary = secondary;
         }
 

--- a/provisioning/service/src/ProvisioningServiceException.cs
+++ b/provisioning/service/src/ProvisioningServiceException.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// <summary>
     /// The Device Provisioning Service exceptions on the Service Client.
     /// </summary>
-    public class DeviceProvisioningServiceException : Exception
+    public class ProvisioningServiceException : Exception
     {
         /// <summary>
         /// Creates an instance of this class.
         /// </summary>
         /// <param name="message">The message.</param>
-        public DeviceProvisioningServiceException(string message)
+        public ProvisioningServiceException(string message)
             : this(message, innerException: null, isTransient: false)
         {
         }
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="isTransient">True if the error is transient and the operation should be retried.</param>
-        public DeviceProvisioningServiceException(string message, bool isTransient)
+        public ProvisioningServiceException(string message, bool isTransient)
             : this(message, innerException: null, isTransient: isTransient)
         {
         }
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Creates an instance of this class.
         /// </summary>
         /// <param name="innerException">The inner exception.</param>
-        public DeviceProvisioningServiceException(Exception innerException)
+        public ProvisioningServiceException(Exception innerException)
             : this(string.Empty, innerException, isTransient: false)
         {
         }
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="message">The message</param>
         /// <param name="innerException">The inner exception</param>
         /// <param name="isTransient">True if the error is transient and the operation should be retried.</param>
-        internal DeviceProvisioningServiceException(string message, Exception innerException, bool isTransient)
+        internal ProvisioningServiceException(string message, Exception innerException, bool isTransient)
             : base(message, innerException)
         {
             IsTransient = isTransient;
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="message">The message.</param>
         /// <param name="statusCode">The 3-digit HTTP status code returned by Device Provisioning Service.</param>
         /// <param name="innerException">The inner exception</param>
-        internal DeviceProvisioningServiceException(string message, HttpStatusCode statusCode, Exception innerException = null)
+        internal ProvisioningServiceException(string message, HttpStatusCode statusCode, Exception innerException = null)
             : base(message, innerException)
         {
             IsTransient = DetermineIfTransient(statusCode);
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="message">The message.</param>
         /// <param name="statusCode">The 3-digit HTTP status code returned by Device Provisioning Service.</param>
         /// <param name="fields">The HTTP headers.</param>
-        internal DeviceProvisioningServiceException(string message, HttpStatusCode statusCode, IDictionary<string, string> fields)
+        internal ProvisioningServiceException(string message, HttpStatusCode statusCode, IDictionary<string, string> fields)
             : base(message)
         {
             IsTransient = DetermineIfTransient(statusCode);
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <param name="errorCode">The specific 6-digit error code in the DPS response, if available.</param>
         /// <param name="trackingId">Service reported tracking Id. Use this when reporting a service issue.</param>
         /// <param name="fields">The HTTP headers.</param>
-        internal DeviceProvisioningServiceException(string message, HttpStatusCode statusCode, int errorCode, string trackingId, IDictionary<string, string> fields)
+        internal ProvisioningServiceException(string message, HttpStatusCode statusCode, int errorCode, string trackingId, IDictionary<string, string> fields)
             : base(message)
         {
             IsTransient = DetermineIfTransient(statusCode);

--- a/provisioning/service/tests/Config/EnrollmentGroupTests.cs
+++ b/provisioning/service/tests/Config/EnrollmentGroupTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
 
             // act - assert
             Action act = () => JsonConvert.DeserializeObject<EnrollmentGroup>(invalidJson);
-            FluentAssertions.Specialized.ExceptionAssertions<DeviceProvisioningServiceException> error = act.Should().Throw<DeviceProvisioningServiceException>();
+            FluentAssertions.Specialized.ExceptionAssertions<ProvisioningServiceException> error = act.Should().Throw<ProvisioningServiceException>();
             error.And.StatusCode.Should().Be(HttpStatusCode.BadRequest);
             error.And.IsTransient.Should().BeFalse();
         }

--- a/provisioning/service/tests/Config/IndividualEnrollmentTests.cs
+++ b/provisioning/service/tests/Config/IndividualEnrollmentTests.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
 
             // act - assert
             Action act = () => JsonConvert.DeserializeObject<IndividualEnrollment>(invalidJson);
-            var error = act.Should().Throw<DeviceProvisioningServiceException>();
+            var error = act.Should().Throw<ProvisioningServiceException>();
             error.And.StatusCode.Should().Be(HttpStatusCode.BadRequest);
             error.And.IsTransient.Should().BeFalse();
         }

--- a/provisioning/service/tests/Config/X509CertificateInfoTests.cs
+++ b/provisioning/service/tests/Config/X509CertificateInfoTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
 
                 // act - assert
                 Action act = () => JsonConvert.DeserializeObject<X509CertificateInfo>(json);
-                var error = act.Should().Throw<DeviceProvisioningServiceException>();
+                var error = act.Should().Throw<ProvisioningServiceException>();
                 error.And.StatusCode.Should().Be(HttpStatusCode.BadRequest);
                 error.And.IsTransient.Should().BeFalse();
             }
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
 
                 // act - assert
                 Action act = () => JsonConvert.DeserializeObject<X509CertificateInfo>(json);
-                var error = act.Should().Throw<DeviceProvisioningServiceException>();
+                var error = act.Should().Throw<ProvisioningServiceException>();
                 error.And.StatusCode.Should().Be(HttpStatusCode.BadRequest);
                 error.And.IsTransient.Should().BeFalse();
             }
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
 
             // act - assert
             Action act = () => JsonConvert.DeserializeObject<X509CertificateInfo>(json);
-            var error = act.Should().Throw<DeviceProvisioningServiceException>();
+            var error = act.Should().Throw<ProvisioningServiceException>();
             error.And.StatusCode.Should().Be(HttpStatusCode.BadRequest);
             error.And.IsTransient.Should().BeFalse();
         }

--- a/provisioning/service/tests/Config/X509CertificatesTests.cs
+++ b/provisioning/service/tests/Config/X509CertificatesTests.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
 
             // act - assert
             Action act = () => JsonConvert.DeserializeObject<X509Certificates>(json);
-            var error = act.Should().Throw<DeviceProvisioningServiceException>();
+            var error = act.Should().Throw<ProvisioningServiceException>();
             error.And.StatusCode.Should().Be(HttpStatusCode.BadRequest);
             error.And.IsTransient.Should().BeFalse();
         }


### PR DESCRIPTION
As per discussion in today's standup, rename the exception types for DPS device and service clients.
+ `DeviceProvisioningClientException` -> `ProvisioningClientException`
+ `DeviceProvisioningServiceException` -> `ProvisioningServiceException`