### PR TITLE
Fix build errors in previews/v2

### DIFF
--- a/e2e/test/helpers/TestDevice.cs
+++ b/e2e/test/helpers/TestDevice.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         Device,
     }
 
-    public class TestDevice : IDisposable
+    public sealed class TestDevice : IDisposable
     {
         private static readonly SemaphoreSlim s_semaphore = new(1, 1);
 

--- a/e2e/test/helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/helpers/TestDeviceCallbackHandler.cs
@@ -175,6 +175,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             _methodCallbackSemaphore?.Dispose();
             _twinCallbackSemaphore?.Dispose();
             _receivedMessageCallbackSemaphore?.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/e2e/test/helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/helpers/TestDeviceCallbackHandler.cs
@@ -11,7 +11,7 @@ using Microsoft.Azure.Devices.Client;
 
 namespace Microsoft.Azure.Devices.E2ETests.Helpers
 {
-    public class TestDeviceCallbackHandler : IDisposable
+    public sealed class TestDeviceCallbackHandler : IDisposable
     {
         private readonly IotHubDeviceClient _deviceClient;
         private readonly TestDevice _testDevice;
@@ -175,7 +175,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             _methodCallbackSemaphore?.Dispose();
             _twinCallbackSemaphore?.Dispose();
             _receivedMessageCallbackSemaphore?.Dispose();
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/e2e/test/iothub/device/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
+++ b/e2e/test/iothub/device/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
             await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSettings));
-            await AzureSecurityCenterForIoTSecurityMessageE2ETests.SendSingleSecurityMessageAsync(deviceClient).ConfigureAwait(false);
+            await SendSingleSecurityMessageAsync(deviceClient).ConfigureAwait(false);
         }
 
         private async Task TestSecurityMessageModuleAsync(IotHubClientTransportSettings transportSettings)
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             var options = new IotHubClientOptions(transportSettings);
             await using var moduleClient = new IotHubModuleClient(testModule.ConnectionString, options);
-            await AzureSecurityCenterForIoTSecurityMessageE2ETests.SendSingleSecurityMessageModuleAsync(moduleClient).ConfigureAwait(false);
+            await SendSingleSecurityMessageModuleAsync(moduleClient).ConfigureAwait(false);
         }
 
         private static async Task SendSingleSecurityMessageAsync(
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         {
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
-            TelemetryMessage testMessage = AzureSecurityCenterForIoTSecurityMessageE2ETests.ComposeD2CSecurityTestMessage();
+            TelemetryMessage testMessage = ComposeD2CSecurityTestMessage();
             await deviceClient.SendTelemetryAsync(testMessage).ConfigureAwait(false);
         }
 
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             IotHubModuleClient moduleClient)
         {
             await moduleClient.OpenAsync().ConfigureAwait(false);
-            TelemetryMessage testMessage = AzureSecurityCenterForIoTSecurityMessageE2ETests.ComposeD2CSecurityTestMessage();
+            TelemetryMessage testMessage = ComposeD2CSecurityTestMessage();
             await moduleClient.SendTelemetryAsync(testMessage).ConfigureAwait(false);
         }
 

--- a/e2e/test/iothub/device/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
+++ b/e2e/test/iothub/device/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             return TestSecurityMessageModuleAsync(new IotHubClientMqttSettings(IotHubClientTransportProtocol.WebSocket));
         }
 
-        private TelemetryMessage ComposeD2CSecurityTestMessage()
+        private static TelemetryMessage ComposeD2CSecurityTestMessage()
         {
             string eventId = Guid.NewGuid().ToString();
             string p1Value = eventId;
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
             await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSettings));
-            await SendSingleSecurityMessageAsync(deviceClient).ConfigureAwait(false);
+            await AzureSecurityCenterForIoTSecurityMessageE2ETests.SendSingleSecurityMessageAsync(deviceClient).ConfigureAwait(false);
         }
 
         private async Task TestSecurityMessageModuleAsync(IotHubClientTransportSettings transportSettings)
@@ -134,23 +134,23 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             var options = new IotHubClientOptions(transportSettings);
             await using var moduleClient = new IotHubModuleClient(testModule.ConnectionString, options);
-            await SendSingleSecurityMessageModuleAsync(moduleClient).ConfigureAwait(false);
+            await AzureSecurityCenterForIoTSecurityMessageE2ETests.SendSingleSecurityMessageModuleAsync(moduleClient).ConfigureAwait(false);
         }
 
-        private async Task SendSingleSecurityMessageAsync(
+        private static async Task SendSingleSecurityMessageAsync(
             IotHubDeviceClient deviceClient)
         {
             await deviceClient.OpenAsync().ConfigureAwait(false);
 
-            TelemetryMessage testMessage = ComposeD2CSecurityTestMessage();
+            TelemetryMessage testMessage = AzureSecurityCenterForIoTSecurityMessageE2ETests.ComposeD2CSecurityTestMessage();
             await deviceClient.SendTelemetryAsync(testMessage).ConfigureAwait(false);
         }
 
-        private async Task SendSingleSecurityMessageModuleAsync(
+        private static async Task SendSingleSecurityMessageModuleAsync(
             IotHubModuleClient moduleClient)
         {
             await moduleClient.OpenAsync().ConfigureAwait(false);
-            TelemetryMessage testMessage = ComposeD2CSecurityTestMessage();
+            TelemetryMessage testMessage = AzureSecurityCenterForIoTSecurityMessageE2ETests.ComposeD2CSecurityTestMessage();
             await moduleClient.SendTelemetryAsync(testMessage).ConfigureAwait(false);
         }
 

--- a/e2e/test/iothub/device/DeviceClientX509AuthenticationE2ETests.cs
+++ b/e2e/test/iothub/device/DeviceClientX509AuthenticationE2ETests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task X509_Enable_CertificateRevocationCheck_MqttTcp()
         {
             IotHubClientTransportSettings transportSetting = CreateMqttTransportSettingWithCertificateRevocationCheck(IotHubClientTransportProtocol.Tcp);
-            await DeviceClientX509AuthenticationE2ETests.SendMessageTestAsync(transportSetting).ConfigureAwait(false);
+            await SendMessageTestAsync(transportSetting).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task X509_Enable_CertificateRevocationCheck_MqttWs()
         {
             IotHubClientTransportSettings transportSetting = CreateMqttTransportSettingWithCertificateRevocationCheck(IotHubClientTransportProtocol.WebSocket);
-            await DeviceClientX509AuthenticationE2ETests.SendMessageTestAsync(transportSetting).ConfigureAwait(false);
+            await SendMessageTestAsync(transportSetting).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task X509_Enable_CertificateRevocationCheck_AmqpTcp()
         {
             IotHubClientTransportSettings transportSetting = CreateAmqpTransportSettingWithCertificateRevocationCheck(IotHubClientTransportProtocol.Tcp);
-            await DeviceClientX509AuthenticationE2ETests.SendMessageTestAsync(transportSetting).ConfigureAwait(false);
+            await SendMessageTestAsync(transportSetting).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task X509_Enable_CertificateRevocationCheck_AmqpWs()
         {
             IotHubClientTransportSettings transportSetting = CreateAmqpTransportSettingWithCertificateRevocationCheck(IotHubClientTransportProtocol.WebSocket);
-            await DeviceClientX509AuthenticationE2ETests.SendMessageTestAsync(transportSetting).ConfigureAwait(false);
+            await SendMessageTestAsync(transportSetting).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task X509_CustomWebSocket_AmqpWs()
         {
             IotHubClientTransportSettings transportSetting = CreateAmqpTransportSettingWithCustomWebSocket(IotHubClientTransportProtocol.WebSocket);
-            await DeviceClientX509AuthenticationE2ETests.SendMessageTestAsync(transportSetting).ConfigureAwait(false);
+            await SendMessageTestAsync(transportSetting).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             await deviceClient.CloseAsync().ConfigureAwait(false);
 
             // assert
-            DeviceClientX509AuthenticationE2ETests.ValidateCertsAreInstalled(chainCerts);
+            ValidateCertsAreInstalled(chainCerts);
         }
 
         [TestMethod]
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSetting));
             await deviceClient.OpenAsync().ConfigureAwait(false);
-            var message = TelemetryE2ETests.ComposeD2cTestMessage(out string _, out string _);
+            TelemetryMessage message = TelemetryE2ETests.ComposeD2cTestMessage(out string _, out string _);
             await deviceClient.SendTelemetryAsync(message).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);
         }

--- a/e2e/test/iothub/device/DeviceClientX509AuthenticationE2ETests.cs
+++ b/e2e/test/iothub/device/DeviceClientX509AuthenticationE2ETests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task X509_Enable_CertificateRevocationCheck_MqttTcp()
         {
             IotHubClientTransportSettings transportSetting = CreateMqttTransportSettingWithCertificateRevocationCheck(IotHubClientTransportProtocol.Tcp);
-            await SendMessageTestAsync(transportSetting).ConfigureAwait(false);
+            await DeviceClientX509AuthenticationE2ETests.SendMessageTestAsync(transportSetting).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task X509_Enable_CertificateRevocationCheck_MqttWs()
         {
             IotHubClientTransportSettings transportSetting = CreateMqttTransportSettingWithCertificateRevocationCheck(IotHubClientTransportProtocol.WebSocket);
-            await SendMessageTestAsync(transportSetting).ConfigureAwait(false);
+            await DeviceClientX509AuthenticationE2ETests.SendMessageTestAsync(transportSetting).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task X509_Enable_CertificateRevocationCheck_AmqpTcp()
         {
             IotHubClientTransportSettings transportSetting = CreateAmqpTransportSettingWithCertificateRevocationCheck(IotHubClientTransportProtocol.Tcp);
-            await SendMessageTestAsync(transportSetting).ConfigureAwait(false);
+            await DeviceClientX509AuthenticationE2ETests.SendMessageTestAsync(transportSetting).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task X509_Enable_CertificateRevocationCheck_AmqpWs()
         {
             IotHubClientTransportSettings transportSetting = CreateAmqpTransportSettingWithCertificateRevocationCheck(IotHubClientTransportProtocol.WebSocket);
-            await SendMessageTestAsync(transportSetting).ConfigureAwait(false);
+            await DeviceClientX509AuthenticationE2ETests.SendMessageTestAsync(transportSetting).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task X509_CustomWebSocket_AmqpWs()
         {
             IotHubClientTransportSettings transportSetting = CreateAmqpTransportSettingWithCustomWebSocket(IotHubClientTransportProtocol.WebSocket);
-            await SendMessageTestAsync(transportSetting).ConfigureAwait(false);
+            await DeviceClientX509AuthenticationE2ETests.SendMessageTestAsync(transportSetting).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             store?.Dispose();
         }
 
-        private async Task SendMessageTestAsync(IotHubClientTransportSettings transportSetting)
+        private static async Task SendMessageTestAsync(IotHubClientTransportSettings transportSetting)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(s_devicePrefix, TestDeviceType.X509).ConfigureAwait(false);
 

--- a/e2e/test/iothub/device/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/device/MessageReceiveE2ETests.cs
@@ -35,14 +35,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [Timeout(TestTimeoutMilliseconds)]
         public async Task DeviceReceiveMessageUsingCallbackAndUnsubscribe_Amqp()
         {
-            await MessageReceiveE2ETests.ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, new IotHubClientAmqpSettings()).ConfigureAwait(false);
+            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, new IotHubClientAmqpSettings()).ConfigureAwait(false);
         }
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task DeviceReceiveMessageUsingCallbackAndUnsubscribe_Mqtt()
         {
-            await MessageReceiveE2ETests.ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, new IotHubClientMqttSettings()).ConfigureAwait(false);
+            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, new IotHubClientMqttSettings()).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         public async Task DeviceDoesNotReceivePendingMessageUsingCallback_Mqtt()
         {
             var settings = new IotHubClientMqttSettings() { CleanSession = true };
-            await MessageReceiveE2ETests.DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
+            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         public async Task DeviceDoesNotReceivePendingMessageUsingCallback_Amqp()
         {
             var settings = new IotHubClientAmqpSettings();
-            await MessageReceiveE2ETests.DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
+            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -79,14 +79,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [Timeout(TestTimeoutMilliseconds)]
         public async Task DeviceReceiveMessageAfterOpenCloseOpen_Amqp()
         {
-            await MessageReceiveE2ETests.ReceiveMessageAfterOpenCloseOpenAsync(TestDeviceType.Sasl, new IotHubClientAmqpSettings()).ConfigureAwait(false);
+            await ReceiveMessageAfterOpenCloseOpenAsync(TestDeviceType.Sasl, new IotHubClientAmqpSettings()).ConfigureAwait(false);
         }
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task DeviceReceiveMessageAfterOpenCloseOpen_Mqtt()
         {
-            await MessageReceiveE2ETests.ReceiveMessageAfterOpenCloseOpenAsync(TestDeviceType.Sasl, new IotHubClientMqttSettings()).ConfigureAwait(false);
+            await ReceiveMessageAfterOpenCloseOpenAsync(TestDeviceType.Sasl, new IotHubClientMqttSettings()).ConfigureAwait(false);
         }
 
         public static Message ComposeC2dTestMessage(out string payload, out string p1Value)

--- a/e2e/test/iothub/device/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/device/MessageReceiveE2ETests.cs
@@ -35,14 +35,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [Timeout(TestTimeoutMilliseconds)]
         public async Task DeviceReceiveMessageUsingCallbackAndUnsubscribe_Amqp()
         {
-            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, new IotHubClientAmqpSettings()).ConfigureAwait(false);
+            await MessageReceiveE2ETests.ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, new IotHubClientAmqpSettings()).ConfigureAwait(false);
         }
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task DeviceReceiveMessageUsingCallbackAndUnsubscribe_Mqtt()
         {
-            await ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, new IotHubClientMqttSettings()).ConfigureAwait(false);
+            await MessageReceiveE2ETests.ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType.Sasl, new IotHubClientMqttSettings()).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         public async Task DeviceDoesNotReceivePendingMessageUsingCallback_Mqtt()
         {
             var settings = new IotHubClientMqttSettings() { CleanSession = true };
-            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
+            await MessageReceiveE2ETests.DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         public async Task DeviceDoesNotReceivePendingMessageUsingCallback_Amqp()
         {
             var settings = new IotHubClientAmqpSettings();
-            await DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
+            await MessageReceiveE2ETests.DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType.Sasl, settings).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -79,14 +79,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [Timeout(TestTimeoutMilliseconds)]
         public async Task DeviceReceiveMessageAfterOpenCloseOpen_Amqp()
         {
-            await ReceiveMessageAfterOpenCloseOpenAsync(TestDeviceType.Sasl, new IotHubClientAmqpSettings()).ConfigureAwait(false);
+            await MessageReceiveE2ETests.ReceiveMessageAfterOpenCloseOpenAsync(TestDeviceType.Sasl, new IotHubClientAmqpSettings()).ConfigureAwait(false);
         }
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task DeviceReceiveMessageAfterOpenCloseOpen_Mqtt()
         {
-            await ReceiveMessageAfterOpenCloseOpenAsync(TestDeviceType.Sasl, new IotHubClientMqttSettings()).ConfigureAwait(false);
+            await MessageReceiveE2ETests.ReceiveMessageAfterOpenCloseOpenAsync(TestDeviceType.Sasl, new IotHubClientMqttSettings()).ConfigureAwait(false);
         }
 
         public static Message ComposeC2dTestMessage(out string payload, out string p1Value)
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             received.Should().BeTrue($"No message received for device {deviceId} with payload={payload} in {FaultInjection.RecoveryTime}.");
         }
 
-        private async Task ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType type, IotHubClientTransportSettings transportSettings)
+        private static async Task ReceiveMessageUsingCallbackAndUnsubscribeAsync(TestDeviceType type, IotHubClientTransportSettings transportSettings)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(s_devicePrefix, type).ConfigureAwait(false);
             await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSettings));
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             }
         }
 
