### PR TITLE
fix docker version config and enable invalid cert tests

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -391,12 +391,6 @@ try
         $testCategory += "&TestCategory!=FaultInjection"
         $testCategory += "&TestCategory!=Flaky"
 
-        # Invalid certificate tests are currently disabled on both Windows and Linux
-        # Windows - Invalid cert tests don't currently work with docker on Windows within pipeline agent setup because of virtual host networking configuration issue
-        # Linux - The hosted agents are currently referencing a pre-installed newer version of docker (20.10.21+azure-1) which has some compatibility issues with commands
-        # that were used with older versions of docker. We're disabling this task until those compatibility issues can be investigated and resolved.
-        $testCategory += "&TestCategory!=InvalidServiceCertificate"
-
         if ($skipIotHubTests)
         {
             $testCategory += "&TestCategory!=IoTHub"
@@ -452,15 +446,14 @@ try
         # Tests categories to include
         $testCategory = "("
         $testCategory += "TestCategory=E2E"
+        # Invalid Service Cert Tests currently work with docker on Linux agent only.
+        # TODO: remove this condition in future docker on windows version when this is working.
+        if (-not(IsWindows)) 
+        {
+            $testCategory += "|"
+            $testCategory += "TestCategory=InvalidServiceCertificate"
+        }
         $testCategory += ")"
-
-        # Tests categories to exclude
-
-        # Invalid certificate tests are currently disabled on both Windows and Linux
-        # Windows - Invalid cert tests don't currently work with docker on Windows within pipeline agent setup because of virtual host networking configuration issue
-        # Linux - The hosted agents are currently referencing a pre-installed newer version of docker (20.10.21+azure-1) which has some compatibility issues with commands
-        # that were used with older versions of docker. We're disabling this task until those compatibility issues can be investigated and resolved.
-        $testCategory += "&TestCategory!=InvalidServiceCertificate"
 
         # Override verbosity to display individual test execution.
         $oldVerbosity = $verbosity

--- a/vsts/build-test-nuget.yml
+++ b/vsts/build-test-nuget.yml
@@ -299,11 +299,6 @@ jobs:
           command: "login"
           containerRegistry: "Azure IoT ACR"
 
-      - task: DockerInstaller@0
-        displayName: "Cert Validation - Install Docker CLI"
-        inputs:
-          dockerVersion: '20.10.17'
-
       - task: PowerShell@2
         displayName: 'Cert Validation - Setup Certificate Proxy'
         inputs:
@@ -328,87 +323,63 @@ jobs:
             docker run -h invalidcertiothub1.westus.cloudapp.azure.com --name invalid-hub --expose=443 --expose=5671 --expose=8883 -v $(Build.SourcesDirectory)/e2e/test/docker/haproxy:/usr/local/etc/haproxy:ro -d aziotacr.azurecr.io/haproxy haproxy -f /usr/local/etc/haproxy/haproxyhub.cfg
             docker ps -a
 
-      # The hosted agents are currently referencing a pre-installed newer version of docker (20.10.21+azure-1) which has some compatibility issues with commands
-      # that were used with older versions of docker. We're disabling this task until those compatibility issues can be investigated and resolved.
-      # Explicit installation of an older docker version through DockerInstaller@0 task doesn't help as the hosted agent keeps referencing the newer version that comes pre-installed.
-
-      # - task: Bash@3
-      #   displayName: 'Cert Validation - Setup local hostname'
-      #   name: CVTEST_NET
-      #   inputs:
-      #     targetType: 'inline'
-      #     script: |
-      #       echo "==============="
-      #       echo "Inspect network"
-      #       echo "==============="
-      #       ip -4 addr
-      #       export CVTEST_HOST_IP=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+')
-      #       export CVTEST_HOST_NETWORK=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+/*\d.')
-      #       export CVTEST_HOST_SUBNET=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+' | grep -Po '[\d]{1,3}.[\d]{1,3}.[\d]{1,3}')
-      #       export CVTEST_HOST_SUBNET_MASK=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+/*\d.' | grep -Po '/[\d]{1,2}')
-      #       export CVTEST_CONTAINER_IP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
-      #       echo "HOST=$CVTEST_HOST_IP"
-      #       echo "HOST NETWORK=$CVTEST_HOST_NETWORK"
-      #       echo "HOST SUBNET=$CVTEST_HOST_SUBNET"
-      #       echo "HOST SUBNET MASK=$CVTEST_HOST_SUBNET_MASK"
-      #       echo "CONTAINER=$CVTEST_CONTAINER_IP"
-      #       #echo "##vso[task.setvariable variable=AGENT_HOST;isoutput=true;]$CVTEST_HOST_IP"
-      #       #echo "##vso[task.setvariable variable=AGENT_NETWORK;isoutput=true;]$CVTEST_HOST_NETWORK"
-      #       #echo "##vso[task.setvariable variable=AGENT_SUBNET;isoutput=true;]$CVTEST_HOST_SUBNET"
-      #       #echo "##vso[task.setvariable variable=AGENT_SUBNET_MASK;isoutput=true;]$CVTEST_HOST_SUBNET_MASK"
-      #       #echo "##vso[task.setvariable variable=AGENT_CONTAINER;isoutput=true;]$CVTEST_CONTAINER_IP"
-      #       #echo "=========="
-      #       #echo "Ping hosts"
-      #       #echo "=========="
-      #       #ping -c 5 $CVTEST_HOST_IP
-      #       #ping -c 5 $CVTEST_CONTAINER_IP
-      #       #echo "=================="
-      #       #echo "Inspect containers"
-      #       #echo "=================="
-      #       #docker ps -a
-      #       #docker inspect invalid-gde
-      #       #docker inspect invalid-dps
-      #       #docker inspect invalid-hub
-      #       export CVTEST_GDE_IP=$(docker inspect invalid-gde | grep -Po -m 1 '"IPAddress": "\K[\d.]+')
-      #       export CVTEST_DPS_IP=$(docker inspect invalid-dps | grep -Po -m 1 '"IPAddress": "\K[\d.]+')
-      #       export CVTEST_HUB_IP=$(docker inspect invalid-hub | grep -Po -m 1 '"IPAddress": "\K[\d.]+')
-      #       echo "invalid-gde=$CVTEST_GDE_IP"
-      #       echo "invalid-dps=$CVTEST_DPS_IP"
-      #       echo "invalid-hub=$CVTEST_HUB_IP"
-      #       #echo "##vso[task.setvariable variable=AGENT_GDE_IP;isoutput=true;]$CVTEST_GDE_IP"
-      #       #echo "##vso[task.setvariable variable=AGENT_DPS_IP;isoutput=true;]$CVTEST_DPS_IP"
-      #       #echo "##vso[task.setvariable variable=AGENT_HUB_IP;isoutput=true;]$CVTEST_HUB_IP"
-      #       #echo "==============="
-      #       #echo "Ping containers"
-      #       #echo "==============="
-      #       #docker ps -a
-      #       #ping -c 2 $CVTEST_GDE_IP
-      #       #ping -c 2 $CVTEST_DPS_IP
-      #       #ping -c 2 $CVTEST_HUB_IP
-      #       #cat /etc/hosts
-      #       echo "================="
-      #       echo "Update hosts file"
-      #       echo "================="
-      #       sudo bash -c 'mv /etc/hosts /etc/hosts.org'
-      #       sudo bash -c 'cp /etc/hosts.org /etc/hosts'
-      #       echo "$CVTEST_GDE_IP invalidcertgde1.westus.cloudapp.azure.com"
-      #       echo "$CVTEST_DPS_IP invalidcertdps1.westus.cloudapp.azure.com"
-      #       echo "$CVTEST_HUB_IP invalidcertiothub1.westus.cloudapp.azure.com"
-      #       echo "" >> /tmp/hosts.cvtest
-      #       echo "# Local host for invalid cert test" >> /tmp/hosts.cvtest
-      #       echo "$CVTEST_GDE_IP invalidcertgde1.westus.cloudapp.azure.com" >> /tmp/hosts.cvtest
-      #       echo "$CVTEST_DPS_IP invalidcertdps1.westus.cloudapp.azure.com" >> /tmp/hosts.cvtest
-      #       echo "$CVTEST_HUB_IP invalidcertiothub1.westus.cloudapp.azure.com" >> /tmp/hosts.cvtest
-      #       sudo bash -c 'cat /tmp/hosts.cvtest >> /etc/hosts'
-      #       cat /etc/hosts
-      #       echo "====================="
-      #       echo "Ping containers (URL)"
-      #       echo "====================="
-      #       docker ps -a
-      #       route
-      #       ping -c 2 invalidcertgde1.westus.cloudapp.azure.com
-      #       ping -c 2 invalidcertdps1.westus.cloudapp.azure.com
-      #       ping -c 2 invalidcertiothub1.westus.cloudapp.azure.com
+      - task: Bash@3
+        displayName: 'Cert Validation - Setup local hostname'
+        name: CVTEST_NET
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo "==============="
+            echo "Inspect network"
+            echo "==============="
+            ip -4 addr
+            export CVTEST_HOST_IP=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+')
+            export CVTEST_HOST_NETWORK=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+/*\d.')
+            export CVTEST_HOST_SUBNET=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+' | grep -Po '[\d]{1,3}.[\d]{1,3}.[\d]{1,3}')
+            export CVTEST_HOST_SUBNET_MASK=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+/*\d.' | grep -Po '/[\d]{1,2}')
+            export CVTEST_CONTAINER_IP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
+            echo "HOST=$CVTEST_HOST_IP"
+            echo "HOST NETWORK=$CVTEST_HOST_NETWORK"
+            echo "HOST SUBNET=$CVTEST_HOST_SUBNET"
+            echo "HOST SUBNET MASK=$CVTEST_HOST_SUBNET_MASK"
+            echo "CONTAINER=$CVTEST_CONTAINER_IP"
+            #echo "##vso[task.setvariable variable=AGENT_HOST;isoutput=true;]$CVTEST_HOST_IP"
+            #echo "##vso[task.setvariable variable=AGENT_NETWORK;isoutput=true;]$CVTEST_HOST_NETWORK"
+            #echo "##vso[task.setvariable variable=AGENT_SUBNET;isoutput=true;]$CVTEST_HOST_SUBNET"
+            #echo "##vso[task.setvariable variable=AGENT_SUBNET_MASK;isoutput=true;]$CVTEST_HOST_SUBNET_MASK"
+            #echo "##vso[task.setvariable variable=AGENT_CONTAINER;isoutput=true;]$CVTEST_CONTAINER_IP"
+            export CVTEST_GDE_IP=$(docker inspect invalid-gde | grep -Po -m 1 '"IPAddress": "\K[\d.]+')
+            export CVTEST_DPS_IP=$(docker inspect invalid-dps | grep -Po -m 1 '"IPAddress": "\K[\d.]+')
+            export CVTEST_HUB_IP=$(docker inspect invalid-hub | grep -Po -m 1 '"IPAddress": "\K[\d.]+')
+            echo "invalid-gde=$CVTEST_GDE_IP"
+            echo "invalid-dps=$CVTEST_DPS_IP"
+            echo "invalid-hub=$CVTEST_HUB_IP"
+            #echo "##vso[task.setvariable variable=AGENT_GDE_IP;isoutput=true;]$CVTEST_GDE_IP"
+            #echo "##vso[task.setvariable variable=AGENT_DPS_IP;isoutput=true;]$CVTEST_DPS_IP"
+            #echo "##vso[task.setvariable variable=AGENT_HUB_IP;isoutput=true;]$CVTEST_HUB_IP"
+            echo "================="
+            echo "Update hosts file"
+            echo "================="
+            sudo bash -c 'mv /etc/hosts /etc/hosts.org'
+            sudo bash -c 'cp /etc/hosts.org /etc/hosts'
+            echo "$CVTEST_GDE_IP invalidcertgde1.westus.cloudapp.azure.com"
+            echo "$CVTEST_DPS_IP invalidcertdps1.westus.cloudapp.azure.com"
+            echo "$CVTEST_HUB_IP invalidcertiothub1.westus.cloudapp.azure.com"
+            echo "" >> /tmp/hosts.cvtest
+            echo "# Local host for invalid cert test" >> /tmp/hosts.cvtest
+            echo "$CVTEST_GDE_IP invalidcertgde1.westus.cloudapp.azure.com" >> /tmp/hosts.cvtest
+            echo "$CVTEST_DPS_IP invalidcertdps1.westus.cloudapp.azure.com" >> /tmp/hosts.cvtest
+            echo "$CVTEST_HUB_IP invalidcertiothub1.westus.cloudapp.azure.com" >> /tmp/hosts.cvtest
+            sudo bash -c 'cat /tmp/hosts.cvtest >> /etc/hosts'
+            cat /etc/hosts
+            echo "====================="
+            echo "Ping containers (URL)"
+            echo "====================="
+            docker ps -a
+            route
+            ping -c 2 invalidcertgde1.westus.cloudapp.azure.com
+            ping -c 2 invalidcertdps1.westus.cloudapp.azure.com
+            ping -c 2 invalidcertiothub1.westus.cloudapp.azure.com
 
       - task: Docker@1
         displayName: "Start TPM Simulator"

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -152,11 +152,6 @@ jobs:
           command: "login"
           containerRegistry: "Azure IoT ACR"
 
-      - task: DockerInstaller@0
-        displayName: "Cert Validation - Install Docker CLI"
-        inputs:
-          dockerVersion: '20.10.17'
-
       - task: PowerShell@2
         displayName: 'Cert Validation - Setup Certificate Proxy'
         inputs:
@@ -181,87 +176,63 @@ jobs:
             docker run -h invalidcertiothub1.westus.cloudapp.azure.com --name invalid-hub --expose=443 --expose=5671 --expose=8883 -v $(Build.SourcesDirectory)/e2e/test/docker/haproxy:/usr/local/etc/haproxy:ro -d aziotacr.azurecr.io/haproxy haproxy -f /usr/local/etc/haproxy/haproxyhub.cfg
             docker ps -a
 
-      # The hosted agents are currently referencing a pre-installed newer version of docker (20.10.21+azure-1) which has some compatibility issues with commands
-      # that were used with older versions of docker. We're disabling this task until those compatibility issues can be investigated and resolved.
-      # Explicit installation of an older docker version through DockerInstaller@0 task doesn't help as the hosted agent keeps referencing the newer version that comes pre-installed.
-
-      # - task: Bash@3
-      #   displayName: 'Cert Validation - Setup local hostname'
-      #   name: CVTEST_NET
-      #   inputs:
-      #     targetType: 'inline'
-      #     script: |
-      #       echo "==============="
-      #       echo "Inspect network"
-      #       echo "==============="
-      #       ip -4 addr
-      #       export CVTEST_HOST_IP=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+')
-      #       export CVTEST_HOST_NETWORK=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+/*\d.')
-      #       export CVTEST_HOST_SUBNET=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+' | grep -Po '[\d]{1,3}.[\d]{1,3}.[\d]{1,3}')
-      #       export CVTEST_HOST_SUBNET_MASK=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+/*\d.' | grep -Po '/[\d]{1,2}')
-      #       export CVTEST_CONTAINER_IP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
-      #       echo "HOST=$CVTEST_HOST_IP"
-      #       echo "HOST NETWORK=$CVTEST_HOST_NETWORK"
-      #       echo "HOST SUBNET=$CVTEST_HOST_SUBNET"
-      #       echo "HOST SUBNET MASK=$CVTEST_HOST_SUBNET_MASK"
-      #       echo "CONTAINER=$CVTEST_CONTAINER_IP"
-      #       #echo "##vso[task.setvariable variable=AGENT_HOST;isoutput=true;]$CVTEST_HOST_IP"
-      #       #echo "##vso[task.setvariable variable=AGENT_NETWORK;isoutput=true;]$CVTEST_HOST_NETWORK"
-      #       #echo "##vso[task.setvariable variable=AGENT_SUBNET;isoutput=true;]$CVTEST_HOST_SUBNET"
-      #       #echo "##vso[task.setvariable variable=AGENT_SUBNET_MASK;isoutput=true;]$CVTEST_HOST_SUBNET_MASK"
-      #       #echo "##vso[task.setvariable variable=AGENT_CONTAINER;isoutput=true;]$CVTEST_CONTAINER_IP"
-      #       #echo "=========="
-      #       #echo "Ping hosts"
-      #       #echo "=========="
-      #       #ping -c 5 $CVTEST_HOST_IP
-      #       #ping -c 5 $CVTEST_CONTAINER_IP
-      #       #echo "=================="
-      #       #echo "Inspect containers"
-      #       #echo "=================="
-      #       #docker ps -a
-      #       #docker inspect invalid-gde
-      #       #docker inspect invalid-dps
-      #       #docker inspect invalid-hub
-      #       export CVTEST_GDE_IP=$(docker inspect invalid-gde | grep -Po -m 1 '"IPAddress": "\K[\d.]+')
-      #       export CVTEST_DPS_IP=$(docker inspect invalid-dps | grep -Po -m 1 '"IPAddress": "\K[\d.]+')
-      #       export CVTEST_HUB_IP=$(docker inspect invalid-hub | grep -Po -m 1 '"IPAddress": "\K[\d.]+')
-      #       echo "invalid-gde=$CVTEST_GDE_IP"
-      #       echo "invalid-dps=$CVTEST_DPS_IP"
-      #       echo "invalid-hub=$CVTEST_HUB_IP"
-      #       #echo "##vso[task.setvariable variable=AGENT_GDE_IP;isoutput=true;]$CVTEST_GDE_IP"
-      #       #echo "##vso[task.setvariable variable=AGENT_DPS_IP;isoutput=true;]$CVTEST_DPS_IP"
-      #       #echo "##vso[task.setvariable variable=AGENT_HUB_IP;isoutput=true;]$CVTEST_HUB_IP"
-      #       #echo "==============="
-      #       #echo "Ping containers"
-      #       #echo "==============="
-      #       #docker ps -a
-      #       #ping -c 2 $CVTEST_GDE_IP
-      #       #ping -c 2 $CVTEST_DPS_IP
-      #       #ping -c 2 $CVTEST_HUB_IP
-      #       #cat /etc/hosts
-      #       echo "================="
-      #       echo "Update hosts file"
-      #       echo "================="
-      #       sudo bash -c 'mv /etc/hosts /etc/hosts.org'
-      #       sudo bash -c 'cp /etc/hosts.org /etc/hosts'
-      #       echo "$CVTEST_GDE_IP invalidcertgde1.westus.cloudapp.azure.com"
-      #       echo "$CVTEST_DPS_IP invalidcertdps1.westus.cloudapp.azure.com"
-      #       echo "$CVTEST_HUB_IP invalidcertiothub1.westus.cloudapp.azure.com"
-      #       echo "" >> /tmp/hosts.cvtest
-      #       echo "# Local host for invalid cert test" >> /tmp/hosts.cvtest
-      #       echo "$CVTEST_GDE_IP invalidcertgde1.westus.cloudapp.azure.com" >> /tmp/hosts.cvtest
-      #       echo "$CVTEST_DPS_IP invalidcertdps1.westus.cloudapp.azure.com" >> /tmp/hosts.cvtest
-      #       echo "$CVTEST_HUB_IP invalidcertiothub1.westus.cloudapp.azure.com" >> /tmp/hosts.cvtest
-      #       sudo bash -c 'cat /tmp/hosts.cvtest >> /etc/hosts'
-      #       cat /etc/hosts
-      #       echo "====================="
-      #       echo "Ping containers (URL)"
-      #       echo "====================="
-      #       docker ps -a
-      #       route
-      #       ping -c 2 invalidcertgde1.westus.cloudapp.azure.com
-      #       ping -c 2 invalidcertdps1.westus.cloudapp.azure.com
-      #       ping -c 2 invalidcertiothub1.westus.cloudapp.azure.com
+      - task: Bash@3
+        displayName: 'Cert Validation - Setup local hostname'
+        name: CVTEST_NET
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo "==============="
+            echo "Inspect network"
+            echo "==============="
+            ip -4 addr
+            export CVTEST_HOST_IP=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+')
+            export CVTEST_HOST_NETWORK=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+/*\d.')
+            export CVTEST_HOST_SUBNET=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+' | grep -Po '[\d]{1,3}.[\d]{1,3}.[\d]{1,3}')
+            export CVTEST_HOST_SUBNET_MASK=$(ip -4 addr show eth0 | grep -Po 'inet \K[\d.]+/*\d.' | grep -Po '/[\d]{1,2}')
+            export CVTEST_CONTAINER_IP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
+            echo "HOST=$CVTEST_HOST_IP"
+            echo "HOST NETWORK=$CVTEST_HOST_NETWORK"
+            echo "HOST SUBNET=$CVTEST_HOST_SUBNET"
+            echo "HOST SUBNET MASK=$CVTEST_HOST_SUBNET_MASK"
+            echo "CONTAINER=$CVTEST_CONTAINER_IP"
+            #echo "##vso[task.setvariable variable=AGENT_HOST;isoutput=true;]$CVTEST_HOST_IP"
+            #echo "##vso[task.setvariable variable=AGENT_NETWORK;isoutput=true;]$CVTEST_HOST_NETWORK"
+            #echo "##vso[task.setvariable variable=AGENT_SUBNET;isoutput=true;]$CVTEST_HOST_SUBNET"
+            #echo "##vso[task.setvariable variable=AGENT_SUBNET_MASK;isoutput=true;]$CVTEST_HOST_SUBNET_MASK"
+            #echo "##vso[task.setvariable variable=AGENT_CONTAINER;isoutput=true;]$CVTEST_CONTAINER_IP"
+            export CVTEST_GDE_IP=$(docker inspect invalid-gde | grep -Po -m 1 '"IPAddress": "\K[\d.]+')
+            export CVTEST_DPS_IP=$(docker inspect invalid-dps | grep -Po -m 1 '"IPAddress": "\K[\d.]+')
+            export CVTEST_HUB_IP=$(docker inspect invalid-hub | grep -Po -m 1 '"IPAddress": "\K[\d.]+')
+            echo "invalid-gde=$CVTEST_GDE_IP"
+            echo "invalid-dps=$CVTEST_DPS_IP"
+            echo "invalid-hub=$CVTEST_HUB_IP"
+            #echo "##vso[task.setvariable variable=AGENT_GDE_IP;isoutput=true;]$CVTEST_GDE_IP"
+            #echo "##vso[task.setvariable variable=AGENT_DPS_IP;isoutput=true;]$CVTEST_DPS_IP"
+            #echo "##vso[task.setvariable variable=AGENT_HUB_IP;isoutput=true;]$CVTEST_HUB_IP"
+            echo "================="
+            echo "Update hosts file"
+            echo "================="
+            sudo bash -c 'mv /etc/hosts /etc/hosts.org'
+            sudo bash -c 'cp /etc/hosts.org /etc/hosts'
+            echo "$CVTEST_GDE_IP invalidcertgde1.westus.cloudapp.azure.com"
+            echo "$CVTEST_DPS_IP invalidcertdps1.westus.cloudapp.azure.com"
+            echo "$CVTEST_HUB_IP invalidcertiothub1.westus.cloudapp.azure.com"
+            echo "" >> /tmp/hosts.cvtest
+            echo "# Local host for invalid cert test" >> /tmp/hosts.cvtest
+            echo "$CVTEST_GDE_IP invalidcertgde1.westus.cloudapp.azure.com" >> /tmp/hosts.cvtest
+            echo "$CVTEST_DPS_IP invalidcertdps1.westus.cloudapp.azure.com" >> /tmp/hosts.cvtest
+            echo "$CVTEST_HUB_IP invalidcertiothub1.westus.cloudapp.azure.com" >> /tmp/hosts.cvtest
+            sudo bash -c 'cat /tmp/hosts.cvtest >> /etc/hosts'
+            cat /etc/hosts
+            echo "====================="
+            echo "Ping containers (URL)"
+            echo "====================="
+            docker ps -a
+            route
+            ping -c 2 invalidcertgde1.westus.cloudapp.azure.com
+            ping -c 2 invalidcertdps1.westus.cloudapp.azure.com
+            ping -c 2 invalidcertiothub1.westus.cloudapp.azure.com
 
       - task: Docker@1
         displayName: "Start TPM Simulator"
@@ -274,7 +245,6 @@ jobs:
           ports: |
             127.0.0.1:2321:2321
             127.0.0.1:2322:2322
-
           restartPolicy: unlessStopped
 
       - task: Docker@1
@@ -350,13 +320,12 @@ jobs:
           SourceFolder: "$(Build.SourcesDirectory)"
           Contents: "**/*.trx"
           TargetFolder: "$(Build.ArtifactStagingDirectory)"
-
         condition: always()
+
       - task: PublishBuildArtifacts@1
         displayName: "Publish Artifact: testresults_linux_$(FRAMEWORK)"
         inputs:
           ArtifactName: testresults_linux_$(FRAMEWORK)
-
         condition: always()
 
       - task: PublishTestResults@2
@@ -365,7 +334,6 @@ jobs:
           testRunner: VSTest
           testRunTitle: "Linux Tests ($(FRAMEWORK)) (Attempt $(System.JobAttempt))"
           testResultsFiles: "**/*.trx"
-
         condition: always()
         
       - task: ComponentGovernanceComponentDetection@0
@@ -401,7 +369,6 @@ jobs:
         .NET 4.5.1:
           FRAMEWORK: net451
           SHOULD_RUN: ${{ eq(variables['testNet451'], 'True') }}
-
     condition: succeeded()
     pool:
       # If this is changed, don't forget to update supported_platforms.md in the root directory. That document outlines what OS we test on and should stay up to date.
@@ -538,7 +505,6 @@ jobs:
           SourceFolder: "$(Build.SourcesDirectory)"
           Contents: "**/*.trx"
           TargetFolder: "$(Build.ArtifactStagingDirectory)"
-
         condition: always()
 
       - task: CopyFiles@2
@@ -547,14 +513,12 @@ jobs:
           SourceFolder: "$(Build.SourcesDirectory)"
           Contents: "**/*.etl"
           TargetFolder: "$(Build.ArtifactStagingDirectory)"
-
         condition: always()
 
       - task: PublishBuildArtifacts@1
         displayName: "Publish Artifact: testresults"
         inputs:
           ArtifactName: testresults_windows_$(FRAMEWORK)
-
         condition: always()
 
       - task: PublishTestResults@2
@@ -565,7 +529,6 @@ jobs:
           testRunTitle: "Windows Tests ($(FRAMEWORK)) (Attempt $(System.JobAttempt))"
           platform: Windows
           configuration: "Debug UT + Release E2E ($(FRAMEWORK))"
-
         condition: always()
 
       - task: ComponentGovernanceComponentDetection@0
@@ -590,8 +553,7 @@ jobs:
           dotnet new
           rem Start build
           build.cmd -clean -build -configuration Debug -package
-
-        displayName: build
+        displayName: Build Package
 
       - task: ComponentGovernanceComponentDetection@0
         displayName: "Component Detection"
@@ -617,9 +579,7 @@ jobs:
         displayName: "Run AutoApplicability"
         inputs:
           ExternalRelease: true
-
           IsSoftware: true
-
           UsesHSM: true
 
       - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3


### PR DESCRIPTION
Pipeline agent now include Azure specific docker CLI package and no need to install on the go
- Removed script for Docker CLI setup
- Undo commented out scripts for the invalid certificate tests
- Revised and clean up the docker setup script