### PR TITLE
Microsoft Azure IoT Hub SDK for .NET Release 2022-11-16

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -37,7 +37,7 @@
     <Description>Device SDK for Azure IoT Hub</Description>
     <PackageIcon>nugetIcon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/Azure/azure-iot-sdk-csharp</PackageProjectUrl>
-    <Copyright>Â© Microsoft Corporation. All rights reserved.</Copyright>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>IoT Microsoft Azure IoTHub Device Client .NET AMQP MQTT HTTP</PackageTags>
   </PropertyGroup>
 

--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net5.0;netstandard2.1;netstandard2.0;net472;net451</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.41.2</Version>
+    <Version>1.41.3</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
@@ -37,7 +37,7 @@
     <Description>Device SDK for Azure IoT Hub</Description>
     <PackageIcon>nugetIcon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/Azure/azure-iot-sdk-csharp</PackageProjectUrl>
-    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <Copyright>Â© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>IoT Microsoft Azure IoTHub Device Client .NET AMQP MQTT HTTP</PackageTags>
   </PropertyGroup>
 

--- a/versions.csv
+++ b/versions.csv
@@ -1,5 +1,5 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.41.2
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.41.3
 iothub\service\src\Microsoft.Azure.Devices.csproj, 1.38.2
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.30.2
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.19.2


### PR DESCRIPTION
## Microsoft.Azure.Devices.Client 1.41.3

- Fixed M2M message (MQTT) failure after receiving Twin response or Direct method [#2938](https://github.com/Azure/azure-iot-sdk-csharp/pull/2938)
- Cancel amqp token refresher as a part of transport cleanup [#2935](https://github.com/Azure/azure-iot-sdk-csharp/pull/2935)