### PR TITLE
Address corner cases around sas token refresh loop cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Track1 .NET Azure IoT Hub and DPS SDKs
 
-*	@drwill-ms @timtay-microsoft @abhipsaMisra @andyk-ms @brycewang-microsoft @tmahmood-microsoft @ngastelum-ms @patilsnr
+*	@drwill-ms @timtay-microsoft @abhipsaMisra @andyk-ms @brycewang-microsoft @tmahmood-microsoft @ngastelum-ms @patilsnr @schoims

--- a/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
@@ -213,9 +213,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             try
             {
                 if (Logging.IsEnabled)
-                {
                     Logging.Enter(this, $"Disposed={_disposed}; disposing={disposing}", $"{nameof(AmqpAuthenticationRefresher)}.{nameof(Dispose)}");
-                }
 
                 if (!_disposed)
                 {

--- a/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
@@ -228,9 +228,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             finally
             {
                 if (Logging.IsEnabled)
-                {
                     Logging.Exit(this, $"Disposed={_disposed}; disposing={disposing}", $"{nameof(AmqpAuthenticationRefresher)}.{nameof(Dispose)}");
-                }
             }
         }
     }

--- a/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             if (_refresherCancellationTokenSource != null)
             {
                 if (Logging.IsEnabled)
-                    Logging.Info(this, "_refresherCancellationTokenSource was already initialized, whhich was unexpected. Canceling and disposing the previous instance.", nameof(IAmqpAuthenticationRefresher.InitLoopAsync));
+                    Logging.Info(this, "_refresherCancellationTokenSource was already initialized, which was unexpected. Canceling and disposing the previous instance.", nameof(IAmqpAuthenticationRefresher.InitLoopAsync));
 
                 try
                 {

--- a/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
@@ -71,8 +71,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
             _refresherCancellationTokenSource = new CancellationTokenSource();
 
-            // AmqpAuthenticationRefresher.StartLoop 
-            // TODO
+            // AmqpAuthenticationRefresher.StartLoop is implemented as an explicit interface implementation. 
+            // This is because we do not wish to make the interface and its methods public.
+            // Implicit interface implementation requires the interface and its methods to be public.
+            // Since StartLoop can only be accessed through an AmqpAuthenticationRefresher instance, we have to add the instance check.
             if (refreshOn < DateTime.MaxValue
                 && this is IAmqpAuthenticationRefresher refresher)
             {

--- a/iothub/device/src/Transport/Amqp/IAmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/IAmqpAuthenticationRefresher.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
     internal interface IAmqpAuthenticationRefresher
     {
         Task InitLoopAsync(CancellationToken cancellationToken);
-        void StartLoop(DateTime refreshOn);
-        void StopLoop();
+        void StartLoop(DateTime refreshOn, CancellationToken cancellationToken);
+        Task StopLoopAsync();
     }
 }

--- a/iothub/device/src/Transport/Amqp/IAmqpConnectionHolder.cs
+++ b/iothub/device/src/Transport/Amqp/IAmqpConnectionHolder.cs
@@ -16,6 +16,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         Task<IAmqpAuthenticationRefresher> CreateRefresherAsync(IConnectionCredentials connectionCredentials, CancellationToken cancellationToken);
 
-        void Shutdown();
+        Task ShutdownAsync();
     }
 }


### PR DESCRIPTION
Related:

https://github.com/Azure/azure-iot-sdk-csharp/pull/2935 - Cancel amqp token refresher as a part of transport cleanup
https://github.com/Azure/azure-iot-sdk-csharp/pull/3021 - Await completion of refresh loop