### PR TITLE
fix - v2 GatewayHostname ignored for MQTT

### DIFF
--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             _mqttClient = mqttFactory.CreateMqttClient();
             _mqttClientOptionsBuilder = new MqttClientOptionsBuilder();
 
-            _hostName = context.IotHubConnectionCredentials.IotHubHostName;
+            _hostName = context.IotHubConnectionCredentials.HostName;
             _connectionCredentials = context.IotHubConnectionCredentials;
 
             if (_mqttTransportSettings.Protocol == IotHubClientTransportProtocol.Tcp)
@@ -217,12 +217,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
 
             var tlsParameters = new MqttClientOptionsBuilderTlsParameters();
-
-            List<X509Certificate> certs = _connectionCredentials.ClientCertificate == null
-                ? new List<X509Certificate>(0)
-                : new List<X509Certificate> { _connectionCredentials.ClientCertificate };
-
-            tlsParameters.Certificates = certs;
+            if (_connectionCredentials.ClientCertificate != null)
+            {
+                tlsParameters.Certificates = new List<X509Certificate> { _connectionCredentials.ClientCertificate };
+            }
+            else
+            {
+                tlsParameters.IgnoreCertificateRevocationErrors = true;
+            }
 
             if (_mqttTransportSettings?.RemoteCertificateValidationCallback != null)
             {
@@ -1108,12 +1110,12 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             _ = _twinResponseTimeouts
                 .Where(x => DateTimeOffset.UtcNow - x.Value > s_twinResponseTimeout)
                 .Select(x =>
-                    {
-                        _getTwinResponseCompletions.TryRemove(x.Key, out TaskCompletionSource<GetTwinResponse> _);
-                        _reportedPropertyUpdateResponseCompletions.TryRemove(x.Key, out TaskCompletionSource<PatchTwinResponse> _);
-                        _twinResponseTimeouts.TryRemove(x.Key, out DateTimeOffset _);
-                        return true;
-                    });
+                {
+                    _getTwinResponseCompletions.TryRemove(x.Key, out TaskCompletionSource<GetTwinResponse> _);
+                    _reportedPropertyUpdateResponseCompletions.TryRemove(x.Key, out TaskCompletionSource<PatchTwinResponse> _);
+                    _twinResponseTimeouts.TryRemove(x.Key, out DateTimeOffset _);
+                    return true;
+                });
         }
 
         private static void PopulateMessagePropertiesFromMqttMessage(IncomingMessage message, MqttApplicationMessage mqttMessage)


### PR DESCRIPTION
1. Updated implementation to use GatewayHostname when provided instead of always using IotHubHostname (MQTT).
2. For [AMQP implementation](https://github.com/Azure/azure-amqp/blob/6ae2104a3497dbe71113941c003b5ae0d94a6414/src/Transport/TlsTransport.cs#L189), if certificate information is not provided, certificate revocation checks are set to false. MQTT implementation in v2 was missing this change. To fix this, for cases when certificate information is not provided, boolean 'IgnoreCertificateRevocationErrors' needs to be set to true, based on this [MQTT net implementation](https://github.com/dotnet/MQTTnet/blob/e88b280eb0fac04267487555399bff7241af4349/Source/MQTTnet/Implementations/MqttTcpChannel.cs#L113).