### PR TITLE
Bump versions of remaining packages since shared package was updated

### DIFF
--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.16.4</Version>
+    <Version>1.16.5</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
+++ b/provisioning/transport/amqp/src/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.13.7</Version>
+    <Version>1.13.8</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client AMQP Transport</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
+++ b/security/tpm/src/Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>1.12.4</Version>
+    <Version>1.12.5</Version>
     <Title>Microsoft Azure IoT Provisioning Device Security TPM Client</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/shared/src/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/src/Microsoft.Azure.Devices.Shared.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.27.2</Version>
+    <Version>1.27.3</Version>
     <Title>Microsoft Azure IoT Devices Shared</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/shared/src/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/src/Microsoft.Azure.Devices.Shared.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.27.3</Version>
+    <Version>1.27.2</Version>
     <Title>Microsoft Azure IoT Devices Shared</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,10 +1,10 @@
 AssemblyPath, Version
 iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.36.7
 iothub\service\src\Microsoft.Azure.Devices.csproj, 1.31.4
-shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.27.2
-provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.4
-provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.7
+shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.27.3
+provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.5
+provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.8
 provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.12.5
 provisioning\transport\mqtt\src\Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.csproj, 1.14.3
-security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.12.4
+security\tpm\src\Microsoft.Azure.Devices.Provisioning.Security.Tpm.csproj, 1.12.5
 provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 1.16.5

--- a/versions.csv
+++ b/versions.csv
@@ -1,7 +1,7 @@
 AssemblyPath, Version
 iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.36.7
 iothub\service\src\Microsoft.Azure.Devices.csproj, 1.31.4
-shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.27.3
+shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.27.2
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.5
 provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.8
 provisioning\transport\http\src\Microsoft.Azure.Devices.Provisioning.Transport.Http.csproj, 1.12.5


### PR DESCRIPTION
## Microsoft.Azure.Devices.Client 1.36.7
- Update DotNetty versions (https://github.com/Azure/azure-iot-sdk-csharp/pull/2970)
- Bring amqp sas token refresh cleanup logic to LTS (https://github.com/Azure/azure-iot-sdk-csharp/pull/3039)
- Setting MaxDepth parameter in the JsonSerializerSettings as safe default #3045
- Updated reference to `Microsoft.Azure.Devices.Shared` nuget

## Microsoft.Azure.Devices  1.31.4
- Setting MaxDepth parameter in the JsonSerializerSettings as safe default #3045
- Updated reference to `Microsoft.Azure.Devices.Shared` nuget

## Microsoft.Azure.Devices.Shared 1.27.2
- Setting MaxDepth parameter in the JsonSerializerSettings as safe default #3045

## Microsoft.Azure.Devices.Provisioning.Transport.Mqtt 1.14.3
- Update DotNetty versions (https://github.com/Azure/azure-iot-sdk-csharp/pull/2970)
- Add M2M message failure fix (https://github.com/Azure/azure-iot-sdk-csharp/pull/3006)
- Updated reference to `Microsoft.Azure.Devices.Shared` nuget

## Microsoft.Azure.Devices.Provisioning.Service 1.16.5
- Setting MaxDepth parameter in the JsonSerializerSettings as safe default #3045
- Updated reference to `Microsoft.Azure.Devices.Shared` nuget

## Microsoft.Azure.Devices.Provisioning.Client 1.16.5
- Updated reference to `Microsoft.Azure.Devices.Shared` nuget

## Microsoft.Azure.Devices.Provisioning.Transport.Amqp 1.13.8
- Updated reference to `Microsoft.Azure.Devices.Shared` nuget

## Microsoft.Azure.Devices.Provisioning.Transport.Http 1.12.5
- Updated reference to `Microsoft.Azure.Devices.Shared` nuget
- Fix DPS device client group enrollment provisioning over symmetric key when registration Id contains invalid URI characters (#3061)

## Microsoft.Azure.Devices.Provisioning.Security.Tpm 1.12.5
- Updated reference to `Microsoft.Azure.Devices.Shared` nuget