-        private async Task DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType type, IotHubClientTransportSettings transportSettings)
+        private static async Task DoNotReceiveMessagesSentBeforeSubscriptionAsync(TestDeviceType type, IotHubClientTransportSettings transportSettings)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(s_devicePrefix, type).ConfigureAwait(false);
             var options = new IotHubClientOptions(transportSettings);
@@ -253,7 +253,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             testDeviceCallbackHandler.Dispose();
         }
 
-        private async Task ReceiveMessageAfterOpenCloseOpenAsync(TestDeviceType type, IotHubClientTransportSettings transportSettings)
+        private static async Task ReceiveMessageAfterOpenCloseOpenAsync(TestDeviceType type, IotHubClientTransportSettings transportSettings)
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(s_devicePrefix, type).ConfigureAwait(false);
             await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSettings));

--- a/e2e/test/iothub/device/TelemetryE2eTests.cs
+++ b/e2e/test/iothub/device/TelemetryE2eTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await using var moduleClient = new IotHubModuleClient(testModule.ConnectionString, options);
 
             await moduleClient.OpenAsync().ConfigureAwait(false);
-            await TelemetryE2ETests.SendSingleMessageModuleAsync(moduleClient).ConfigureAwait(false);
+            await SendSingleMessageModuleAsync(moduleClient).ConfigureAwait(false);
         }
 
         public static async Task SendSingleMessageAsync(IotHubDeviceClient deviceClient, int messageSize = 0)

--- a/e2e/test/iothub/device/TelemetryE2eTests.cs
+++ b/e2e/test/iothub/device/TelemetryE2eTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await using var moduleClient = new IotHubModuleClient(testModule.ConnectionString, options);
 
             await moduleClient.OpenAsync().ConfigureAwait(false);
-            await SendSingleMessageModuleAsync(moduleClient).ConfigureAwait(false);
+            await TelemetryE2ETests.SendSingleMessageModuleAsync(moduleClient).ConfigureAwait(false);
         }
 
         public static async Task SendSingleMessageAsync(IotHubDeviceClient deviceClient, int messageSize = 0)
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await deviceClient.SendTelemetryBatchAsync(messagesToBeSent.Keys.ToList()).ConfigureAwait(false);
         }
 
-        private async Task SendSingleMessageModuleAsync(IotHubModuleClient moduleClient)
+        private static async Task SendSingleMessageModuleAsync(IotHubModuleClient moduleClient)
         {
             TelemetryMessage testMessage = ComposeD2cTestMessage(out string _, out string _);
 

--- a/e2e/test/iothub/service/BulkOperationsE2ETests.cs
+++ b/e2e/test/iothub/service/BulkOperationsE2ETests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             twin.Tags[tagName] = tagValue;
 
             BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<ClientTwin> { twin }, false).ConfigureAwait(false);
-            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{ResultErrorsToString(result)}");
+            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{BulkOperationsE2ETests.ResultErrorsToString(result)}");
 
             ClientTwin twinUpd = await serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
 
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             twin.Tags[tagName] = tagValue;
 
             BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<ClientTwin> { twin }, false).ConfigureAwait(false);
-            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{ResultErrorsToString(result)}");
+            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{BulkOperationsE2ETests.ResultErrorsToString(result)}");
 
             ClientTwin twinUpd = await serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
 
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             twin.Tags[tagName] = tagValue;
 
             BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<ClientTwin> { twin }, false).ConfigureAwait(false);
-            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{ResultErrorsToString(result)}");
+            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{BulkOperationsE2ETests.ResultErrorsToString(result)}");
 
             ClientTwin twinUpd = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
 
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             twin.Tags[tagName] = tagValue;
 
             BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<ClientTwin> { twin }, false).ConfigureAwait(false);
-            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{ResultErrorsToString(result)}");
+            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{BulkOperationsE2ETests.ResultErrorsToString(result)}");
 
             ClientTwin twinUpd = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
 
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             Assert.AreEqual((string)twin.Tags[tagName], (string)twinUpd.Tags[tagName], "Tag value changed");
         }
 
-        private string ResultErrorsToString(BulkRegistryOperationResult result)
+        private static string ResultErrorsToString(BulkRegistryOperationResult result)
         {
             string errorString = "";
 

--- a/e2e/test/iothub/service/BulkOperationsE2ETests.cs
+++ b/e2e/test/iothub/service/BulkOperationsE2ETests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             twin.Tags[tagName] = tagValue;
 
             BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<ClientTwin> { twin }, false).ConfigureAwait(false);
-            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{BulkOperationsE2ETests.ResultErrorsToString(result)}");
+            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{ResultErrorsToString(result)}");
 
             ClientTwin twinUpd = await serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
 
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             twin.Tags[tagName] = tagValue;
 
             BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<ClientTwin> { twin }, false).ConfigureAwait(false);
-            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{BulkOperationsE2ETests.ResultErrorsToString(result)}");
+            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{ResultErrorsToString(result)}");
 
             ClientTwin twinUpd = await serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
 
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             twin.Tags[tagName] = tagValue;
 
             BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<ClientTwin> { twin }, false).ConfigureAwait(false);
-            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{BulkOperationsE2ETests.ResultErrorsToString(result)}");
+            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{ResultErrorsToString(result)}");
 
             ClientTwin twinUpd = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
 
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             twin.Tags[tagName] = tagValue;
 
             BulkRegistryOperationResult result = await serviceClient.Twins.UpdateAsync(new List<ClientTwin> { twin }, false).ConfigureAwait(false);
-            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{BulkOperationsE2ETests.ResultErrorsToString(result)}");
+            Assert.IsTrue(result.IsSuccessful, $"UpdateTwins2Async error:\n{ResultErrorsToString(result)}");
 
             ClientTwin twinUpd = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
 

--- a/e2e/test/iothub/service/ExportDevicesTests.cs
+++ b/e2e/test/iothub/service/ExportDevicesTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
                 // act
 
