### PR TITLE
Parse service error fot get twin failures - mqtt

### DIFF
--- a/iothub/device/src/Exceptions/IotHubClientErrorCode.cs
+++ b/iothub/device/src/Exceptions/IotHubClientErrorCode.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Devices.Client
         /// Retrying with exponential back-off could resolve this error. For information on the IoT hub quotas and
         /// throttling, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-quotas-throttling"/>.
         /// </remark>
-        Throttled,
+        Throttled = 429,
 
         /// <summary>
         /// The ETag in the request does not match the ETag of the existing resource.

--- a/iothub/device/src/Exceptions/IotHubClientErrorResponseMessage.cs
+++ b/iothub/device/src/Exceptions/IotHubClientErrorResponseMessage.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices.Client
     internal class IotHubClientErrorResponseMessage
     {
         [JsonProperty("errorCode")]
-        internal string ErrorCode { get; set; }
+        internal int ErrorCode { get; set; }
 
         [JsonProperty("trackingId")]
         internal string TrackingId { get; set; }

--- a/iothub/device/src/Transport/Mqtt/GetTwinResponse.cs
+++ b/iothub/device/src/Transport/Mqtt/GetTwinResponse.cs
@@ -30,6 +30,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         /// <summary>
         /// The error message if the request failed.
         /// </summary>
-        internal string Message { get; set; }
+        internal IotHubClientErrorResponseMessage ErrorResponseMessage { get; set; }
     }
 }

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -642,8 +642,9 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     // Check if we have an int to string error code translation for the service returned error code.
                     // The error code could be a part of the service returned error message, or it can be a part of the topic string.
                     // We will check with the error code in the error message first (if present) since that is the more specific error code returned.
