### PR TITLE
Fixing broken readme links for samples

### DIFF
--- a/provisioning/device/samples/readme.md
+++ b/provisioning/device/samples/readme.md
@@ -7,7 +7,7 @@
 * [Provisioning device client symmetric key][symmetric-key-sample] sample
 * [Compute derived symmetric key][compute-derived-symmetric-key-sample] sample
 
-[x509-sample]:https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/device/samples/Getting%20Started/X509Sample
-[tpm-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/device/samples/How%20To/TpmSample
-[symmetric-key-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/device/samples/How%20To/SymmetricKeySample
-[compute-derived-symmetric-key-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/device/samples/Getting%20Started/ComputeDerivedSymmetricKeySample
+[x509-sample]:https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/device/samples/getting%20started/X509Sample
+[tpm-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/device/samples/how%20to%20guides/TpmSample
+[symmetric-key-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/device/samples/how%20to%20guides/SymmetricKeySample
+[compute-derived-symmetric-key-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/device/samples/getting%20started/ComputeDerivedSymmetricKeySample

--- a/provisioning/service/samples/readme.md
+++ b/provisioning/service/samples/readme.md
@@ -8,8 +8,8 @@
 - [Enrollment group][enrollment-group-sample] sample
 - [Clean up enrollments][clean-up-enrollments-sample] sample
 
-[group-cert-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/service/samples/How%20To/GroupCertificateVerificationSample
-[bulk-op-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/service/samples/How%20To/BulkOperationSample
-[enrollment-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/service/samples/Getting%20Started/EnrollmentSample
-[enrollment-group-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/service/samples/Getting%20Started/EnrollmentGroupSample
-[clean-up-enrollments-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/service/samples/Getting%20Started/CleanupEnrollmentsSample
+[group-cert-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/service/samples/how%20to%20guides/GroupCertificateVerificationSample
+[bulk-op-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/service/samples/how%20to%20guides/BulkOperationSample
+[enrollment-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/service/samples/getting%20started/EnrollmentSample
+[enrollment-group-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/service/samples/getting%20started/EnrollmentGroupSample
+[clean-up-enrollments-sample]: https://github.com/Azure/azure-iot-sdk-csharp/tree/main/provisioning/service/samples/getting%20started/CleanupEnrollmentsSample

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ All of our samples are located in this repository. The samples live alongside th
 Samples for each of these categories are further separated into three sub-categories (from simplest to complex):
 
 1. `Getting Started`
-2. `How To`
+2. `How To Guides`
 3. `Solutions`
 
 If you are looking for a good device sample to get started with, please see the [device reconnection sample](https://github.com/Azure/azure-iot-sdk-csharp/tree/main/iothub/device/samples/how%20to%20guides/DeviceReconnectionSample).


### PR DESCRIPTION
After the pipeline change was checked in, our DPS sample folders were changed from `How To` to `how to guides`. This PR passes that change to our readmes.