### PR TITLE
Setting MaxDepth parameter in the JsonSerializerSettings as safe defaults

### DIFF
--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.Devices.Shared;
 using System.Security.Cryptography.X509Certificates;
 using System.IO;
 using Microsoft.Azure.Devices.Client.Exceptions;
+using Newtonsoft.Json;
 
 #if NET451
 
@@ -155,6 +156,8 @@ namespace Microsoft.Azure.Devices.Client
             {
                 Logging.Enter(this, transportSettings, pipelineBuilder, nameof(InternalClient) + "_ctor");
             }
+
+            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
 
             TlsVersions.Instance.SetLegacyAcceptableVersions();
 
@@ -989,7 +992,7 @@ namespace Microsoft.Azure.Devices.Client
                     methodResponseInternal?.Dispose();
                 }
                 finally
-                { 
+                {
                     // Need to release this semaphore even if the above dispose call fails
                     _methodsDictionarySemaphore.Release();
                 }
@@ -1405,7 +1408,7 @@ namespace Microsoft.Azure.Devices.Client
                 return;
             }
 
-            // Grab this semaphore so that there is no chance that the _deviceReceiveMessageCallback instance is set in between the read of the 
+            // Grab this semaphore so that there is no chance that the _deviceReceiveMessageCallback instance is set in between the read of the
             // item1 and the read of the item2
             await _deviceReceiveMessageSemaphore.WaitAsync().ConfigureAwait(false);
             ReceiveMessageCallback callback = _deviceReceiveMessageCallback?.Item1;

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Devices.Client
                 Logging.Enter(this, transportSettings, pipelineBuilder, nameof(InternalClient) + "_ctor");
             }
 
-            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
+            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettingsDelegate();
 
             TlsVersions.Instance.SetLegacyAcceptableVersions();
 

--- a/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Authentication;
 using Microsoft.Azure.Devices.Extensions;
 using Microsoft.Azure.Devices.Generated;
+using Microsoft.Azure.Devices.Shared;
 using Microsoft.Rest;
 using Newtonsoft.Json;
 
@@ -38,6 +39,8 @@ namespace Microsoft.Azure.Devices
         {
             _client = new IotHubGatewayServiceAPIs(uri, credentials, handlers);
             _protocolLayer = new DigitalTwin(_client);
+
+            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
         }
 
         /// <summary>