-                IotHubJobResponse exportJobProperties = await CreateAndWaitForJobAsync(
+                IotHubJobResponse exportJobProperties = await ExportDevicesTests.CreateAndWaitForJobAsync(
                         storageAuthenticationType,
                         isUserAssignedMsi,
                         devicesFileName,
@@ -126,14 +126,14 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 exportJobProperties.Status.Should().Be(JobStatus.Completed, $"Export failed due to '{exportJobProperties.FailureReason}'.");
                 exportJobProperties.FailureReason.Should().BeNullOrEmpty("Otherwise export failed");
 
-                await ValidateDevicesAsync(
+                await ExportDevicesTests.ValidateDevicesAsync(
                         devicesFileName,
                         storageContainer,
                         edge1,
                         edge2,
                         device)
                     .ConfigureAwait(false);
-                await ValidateConfigurationsAsync(
+                await ExportDevicesTests.ValidateConfigurationsAsync(
                         configsFileName,
                         storageContainer,
                         configuration)
@@ -141,11 +141,11 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             }
             finally
             {
-                await CleanUpDevicesAsync(edgeId1, edgeId2, deviceId, configurationId, serviceClient).ConfigureAwait(false);
+                await ExportDevicesTests.CleanUpDevicesAsync(edgeId1, edgeId2, deviceId, configurationId, serviceClient).ConfigureAwait(false);
             }
         }
 
-        private async Task<IotHubJobResponse> CreateAndWaitForJobAsync(
+        private static async Task<IotHubJobResponse> CreateAndWaitForJobAsync(
             StorageAuthenticationType storageAuthenticationType,
             bool isUserAssignedMsi,
             string devicesFileName,
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             return jobResponse;
         }
 
-        private async Task ValidateDevicesAsync(
+        private static async Task ValidateDevicesAsync(
             string devicesFileName,
             StorageContainer storageContainer,
             Device edge1,
@@ -272,7 +272,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             foundDeviceInExport.Should().BeTrue("Expected device did not appear in the export");
         }
 
-        private async Task ValidateConfigurationsAsync(
+        private static async Task ValidateConfigurationsAsync(
             string configsFileName,
             StorageContainer storageContainer,
             Configuration configuration)
@@ -300,7 +300,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             return await exportFile.DownloadTextAsync().ConfigureAwait(false);
         }
 
-        private async Task CleanUpDevicesAsync(
+        private static async Task CleanUpDevicesAsync(
             string edgeId1,
             string edgeId2,
             string deviceId,

--- a/e2e/test/iothub/service/ExportDevicesTests.cs
+++ b/e2e/test/iothub/service/ExportDevicesTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
                 // act
 
-                IotHubJobResponse exportJobProperties = await ExportDevicesTests.CreateAndWaitForJobAsync(
+                IotHubJobResponse exportJobProperties = await CreateAndWaitForJobAsync(
                         storageAuthenticationType,
                         isUserAssignedMsi,
                         devicesFileName,
@@ -126,14 +126,14 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 exportJobProperties.Status.Should().Be(JobStatus.Completed, $"Export failed due to '{exportJobProperties.FailureReason}'.");
                 exportJobProperties.FailureReason.Should().BeNullOrEmpty("Otherwise export failed");
 
-                await ExportDevicesTests.ValidateDevicesAsync(
+                await ValidateDevicesAsync(
                         devicesFileName,
                         storageContainer,
                         edge1,
                         edge2,
                         device)
                     .ConfigureAwait(false);
-                await ExportDevicesTests.ValidateConfigurationsAsync(
+                await ValidateConfigurationsAsync(
                         configsFileName,
                         storageContainer,
                         configuration)
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             }
             finally
             {
-                await ExportDevicesTests.CleanUpDevicesAsync(edgeId1, edgeId2, deviceId, configurationId, serviceClient).ConfigureAwait(false);
+                await CleanUpDevicesAsync(edgeId1, edgeId2, deviceId, configurationId, serviceClient).ConfigureAwait(false);
             }
         }
 

--- a/e2e/test/iothub/service/FileUploadNotificationE2ETest.cs
+++ b/e2e/test/iothub/service/FileUploadNotificationE2ETest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             await serviceClient.FileUploadNotifications.OpenAsync().ConfigureAwait(false);
             await UploadFile().ConfigureAwait(false);
-            await WaitForFileUploadNotification(counter, 1);
+            await FileUploadNotificationE2ETest.WaitForFileUploadNotification(counter, 1);
             await serviceClient.FileUploadNotifications.CloseAsync().ConfigureAwait(false);
         }
 
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             // Client should still be able to receive file upload notifications after being closed and re-opened.
             await UploadFile().ConfigureAwait(false);
-            await WaitForFileUploadNotification(counter, 1);
+            await FileUploadNotificationE2ETest.WaitForFileUploadNotification(counter, 1);
             await serviceClient.FileUploadNotifications.CloseAsync().ConfigureAwait(false);
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             // The open file upload notification processor should be able to receive more than one
             // file upload notification without closing and re-opening as long as there is more
             // than one file upload notification to consume.
-            await WaitForFileUploadNotification(counter, 2);
+            await FileUploadNotificationE2ETest.WaitForFileUploadNotification(counter, 2);
             await serviceClient.FileUploadNotifications.CloseAsync().ConfigureAwait(false);
         }
 
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         /// </summary>
         /// <param name="fileUploadNotificationReceivedCount">The current number of file upload notifications received.</param>
         /// <param name="expectedFileUploadNotificationReceivedCount">The expected number of file upload notifications to receive in this test.</param>
-        private async Task WaitForFileUploadNotification(FileUploadNotificationCounter counter, int expectedFileUploadNotificationReceivedCount)
+        private static async Task WaitForFileUploadNotification(FileUploadNotificationCounter counter, int expectedFileUploadNotificationReceivedCount)
         {
             var timer = Stopwatch.StartNew();
             try

--- a/e2e/test/iothub/service/FileUploadNotificationE2ETest.cs
+++ b/e2e/test/iothub/service/FileUploadNotificationE2ETest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString, options);
 
-            FileUploadNotificationCounter counter = new FileUploadNotificationCounter();
+            var counter = new FileUploadNotificationCounter();
             Func<FileUploadNotification, AcknowledgementType> OnFileUploadNotificationReceived = (fileUploadNotification) =>
             {
                 counter.FileUploadNotificationsReceived++;
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             await serviceClient.FileUploadNotifications.OpenAsync().ConfigureAwait(false);
             await UploadFile().ConfigureAwait(false);
-            await FileUploadNotificationE2ETest.WaitForFileUploadNotification(counter, 1);
+            await WaitForFileUploadNotification(counter, 1);
             await serviceClient.FileUploadNotifications.CloseAsync().ConfigureAwait(false);
         }
 
@@ -64,14 +64,14 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         [DataRow(IotHubTransportProtocol.WebSocket)]
         public async Task FileUploadNotification_Operation_OpenCloseOpen(IotHubTransportProtocol protocol)
         {
-            IotHubServiceClientOptions options = new IotHubServiceClientOptions()
+            var options = new IotHubServiceClientOptions()
             {
                 Protocol = protocol
             };
 
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString, options);
 
-            FileUploadNotificationCounter counter = new FileUploadNotificationCounter();
+            var counter = new FileUploadNotificationCounter();
             Func<FileUploadNotification, AcknowledgementType> OnFileUploadNotificationReceived = (fileUploadNotification) =>
             {
                 counter.FileUploadNotificationsReceived++;
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             // Client should still be able to receive file upload notifications after being closed and re-opened.
             await UploadFile().ConfigureAwait(false);
-            await FileUploadNotificationE2ETest.WaitForFileUploadNotification(counter, 1);
+            await WaitForFileUploadNotification(counter, 1);
             await serviceClient.FileUploadNotifications.CloseAsync().ConfigureAwait(false);
         }
 
@@ -97,14 +97,14 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         [DataRow(IotHubTransportProtocol.WebSocket)]
         public async Task FileUploadNotification_ReceiveMultipleNotificationsInOneConnection(IotHubTransportProtocol protocol)
         {
-            IotHubServiceClientOptions options = new IotHubServiceClientOptions()
+            var options = new IotHubServiceClientOptions()
             {
                 Protocol = protocol
             };
 
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString, options);
 
-            FileUploadNotificationCounter counter = new FileUploadNotificationCounter();
+            var counter = new FileUploadNotificationCounter();
             Func<FileUploadNotification, AcknowledgementType> OnFileUploadNotificationReceived = (fileUploadNotification) =>
             {
                 counter.FileUploadNotificationsReceived++;
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             // The open file upload notification processor should be able to receive more than one
             // file upload notification without closing and re-opening as long as there is more
             // than one file upload notification to consume.
-            await FileUploadNotificationE2ETest.WaitForFileUploadNotification(counter, 2);
+            await WaitForFileUploadNotification(counter, 2);
             await serviceClient.FileUploadNotifications.CloseAsync().ConfigureAwait(false);
         }
 

--- a/e2e/test/iothub/service/ImportDevicesTests.cs
+++ b/e2e/test/iothub/service/ImportDevicesTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
                 // act
 
-                IotHubJobResponse importJobResponse = await CreateAndWaitForJobAsync(
+                IotHubJobResponse importJobResponse = await ImportDevicesTests.CreateAndWaitForJobAsync(
                         storageAuthenticationType,
                         devicesFileName,
                         configsFileName,
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             foundBlob.Should().BeTrue($"Failed to find {fileName} in storage container - required for test.");
         }
 
-        private async Task<IotHubJobResponse> CreateAndWaitForJobAsync(
+        private static async Task<IotHubJobResponse> CreateAndWaitForJobAsync(
             StorageAuthenticationType storageAuthenticationType,
             string devicesFileName,
             string configsFileName,

--- a/e2e/test/iothub/service/ImportDevicesTests.cs
+++ b/e2e/test/iothub/service/ImportDevicesTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
                 // act
 
-                IotHubJobResponse importJobResponse = await ImportDevicesTests.CreateAndWaitForJobAsync(
+                IotHubJobResponse importJobResponse = await CreateAndWaitForJobAsync(
                         storageAuthenticationType,
                         devicesFileName,
                         configsFileName,

--- a/e2e/test/iothub/service/PurgeMessageQueueE2ETests.cs
+++ b/e2e/test/iothub/service/PurgeMessageQueueE2ETests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             using var sc = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
             PurgeMessageQueueResult result = await sc.Messages.PurgeMessageQueueAsync(expectedDeviceId, CancellationToken.None).ConfigureAwait(false); // making sure the queue is empty
 
-            Message testMessage = ComposeD2CTestMessage();
+            Message testMessage = PurgeMesageQueueE2ETests.ComposeD2CTestMessage();
 
             await sc.Messages.OpenAsync().ConfigureAwait(false);
             const int numberOfSends = 3;
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             result.TotalMessagesPurged.Should().Be(numberOfSends);
         }
 
-        private Message ComposeD2CTestMessage()
+        private static Message ComposeD2CTestMessage()
         {
             return new Message(Encoding.UTF8.GetBytes("some payload"));
         }

--- a/e2e/test/iothub/service/PurgeMessageQueueE2ETests.cs
+++ b/e2e/test/iothub/service/PurgeMessageQueueE2ETests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             using var sc = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
             PurgeMessageQueueResult result = await sc.Messages.PurgeMessageQueueAsync(expectedDeviceId, CancellationToken.None).ConfigureAwait(false); // making sure the queue is empty
 
-            Message testMessage = PurgeMesageQueueE2ETests.ComposeD2CTestMessage();
+            Message testMessage = ComposeD2CTestMessage();
 
             await sc.Messages.OpenAsync().ConfigureAwait(false);
             const int numberOfSends = 3;

--- a/iothub/device/src/Exceptions/IotHubClientException.cs
+++ b/iothub/device/src/Exceptions/IotHubClientException.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
-        protected internal IotHubClientException(SerializationInfo info, StreamingContext context)
+        protected IotHubClientException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             if (info != null)

--- a/iothub/device/src/Messaging/IncomingMessage.cs
+++ b/iothub/device/src/Messaging/IncomingMessage.cs
@@ -190,9 +190,7 @@ namespace Microsoft.Azure.Devices.Client
 
         private T GetSystemProperty<T>(string key)
         {
-            return SystemProperties.ContainsKey(key)
-                ? (T)SystemProperties[key]
-                : default;
+            return SystemProperties.TryGetValue(key, out object value) ? (T)value : default;
         }
     }
 }

--- a/iothub/device/src/Messaging/TelemetryMessage.cs
+++ b/iothub/device/src/Messaging/TelemetryMessage.cs
@@ -239,9 +239,7 @@ namespace Microsoft.Azure.Devices.Client
 
         private T GetSystemProperty<T>(string key)
         {
-            return SystemProperties.ContainsKey(key)
-                ? (T)SystemProperties[key]
-                : default;
+            return SystemProperties.TryGetValue(key, out object value) ? (T)value : default;
         }
     }
 }

--- a/iothub/device/src/RetryPolicies/IotHubClientExponentialBackoffRetryPolicy.cs
+++ b/iothub/device/src/RetryPolicies/IotHubClientExponentialBackoffRetryPolicy.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <inheritdoc/>
-        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            if (!base.ShouldRetry(currentRetryCount, lastException, out retryInterval))
+            if (!base.ShouldRetry(currentRetryCount, lastException, out retryDelay))
             {
                 return false;
             }
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Client
 
             double clampedWaitMs = Math.Min(exponentialIntervalMs, _maxDelay.TotalMilliseconds);
 
-            retryInterval = _useJitter
+            retryDelay = _useJitter
                 ? UpdateWithJitter(clampedWaitMs)
                 : TimeSpan.FromMilliseconds(clampedWaitMs);
 

--- a/iothub/device/src/RetryPolicies/IotHubClientFixedDelayRetryPolicy.cs
+++ b/iothub/device/src/RetryPolicies/IotHubClientFixedDelayRetryPolicy.cs
@@ -33,14 +33,14 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <inheritdoc/>
-        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            if (!base.ShouldRetry(currentRetryCount, lastException, out retryInterval))
+            if (!base.ShouldRetry(currentRetryCount, lastException, out retryDelay))
             {
                 return false;
             }
 
-            retryInterval = _useJitter
+            retryDelay = _useJitter
                 ? UpdateWithJitter(_fixedDelay.TotalMilliseconds)
                 : _fixedDelay;
 

--- a/iothub/device/src/RetryPolicies/IotHubClientIncrementalDelayRetryPolicy.cs
+++ b/iothub/device/src/RetryPolicies/IotHubClientIncrementalDelayRetryPolicy.cs
@@ -47,9 +47,9 @@ namespace Microsoft.Azure.Devices.Client
         internal protected bool UseJitter { get; }
 
         /// <inheritdoc/>
-        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            if (!base.ShouldRetry(currentRetryCount, lastException, out retryInterval))
+            if (!base.ShouldRetry(currentRetryCount, lastException, out retryDelay))
             {
                 return false;
             }
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Devices.Client
                 currentRetryCount * DelayIncrement.TotalMilliseconds,
                 MaxDelay.TotalMilliseconds);
 
-            retryInterval = UseJitter
+            retryDelay = UseJitter
                 ? UpdateWithJitter(waitDurationMs)
                 : TimeSpan.FromMilliseconds(waitDurationMs);
 

--- a/iothub/device/src/RetryPolicies/IotHubClientNoRetry.cs
+++ b/iothub/device/src/RetryPolicies/IotHubClientNoRetry.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <inheritdoc/>
-        public bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            retryInterval = TimeSpan.Zero;
+            retryDelay = TimeSpan.Zero;
             return false;
         }
     }

--- a/iothub/device/src/Serialization/NewtonsoftJsonPayloadSerializer.cs
+++ b/iothub/device/src/Serialization/NewtonsoftJsonPayloadSerializer.cs
@@ -42,11 +42,11 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <inheritdoc/>
-        public override T ConvertFromJsonObject<T>(object objectToConvert)
+        public override T ConvertFromJsonObject<T>(object jsonObjectToConvert)
         {
-            var token = JToken.FromObject(objectToConvert);
+            var token = JToken.FromObject(jsonObjectToConvert);
 
-            return objectToConvert == null
+            return jsonObjectToConvert == null
                 ? default
                 : token.ToObject<T>();
         }

--- a/iothub/device/src/Serialization/SystemTextJsonPayloadSerializer.cs
+++ b/iothub/device/src/Serialization/SystemTextJsonPayloadSerializer.cs
@@ -36,9 +36,9 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <inheritdoc/>
-        public override T ConvertFromJsonObject<T>(object objectToConvert)
+        public override T ConvertFromJsonObject<T>(object jsonObjectToConvert)
         {
-            return DeserializeToType<T>(SerializeToString(objectToConvert));
+            return DeserializeToType<T>(SerializeToString(jsonObjectToConvert));
         }
     }
 }

--- a/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
@@ -10,7 +10,7 @@ using Microsoft.Azure.Devices.Client.Transport.AmqpIot;
 
 namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 {
-    internal class AmqpAuthenticationRefresher : IAmqpAuthenticationRefresher
+    internal class AmqpAuthenticationRefresher : IAmqpAuthenticationRefresher, IDisposable
     {
         private static readonly string[] s_accessRightsStringArray = new[] { "DeviceConnect" };
         private readonly Uri _amqpEndpoint;
@@ -169,6 +169,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             // If the shared access key name is not null then this is a group SAS authenticated client.
             // SAS tokens granted to a group SAS authenticated client will scoped to the IoT hub-level; for example, myHub.azure-devices.net
             return connectionCredentials.HostName;
+        }
+
+        public void Dispose()
+        {
+            _loopCancellationTokenSource?.Dispose();
         }
     }
 }

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotReceivingLink.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotReceivingLink.cs
@@ -4,13 +4,13 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Amqp;
 using Microsoft.Azure.Amqp.Framing;
