### PR TITLE
fix: use convention method to get payload bytes

### DIFF
--- a/iothub/device/src/DirectMethod/DirectMethodResponse.cs
+++ b/iothub/device/src/DirectMethod/DirectMethodResponse.cs
@@ -50,18 +50,11 @@ namespace Microsoft.Azure.Devices.Client
         [JsonIgnore]
         protected internal PayloadConvention PayloadConvention { get; set; }
 
-        internal string GetPayloadAsString()
+        internal byte[] GetPayloadObjectBytes()
         {
             return Payload == null
                 ? null
-                : PayloadConvention.PayloadSerializer.SerializeToString(Payload);
-        }
-
-        internal byte[] GetPayloadAsBytes()
-        {
-            return Payload == null
-                ? null
-                : PayloadConvention.PayloadEncoder.ContentEncoding.GetBytes(GetPayloadAsString());
+                : PayloadConvention.GetObjectBytes(Payload); ;
         }
     }
 }

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotMessageConverter.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotMessageConverter.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
         {
             AmqpMessage amqpMessage = directMethodResponse.Payload == null
                 ? AmqpMessage.Create()
-                : AmqpMessage.Create(new MemoryStream(directMethodResponse.GetPayloadAsBytes()), true);
+                : AmqpMessage.Create(new MemoryStream(directMethodResponse.GetPayloadObjectBytes()), true);
 
             PopulateAmqpMessageFromMethodResponse(amqpMessage, directMethodResponse);
             return amqpMessage;

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -430,7 +430,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         public override async Task SendMethodResponseAsync(DirectMethodResponse methodResponse, CancellationToken cancellationToken)
         {
             string topic = DirectMethodsResponseTopicFormat.FormatInvariant(methodResponse.Status, methodResponse.RequestId);
-            byte[] serializedPayload = methodResponse.GetPayloadAsBytes();
+            byte[] serializedPayload = methodResponse.GetPayloadObjectBytes();
             MqttApplicationMessage mqttMessage = new MqttApplicationMessageBuilder()
                 .WithTopic(topic)
                 .WithPayload(serializedPayload)


### PR DESCRIPTION
The direct method response implementation was using the individual serializer and encoder implementations to get the payload bytes instead of getting it off the payload convention directly. This PR fixes that.

For reference:
PayloadConvention.cs

```c#
/// <summary>
/// Returns the byte array for the convention-based message.
/// </summary>
/// <remarks>This will use the <see cref="PayloadSerializer"/> and <see cref="PayloadEncoder"/> to create the byte array.</remarks>
/// <param name="objectToSendWithConvention">The convention-based message to be sent.</param>
/// <returns>The correctly encoded object for this convention.</returns>
public virtual byte[] GetObjectBytes(object objectToSendWithConvention)
{
    string serializedString = PayloadSerializer.SerializeToString(objectToSendWithConvention);
    return PayloadEncoder.EncodeStringToByteArray(serializedString);
}
```