@@ -69,9 +72,9 @@ namespace Microsoft.Azure.Devices
         /// <param name="cancellationToken">The cancellationToken.</param>
         /// <returns>The http response.</returns>
         public Task<HttpOperationHeaderResponse<DigitalTwinUpdateHeaders>> UpdateDigitalTwinAsync(
-            string digitalTwinId, 
-            string digitalTwinUpdateOperations, 
-            DigitalTwinUpdateRequestOptions requestOptions = default, 
+            string digitalTwinId,
+            string digitalTwinUpdateOperations,
+            DigitalTwinUpdateRequestOptions requestOptions = default,
             CancellationToken cancellationToken = default)
         {
             return _protocolLayer.UpdateDigitalTwinWithHttpMessagesAsync(digitalTwinId, digitalTwinUpdateOperations, requestOptions?.IfMatch, null, cancellationToken);
@@ -87,19 +90,19 @@ namespace Microsoft.Azure.Devices
         /// <param name="cancellationToken">The cancellationToken.</param>
         /// <returns>The application/json command invocation response and the http response. </returns>
         public async Task<HttpOperationResponse<DigitalTwinCommandResponse, DigitalTwinInvokeCommandHeaders>> InvokeCommandAsync(
-            string digitalTwinId, 
-            string commandName, 
-            string payload = default, 
-            DigitalTwinInvokeCommandRequestOptions requestOptions = default, 
+            string digitalTwinId,
+            string commandName,
+            string payload = default,
+            DigitalTwinInvokeCommandRequestOptions requestOptions = default,
             CancellationToken cancellationToken = default)
         {
             using HttpOperationResponse<string, DigitalTwinInvokeRootLevelCommandHeaders> response = await _protocolLayer.InvokeRootLevelCommandWithHttpMessagesAsync(
-                digitalTwinId, 
-                commandName, 
-                payload, 
-                requestOptions?.ConnectTimeoutInSeconds, 
-                requestOptions?.ResponseTimeoutInSeconds, 
-                null, 
+                digitalTwinId,
+                commandName,
+                payload,
+                requestOptions?.ConnectTimeoutInSeconds,
+                requestOptions?.ResponseTimeoutInSeconds,
+                null,
                 cancellationToken)
                 .ConfigureAwait(false);
             return new HttpOperationResponse<DigitalTwinCommandResponse, DigitalTwinInvokeCommandHeaders>
@@ -122,21 +125,21 @@ namespace Microsoft.Azure.Devices
         /// <param name="cancellationToken">The cancellationToken.</param>
         /// <returns>The application/json command invocation response and the http response. </returns>
         public async Task<HttpOperationResponse<DigitalTwinCommandResponse, DigitalTwinInvokeCommandHeaders>> InvokeComponentCommandAsync(
-            string digitalTwinId, 
-            string componentName, 
-            string commandName, 
-            string payload = default, 
-            DigitalTwinInvokeCommandRequestOptions requestOptions = default, 
+            string digitalTwinId,
+            string componentName,
+            string commandName,
+            string payload = default,
+            DigitalTwinInvokeCommandRequestOptions requestOptions = default,
             CancellationToken cancellationToken = default)
         {
             using HttpOperationResponse<string, DigitalTwinInvokeComponentCommandHeaders> response = await _protocolLayer.InvokeComponentCommandWithHttpMessagesAsync(
-                digitalTwinId, 
-                componentName, 
-                commandName, 
-                payload, 
-                requestOptions?.ConnectTimeoutInSeconds, 
-                requestOptions?.ResponseTimeoutInSeconds, 
-                null, 
+                digitalTwinId,
+                componentName,
+                commandName,
+                payload,
+                requestOptions?.ConnectTimeoutInSeconds,
+                requestOptions?.ResponseTimeoutInSeconds,
+                null,
                 cancellationToken)
                 .ConfigureAwait(false);
             return new HttpOperationResponse<DigitalTwinCommandResponse, DigitalTwinInvokeCommandHeaders>

--- a/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices
             _client = new IotHubGatewayServiceAPIs(uri, credentials, handlers);
             _protocolLayer = new DigitalTwin(_client);
 
-            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
+            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettingsDelegate();
         }
 
         /// <summary>

--- a/iothub/service/src/JobClient/JobClient.cs
+++ b/iothub/service/src/JobClient/JobClient.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.Devices
 {
     using Microsoft.Azure.Devices.Shared;
+    using Newtonsoft.Json;
     using System;
     using System.Threading;
     using System.Threading.Tasks;
@@ -35,6 +36,7 @@ namespace Microsoft.Azure.Devices
             {
                 throw new ArgumentNullException(nameof(transportSettings), "HTTP Transport settings cannot be null.");
             }
+            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
             TlsVersions.Instance.SetLegacyAcceptableVersions();
 
             var iotHubConnectionString = IotHubConnectionString.Parse(connectionString);
@@ -52,7 +54,8 @@ namespace Microsoft.Azure.Devices
         /// Releases unmanaged and - optionally - managed resources.
         /// </summary>
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposing) { }
+        protected virtual void Dispose(bool disposing)
+        { }
 
         /// <summary>
         /// Explicitly open the JobClient instance.

--- a/iothub/service/src/JobClient/JobClient.cs
+++ b/iothub/service/src/JobClient/JobClient.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Devices
             {
                 throw new ArgumentNullException(nameof(transportSettings), "HTTP Transport settings cannot be null.");
             }
-            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
+            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettingsDelegate();
             TlsVersions.Instance.SetLegacyAcceptableVersions();
 
             var iotHubConnectionString = IotHubConnectionString.Parse(connectionString);

--- a/iothub/service/src/RegistryManager.cs
+++ b/iothub/service/src/RegistryManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Shared;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices
 {
@@ -40,6 +41,8 @@ namespace Microsoft.Azure.Devices
             {
                 throw new ArgumentNullException(nameof(transportSettings), "The HTTP transport settings cannot be null.");
             }
+
+            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
             TlsVersions.Instance.SetLegacyAcceptableVersions();
 
             var iotHubConnectionString = IotHubConnectionString.Parse(connectionString);
@@ -57,7 +60,8 @@ namespace Microsoft.Azure.Devices
         /// Releases unmanaged and - optionally - managed resources.
         /// </summary>
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposing) { }
+        protected virtual void Dispose(bool disposing)
+        { }
 
         /// <summary>
         /// Explicitly open the RegistryManager instance.

--- a/iothub/service/src/RegistryManager.cs
+++ b/iothub/service/src/RegistryManager.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Devices
                 throw new ArgumentNullException(nameof(transportSettings), "The HTTP transport settings cannot be null.");
             }
 
-            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
+            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettingsDelegate();
             TlsVersions.Instance.SetLegacyAcceptableVersions();
 
             var iotHubConnectionString = IotHubConnectionString.Parse(connectionString);

--- a/iothub/service/src/ServiceClient.cs
+++ b/iothub/service/src/ServiceClient.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         internal ServiceClient()
         {
-            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
+            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettingsDelegate();
             TlsVersions.Instance.SetLegacyAcceptableVersions();
         }
 

--- a/iothub/service/src/ServiceClient.cs
+++ b/iothub/service/src/ServiceClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Shared;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices
 {
@@ -39,6 +40,7 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         internal ServiceClient()
         {
+            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
             TlsVersions.Instance.SetLegacyAcceptableVersions();
         }
 
@@ -64,7 +66,8 @@ namespace Microsoft.Azure.Devices
         /// Releases unmanaged and - optionally - managed resources.
         /// </summary>
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposing) { }
+        protected virtual void Dispose(bool disposing)
+        { }
 
         /// <summary>
         /// Create an instance of ServiceClient from the specified IoT Hub connection string using specified Transport Type.

--- a/iothub/service/tests/JobClient/JobClientTests.cs
+++ b/iothub/service/tests/JobClient/JobClientTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Azure.Devices.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Azure.Devices;
+using FluentAssertions;
+using Newtonsoft.Json;
+using System.Linq;
+
+namespace Microsoft.Azure.Devices
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class JobClientTests
+    {
+        [TestMethod]
+        public void JobClient_DefaultMaxDepth()
+        {
+            // arrange
+            string fakeConnectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;SharedAccessKey=dGVzdFN0cmluZzE=";
+            using var jobClient = JobClient.CreateFromConnectionString(fakeConnectionString);
+            // above arragement is only for setting the defaultJsonSerializerSettings
+
+            var defaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
+            defaultSettings.MaxDepth.Should().Be(128);
+        }
+
+        [TestMethod]
+        public void JobClient_Json_OverrideDefaultJsonSerializer_ExceedMaxDepthThrows()
+        {
+            // arrange
+            string fakeConnectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;SharedAccessKey=dGVzdFN0cmluZzE=";
+            using var jobClient = JobClient.CreateFromConnectionString(fakeConnectionString);
+            // above arragement is only for setting the defaultJsonSerializerSettings
+
+            //Create a string representation of a nested object (JSON serialized)
+            int nRep = 3;
+            string json = string.Concat(Enumerable.Repeat("{a:", nRep)) + "1" +
+            string.Concat(Enumerable.Repeat("}", nRep));
+
+            var settings = new JsonSerializerSettings { MaxDepth = 2 };
+            //// deserialize
+            // act
+            Func<object> act = () => JsonConvert.DeserializeObject(json, settings);
+
+            // assert
+            act.Should().Throw<Newtonsoft.Json.JsonReaderException>();
+        }
+    }
+}

