### PR TITLE
release changes

### DIFF
--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!--netcoreapp2.1 target framework here is solely so that this library can use the SocketsHttpHandler class to handle connection lease timeout issues.-->
     <!--See #1874 for additional details-->
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.38.1</Version>
+    <Version>1.38.2</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,6 +1,6 @@
 AssemblyPath, Version
 iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.41.2
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.38.1
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.38.2
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.30.2
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.19.2
 provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.18.2


### PR DESCRIPTION
## Microsoft.Azure.Devices.Client 1.38.2

- Fixed M2M message (MQTT) failure after receiving Twin response or Direct method [#2938](https://github.com/Azure/azure-iot-sdk-csharp/pull/2938)
- Cancel amqp token refresher as a part of transport cleanup [#2935](https://github.com/Azure/azure-iot-sdk-csharp/pull/2935)