### PR TITLE
Fixed M2M message (MQTT) failure after receiving Twin response or Direct method

### DIFF
--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -719,11 +719,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                     case PacketType.PUBLISH:
                         ProcessPublish(context, (PublishPacket)packet);
-                        // Checking if acknowledgement is needed after receiving direct method from Hub with QoS = 1,
-                        // otherwise its not acknowledged because direct method response does not require CompleteAsync() call.
+                        // Checking if acknowledgement is needed after receiving twin response or direct method from Hub with QoS = 1,
+                        // otherwise its not acknowledged because direct method and twin response do not require CompleteAsync() call.
                         // Other messages with QoS = 1 are acknowledged from WriteAsync() after CompleteAsync() call.
                         if (((PublishPacket)packet).QualityOfService == QualityOfService.AtLeastOnce &&
-                            ((PublishPacket)packet).TopicName.StartsWith(MqttTransportHandler.MethodPostTopicPrefix, StringComparison.OrdinalIgnoreCase))
+                            !((PublishPacket)packet).TopicName.StartsWith(string.Format(MqttTransportHandler.ReceiveEventMessagePrefixPattern, _deviceId, _moduleId), StringComparison.OrdinalIgnoreCase))
                         {
                             await AcknowledgeAsync(context, ((PublishPacket)packet).PacketId.ToString()).ConfigureAwait(false);
                         }

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -719,14 +719,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                     case PacketType.PUBLISH:
                         ProcessPublish(context, (PublishPacket)packet);
-                        // Checking if acknowledgement is needed after receiving twin response or direct method from Hub with QoS = 1,
-                        // otherwise its not acknowledged because direct method and twin response do not require CompleteAsync() call.
-                        // Other messages with QoS = 1 are acknowledged from WriteAsync() after CompleteAsync() call.
-                        if (((PublishPacket)packet).QualityOfService == QualityOfService.AtLeastOnce &&
-                            !((PublishPacket)packet).TopicName.StartsWith(string.Format(MqttTransportHandler.ReceiveEventMessagePrefixPattern, _deviceId, _moduleId), StringComparison.OrdinalIgnoreCase))
-                        {
-                            await AcknowledgeAsync(context, ((PublishPacket)packet).PacketId.ToString()).ConfigureAwait(false);
-                        }
                         break;
 
                     case PacketType.PUBACK:

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -655,7 +655,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         {
             try
             {
-                if (_qosReceivePacketFromService == QualityOfService.AtLeastOnce)
+                if (_qosReceivePacketFromService == QualityOfService.AtLeastOnce && message.LockToken != null)
                 {
                     _completionQueue.Enqueue(message.LockToken);
                     await CompleteAsync(_generationId + message.LockToken, CancellationToken.None).ConfigureAwait(false);

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         // The client first subscribes to "$iothub/twin/res/#", to receive the operation's responses.
         // It then sends an empty message to the topic "$iothub/twin/GET/?$rid={request id}, with a populated value for request Id.
         // The service then sends a response message containing the device twin data on topic "$iothub/twin/res/{status}/?$rid={request id}", using the same request Id as the request.
-
+        
         private const string TwinResponseTopicFilter = "$iothub/twin/res/#";
         private const string TwinResponseTopicPrefix = "$iothub/twin/res/";
         private const string TwinGetTopic = "$iothub/twin/GET/?$rid={0}";
@@ -86,14 +86,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         // The service sends method requests to the topic "$iothub/methods/POST/{method name}/?$rid={request id}".
         // The client responds to the direct method invocation by sending a message to the topic "$iothub/methods/res/{status}/?$rid={request id}", using the same request Id as the request.
 
-        internal const string MethodPostTopicPrefix = "$iothub/methods/POST/";
         private const string MethodPostTopicFilter = "$iothub/methods/POST/#";
+        private const string MethodPostTopicPrefix = "$iothub/methods/POST/";
         private const string MethodResponseTopic = "$iothub/methods/res/{0}/?$rid={1}";
 
         // Topic names for enabling events on Modules.
 
         private const string ReceiveEventMessagePatternFilter = "devices/{0}/modules/{1}/#";
-        private const string ReceiveEventMessagePrefixPattern = "devices/{0}/modules/{1}/";
+        internal const string ReceiveEventMessagePrefixPattern = "devices/{0}/modules/{1}/";
 
         private static readonly int s_generationPrefixLength = Guid.NewGuid().ToString().Length;
         private static readonly Lazy<IEventLoopGroup> s_eventLoopGroup = new Lazy<IEventLoopGroup>(GetEventLoopGroup);


### PR DESCRIPTION
Module-to-module message (MQTT) failed after receiving a twin response from EdgeHub. The issue was occurring due to mis-matched Ack for the M2M message after twin response. The Mqtt client was not processing the Ack for twin response properly that caused sending incorrect Ack for each M2M message after receiving twin response.