--- a/iothub/service/tests/QueryTests.cs
+++ b/iothub/service/tests/QueryTests.cs
@@ -297,26 +297,27 @@ namespace Microsoft.Azure.Devices.Api.Test
         [TestMethod]
         public void QueryResult_OverrideDefaultJsonSerializer_ExceedMaxDepthThrows()
         {
-            // simulate json serialize/deserialize
-            var serverQueryResult = new QueryResult
-            {
-                Type = QueryResultType.Twin,
-                Items = new List<Twin>
-                {
-                    new Twin
-                    {
-                        DeviceId = "test",
-                    }
-                },
-                ContinuationToken = "GYUVJDBJFKJ"
-            };
-
             var settings = new JsonSerializerSettings { MaxDepth = 2 };
-            // serialize
-            var jsonQueryResult = JsonConvert.SerializeObject(serverQueryResult, settings);
-            jsonQueryResult.Should().Be("{\"type\":\"twin\",\"items\":[{\"deviceId\":\"test\",\"etag\":null,\"version\":null,\"properties\":{\"desired\":{},\"reported\":{}}}],\"continuationToken\":\"GYUVJDBJFKJ\"}");            // deserialize
+            // simulate json deserialize
+            const string jsonString = @"
+{
+""type"":""twin"",
+""items"":
+    [{
+        ""deviceId"": ""test"",
+        ""etag"":null,
+        ""version"":null,
+        ""properties"":
+            {
+                ""desired"":{},
+                ""reported"":{}
+            }
+    }],
+""continuationToken"":""GYUVJDBJFKJ""
+}";
+            // deserialize
             // act
-            Func<QueryResult> act = () => JsonConvert.DeserializeObject<QueryResult>(jsonQueryResult, settings);
+            Func<QueryResult> act = () => JsonConvert.DeserializeObject<QueryResult>(jsonString, settings);
 
             // assert
             act.Should().Throw<Newtonsoft.Json.JsonReaderException>();

--- a/iothub/service/tests/SerializationTests.cs
+++ b/iothub/service/tests/SerializationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
+using FluentAssertions;
 using Microsoft.Azure.Devices.Shared;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -67,6 +68,32 @@ namespace Microsoft.Azure.Devices.Test
 }";
 
             JsonConvert.DeserializeObject<Configuration>(jsonString);