-using Microsoft.Azure.Devices.Client.Transport.Mqtt;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
@@ -237,8 +237,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
                         // Check if we have an int to string error code translation for the service returned error code.
                         // The error code could be a part of the service returned error message, or it can be a part of the amqp message annotations map.
                         // We will check with the error code in the error message first (if present) since that is the more specific error code returned.
-                        if ((Enum.TryParse(errorResponse.ErrorCode.ToString(), out IotHubClientErrorCode errorCode)
-                            || Enum.TryParse(status.ToString(), out errorCode))
+                        if ((Enum.TryParse(errorResponse.ErrorCode.ToString(CultureInfo.InvariantCulture), out IotHubClientErrorCode errorCode)
+                            || Enum.TryParse(status.ToString(CultureInfo.InvariantCulture), out errorCode))
                             && Enum.IsDefined(typeof(IotHubClientErrorCode), errorCode))
                         {
                             twinException = new IotHubClientException(errorResponse.Message, errorCode)

--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -17,7 +17,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Client.Transport
 {
-    internal sealed class HttpClientHelper
+    internal sealed class HttpClientHelper : IDisposable
     {
         private readonly Uri _baseAddress;
         private readonly IConnectionCredentials _connectionCredentials;
@@ -236,6 +236,11 @@ namespace Microsoft.Azure.Devices.Client.Transport
             using var reader = new StreamReader(stream);
             using var jsonReader = new JsonTextReader(reader);
             return new JsonSerializer().Deserialize<T>(jsonReader);
+        }
+
+        public void Dispose()
+        {
+            _httpClientObj?.Dispose();
         }
     }
 }

--- a/iothub/device/src/Transport/Mqtt/MqttLogger.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttLogger.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.Tracing;
+using System.Globalization;
 using MQTTnet.Diagnostics;
 
 namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
@@ -21,7 +22,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             string formattedMessage = message;
             if (parameters != null && parameters.Length > 0)
             {
-                formattedMessage = string.Format(message, parameters);
+                formattedMessage = string.Format(CultureInfo.InvariantCulture, message, parameters);
             }
 
             Logging.Log.Write(formattedMessage, options);

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -637,8 +637,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     // Check if we have an int to string error code translation for the service returned error code.
                     // The error code could be a part of the service returned error message, or it can be a part of the topic string.
                     // We will check with the error code in the error message first (if present) since that is the more specific error code returned.
-                    if ((Enum.TryParse(getTwinResponse.ErrorResponseMessage.ErrorCode.ToString(), out IotHubClientErrorCode errorCode)
-                        || Enum.TryParse(getTwinResponse.Status.ToString(), out errorCode))
+                    if ((Enum.TryParse(getTwinResponse.ErrorResponseMessage.ErrorCode.ToString(CultureInfo.InvariantCulture), out IotHubClientErrorCode errorCode)
+                        || Enum.TryParse(getTwinResponse.Status.ToString(CultureInfo.InvariantCulture), out errorCode))
                         && Enum.IsDefined(typeof(IotHubClientErrorCode), errorCode))
                     {
                         throw new IotHubClientException(getTwinResponse.ErrorResponseMessage.Message, errorCode)
@@ -694,7 +694,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             }
 
             string requestId = Guid.NewGuid().ToString();
-            string topic = string.Format(TwinReportedPropertiesPatchTopicFormat, requestId);
+            string topic = string.Format(CultureInfo.InvariantCulture, TwinReportedPropertiesPatchTopicFormat, requestId);
 
             byte[] body = reportedProperties.GetObjectBytes();
 
@@ -739,8 +739,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                     // Check if we have an int to string error code translation for the service returned error code.
                     // The error code could be a part of the service returned error message, or it can be a part of the topic string.
                     // We will check with the error code in the error message first (if present) since that is the more specific error code returned.
-                    if ((Enum.TryParse(patchTwinResponse.ErrorResponseMessage.ErrorCode.ToString(), out IotHubClientErrorCode errorCode)
-                        || Enum.TryParse(patchTwinResponse.Status.ToString(), out errorCode))
+                    if ((Enum.TryParse(patchTwinResponse.ErrorResponseMessage.ErrorCode.ToString(CultureInfo.InvariantCulture), out IotHubClientErrorCode errorCode)
+                        || Enum.TryParse(patchTwinResponse.Status.ToString(CultureInfo.InvariantCulture), out errorCode))
                         && Enum.IsDefined(typeof(IotHubClientErrorCode), errorCode))
                     {
                         throw new IotHubClientException(patchTwinResponse.ErrorResponseMessage.Message, errorCode)
@@ -854,7 +854,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 MqttClientSubscribeResultItem subscribeResult = subscribeResults.Items.FirstOrDefault();
 
-                if (!subscribeResult.TopicFilter.Topic.Equals(fullTopic))
+                if (!subscribeResult.TopicFilter.Topic.Equals(fullTopic, StringComparison.Ordinal))
                 {
                     throw new IotHubClientException(
                         $"Received unexpected subscription to topic {subscribeResult.TopicFilter.Topic}",
@@ -898,7 +898,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 }
 
                 MqttClientUnsubscribeResultItem unsubscribeResult = unsubscribeResults.Items.FirstOrDefault();
-                if (!unsubscribeResult.TopicFilter.Equals(fullTopic))
+                if (!unsubscribeResult.TopicFilter.Equals(fullTopic, StringComparison.Ordinal))
                 {
                     throw new IotHubClientException(
                         $"Received unexpected unsubscription from topic {unsubscribeResult.TopicFilter}",
@@ -1239,7 +1239,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 {
                     // This query string key-value pair is only expected in a successful patch twin response message.
                     // Get twin requests will contain the twin version in the payload instead.
-                    version = int.Parse(queryStringKeyValuePairs.Get(VersionTopicKey));
+                    version = int.Parse(queryStringKeyValuePairs.Get(VersionTopicKey), CultureInfo.InvariantCulture);
                 }
 
                 return true;

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -947,24 +947,24 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             receivedEventArgs.AutoAcknowledge = false;
             string topic = receivedEventArgs.ApplicationMessage.Topic;
 
-            if (topic.StartsWith(_deviceBoundMessagesTopic))
+            if (topic.StartsWith(_deviceBoundMessagesTopic, StringComparison.InvariantCulture))
             {
                 await HandleReceivedCloudToDeviceMessageAsync(receivedEventArgs).ConfigureAwait(false);
             }
-            else if (topic.StartsWith(TwinDesiredPropertiesPatchTopic))
+            else if (topic.StartsWith(TwinDesiredPropertiesPatchTopic, StringComparison.InvariantCulture))
             {
                 HandleReceivedDesiredPropertiesUpdateRequest(receivedEventArgs);
             }
-            else if (topic.StartsWith(TwinResponseTopic))
+            else if (topic.StartsWith(TwinResponseTopic, StringComparison.InvariantCulture))
             {
                 HandleTwinResponse(receivedEventArgs);
             }
-            else if (topic.StartsWith(DirectMethodsRequestTopic))
+            else if (topic.StartsWith(DirectMethodsRequestTopic, StringComparison.InvariantCulture))
             {
                 HandleReceivedDirectMethodRequest(receivedEventArgs);
             }
-            else if (topic.StartsWith(_moduleEventMessageTopic)
-                || topic.StartsWith(_edgeModuleInputEventsTopic))
+            else if (topic.StartsWith(_moduleEventMessageTopic, StringComparison.InvariantCulture)
+                || topic.StartsWith(_edgeModuleInputEventsTopic, StringComparison.InvariantCulture))
             {
                 // This works regardless of if the event is on a particular Edge module input or if
                 // the module is not an Edge module.

--- a/iothub/device/tests/IotHubDeviceClientTests.cs
+++ b/iothub/device/tests/IotHubDeviceClientTests.cs
@@ -3,22 +3,20 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.Azure.Devices.Client.Transport;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 using Moq;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Client.Test
 {
     [TestClass]
     [TestCategory("Unit")]
-    public class IotHubDeviceClientTests : IDisposable
+    public sealed class IotHubDeviceClientTests : IDisposable
     {
         private const string FakeConnectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=fake;SharedAccessKey=dGVzdFN0cmluZzE=";
         private const string FakeHostName = "acme.azure-devices.net";
@@ -29,27 +27,27 @@ namespace Microsoft.Azure.Devices.Client.Test
 #pragma warning restore SYSLIB0026 // Type or member is obsolete
         private static readonly X509Certificate2Collection s_certs = new();
 
-        private DirectMethodResponse _directMethodResponseWithPayload = new(200)
+        private readonly DirectMethodResponse _directMethodResponseWithPayload = new(200)
         {
             Payload = 123,
         };
 
-        private DirectMethodResponse _directMethodResponseWithEmptyByteArrayPayload = new(200)
+        private readonly DirectMethodResponse _directMethodResponseWithEmptyByteArrayPayload = new(200)
         {
-            Payload = new byte[0]
+            Payload = Array.Empty<byte>()
         };
 
         [TestMethod]
         public void DeviceAuthenticationWithX509Certificate_NullCertificate_Throws()
         {
-            Action act = () => new ClientAuthenticationWithX509Certificate(null, "device1");
+            Action act = () => _= new ClientAuthenticationWithX509Certificate(null, "device1");
 
             act.Should().Throw<ArgumentException>();
         }
 
         [TestMethod]
         public void DeviceAuthenticationWithX509Certificate_NullCertificateChain_Throws()
-        {            Action act = () => new ClientAuthenticationWithX509Certificate(s_cert, certificateChain: null, "device1");
+        {            Action act = () => _ = new ClientAuthenticationWithX509Certificate(s_cert, certificateChain: null, "device1");
 
             act.Should().Throw<ArgumentException>();
         }
@@ -221,7 +219,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public void IotHubDeviceClient_CreateFromConnectionString_WithModuleIdThrows()
         {
-            Action act = () => new IotHubDeviceClient("HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=fake;SharedAccessKey=dGVzdFN0cmluZzE=;ModuleId=mod1");
+            Action act = () => _ = new IotHubDeviceClient("HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=fake;SharedAccessKey=dGVzdFN0cmluZzE=;ModuleId=mod1");
             act.Should().Throw<InvalidOperationException>();
         }
 
@@ -1042,7 +1040,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             // arrange
             // act
-            Action createDeviceClientAuth = () => { new ClientAuthenticationWithSharedAccessKeyRefresh(FakeConnectionString, TimeSpan.FromSeconds(-60)); };
+            Action createDeviceClientAuth = () => _ = new ClientAuthenticationWithSharedAccessKeyRefresh(FakeConnectionString, TimeSpan.FromSeconds(-60));
 
             // assert
             createDeviceClientAuth.Should().Throw<ArgumentOutOfRangeException>();
@@ -1053,7 +1051,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             // arrange
             // act
-            Action createDeviceClientAuth = () => { new ClientAuthenticationWithSharedAccessKeyRefresh(FakeConnectionString, sasTokenRenewalBuffer: 200); };
+            Action createDeviceClientAuth = () => _ = new ClientAuthenticationWithSharedAccessKeyRefresh(FakeConnectionString, sasTokenRenewalBuffer: 200);
 
             // assert
             createDeviceClientAuth.Should().Throw<ArgumentOutOfRangeException>();
@@ -1127,7 +1125,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         [DataRow(IotHubClientTransportProtocol.WebSocket)]
         public void IotHubDeviceClient_InitWithMqttTransportAndModelId_DoesNotThrow(IotHubClientTransportProtocol protocol)
         {
-            IotHubDeviceClient_InitWithNonHttpTransportAndModelId_DoesNotThrow(new IotHubClientMqttSettings(protocol));
+            IotHubDeviceClientTests.IotHubDeviceClient_InitWithNonHttpTransportAndModelId_DoesNotThrow(new IotHubClientMqttSettings(protocol));
         }
 
         [TestMethod]
@@ -1135,7 +1133,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         [DataRow(IotHubClientTransportProtocol.WebSocket)]
         public void IotHubDeviceClient_InitWithAmqpTransportAndModelId_DoesNotThrow(IotHubClientTransportProtocol protocol)
         {
-            IotHubDeviceClient_InitWithNonHttpTransportAndModelId_DoesNotThrow(new IotHubClientAmqpSettings(protocol));
+            IotHubDeviceClientTests.IotHubDeviceClient_InitWithNonHttpTransportAndModelId_DoesNotThrow(new IotHubClientAmqpSettings(protocol));
         }
 
         [TestMethod]
@@ -1235,7 +1233,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             await act.Should().ThrowAsync<OperationCanceledException>();
         }
 
-        private void IotHubDeviceClient_InitWithNonHttpTransportAndModelId_DoesNotThrow(IotHubClientTransportSettings transportSettings)
+        private static void IotHubDeviceClient_InitWithNonHttpTransportAndModelId_DoesNotThrow(IotHubClientTransportSettings transportSettings)
         {
             // arrange
 

--- a/iothub/device/tests/IotHubModuleClientTests.cs
+++ b/iothub/device/tests/IotHubModuleClientTests.cs
@@ -15,39 +15,11 @@ namespace Microsoft.Azure.Devices.Client.Test
     [TestCategory("Unit")]
     public class IotHubModuleClientTests
     {
-        private const string DeviceId = "module-twin-test";
-        private const string ModuleId = "mongo-server";
         private const string ConnectionStringWithModuleId = "GatewayHostName=edge.iot.microsoft.com;HostName=acme.azure-devices.net;DeviceId=module-twin-test;ModuleId=mongo-server;SharedAccessKey=dGVzdFN0cmluZzQ=";
         private const string ConnectionStringWithoutModuleId = "GatewayHostName=edge.iot.microsoft.com;HostName=acme.azure-devices.net;DeviceId=module-twin-test;SharedAccessKey=dGVzdFN0cmluZzQ=";
         private const string FakeConnectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;DeviceId=dumpy;ModuleId=dummyModuleId;SharedAccessKey=dGVzdFN0cmluZzE=";
 
         public const string NoModuleTwinJson = "{ \"maxConnections\": 10 }";
-
-        public readonly string ValidDeviceTwinJson = string.Format(
-            @"
-{{
-    ""{1}"": {{
-        ""properties"": {{
-            ""desired"": {{
-                ""maxConnections"": 10,
-                ""$metadata"": {{
-                    ""$lastUpdated"": ""2017-05-30T22:37:31.1441889Z"",
-                    ""$lastUpdatedVersion"": 2
-                }}
-            }}
-        }}
-    }},
-    ""nginx-server"": {{
-        ""properties"": {{
-            ""desired"": {{
-                ""forwardUrl"": ""http://example.com""
-            }}
-        }}
-    }}
-}}
-",
-            DeviceId,
-            ModuleId);
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]

--- a/iothub/device/tests/MessageTests.cs
+++ b/iothub/device/tests/MessageTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public void ConstructorTakingEmptyByteArrayTest()
         {
-            var msg = new Message(new byte[0]);
+            var msg = new Message(Array.Empty<byte>());
             msg.Payload.Should().NotBeNull();
             msg.Payload.Length.Should().Be(0);
         }

--- a/iothub/device/tests/Pipeline/ErrorDelegatingHandlerTests.cs
+++ b/iothub/device/tests/Pipeline/ErrorDelegatingHandlerTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             var cancellationToken = new CancellationToken();
             await sut.OpenAsync(cancellationToken).ConfigureAwait(false);
-            await sut.SendTelemetryAsync(new TelemetryMessage(new byte[0]), cancellationToken).ConfigureAwait(false);
+            await sut.SendTelemetryAsync(new TelemetryMessage(Array.Empty<byte>()), cancellationToken).ConfigureAwait(false);
 
             innerHandler.Verify(x => x.OpenAsync(cancellationToken), Times.Once);
             innerHandler.Verify(x => x.SendTelemetryAsync(It.IsAny<TelemetryMessage>(), cancellationToken), Times.Once);
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // set initial operation result that throws
 
-            var message = new TelemetryMessage(new byte[0]);
+            var message = new TelemetryMessage(Array.Empty<byte>());
             bool isSetup = false;
             innerHandler
                 .Setup(x => x.SendTelemetryAsync(message, It.IsAny<CancellationToken>()))

--- a/iothub/device/tests/Transport/Amqp/AmqpConnectionPoolTests.cs
+++ b/iothub/device/tests/Transport/Amqp/AmqpConnectionPoolTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Client.Tests.Amqp
         {
             string sharedAccessKeyName = "HubOwner";
             uint poolSize = 10;
-            IConnectionCredentials testDevice = AmqpConnectionPoolTests.CreatePooledSasGroupedClientIdentity(sharedAccessKeyName);
+            IConnectionCredentials testDevice = CreatePooledSasGroupedClientIdentity(sharedAccessKeyName);
             IDictionary<string, AmqpConnectionHolder[]> injectedDictionary = new Dictionary<string, AmqpConnectionHolder[]>();
             var amqpSettings = new IotHubClientAmqpSettings
             {

--- a/iothub/device/tests/Transport/Amqp/AmqpConnectionPoolTests.cs
+++ b/iothub/device/tests/Transport/Amqp/AmqpConnectionPoolTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Client.Tests.Amqp
         {
             string sharedAccessKeyName = "HubOwner";
             uint poolSize = 10;
-            IConnectionCredentials testDevice = CreatePooledSasGroupedClientIdentity(sharedAccessKeyName);
+            IConnectionCredentials testDevice = AmqpConnectionPoolTests.CreatePooledSasGroupedClientIdentity(sharedAccessKeyName);
             IDictionary<string, AmqpConnectionHolder[]> injectedDictionary = new Dictionary<string, AmqpConnectionHolder[]>();
             var amqpSettings = new IotHubClientAmqpSettings
             {
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices.Client.Tests.Amqp
 
             AmqpUnit addedUnit = pool.CreateAmqpUnit(testDevice, null, amqpSettings, null, null, null, null);
 
-            injectedDictionary[sharedAccessKeyName].Count().Should().Be((int)poolSize);
+            injectedDictionary[sharedAccessKeyName].Length.Should().Be((int)poolSize);
 
             pool.RemoveAmqpUnit(addedUnit);
 
@@ -63,9 +63,9 @@ namespace Microsoft.Azure.Devices.Client.Tests.Amqp
             }
         }
 
-        private IConnectionCredentials CreatePooledSasGroupedClientIdentity(string sharedAccessKeyName)
+        private static IConnectionCredentials CreatePooledSasGroupedClientIdentity(string sharedAccessKeyName)
         {
-            Mock<IConnectionCredentials> clientIdentity = new Mock<IConnectionCredentials>();
+            var clientIdentity = new Mock<IConnectionCredentials>();
 
             clientIdentity.Setup(m => m.SharedAccessKeyName).Returns(sharedAccessKeyName);
             clientIdentity.Setup(m => m.AuthenticationModel).Returns(AuthenticationModel.SasGrouped);

--- a/iothub/device/tests/Transport/Amqp/AmqpTransportHandlerTests.cs
+++ b/iothub/device/tests/Transport/Amqp/AmqpTransportHandlerTests.cs
@@ -25,19 +25,19 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
         [TestMethod]
         public async Task AmqpTransportHandlerOpenAsyncTokenCancellationRequested()
         {
-            await TestOperationCanceledByToken(token => CreateFromConnectionString().OpenAsync(token)).ConfigureAwait(false);
+            await AmqpTransportHandlerTests.TestOperationCanceledByToken(token => AmqpTransportHandlerTests.CreateFromConnectionString().OpenAsync(token)).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task AmqpTransportHandlerSendTelemetryAsyncTokenCancellationRequested()
         {
-            await TestOperationCanceledByToken(token => CreateFromConnectionString().SendTelemetryAsync(new TelemetryMessage(), token)).ConfigureAwait(false);
+            await AmqpTransportHandlerTests.TestOperationCanceledByToken(token => AmqpTransportHandlerTests.CreateFromConnectionString().SendTelemetryAsync(new TelemetryMessage(), token)).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task AmqpTransportHandlerSendTelemetryAsyncMultipleMessagesTokenCancellationRequested()
         {
-            await TestOperationCanceledByToken(token => CreateFromConnectionString().SendTelemetryBatchAsync(new List<TelemetryMessage>(), token)).ConfigureAwait(false);
+            await AmqpTransportHandlerTests.TestOperationCanceledByToken(token => AmqpTransportHandlerTests.CreateFromConnectionString().SendTelemetryBatchAsync(new List<TelemetryMessage>(), token)).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
             }
         }
 
-        private async Task TestOperationCanceledByToken(Func<CancellationToken, Task> asyncMethod)
+        private static async Task TestOperationCanceledByToken(Func<CancellationToken, Task> asyncMethod)
         {
             using var tokenSource = new CancellationTokenSource();
             tokenSource.Cancel();
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
             catch (OperationCanceledException) { }
         }
 
-        private AmqpTransportHandler CreateFromConnectionString()
+        private static AmqpTransportHandler CreateFromConnectionString()
         {
             var pipelineContext = new PipelineContext
             {

--- a/iothub/device/tests/Transport/Amqp/AmqpTransportHandlerTests.cs
+++ b/iothub/device/tests/Transport/Amqp/AmqpTransportHandlerTests.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.Azure.Devices.Client.Test.ConnectionString;
 using Microsoft.Azure.Devices.Client.Transport.Amqp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -25,19 +24,19 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
         [TestMethod]
         public async Task AmqpTransportHandlerOpenAsyncTokenCancellationRequested()
         {
-            await AmqpTransportHandlerTests.TestOperationCanceledByToken(token => AmqpTransportHandlerTests.CreateFromConnectionString().OpenAsync(token)).ConfigureAwait(false);
+            await TestOperationCanceledByToken(token => CreateFromConnectionString().OpenAsync(token)).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task AmqpTransportHandlerSendTelemetryAsyncTokenCancellationRequested()
         {
-            await AmqpTransportHandlerTests.TestOperationCanceledByToken(token => AmqpTransportHandlerTests.CreateFromConnectionString().SendTelemetryAsync(new TelemetryMessage(), token)).ConfigureAwait(false);
+            await TestOperationCanceledByToken(token => CreateFromConnectionString().SendTelemetryAsync(new TelemetryMessage(), token)).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task AmqpTransportHandlerSendTelemetryAsyncMultipleMessagesTokenCancellationRequested()
         {
-            await AmqpTransportHandlerTests.TestOperationCanceledByToken(token => AmqpTransportHandlerTests.CreateFromConnectionString().SendTelemetryBatchAsync(new List<TelemetryMessage>(), token)).ConfigureAwait(false);
+            await TestOperationCanceledByToken(token => CreateFromConnectionString().SendTelemetryBatchAsync(new List<TelemetryMessage>(), token)).ConfigureAwait(false);
         }
 
         [TestMethod]

--- a/iothub/device/tests/Transport/Amqp/MockableAmqpUnit.cs
+++ b/iothub/device/tests/Transport/Amqp/MockableAmqpUnit.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
         {
         }
 
-        public new async Task EnableReceiveMessageAsync(CancellationToken cancellationToken)
+        public new static async Task EnableReceiveMessageAsync(CancellationToken cancellationToken)
         {
             await Task.Yield();
         }

--- a/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
+++ b/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
@@ -28,14 +28,14 @@ namespace Microsoft.Azure.Devices.Client.Tests.Transport.Mqtt
 
             var mockMqttClient = new Mock<IMqttClient>();
 
-            using MqttTransportHandler mqttTransportHandler = CreateTransportHandler(mockMqttClient.Object);
+            using MqttTransportHandler mqttTransportHandler = MqttTransportHandlerTests.CreateTransportHandler(mockMqttClient.Object);
 
             await mqttTransportHandler.OpenAsync(cancellationToken);
 
             mockMqttClient.Verify(p => p.ConnectAsync(It.IsAny<MqttClientOptions>(), cancellationToken));
         }
 
-        internal MqttTransportHandler CreateTransportHandler(IMqttClient mockMqttClient)
+        internal static MqttTransportHandler CreateTransportHandler(IMqttClient mockMqttClient)
         {
             var pipelineContext = new PipelineContext();
             var clientConfigurationMock = new IotHubConnectionCredentials();

--- a/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
+++ b/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
@@ -1,14 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
-using Microsoft.Azure.Devices.Client.Test.ConnectionString;
 using Microsoft.Azure.Devices.Client.Transport.Mqtt;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -28,7 +22,7 @@ namespace Microsoft.Azure.Devices.Client.Tests.Transport.Mqtt
 
             var mockMqttClient = new Mock<IMqttClient>();
 
-            using MqttTransportHandler mqttTransportHandler = MqttTransportHandlerTests.CreateTransportHandler(mockMqttClient.Object);
+            using MqttTransportHandler mqttTransportHandler = CreateTransportHandler(mockMqttClient.Object);
 
             await mqttTransportHandler.OpenAsync(cancellationToken);
 

--- a/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Azure.Devices
                 // No need to deserialize here since the user will deserialize this into their expected type
                 // after this function returns.
                 string responsePayload = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                int responseStatusCode = int.Parse(response.Headers.GetValues(StatusCodeHeaderKey).FirstOrDefault());
+                int responseStatusCode = int.Parse(response.Headers.GetValues(StatusCodeHeaderKey).FirstOrDefault(), CultureInfo.InvariantCulture);
                 string requestId = response.Headers.GetValues(RequestIdHeaderKey).FirstOrDefault();
                 return new InvokeDigitalTwinCommandResponse
                 {
@@ -364,7 +364,7 @@ namespace Microsoft.Azure.Devices
                 // No need to deserialize here since the user will deserialize this into their expected type
                 // after this function returns.
                 string responsePayload = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                int responseStatusCode = int.Parse(response.Headers.GetValues(StatusCodeHeaderKey).FirstOrDefault());
+                int responseStatusCode = int.Parse(response.Headers.GetValues(StatusCodeHeaderKey).FirstOrDefault(), CultureInfo.InvariantCulture);
                 string requestId = response.Headers.GetValues(RequestIdHeaderKey).FirstOrDefault();
                 return new InvokeDigitalTwinCommandResponse
                 {

--- a/iothub/service/src/Exceptions/IotHubServiceException.cs
+++ b/iothub/service/src/Exceptions/IotHubServiceException.cs
@@ -13,8 +13,11 @@ namespace Microsoft.Azure.Devices
     [Serializable]
     public class IotHubServiceException : Exception
     {
+        [NonSerialized]
         private const string IsTransientValueSerializationStoreName = "IotHubServiceException-IsTransient";
-        private const string TrackingIdSerializationStoreName = "IoTHubException-TrackingId";
+
+        [NonSerialized]
+        private const string TrackingIdValueSerializationStoreName = "IotHubServiceException-TrackingId";
 
         /// <summary>
         /// Creates an instance of this class with the specified error message and optional inner exception.
@@ -51,6 +54,21 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <summary>
+        /// Creates an instance of this class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected IotHubServiceException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            if (info != null)
+            {
+                IsTransient = info.GetBoolean(IsTransientValueSerializationStoreName);
+                TrackingId = info.GetString(TrackingIdValueSerializationStoreName);
+            }
+        }
+
+        /// <summary>
         /// Indicates if the error is transient and should be retried.
         /// </summary>
         public bool IsTransient { get; protected internal set; }
@@ -81,7 +99,7 @@ namespace Microsoft.Azure.Devices
         {
             base.GetObjectData(info, context);
             info.AddValue(IsTransientValueSerializationStoreName, IsTransient);
-            info.AddValue(TrackingIdSerializationStoreName, TrackingId);
+            info.AddValue(TrackingIdValueSerializationStoreName, TrackingId);
         }
 
         private static bool DetermineIfTransient(HttpStatusCode statusCode, IotHubServiceErrorCode errorCode)

--- a/iothub/service/src/Exceptions/ResponseMessage2.cs
+++ b/iothub/service/src/Exceptions/ResponseMessage2.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices
 
             foreach (string part in messageParts)
             {
-                if (part.StartsWith(errorCodeLabel))
+                if (part.StartsWith(errorCodeLabel, StringComparison.InvariantCulture))
                 {
                     string[] errorCodeParts = part.Split(':');
 
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Devices
 
             const string trackingIdLabel = "Tracking ID:";
 
-            if (!ExceptionMessage.StartsWith(trackingIdLabel))
+            if (!ExceptionMessage.StartsWith(trackingIdLabel, StringComparison.InvariantCulture))
             {
                 return false;
             }

--- a/iothub/service/src/Feedback/MessageFeedbackProcessorClient.cs
+++ b/iothub/service/src/Feedback/MessageFeedbackProcessorClient.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Azure.Devices
         /// </remarks>
         /// <exception cref="OperationCanceledException">If the provided cancellation token has requested cancellation.</exception>
         /// <exception cref="IotHubServiceException">If an error occurs when communicating with IoT hub service.</exception>
+        /// <exception cref="InvalidOperationException">If the message processor is opened before setting the <see cref="MessageFeedbackProcessor"/> callback.</exception>
         public virtual async Task OpenAsync(CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
@@ -111,7 +112,7 @@ namespace Microsoft.Azure.Devices
             {
                 if (MessageFeedbackProcessor == null)
                 {
-                    throw new Exception("Callback for message feedback must be set before opening the connection.");
+                    throw new InvalidOperationException("Callback for message feedback must be set before opening the connection.");
                 }
 
                 await _internalRetryHandler

--- a/iothub/service/src/Registry/DevicesClient.cs
+++ b/iothub/service/src/Registry/DevicesClient.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Create a device identity in your IoT hub's registry.
         /// </summary>
-        /// <param name="device">The device identity to register.</param>
+        /// <param name="deviceIdentity">The device identity to register.</param>
         /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
         /// <returns>The registered device with the generated keys and ETags.</returns>
         /// <exception cref="ArgumentNullException">When the provided device is null.</exception>
@@ -69,18 +69,18 @@ namespace Microsoft.Azure.Devices
         /// For a complete list of possible error cases, see <see cref="IotHubServiceErrorCode"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided cancellation token has requested cancellation.</exception>
-        public virtual async Task<Device> CreateAsync(Device device, CancellationToken cancellationToken = default)
+        public virtual async Task<Device> CreateAsync(Device deviceIdentity, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Creating device: {device?.Id}", nameof(CreateAsync));
+                Logging.Enter(this, $"Creating device: {deviceIdentity?.Id}", nameof(CreateAsync));
 
-            Argument.AssertNotNull(device, nameof(device));
+            Argument.AssertNotNull(deviceIdentity, nameof(deviceIdentity));
 
             cancellationToken.ThrowIfCancellationRequested();
 
             try
             {
-                using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Put, GetRequestUri(device.Id), _credentialProvider, device);
+                using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Put, GetRequestUri(deviceIdentity.Id), _credentialProvider, deviceIdentity);
                 HttpResponseMessage response = null;
 
                 await _internalRetryHandler
@@ -106,13 +106,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Creating device {device?.Id} threw an exception: {ex}", nameof(CreateAsync));
+                    Logging.Error(this, $"Creating device {deviceIdentity?.Id} threw an exception: {ex}", nameof(CreateAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Creating device: {device?.Id}", nameof(CreateAsync));
+                    Logging.Exit(this, $"Creating device: {deviceIdentity?.Id}", nameof(CreateAsync));
             }
         }
 
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Replace a device identity's state with the provided device identity's state.
         /// </summary>
-        /// <param name="device">The device identity's new state.</param>
+        /// <param name="deviceIdentity">The device identity's new state.</param>
         /// <param name="onlyIfUnchanged">
         /// If false, this update operation will be performed even if the provided device identity has
         /// an out of date ETag. If true, the operation will throw a <see cref="IotHubServiceException"/> with <see cref="IotHubServiceErrorCode.PreconditionFailed"/>
@@ -196,19 +196,19 @@ namespace Microsoft.Azure.Devices
         /// For a complete list of possible error cases, see <see cref="IotHubServiceErrorCode"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided cancellation token has requested cancellation.</exception>
-        public virtual async Task<Device> SetAsync(Device device, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<Device> SetAsync(Device deviceIdentity, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Updating device: {device?.Id}", nameof(SetAsync));
+                Logging.Enter(this, $"Updating device: {deviceIdentity?.Id}", nameof(SetAsync));
 
-            Argument.AssertNotNull(device, nameof(device));
+            Argument.AssertNotNull(deviceIdentity, nameof(deviceIdentity));
 
             cancellationToken.ThrowIfCancellationRequested();
 
             try
             {
-                using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Put, GetRequestUri(device.Id), _credentialProvider, device);
-                HttpMessageHelper.ConditionallyInsertETag(request, device.ETag, onlyIfUnchanged);
+                using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Put, GetRequestUri(deviceIdentity.Id), _credentialProvider, deviceIdentity);
+                HttpMessageHelper.ConditionallyInsertETag(request, deviceIdentity.ETag, onlyIfUnchanged);
 
                 HttpResponseMessage response = null;
 
@@ -235,13 +235,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating device {device?.Id} threw an exception: {ex}", nameof(SetAsync));
+                    Logging.Error(this, $"Updating device {deviceIdentity?.Id} threw an exception: {ex}", nameof(SetAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Updating device: {device?.Id}", nameof(SetAsync));
+                    Logging.Exit(this, $"Updating device: {deviceIdentity?.Id}", nameof(SetAsync));
             }
         }
 
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Delete the device identity with the provided Id from your IoT hub's registry.
         /// </summary>
-        /// <param name="device">
+        /// <param name="deviceIdentity">
         /// The device identity to delete from your IoT hub's registry. If the provided device's ETag
         /// is out of date, this operation will throw a <see cref="IotHubServiceException"/> with <see cref="IotHubServiceErrorCode.PreconditionFailed"/>
         /// An up-to-date ETag can be retrieved using <see cref="GetAsync(string, CancellationToken)"/>.
@@ -289,19 +289,19 @@ namespace Microsoft.Azure.Devices
         /// For a complete list of possible error cases, see <see cref="IotHubServiceErrorCode"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided cancellation token has requested cancellation.</exception>
-        public virtual async Task DeleteAsync(Device device, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task DeleteAsync(Device deviceIdentity, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Deleting device: {device?.Id}", nameof(DeleteAsync));
+                Logging.Enter(this, $"Deleting device: {deviceIdentity?.Id}", nameof(DeleteAsync));
 
-            Argument.AssertNotNull(device, nameof(device));
+            Argument.AssertNotNull(deviceIdentity, nameof(deviceIdentity));
 
             cancellationToken.ThrowIfCancellationRequested();
 
             try
             {
-                using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Delete, GetRequestUri(device.Id), _credentialProvider);
-                HttpMessageHelper.ConditionallyInsertETag(request, device.ETag, onlyIfUnchanged);
+                using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Delete, GetRequestUri(deviceIdentity.Id), _credentialProvider);
+                HttpMessageHelper.ConditionallyInsertETag(request, deviceIdentity.ETag, onlyIfUnchanged);
 
                 HttpResponseMessage response = null;
 
@@ -327,13 +327,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Deleting device {device?.Id} threw an exception: {ex}", nameof(DeleteAsync));
+                    Logging.Error(this, $"Deleting device {deviceIdentity?.Id} threw an exception: {ex}", nameof(DeleteAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Deleting device: {device?.Id}", nameof(DeleteAsync));
+                    Logging.Exit(this, $"Deleting device: {deviceIdentity?.Id}", nameof(DeleteAsync));
             }
         }
 
@@ -344,7 +344,7 @@ namespace Microsoft.Azure.Devices
         /// This API uses the same underlying service API as the bulk create/set/delete APIs defined in
         /// this client such as <see cref="CreateAsync(IEnumerable{Device}, CancellationToken)"/>.
         /// </remarks>
-        /// <param name="device">The device identity to register.</param>
+        /// <param name="deviceIdentity">The device identity to register.</param>
         /// <param name="twin">The initial twin state for the device.</param>
         /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
         /// <returns>The result of the bulk operation.</returns>
@@ -355,12 +355,12 @@ namespace Microsoft.Azure.Devices
         /// For a complete list of possible error cases, see <see cref="IotHubServiceErrorCode"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided cancellation token has requested cancellation.</exception>
-        public virtual async Task<BulkRegistryOperationResult> CreateWithTwinAsync(Device device, ClientTwin twin, CancellationToken cancellationToken = default)
+        public virtual async Task<BulkRegistryOperationResult> CreateWithTwinAsync(Device deviceIdentity, ClientTwin twin, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Creating device with twin: {device?.Id}", nameof(CreateWithTwinAsync));
+                Logging.Enter(this, $"Creating device with twin: {deviceIdentity?.Id}", nameof(CreateWithTwinAsync));
 
-            Argument.AssertNotNull(device, nameof(device));
+            Argument.AssertNotNull(deviceIdentity, nameof(deviceIdentity));
             Argument.AssertNotNull(twin, nameof(twin));
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -369,7 +369,7 @@ namespace Microsoft.Azure.Devices
             {
                 var exportImportDeviceList = new List<ExportImportDevice>
                 {
-                    new ExportImportDevice(device, ImportMode.Create)
+                    new ExportImportDevice(deviceIdentity, ImportMode.Create)
                     {
                         Tags = twin.Tags,
                         Properties =
@@ -393,13 +393,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Creating device with twin {device?.Id} threw an exception: {ex}", nameof(CreateWithTwinAsync));
+                    Logging.Error(this, $"Creating device with twin {deviceIdentity?.Id} threw an exception: {ex}", nameof(CreateWithTwinAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Creating device with twin: {device?.Id}", nameof(CreateWithTwinAsync));
+                    Logging.Exit(this, $"Creating device with twin: {deviceIdentity?.Id}", nameof(CreateWithTwinAsync));
             }
         }
 

--- a/iothub/service/src/Registry/ModulesClient.cs
+++ b/iothub/service/src/Registry/ModulesClient.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure;
 
 namespace Microsoft.Azure.Devices
 {
@@ -51,7 +50,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Create a module identity in your IoT hub's registry.
         /// </summary>
-        /// <param name="module">The module identity to register.</param>
+        /// <param name="moduleIdentity">The module identity to register.</param>
         /// <param name="cancellationToken">The token which allows the operation to be canceled.</param>
         /// <returns>The registered module with the generated keys and ETags.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the provided module is null.</exception>
@@ -61,18 +60,18 @@ namespace Microsoft.Azure.Devices
         /// For a complete list of possible error cases, see <see cref="IotHubServiceErrorCode"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided cancellation token has requested cancellation.</exception>
-        public virtual async Task<Module> CreateAsync(Module module, CancellationToken cancellationToken = default)
+        public virtual async Task<Module> CreateAsync(Module moduleIdentity, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Creating module: {module?.Id} on device: {module?.DeviceId}", nameof(CreateAsync));
+                Logging.Enter(this, $"Creating module: {moduleIdentity?.Id} on device: {moduleIdentity?.DeviceId}", nameof(CreateAsync));
 
-            Argument.AssertNotNull(module, nameof(module));
+            Argument.AssertNotNull(moduleIdentity, nameof(moduleIdentity));
 
             cancellationToken.ThrowIfCancellationRequested();
 
             try
             {
-                using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Put, GetModulesRequestUri(module.DeviceId, module.Id), _credentialProvider, module);
+                using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Put, GetModulesRequestUri(moduleIdentity.DeviceId, moduleIdentity.Id), _credentialProvider, moduleIdentity);
                 HttpResponseMessage response = null;
 
                 await _internalRetryHandler
@@ -98,13 +97,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Creating module {module?.Id} on device {module?.DeviceId} threw an exception: {ex}", nameof(CreateAsync));
+                    Logging.Error(this, $"Creating module {moduleIdentity?.Id} on device {moduleIdentity?.DeviceId} threw an exception: {ex}", nameof(CreateAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Creating module: {module?.Id} on device: {module?.DeviceId}", nameof(CreateAsync));
+                    Logging.Exit(this, $"Creating module: {moduleIdentity?.Id} on device: {moduleIdentity?.DeviceId}", nameof(CreateAsync));
             }
         }
 
@@ -174,7 +173,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Replace a module identity's state with the provided module identity's state.
         /// </summary>
-        /// <param name="module">The module identity's new state.</param>
+        /// <param name="moduleIdentity">The module identity's new state.</param>
         /// <param name="onlyIfUnchanged">
         /// If false, this operation will be performed even if the provided device identity has
         /// an out of date ETag. If true, the operation will throw a <see cref="IotHubServiceException"/> with <see cref="IotHubServiceErrorCode.PreconditionFailed"/>
@@ -190,19 +189,19 @@ namespace Microsoft.Azure.Devices
         /// For a complete list of possible error cases, see <see cref="IotHubServiceErrorCode"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided cancellation token has requested cancellation.</exception>
-        public virtual async Task<Module> SetAsync(Module module, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<Module> SetAsync(Module moduleIdentity, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Updating module: {module?.Id} on device: {module?.DeviceId} - only if changed: {onlyIfUnchanged}", nameof(SetAsync));
+                Logging.Enter(this, $"Updating module: {moduleIdentity?.Id} on device: {moduleIdentity?.DeviceId} - only if changed: {onlyIfUnchanged}", nameof(SetAsync));
 
-            Argument.AssertNotNull(module, nameof(module));
+            Argument.AssertNotNull(moduleIdentity, nameof(moduleIdentity));
 
             cancellationToken.ThrowIfCancellationRequested();
 
             try
             {
-                using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Put, GetModulesRequestUri(module.DeviceId, module.Id), _credentialProvider, module);
-                HttpMessageHelper.ConditionallyInsertETag(request, module.ETag, onlyIfUnchanged);
+                using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Put, GetModulesRequestUri(moduleIdentity.DeviceId, moduleIdentity.Id), _credentialProvider, moduleIdentity);
+                HttpMessageHelper.ConditionallyInsertETag(request, moduleIdentity.ETag, onlyIfUnchanged);
                 HttpResponseMessage response = null;
 
                 await _internalRetryHandler
@@ -228,13 +227,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating module {module?.Id} on device {module?.DeviceId} - only if changed {onlyIfUnchanged} threw an exception: {ex}", nameof(SetAsync));
+                    Logging.Error(this, $"Updating module {moduleIdentity?.Id} on device {moduleIdentity?.DeviceId} - only if changed {onlyIfUnchanged} threw an exception: {ex}", nameof(SetAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Updating module: {module?.Id} on device: {module?.DeviceId} - only if changed: {onlyIfUnchanged}", nameof(SetAsync));
+                    Logging.Exit(this, $"Updating module: {moduleIdentity?.Id} on device: {moduleIdentity?.DeviceId} - only if changed: {onlyIfUnchanged}", nameof(SetAsync));
             }
         }
 
@@ -263,7 +262,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Delete the module identity from your IoT hub's registry.
         /// </summary>
-        /// <param name="module">
+        /// <param name="moduleIdentity">
         /// The module identity to delete from your IoT hub's registry. If the provided module's ETag
         /// is out of date, this operation will throw a <see cref="IotHubServiceException"/> with <see cref="IotHubServiceErrorCode.PreconditionFailed"/>
         /// An up-to-date ETag can be retrieved using <see cref="GetAsync(string, string, CancellationToken)"/>.
@@ -284,19 +283,19 @@ namespace Microsoft.Azure.Devices
         /// For a complete list of possible error cases, see <see cref="IotHubServiceErrorCode"/>.
         /// </exception>
         /// <exception cref="OperationCanceledException">If the provided cancellation token has requested cancellation.</exception>
-        public virtual async Task DeleteAsync(Module module, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task DeleteAsync(Module moduleIdentity, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"Deleting module: {module?.Id} on device: {module?.DeviceId} - only if changed: {onlyIfUnchanged}", nameof(DeleteAsync));
+                Logging.Enter(this, $"Deleting module: {moduleIdentity?.Id} on device: {moduleIdentity?.DeviceId} - only if changed: {onlyIfUnchanged}", nameof(DeleteAsync));
 
-            Argument.AssertNotNull(module, nameof(module));
+            Argument.AssertNotNull(moduleIdentity, nameof(moduleIdentity));
 
             cancellationToken.ThrowIfCancellationRequested();
 
             try
             {
-                using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Delete, GetModulesRequestUri(module.DeviceId, module.Id), _credentialProvider);
-                HttpMessageHelper.ConditionallyInsertETag(request, module.ETag, onlyIfUnchanged);
+                using HttpRequestMessage request = _httpRequestMessageFactory.CreateRequest(HttpMethod.Delete, GetModulesRequestUri(moduleIdentity.DeviceId, moduleIdentity.Id), _credentialProvider);
+                HttpMessageHelper.ConditionallyInsertETag(request, moduleIdentity.ETag, onlyIfUnchanged);
                 HttpResponseMessage response = null;
 
                 await _internalRetryHandler
@@ -321,13 +320,13 @@ namespace Microsoft.Azure.Devices
             catch (Exception ex)
             {
                 if (Logging.IsEnabled)
-                    Logging.Error(this, $"Deleting module {module?.Id} on device {module?.DeviceId} - only if changed {onlyIfUnchanged} threw an exception: {ex}", nameof(DeleteAsync));
+                    Logging.Error(this, $"Deleting module {moduleIdentity?.Id} on device {moduleIdentity?.DeviceId} - only if changed {onlyIfUnchanged} threw an exception: {ex}", nameof(DeleteAsync));
                 throw;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Deleting module: {module?.Id} on device: {module?.DeviceId} - only if changed: {onlyIfUnchanged}", nameof(DeleteAsync));
+                    Logging.Exit(this, $"Deleting module: {moduleIdentity?.Id} on device: {moduleIdentity?.DeviceId} - only if changed: {onlyIfUnchanged}", nameof(DeleteAsync));
             }
         }
 

--- a/iothub/service/src/RetryPolicies/IotHubServiceExponentialBackoffRetryPolicy.cs
+++ b/iothub/service/src/RetryPolicies/IotHubServiceExponentialBackoffRetryPolicy.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <inheritdoc/>
-        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            if (!base.ShouldRetry(currentRetryCount, lastException, out retryInterval))
+            if (!base.ShouldRetry(currentRetryCount, lastException, out retryDelay))
             {
                 return false;
             }
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Devices
 
             double clampedWaitMs = Math.Min(exponentialIntervalMs, _maxDelay.TotalMilliseconds);
 
-            retryInterval = _useJitter
+            retryDelay = _useJitter
                 ? UpdateWithJitter(clampedWaitMs)
                 : TimeSpan.FromMilliseconds(clampedWaitMs);
 

--- a/iothub/service/src/RetryPolicies/IotHubServiceFixedDelayRetryPolicy.cs
+++ b/iothub/service/src/RetryPolicies/IotHubServiceFixedDelayRetryPolicy.cs
@@ -33,14 +33,14 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <inheritdoc/>
-        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            if (!base.ShouldRetry(currentRetryCount, lastException, out retryInterval))
+            if (!base.ShouldRetry(currentRetryCount, lastException, out retryDelay))
             {
                 return false;
             }
 
-            retryInterval = _useJitter
+            retryDelay = _useJitter
                 ? UpdateWithJitter(_fixedDelay.TotalMilliseconds)
                 : _fixedDelay;
 

--- a/iothub/service/src/RetryPolicies/IotHubServiceIncrementalDelayRetryPolicy.cs
+++ b/iothub/service/src/RetryPolicies/IotHubServiceIncrementalDelayRetryPolicy.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Azure.Devices
         internal protected bool UseJitter { get; }
 
         /// <inheritdoc/>
-        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            if (!base.ShouldRetry(currentRetryCount, lastException, out retryInterval))
+            if (!base.ShouldRetry(currentRetryCount, lastException, out retryDelay))
             {
                 return false;
             }
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Devices
                 currentRetryCount * DelayIncrement.TotalMilliseconds,
                 MaxDelay.TotalMilliseconds);
 
-            retryInterval = UseJitter
+            retryDelay = UseJitter
                 ? UpdateWithJitter(waitDurationMs)
                 : TimeSpan.FromMilliseconds(waitDurationMs);
 

--- a/iothub/service/src/RetryPolicies/IotHubServiceNoRetry.cs
+++ b/iothub/service/src/RetryPolicies/IotHubServiceNoRetry.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <inheritdoc/>
-        public bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            retryInterval = TimeSpan.Zero;
+            retryDelay = TimeSpan.Zero;
             return false;
         }
     }

--- a/provisioning/device/src/ProvisioningClientException.cs
+++ b/provisioning/device/src/ProvisioningClientException.cs
@@ -9,9 +9,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
     /// <summary>
     /// The exception that is thrown when an error occurs during device provisioning client operation.
     /// </summary>
+    [Serializable]
     public class ProvisioningClientException : Exception
     {
-        private const string IsTransientValueSerializationStoreName = "ProvisioningClientException-IsTransient";
+        [NonSerialized]
+        private const string IsTransientValueSerializationStoreName = "ProvisioningClientExceptionn-IsTransient";
+
+        [NonSerialized]
+        private const string TrackingIdValueSerializationStoreName = "ProvisioningClientException-TrackingId";
 
         /// <summary>
         /// Creates a new instance of this class.
@@ -56,13 +61,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// </summary>
         /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
-        protected internal ProvisioningClientException(SerializationInfo info, StreamingContext context)
+        protected ProvisioningClientException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             if (info != null)
             {
                 IsTransient = info.GetBoolean(IsTransientValueSerializationStoreName);
-                TrackingId = info.GetString(IsTransientValueSerializationStoreName);
+                TrackingId = info.GetString(TrackingIdValueSerializationStoreName);
             }
         }
 

--- a/provisioning/device/src/RetryPolicies/ProvisioningClientExponentialBackoffRetryPolicy.cs
+++ b/provisioning/device/src/RetryPolicies/ProvisioningClientExponentialBackoffRetryPolicy.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         }
 
         /// <inheritdoc/>
-        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            if (!base.ShouldRetry(currentRetryCount, lastException, out retryInterval))
+            if (!base.ShouldRetry(currentRetryCount, lastException, out retryDelay))
             {
                 return false;
             }
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
             double clampedWaitMs = Math.Min(exponentialIntervalMs, _maxDelay.TotalMilliseconds);
 
-            retryInterval = _useJitter
+            retryDelay = _useJitter
                 ? UpdateWithJitter(clampedWaitMs)
                 : TimeSpan.FromMilliseconds(clampedWaitMs);
 

--- a/provisioning/device/src/RetryPolicies/ProvisioningClientFixedDelayRetryPolicy.cs
+++ b/provisioning/device/src/RetryPolicies/ProvisioningClientFixedDelayRetryPolicy.cs
@@ -33,14 +33,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         }
 
         /// <inheritdoc/>
-        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            if (!base.ShouldRetry(currentRetryCount, lastException, out retryInterval))
+            if (!base.ShouldRetry(currentRetryCount, lastException, out retryDelay))
             {
                 return false;
             }
 
-            retryInterval = _useJitter
+            retryDelay = _useJitter
                 ? UpdateWithJitter(_fixedDelay.TotalMilliseconds)
                 : _fixedDelay;
 

--- a/provisioning/device/src/RetryPolicies/ProvisioningClientIncrementalDelayRetryPolicy.cs
+++ b/provisioning/device/src/RetryPolicies/ProvisioningClientIncrementalDelayRetryPolicy.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         internal protected bool UseJitter { get; }
 
         /// <inheritdoc/>
-        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            if (!base.ShouldRetry(currentRetryCount, lastException, out retryInterval))
+            if (!base.ShouldRetry(currentRetryCount, lastException, out retryDelay))
             {
                 return false;
             }
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                 currentRetryCount * DelayIncrement.TotalMilliseconds,
                 MaxDelay.TotalMilliseconds);
 
-            retryInterval = UseJitter
+            retryDelay = UseJitter
                 ? UpdateWithJitter(waitDurationMs)
                 : TimeSpan.FromMilliseconds(waitDurationMs);
 

--- a/provisioning/device/src/RetryPolicies/ProvisioningClientNoRetry.cs
+++ b/provisioning/device/src/RetryPolicies/ProvisioningClientNoRetry.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         }
 
         /// <inheritdoc/>
-        public bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            retryInterval = TimeSpan.Zero;
+            retryDelay = TimeSpan.Zero;
             return false;
         }
     }

--- a/provisioning/device/src/Transports/Mqtt/MqttLogger.cs
+++ b/provisioning/device/src/Transports/Mqtt/MqttLogger.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.Tracing;
+using System.Globalization;
 using MQTTnet.Diagnostics;
 
 namespace Microsoft.Azure.Devices.Provisioning.Client.Transports.Mqtt
@@ -21,7 +22,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transports.Mqtt
             string formattedMessage = message;
             if (parameters != null && parameters.Length > 0)
             {
-                formattedMessage = string.Format(message, parameters);
+                formattedMessage = string.Format(CultureInfo.InvariantCulture, message, parameters);
             }
 
             Logging.Log.Write(formattedMessage, options);

--- a/provisioning/device/src/Transports/Mqtt/ProvisioningTransportHandlerMqtt.cs
+++ b/provisioning/device/src/Transports/Mqtt/ProvisioningTransportHandlerMqtt.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
 
                 MqttClientSubscribeResultItem subscribeResult = subscribeResults.Items.FirstOrDefault();
 
-                if (!subscribeResult.TopicFilter.Topic.Equals(SubscribeFilter))
+                if (!subscribeResult.TopicFilter.Topic.Equals(SubscribeFilter, StringComparison.Ordinal))
                 {
                     throw new ProvisioningClientException($"Received unexpected subscription to topic '{subscribeResult.TopicFilter.Topic}'.", true);
                 }

--- a/provisioning/service/src/ProvisioningServiceException.cs
+++ b/provisioning/service/src/ProvisioningServiceException.cs
@@ -4,14 +4,22 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Azure.Devices.Provisioning.Service
 {
     /// <summary>
     /// The Device Provisioning Service exceptions on the Service Client.
     /// </summary>
+    [Serializable]
     public class ProvisioningServiceException : Exception
     {
+        [NonSerialized]
+        private const string IsTransientValueSerializationStoreName = "ProvisioningServiceException-IsTransient";
+
+        [NonSerialized]
+        private const string TrackingIdValueSerializationStoreName = "ProvisioningServiceException-TrackingId";
+
         /// <summary>
         /// Creates an instance of this class.
         /// </summary>
@@ -95,6 +103,21 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             ErrorCode = errorCode;
             TrackingId = trackingId;
             Fields = fields;
+        }
+
+        /// <summary>
+        /// Creates a new instance of this class.
+        /// </summary>
+        /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
+        protected ProvisioningServiceException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            if (info != null)
+            {
+                IsTransient = info.GetBoolean(IsTransientValueSerializationStoreName);
+                TrackingId = info.GetString(TrackingIdValueSerializationStoreName);
+            }
         }
 
         /// <summary>

--- a/provisioning/service/src/RetryPolicies/ProvisioningServiceExponentialBackoffRetryPolicy.cs
+++ b/provisioning/service/src/RetryPolicies/ProvisioningServiceExponentialBackoffRetryPolicy.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         }
 
         /// <inheritdoc/>
-        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            if (!base.ShouldRetry(currentRetryCount, lastException, out retryInterval))
+            if (!base.ShouldRetry(currentRetryCount, lastException, out retryDelay))
             {
                 return false;
             }
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
 
             double clampedWaitMs = Math.Min(exponentialIntervalMs, _maxDelay.TotalMilliseconds);
 
-            retryInterval = _useJitter
+            retryDelay = _useJitter
                 ? UpdateWithJitter(clampedWaitMs)
                 : TimeSpan.FromMilliseconds(clampedWaitMs);
 

--- a/provisioning/service/src/RetryPolicies/ProvisioningServiceFixedDelayRetryPolicy.cs
+++ b/provisioning/service/src/RetryPolicies/ProvisioningServiceFixedDelayRetryPolicy.cs
@@ -33,14 +33,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         }
 
         /// <inheritdoc/>
-        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            if (!base.ShouldRetry(currentRetryCount, lastException, out retryInterval))
+            if (!base.ShouldRetry(currentRetryCount, lastException, out retryDelay))
             {
                 return false;
             }
 
-            retryInterval = _useJitter
+            retryDelay = _useJitter
                 ? UpdateWithJitter(_fixedDelay.TotalMilliseconds)
                 : _fixedDelay;
 

--- a/provisioning/service/src/RetryPolicies/ProvisioningServiceIncrementalDelayRetryPolicy.cs
+++ b/provisioning/service/src/RetryPolicies/ProvisioningServiceIncrementalDelayRetryPolicy.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         internal protected bool UseJitter { get; }
 
         /// <inheritdoc/>
-        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public override bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            if (!base.ShouldRetry(currentRetryCount, lastException, out retryInterval))
+            if (!base.ShouldRetry(currentRetryCount, lastException, out retryDelay))
             {
                 return false;
             }
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 currentRetryCount * DelayIncrement.TotalMilliseconds,
                 MaxDelay.TotalMilliseconds);
 
-            retryInterval = UseJitter
+            retryDelay = UseJitter
                 ? UpdateWithJitter(waitDurationMs)
                 : TimeSpan.FromMilliseconds(waitDurationMs);
 

--- a/provisioning/service/src/RetryPolicies/ProvisioningServiceNoRetry.cs
+++ b/provisioning/service/src/RetryPolicies/ProvisioningServiceNoRetry.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         }
 
         /// <inheritdoc/>
-        public bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+        public bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
         {
-            retryInterval = TimeSpan.Zero;
+            retryDelay = TimeSpan.Zero;
             return false;
         }
     }

--- a/provisioning/service/src/Twin/InitialTwinPropertyCollection.cs
+++ b/provisioning/service/src/Twin/InitialTwinPropertyCollection.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// Represents a collection of properties for device twin.
     /// </summary>
     [JsonConverter(typeof(InitialTwinPropertiesJsonConverter))]
-    public class InitialTwinPropertyCollection : IEnumerable
+    public class InitialTwinPropertyCollection : IEnumerable<KeyValuePair<string, object>>
     {
         internal const string MetadataName = "$metadata";
         internal const string LastUpdatedName = "$lastUpdated";
@@ -191,8 +191,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             return JObject.TryGetValue(propertyName, out _);
         }
 
-        /// <inheritdoc />
-        public IEnumerator GetEnumerator()
+        /// <inheritdoc/>
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {
             foreach (KeyValuePair<string, JToken> kvp in JObject)
             {
@@ -203,6 +203,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
 
                 yield return new KeyValuePair<string, dynamic>(kvp.Key, this[kvp.Key]);
             }
+        }
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
 
         /// <summary>

--- a/provisioning/service/tests/Config/AttestationMechanismTests.cs
+++ b/provisioning/service/tests/Config/AttestationMechanismTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
         public void AttestationMechanismConstructorThrowsOnAttestationNull()
         {
             // arrange - act - assert
-            _ = TestAssert.Throws<ArgumentNullException>(() => new AttestationMechanism(null));
+            _ = TestAssert.Throws<ArgumentNullException>(() => _ = new AttestationMechanism(null));
         }
 
         [TestMethod]
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Test
             var unknownAttestation = new UnknownAttestation();
 
             // act - assert
-            TestAssert.Throws<ArgumentException>(() => new AttestationMechanism(unknownAttestation));
+            TestAssert.Throws<ArgumentException>(() => _ = new AttestationMechanism(unknownAttestation));
         }
 
         [TestMethod]


### PR DESCRIPTION
Issues:

- ~Fix param name matching in base class method and derived class overridden method~ - #3023 
- ~String comparison errors -> String.Format, String.Equals, String.StartsWith... etc~ - #3031 
- ~using reserved keyword~ #3025
- ~Add missing constructors to exception classes~ #3026 
- ~CA1010: Collections should implement generic interface~ #3028 
- ~CA2201: Exception type System.Exception is not sufficiently specific~ #3029 
- ~CA1822: Mark members as static~ #3032 