-                    if (Enum.TryParse(getTwinResponse.ErrorResponseMessage.ErrorCode.ToString(), out IotHubClientErrorCode errorCode)
+                    if ((Enum.TryParse(getTwinResponse.ErrorResponseMessage.ErrorCode.ToString(), out IotHubClientErrorCode errorCode)
                         || Enum.TryParse(getTwinResponse.Status.ToString(), out errorCode))
+                        && Enum.IsDefined(typeof(IotHubClientErrorCode), errorCode))
                     {
                         throw new IotHubClientException(getTwinResponse.ErrorResponseMessage.Message, errorCode)
                         {
@@ -743,8 +744,9 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     // Check if we have an int to string error code translation for the service returned error code.
                     // The error code could be a part of the service returned error message, or it can be a part of the topic string.
                     // We will check with the error code in the error message first (if present) since that is the more specific error code returned.
-                    if (Enum.TryParse(patchTwinResponse.ErrorResponseMessage.ErrorCode.ToString(), out IotHubClientErrorCode errorCode)
+                    if ((Enum.TryParse(patchTwinResponse.ErrorResponseMessage.ErrorCode.ToString(), out IotHubClientErrorCode errorCode)
                         || Enum.TryParse(patchTwinResponse.Status.ToString(), out errorCode))
+                        && Enum.IsDefined(typeof(IotHubClientErrorCode), errorCode))
                     {
                         throw new IotHubClientException(patchTwinResponse.ErrorResponseMessage.Message, errorCode)
                         {
@@ -1091,7 +1093,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                             catch (JsonException ex)
                             {
                                 if (Logging.IsEnabled)
-                                    Logging.Error(this, $"Failed to parse twin patch error response JSON: {ex}. Message body: '{errorResponseString}'");
+                                    Logging.Error(this, $"Failed to parse twin patch error response JSON. Message body: '{errorResponseString}'. Exception: {ex}. ");
 
                                 errorResponse = new IotHubClientErrorResponseMessage
                                 {
@@ -1144,7 +1146,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                         catch (JsonReaderException ex)
                         {
                             if (Logging.IsEnabled)
-                                Logging.Error(this, $"Failed to parse Twin JSON: {ex}. Message body: '{Encoding.UTF8.GetString(payloadBytes)}'");
+                                Logging.Error(this, $"Failed to parse Twin JSON.  Message body: '{Encoding.UTF8.GetString(payloadBytes)}'. Exception: {ex}.");
 
                             getTwinCompletion.TrySetException(ex);
                         }
@@ -1168,7 +1170,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                         catch (JsonException ex)
                         {
                             if (Logging.IsEnabled)
-                                Logging.Error(this, $"Failed to parse twin patch error response JSON: {ex}. Message body: '{errorResponseString}'");
+                                Logging.Error(this, $"Failed to parse twin patch error response JSON. Message body: '{errorResponseString}'. Exception: {ex}. ");
 
                             errorResponse = new IotHubClientErrorResponseMessage
                             {

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -639,8 +639,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (getTwinResponse.Status != 200)
                 {
-                    // If an error code is returned in the service returned error message then use that first.
-                    if (Enum.TryParse(getTwinResponse.ErrorResponseMessage.ErrorCode, out IotHubClientErrorCode errorCode))
+                    // Check if we have an int to string error code translation for the service returned error code.
+                    // The error code could be a part of the service returned error message, or it can be a part of the topic string.
+                    // We will compare with the error code in the error message first (if present) since that is the more specific error code returned.
+                    if (Enum.TryParse(getTwinResponse.ErrorResponseMessage.ErrorCode.ToString(), out IotHubClientErrorCode errorCode)
+                        || Enum.TryParse(getTwinResponse.Status.ToString(), out errorCode))
                     {
                         throw new IotHubClientException(getTwinResponse.ErrorResponseMessage.Message, errorCode)
                         {
@@ -737,8 +740,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (patchTwinResponse.Status != 204)
                 {
-                    // If an error code is returned in the service returned error message then use that.
-                    if (Enum.TryParse(patchTwinResponse.ErrorResponseMessage.ErrorCode, out IotHubClientErrorCode errorCode))
+                    // Check if we have an int to string error code translation for the service returned error code.
+                    // The error code could be a part of the service returned error message, or it can be a part of the topic string.
+                    // We will compare with the error code in the error message first (if present) since that is the more specific error code returned.
+                    if (Enum.TryParse(patchTwinResponse.ErrorResponseMessage.ErrorCode.ToString(), out IotHubClientErrorCode errorCode)
+                        || Enum.TryParse(patchTwinResponse.Status.ToString(), out errorCode))
                     {
                         throw new IotHubClientException(patchTwinResponse.ErrorResponseMessage.Message, errorCode)
                         {

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -641,7 +641,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 {
                     // Check if we have an int to string error code translation for the service returned error code.
                     // The error code could be a part of the service returned error message, or it can be a part of the topic string.
-                    // We will compare with the error code in the error message first (if present) since that is the more specific error code returned.
+                    // We will check with the error code in the error message first (if present) since that is the more specific error code returned.
                     if (Enum.TryParse(getTwinResponse.ErrorResponseMessage.ErrorCode.ToString(), out IotHubClientErrorCode errorCode)
                         || Enum.TryParse(getTwinResponse.Status.ToString(), out errorCode))
                     {
@@ -742,7 +742,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 {
                     // Check if we have an int to string error code translation for the service returned error code.
                     // The error code could be a part of the service returned error message, or it can be a part of the topic string.
-                    // We will compare with the error code in the error message first (if present) since that is the more specific error code returned.
+                    // We will check with the error code in the error message first (if present) since that is the more specific error code returned.
                     if (Enum.TryParse(patchTwinResponse.ErrorResponseMessage.ErrorCode.ToString(), out IotHubClientErrorCode errorCode)
                         || Enum.TryParse(patchTwinResponse.Status.ToString(), out errorCode))
                     {

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -644,23 +644,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     {
                         throw new IotHubClientException(getTwinResponse.ErrorResponseMessage.Message, errorCode)
                         {
-                            TrackingId = getTwinResponse.ErrorResponseMessage.TrackingId
+                            TrackingId = getTwinResponse.ErrorResponseMessage.TrackingId,
                         };
-                    }
-
-                    // The Hub team is refactoring the retriable status codes without breaking changes to the existing ones.
-                    // It can be expected that we may bring more retriable codes here in the future.
-                    // Retry for Http status code 429 (too many requests)
-                    if (getTwinResponse.Status == 429)
-                    {
-                        throw new IotHubClientException(
-                            getTwinResponse.ErrorResponseMessage.Message,
-                            IotHubClientErrorCode.Throttled);
                     }
 
                     throw new IotHubClientException(getTwinResponse.ErrorResponseMessage.Message)
                     {
-                        TrackingId = getTwinResponse.ErrorResponseMessage.TrackingId
+                        TrackingId = getTwinResponse.ErrorResponseMessage.TrackingId,
                     };
                 }
 
@@ -747,17 +737,18 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 if (patchTwinResponse.Status != 204)
                 {
+                    // If an error code is returned in the service returned error message then use that.
                     if (Enum.TryParse(patchTwinResponse.ErrorResponseMessage.ErrorCode, out IotHubClientErrorCode errorCode))
                     {
                         throw new IotHubClientException(patchTwinResponse.ErrorResponseMessage.Message, errorCode)
                         {
-                            TrackingId = patchTwinResponse.ErrorResponseMessage.TrackingId
+                            TrackingId = patchTwinResponse.ErrorResponseMessage.TrackingId,
                         };
                     }
 
                     throw new IotHubClientException(patchTwinResponse.ErrorResponseMessage.Message)
                     {
-                        TrackingId = patchTwinResponse.ErrorResponseMessage.TrackingId
+                        TrackingId = patchTwinResponse.ErrorResponseMessage.TrackingId,
                     };
                 }
 

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -637,7 +637,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 if (Logging.IsEnabled)
                     Logging.Info(this, $"Received get twin response for request id {requestId} with status {getTwinResponse.Status}.");
 
-                if (getTwinResponse.Status >= 300)
+                if (getTwinResponse.Status != 200)
                 {
                     // If an error code is returned in the service returned error message then use that first.
                     if (Enum.TryParse(getTwinResponse.ErrorResponseMessage.ErrorCode, out IotHubClientErrorCode errorCode))


### PR DESCRIPTION
Related #2967 

Our transport layer currently isn't inspecting and parsing out the service returned error message over AMQP and MQTT. Instead, the entire error "message" block containing the error code, description, tracking Id etc. is put into IotHubClientException.Message. This leaves the parsing responsibility onto the customer.
This PR proposes a change where we inspect the received error message and parse it out.

Another related issue is that as a result of us not parsing out the error message, we currently mark all unsuccessful MQTT twin operations as retryable. This results in the actual error being hidden from the user and the SDK unnecessarily retying non-retryable error scenarios.

This PR also adds back the error parsing logic from here: https://github.com/Azure/azure-iot-sdk-csharp/blob/main/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs#L1130-L1143