+        }
+
+        [TestMethod]
+        public void Twin_Json_OverrideDefaultJsonSerializer_ExceedMaxDepthThrows()
+        {
+            // arrange
+            const string jsonString = @"
+{
+ ""deviceId"": ""test"",
+ ""etag"": ""AAAAAAAAAAM="",
+ ""version"": 5,
+ ""status"": ""enabled"",
+ ""statusUpdateTime"": ""2018-06-29T21:17:08.7759733"",
+ ""connectionState"": ""Connected"",
+ ""lastActivityTime"": ""2018-06-29T21:17:08.7759733"",
+ ""Capabilities"": {
+    ""IotEdge"": false
+ }
+}";
+            var settings = new JsonSerializerSettings { MaxDepth = 1 };
+
+            // act
+            Func<Twin> act = () => JsonConvert.DeserializeObject<Twin>(jsonString, settings);
+
+            // assert
+            act.Should().Throw<Newtonsoft.Json.JsonReaderException>();
         }
     }
 }

--- a/iothub/service/tests/SerializationTests.cs
+++ b/iothub/service/tests/SerializationTests.cs
@@ -74,6 +74,10 @@ namespace Microsoft.Azure.Devices.Test
         public void Twin_Json_OverrideDefaultJsonSerializer_ExceedMaxDepthThrows()
         {
             // arrange
+            string fakeConnectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;SharedAccessKey=dGVzdFN0cmluZzE=";
+            var ServiceClinet = ServiceClient.CreateFromConnectionString(fakeConnectionString);
+            // above arragement is only for setting the defaultJsonSerializerSettings
+
             const string jsonString = @"
 {
  ""deviceId"": ""test"",

--- a/iothub/service/tests/ServiceClientTests.cs
+++ b/iothub/service/tests/ServiceClientTests.cs
@@ -5,15 +5,19 @@ namespace Microsoft.Azure.Devices.Api.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
+    using FluentAssertions;
     using Microsoft.Azure.Amqp;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Common.Exceptions;
+    using Microsoft.Azure.Devices.Shared;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
+    using Newtonsoft.Json;
 
     [TestClass]
     [TestCategory("Unit")]
@@ -56,7 +60,7 @@ namespace Microsoft.Azure.Devices.Api.Test
             PurgeMessageQueueResult result = await serviceClient.PurgeMessageQueueAsync("TestDevice", CancellationToken.None).ConfigureAwait(false);
         }
 
-        Tuple<Mock<IHttpClientHelper>, AmqpServiceClient, PurgeMessageQueueResult> SetupPurgeMessageQueueTests()
+        private Tuple<Mock<IHttpClientHelper>, AmqpServiceClient, PurgeMessageQueueResult> SetupPurgeMessageQueueTests()
         {
             // Create expected return object
             var deviceId = "TestDevice";
@@ -116,6 +120,40 @@ namespace Microsoft.Azure.Devices.Api.Test
             await serviceClient.CloseAsync().ConfigureAwait(false);
             restOpMock.Verify(restOp => restOp.Dispose(), Times.Never());
             Assert.IsTrue(connectionClosed);
+        }
+
+        [TestMethod]
+        public void ServiceClient_DefaultMaxDepth()
+        {
+            // arrange
+            string fakeConnectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;SharedAccessKey=dGVzdFN0cmluZzE=";
+            var serviceClinet = ServiceClient.CreateFromConnectionString(fakeConnectionString);
+            // above arragement is only for setting the defaultJsonSerializerSettings
+
+            var defaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
+            defaultSettings.MaxDepth.Should().Be(128);
+        }
+
+        [TestMethod]
+        public void ServiceClient_Json_OverrideDefaultJsonSerializer_ExceedMaxDepthThrows()
+        {
+            // arrange
+            string fakeConnectionString = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;SharedAccessKey=dGVzdFN0cmluZzE=";
+            var serviceClinet = ServiceClient.CreateFromConnectionString(fakeConnectionString);
+            // above arragement is only for setting the defaultJsonSerializerSettings
+
+            //Create a string representation of a nested object (JSON serialized)
+            int nRep = 3;
+            string json = string.Concat(Enumerable.Repeat("{a:", nRep)) + "1" +
+            string.Concat(Enumerable.Repeat("}", nRep));
+
+            var settings = new JsonSerializerSettings { MaxDepth = 2 };
+            //// deserialize
+            // act
+            Func<object> act = () => JsonConvert.DeserializeObject(json, settings);
+
+            // assert
+            act.Should().Throw<Newtonsoft.Json.JsonReaderException>();
         }
     }
 }

