### PR TITLE
IDisposable fixes

### DIFF
--- a/e2e/test/helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/helpers/TestDeviceCallbackHandler.cs
@@ -175,6 +175,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             _methodCallbackSemaphore?.Dispose();
             _twinCallbackSemaphore?.Dispose();
             _receivedMessageCallbackSemaphore?.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
@@ -10,7 +10,7 @@ using Microsoft.Azure.Devices.Client.Transport.AmqpIot;
 
 namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 {
-    internal class AmqpAuthenticationRefresher : IAmqpAuthenticationRefresher
+    internal class AmqpAuthenticationRefresher : IAmqpAuthenticationRefresher, IDisposable
     {
         private static readonly string[] s_accessRightsStringArray = new[] { "DeviceConnect" };
         private readonly Uri _amqpEndpoint;
@@ -169,6 +169,11 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             // If the shared access key name is not null then this is a group SAS authenticated client.
             // SAS tokens granted to a group SAS authenticated client will scoped to the IoT hub-level; for example, myHub.azure-devices.net
             return connectionCredentials.HostName;
+        }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         public void Dispose()
         {
-            throw new NotImplementedException();
+            _loopCancellationTokenSource?.Dispose();
         }
     }
 }

--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -17,7 +17,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Client.Transport
 {
-    internal sealed class HttpClientHelper
+    internal sealed class HttpClientHelper : IDisposable
     {
         private readonly Uri _baseAddress;
         private readonly IConnectionCredentials _connectionCredentials;
@@ -236,6 +236,11 @@ namespace Microsoft.Azure.Devices.Client.Transport
             using var reader = new StreamReader(stream);
             using var jsonReader = new JsonTextReader(reader);
             return new JsonSerializer().Deserialize<T>(jsonReader);
+        }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public void Dispose()
         {
-            throw new NotImplementedException();
+            _httpClientObj?.Dispose();
         }
     }
 }


### PR DESCRIPTION
[CA1001: Types that own disposable fields should be disposable](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1001)

[CA1816: Call GC.SuppressFinalize correctly](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1816)