### PR TITLE
Add missing constructors to exception classes

### DIFF
--- a/iothub/device/src/Exceptions/IotHubClientException.cs
+++ b/iothub/device/src/Exceptions/IotHubClientException.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
-        protected internal IotHubClientException(SerializationInfo info, StreamingContext context)
+        protected IotHubClientException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             if (info != null)

--- a/iothub/service/src/Exceptions/IotHubServiceException.cs
+++ b/iothub/service/src/Exceptions/IotHubServiceException.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices
     public class IotHubServiceException : Exception
     {
         private const string IsTransientValueSerializationStoreName = "IotHubServiceException-IsTransient";
-        private const string TrackingIdSerializationStoreName = "IoTHubException-TrackingId";
+        private const string TrackingIdValueSerializationStoreName = "IoTHubException-TrackingId";
 
         /// <summary>
         /// Creates an instance of this class with the specified error message and optional inner exception.
@@ -51,6 +51,21 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <summary>
+        /// Creates an instance of this class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected IotHubServiceException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            if (info != null)
+            {
+                IsTransient = info.GetBoolean(IsTransientValueSerializationStoreName);
+                TrackingId = info.GetString(TrackingIdValueSerializationStoreName);
+            }
+        }
+
+        /// <summary>
         /// Indicates if the error is transient and should be retried.
         /// </summary>
         public bool IsTransient { get; protected internal set; }
@@ -81,7 +96,7 @@ namespace Microsoft.Azure.Devices
         {
             base.GetObjectData(info, context);
             info.AddValue(IsTransientValueSerializationStoreName, IsTransient);
-            info.AddValue(TrackingIdSerializationStoreName, TrackingId);
+            info.AddValue(TrackingIdValueSerializationStoreName, TrackingId);
         }
 
         private static bool DetermineIfTransient(HttpStatusCode statusCode, IotHubServiceErrorCode errorCode)

--- a/iothub/service/src/Exceptions/IotHubServiceException.cs
+++ b/iothub/service/src/Exceptions/IotHubServiceException.cs
@@ -13,8 +13,11 @@ namespace Microsoft.Azure.Devices
     [Serializable]
     public class IotHubServiceException : Exception
     {
+        [NonSerialized]
         private const string IsTransientValueSerializationStoreName = "IotHubServiceException-IsTransient";
-        private const string TrackingIdValueSerializationStoreName = "IoTHubException-TrackingId";
+
+        [NonSerialized]
+        private const string TrackingIdValueSerializationStoreName = "IotHubServiceException-TrackingId";
 
         /// <summary>
         /// Creates an instance of this class with the specified error message and optional inner exception.

--- a/provisioning/device/src/ProvisioningClientException.cs
+++ b/provisioning/device/src/ProvisioningClientException.cs
@@ -9,9 +9,14 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
     /// <summary>
     /// The exception that is thrown when an error occurs during device provisioning client operation.
     /// </summary>
+    [Serializable]
     public class ProvisioningClientException : Exception
     {
-        private const string IsTransientValueSerializationStoreName = "ProvisioningClientException-IsTransient";
+        [NonSerialized]
+        private const string IsTransientValueSerializationStoreName = "ProvisioningClientExceptionn-IsTransient";
+
+        [NonSerialized]
+        private const string TrackingIdValueSerializationStoreName = "ProvisioningClientException-TrackingId";
 
         /// <summary>
         /// Creates a new instance of this class.
@@ -56,13 +61,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// </summary>
         /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
-        protected internal ProvisioningClientException(SerializationInfo info, StreamingContext context)
+        protected ProvisioningClientException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             if (info != null)
             {
                 IsTransient = info.GetBoolean(IsTransientValueSerializationStoreName);
-                TrackingId = info.GetString(IsTransientValueSerializationStoreName);
+                TrackingId = info.GetString(TrackingIdValueSerializationStoreName);
             }
         }
 

--- a/provisioning/service/src/ProvisioningServiceException.cs
+++ b/provisioning/service/src/ProvisioningServiceException.cs
@@ -4,14 +4,22 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Azure.Devices.Provisioning.Service
 {
     /// <summary>
     /// The Device Provisioning Service exceptions on the Service Client.
     /// </summary>
+    [Serializable]
     public class ProvisioningServiceException : Exception
     {
+        [NonSerialized]
+        private const string IsTransientValueSerializationStoreName = "ProvisioningServiceException-IsTransient";
+
+        [NonSerialized]
+        private const string TrackingIdValueSerializationStoreName = "ProvisioningServiceException-TrackingId";
+
         /// <summary>
         /// Creates an instance of this class.
         /// </summary>
@@ -95,6 +103,21 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             ErrorCode = errorCode;
             TrackingId = trackingId;
             Fields = fields;
+        }
+
+        /// <summary>
+        /// Creates a new instance of this class.
+        /// </summary>
+        /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
+        protected ProvisioningServiceException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            if (info != null)
+            {
+                IsTransient = info.GetBoolean(IsTransientValueSerializationStoreName);
+                TrackingId = info.GetString(TrackingIdValueSerializationStoreName);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Custom exceptions should be serializable so that the exception information can be serialized and shared between different services/processes.

[CA2229: Implement serialization constructors](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2229)