--- a/provisioning/service/src/ProvisioningServiceClient.cs
+++ b/provisioning/service/src/ProvisioningServiceClient.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Common.Service.Auth;
+using Microsoft.Azure.Devices.Shared;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Provisioning.Service
 {
@@ -112,6 +114,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <exception cref="ArgumentException">if the connectionString is <code>null</code>, empty, or invalid.</exception>
         private ProvisioningServiceClient(string connectionString, HttpTransportSettings httpTransportSettings)
         {
+            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
+
             /* SRS_PROVISIONING_SERVICE_CLIENT_21_002: [The constructor shall throw ArgumentException if the provided connectionString is null or empty.] */
             if (string.IsNullOrWhiteSpace(connectionString ?? throw new ArgumentNullException(nameof(connectionString))))
             {

--- a/provisioning/service/src/ProvisioningServiceClient.cs
+++ b/provisioning/service/src/ProvisioningServiceClient.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <exception cref="ArgumentException">if the connectionString is <code>null</code>, empty, or invalid.</exception>
         private ProvisioningServiceClient(string connectionString, HttpTransportSettings httpTransportSettings)
         {
-            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
+            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettingsDelegate();
 
             /* SRS_PROVISIONING_SERVICE_CLIENT_21_002: [The constructor shall throw ArgumentException if the provided connectionString is null or empty.] */
             if (string.IsNullOrWhiteSpace(connectionString ?? throw new ArgumentNullException(nameof(connectionString))))

--- a/provisioning/service/tests/Config/ProvisioningServiceClientTests.cs
+++ b/provisioning/service/tests/Config/ProvisioningServiceClientTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Linq;
+using System;
+using Microsoft.Azure.Devices.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.Devices.Provisioning.Service.Tests.Config
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class ProvisioningServiceClientTests
+    {
+        [TestMethod]
+        public void ProvisioningServiceClient_DefaultMaxDepth()
+        {
+            // arrange
+            string fakeConnectionString = "HostName=acme-dps.azure-devices-provisioning.net;SharedAccessKeyName=provisioningserviceowner;SharedAccessKey=dGVzdFN0cmluZzE=";
+            using var deviceClient = ProvisioningServiceClient.CreateFromConnectionString(fakeConnectionString);
+            // above arragement is only for setting the defaultJsonSerializerSettings
+
+            var defaultSettings = JsonSerializerSettingsInitializer.GetDefaultJsonSerializerSettings();
+            Assert.AreEqual(defaultSettings.MaxDepth, 128);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(Newtonsoft.Json.JsonReaderException))]
+        public void ProvisioningServiceClientJson_OverrideDefaultJsonSerializer_ExceedMaxDepthThrows()
+        {
+            // arrange
+            string fakeConnectionString = "HostName=acme-dps.azure-devices-provisioning.net;SharedAccessKeyName=provisioningserviceowner;SharedAccessKey=dGVzdFN0cmluZzE=";
+            using var deviceClient = ProvisioningServiceClient.CreateFromConnectionString(fakeConnectionString);
+            // above arragement is only for setting the defaultJsonSerializerSettings
+
+            //Create a string representation of a nested object (JSON serialized)
+            int nRep = 3;
+            string json = string.Concat(Enumerable.Repeat("{a:", nRep)) + "1" +
+            string.Concat(Enumerable.Repeat("}", nRep));
+
+            var settings = new JsonSerializerSettings { MaxDepth = 2 };
+            //// deserialize
+            // act
+            JsonConvert.DeserializeObject(json, settings);
+        }
+    }
+}

--- a/shared/src/JsonSerializerInitializer.cs
+++ b/shared/src/JsonSerializerInitializer.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// A static class to initialize JsonSerializerSettings with the default MaxDepth of 128 for the project
+    /// </summary>
+    public static class JsonSerializerSettingsInitializer
+    {
+        /// <summary>
+        /// A static instance of JsonSerializerSettings which sets MaxDepth to 128.
+        /// </summary>
+        public static readonly JsonSerializerSettings SettingsInstance = new JsonSerializerSettings
+        {
+            MaxDepth = 128
+        };
+
+        /// <summary>
+        /// Returns DefaultJsonSerializerSettings
+        /// </summary>
+        public static Func<JsonSerializerSettings> GetDefaultJsonSerializerSettings()
+        {
+            return () => SettingsInstance;
+        }
+    }
+}

--- a/shared/src/JsonSerializerInitializer.cs
+++ b/shared/src/JsonSerializerInitializer.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Azure.Devices.Shared
 {
     /// <summary>
-    /// A static class to initialize JsonSerializerSettings with the default MaxDepth of 128 for the project
+    /// A class to initialize JsonSerializerSettings with the default MaxDepth of 128 for the project
     /// </summary>
     public static class JsonSerializerSettingsInitializer
     {
@@ -19,11 +19,19 @@ namespace Microsoft.Azure.Devices.Shared
         };
 
         /// <summary>
-        /// Returns DefaultJsonSerializerSettings
+        /// Returns DefaultJsonSerializerSettings Func delegate
         /// </summary>
-        public static Func<JsonSerializerSettings> GetDefaultJsonSerializerSettings()
+        public static Func<JsonSerializerSettings> GetDefaultJsonSerializerSettingsDelegate()
         {
             return () => SettingsInstance;
+        }
+
+        /// <summary>
+        /// For testing only, returns DefaultJsonSerializerSettings
+        /// </summary>
+        public static JsonSerializerSettings GetDefaultJsonSerializerSettings()
+        {
+            return JsonConvert.DefaultSettings();
         }
     }
 }


### PR DESCRIPTION
Reference: https://github.com/advisories/GHSA-5crp-9r3c-p9vr 
- Setting the MaxDepth parameter to 128 in the JsonSerializerSettings in clients
