### PR TITLE
Bump version numbers for LTS patch release

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.36.6</Version>
+    <Version>1.36.7</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.31.3</Version>
+    <Version>1.31.4</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.16.4</Version>
+    <Version>1.16.5</Version>
     <Title>Microsoft Azure IoT Provisioning Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
+++ b/provisioning/transport/mqtt/src/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.14.2</Version>
+    <Version>1.14.3</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client MQTT Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/readme.md
+++ b/readme.md
@@ -205,7 +205,7 @@ This table shows previous LTS releases and end dates.
 
 | Release                                                                                                                        | LTS Start Date | Maintenance End Date |
 | :----------------------------------------------------------------------------------------------------------------------------: | :------------: | :------------------: |
-| [2022-05-11](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2021-3-18_patch5) <sub>patch 5 of 2021-03-18</sub> | 2021-03-18     | current              |
+| [2023-01-09](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2021-3-18_patch7) <sub>patch 7 of 2021-03-18</sub> | 2021-03-18     | current              |
 | [2020-9-23](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2020-8-19_patch1) <sub>patch 1 of 2020-08-19</sub>  | 2020-08-19     | 2021-08-19           |
 | [2020-4-3](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2020-1-31_patch1) <sub>patch 1 of 2020-01-31</sub>   | 2020-01-31     | 2021-01-30           |
 

--- a/shared/src/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/src/Microsoft.Azure.Devices.Shared.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.27.1</Version>
+    <Version>1.27.2</Version>
     <Title>Microsoft Azure IoT Devices Shared</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,10 +1,10 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.36.6
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.31.3
-shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.27.1
-provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.4
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.36.7
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.31.4
+shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.27.2
+provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.5
 provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.7
 provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.12.4
-provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.14.2
+provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.14.3
 security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.12.4
-provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.16.4
+provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.16.5

--- a/versions.csv
+++ b/versions.csv
@@ -2,7 +2,7 @@ AssemblyPath, Version
 iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.36.7
 iothub\service\src\Microsoft.Azure.Devices.csproj, 1.31.4
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.27.2
-provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.5
+provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.4
 provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.7
 provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.12.4
 provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.14.3


### PR DESCRIPTION
| packages | updated version | 
|:--------------|:--------------:|
|Microsoft.Azure.Devices.Client| 1.36.7 |
| Microsoft.Azure.Devices |   1.31.4 |
|Microsoft.Azure.Devices.Shared | 1.27.2 |
|Microsoft.Azure.Devices.Provisioning.Transport.Mqtt | 1.14.3 |
|Microsoft.Azure.Devices.Provisioning.Service |   1.16.5 |

## Microsoft.Azure.Devices.Client 1.36.7
- Update DotNetty versions (https://github.com/Azure/azure-iot-sdk-csharp/pull/2970)
- Bring amqp sas token refresh cleanup logic to LTS (https://github.com/Azure/azure-iot-sdk-csharp/pull/3039)
- Setting MaxDepth parameter in the JsonSerializerSettings as safe defaults #3045

## Microsoft.Azure.Devices  1.31.4
- Setting MaxDepth parameter in the JsonSerializerSettings as safe defaults #3045

## Microsoft.Azure.Devices.Shared 1.27.2
- Setting MaxDepth parameter in the JsonSerializerSettings as safe defaults #3045

## Microsoft.Azure.Devices.Provisioning.Transport.Mqtt 1.14.3
- Update DotNetty versions (https://github.com/Azure/azure-iot-sdk-csharp/pull/2970)
- Add M2M message failure fix (https://github.com/Azure/azure-iot-sdk-csharp/pull/3006)

## Microsoft.Azure.Devices.Provisioning.Service 1.16.5
- Setting MaxDepth parameter in the JsonSerializerSettings as safe defaults #3045

