### PR TITLE
Remove ShouldSerialize*()

### DIFF
--- a/iothub/service/src/Configurations/Models/Configuration.cs
+++ b/iothub/service/src/Configurations/Models/Configuration.cs
@@ -106,15 +106,5 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         [JsonPropertyName("etag")]
         public ETag ETag { get; set; }
-
-        /// <summary>
-        /// For use in serialization.
-        /// </summary>
-        /// <seealso href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm#ShouldSerialize"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeLabels()
-        {
-            return Labels != null && Labels.Any();
-        }
     }
 }

--- a/iothub/service/src/Configurations/Models/ConfigurationContent.cs
+++ b/iothub/service/src/Configurations/Models/ConfigurationContent.cs
@@ -38,50 +38,5 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         [JsonPropertyName("deviceContent")]
         public IDictionary<string, object> DeviceContent { get; set; } = new Dictionary<string, object>();
-
-        /// <summary>
-        /// For use in serialization.
-        /// </summary>
-        /// <remarks>
-        /// To give the properties above a default instance to prevent <see cref="NullReferenceException"/> but
-        /// avoid serializing them when the dictionary is empty, we use this feature of Newtonsoft.Json, which must
-        /// be public, and hide it from web docs and intellisense using the EditorBrowsable attribute.
-        /// </remarks>
-        /// <seealso href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm#ShouldSerialize"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeModulesContent()
-        {
-            return ModulesContent != null && ModulesContent.Any();
-        }
-
-        /// <summary>
-        /// For use in serialization.
-        /// </summary>
-        /// <remarks>
-        /// To give the properties above a default instance to prevent <see cref="NullReferenceException"/> but
-        /// avoid serializing them when the dictionary is empty, we use this feature of Newtonsoft.Json, which must
-        /// be public, and hide it from web docs and intellisense using the EditorBrowsable attribute.
-        /// </remarks>
-        /// <seealso href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm#ShouldSerialize"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeModuleContent()
-        {
-            return ModuleContent != null && ModuleContent.Any();
-        }
-
-        /// <summary>
-        /// For use in serialization.
-        /// </summary>
-        /// <remarks>
-        /// To give the properties above a default instance to prevent <see cref="NullReferenceException"/> but
-        /// avoid serializing them when the dictionary is empty, we use this feature of Newtonsoft.Json, which must
-        /// be public, and hide it from web docs and intellisense using the EditorBrowsable attribute.
-        /// </remarks>
-        /// <seealso href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm#ShouldSerialize"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeDeviceContent()
-        {
-            return DeviceContent != null && DeviceContent.Any();
-        }
     }
 }

--- a/iothub/service/src/Configurations/Models/ConfigurationMetrics.cs
+++ b/iothub/service/src/Configurations/Models/ConfigurationMetrics.cs
@@ -28,35 +28,5 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         [JsonPropertyName("queries")]
         public IDictionary<string, string> Queries { get; set; } = new Dictionary<string, string>();
-
-        /// <summary>
-        /// For use in serialization.
-        /// </summary>
-        /// <remarks>
-        /// To give the properties above a default instance to prevent <see cref="NullReferenceException"/> but
-        /// avoid serializing them when the dictionary is empty, we use this feature of Newtonsoft.Json, which must
-        /// be public, and hide it from web docs and intellisense using the EditorBrowsable attribute.
-        /// </remarks>
-        /// <seealso href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm#ShouldSerialize"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeResults()
-        {
-            return Results != null && Results.Any();
-        }
-
-        /// <summary>
-        /// For use in serialization.
-        /// </summary>
-        /// <remarks>
-        /// To give the properties above a default instance to prevent <see cref="NullReferenceException"/> but
-        /// avoid serializing them when the dictionary is empty, we use this feature of Newtonsoft.Json, which must
-        /// be public, and hide it from web docs and intellisense using the EditorBrowsable attribute.
-        /// </remarks>
-        /// <seealso href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm#ShouldSerialize"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeQueries()
-        {
-            return Queries != null && Queries.Any();
-        }
     }
 }

--- a/iothub/service/src/DigitalTwin/Serialization/BasicDigitalTwin.cs
+++ b/iothub/service/src/DigitalTwin/Serialization/BasicDigitalTwin.cs
@@ -39,15 +39,5 @@ namespace Microsoft.Azure.Devices
         /// </remarks>
         [JsonExtensionData]
         public IDictionary<string, object> CustomProperties { get; set; } = new Dictionary<string, object>();
-
-        /// <summary>
-        /// For use in serialization.
-        /// </summary>
-        /// <seealso href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm#ShouldSerialize"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeCustomProperties()
-        {
-            return CustomProperties != null && CustomProperties.Any();
-        }
     }
 }

--- a/iothub/service/src/Twin/Models/ClientTwin.cs
+++ b/iothub/service/src/Twin/Models/ClientTwin.cs
@@ -172,35 +172,5 @@ namespace Microsoft.Azure.Devices
         /// </remarks>
         [JsonPropertyName(NullValueHandling = NullValueHandling.Ignore)]
         public virtual IReadOnlyList<string> ParentScopes { get; internal set; } = new List<string>();
-
-        /// <summary>
-        /// For use in serialization.
-        /// </summary>
-        /// <seealso href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm#ShouldSerialize"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeTags()
-        {
-            return Tags != null && Tags.Count > 0;
-        }
-
-        /// <summary>
-        /// For use in serialization.
-        /// </summary>
-        /// <seealso href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm#ShouldSerialize"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeConfigurations()
-        {
-            return Configurations != null && Configurations.Any();
-        }
-
-        /// <summary>
-        /// For use in serialization.
-        /// </summary>
-        /// <seealso href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm#ShouldSerialize"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeParentScopes()
-        {
-            return ParentScopes != null && ParentScopes.Any();
-        }
     }
 }

--- a/provisioning/service/src/Models/EnrollmentGroup.cs
+++ b/provisioning/service/src/Models/EnrollmentGroup.cs
@@ -288,15 +288,5 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </summary>
         [JsonPropertyName("customAllocationDefinition")]
         public CustomAllocationDefinition CustomAllocationDefinition { get; set; }
-
-        /// <summary>
-        /// For use in serialization.
-        /// </summary>
-        /// <seealso href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm#ShouldSerialize"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeIotHubs()
-        {
-            return IotHubs != null && IotHubs.Any();
-        }
     }
 }

--- a/provisioning/service/src/Models/IndividualEnrollment.cs
+++ b/provisioning/service/src/Models/IndividualEnrollment.cs
@@ -213,24 +213,5 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// </summary>
         [JsonPropertyName("iotHubs")]
         public IList<string> IotHubs { get; set; } = new List<string>();
-
-        /// <summary>
-        /// Convert this object in a pretty print format.
-        /// </summary>
-        /// <returns>The string with the content of this class in a pretty print format.</returns>
-        public override string ToString()
-        {
-            return JsonSerializer.Serialize(this, Formatting.Indented);
-        }
-
-        /// <summary>
-        /// For use in serialization.
-        /// </summary>
-        /// <seealso href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm#ShouldSerialize"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeIotHubs()
-        {
-            return IotHubs != null && IotHubs.Any();
-        }
     }
 }


### PR DESCRIPTION
It looks like there isn't a proxy for this in System.Text.Json, at least not until net7.0.

I suspect we'll be okay letting empty collections get serialized, but we'll need to validate with E2E tests.