### PR TITLE
Cancel amqp token refresher as a part of transport cleanup

### DIFF
--- a/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
             // Create a linked cancellation token source which can be signaled for cancellation by both the SDK
             // and the supplied cancellation token.
-            _refresherCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _refresherCancellationTokenSource ??= CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             if (refreshOn < DateTime.MaxValue)
             {
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             if (Logging.IsEnabled)
                 Logging.Enter(this, nameof(StopLoop));
 
-            _refresherCancellationTokenSource.Cancel();
+            _refresherCancellationTokenSource?.Cancel();
 
             if (Logging.IsEnabled)
                 Logging.Exit(this, nameof(StopLoop));
@@ -156,6 +156,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                     {
                         StopLoop();
                         _refresherCancellationTokenSource?.Dispose();
+                        _refresherCancellationTokenSource = null;
+
                         _amqpIotCbsTokenProvider?.Dispose();
                     }
 

--- a/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
@@ -59,7 +59,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                 if (Logging.IsEnabled)
                     Logging.Info(this, "_refresherCancellationTokenSource was already initialized, whhich was unexpected. Canceling and disposing the previous instance.", nameof(InitLoopAsync));
 
-                _refresherCancellationTokenSource.Cancel();
+                try
+                {
+                    _refresherCancellationTokenSource.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
                 _refresherCancellationTokenSource.Dispose();
             }
             _refresherCancellationTokenSource = new CancellationTokenSource();


### PR DESCRIPTION
The amqp sas token refresher runs as a background unmonitored task. We need to ensure that the task is cancelled as a part of transport layer cleanup.

Related: #2339 , maybe #2351