### PR TITLE
add group registration enumeration

### DIFF
--- a/provisioning/service/samples/getting started/EnrollmentGroupSample/EnrollmentGroupSample.cs
+++ b/provisioning/service/samples/getting started/EnrollmentGroupSample/EnrollmentGroupSample.cs
@@ -52,7 +52,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Samples
             Console.WriteLine($"\nCreating a query for registrations within group '{group.EnrollmentGroupId}'...");
             using Query registrationQuery = _provisioningServiceClient.CreateEnrollmentGroupRegistrationStateQuery(querySpecification, group.EnrollmentGroupId);
             Console.WriteLine($"\nQuerying the next registrations within group '{group.EnrollmentGroupId}'...");
-            QueryResult registrationQueryResult = await registrationQuery.NextAsync();
+            while (registrationQuery.HasNext()) {
+                QueryResult registrationQueryResult = await registrationQuery.NextAsync();
+                Console.WriteLine(registrationQueryResult.ToString());
+            }
         }
 
         public async Task CreateEnrollmentGroupAsync()

--- a/provisioning/service/samples/getting started/EnrollmentGroupSample/EnrollmentGroupSample.cs
+++ b/provisioning/service/samples/getting started/EnrollmentGroupSample/EnrollmentGroupSample.cs
@@ -52,7 +52,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Samples
             Console.WriteLine($"\nCreating a query for registrations within group '{group.EnrollmentGroupId}'...");
             using Query registrationQuery = _provisioningServiceClient.CreateEnrollmentGroupRegistrationStateQuery(querySpecification, group.EnrollmentGroupId);
             Console.WriteLine($"\nQuerying the next registrations within group '{group.EnrollmentGroupId}'...");
-            while (registrationQuery.HasNext()) {
+            while (registrationQuery.HasNext())
+            {
                 QueryResult registrationQueryResult = await registrationQuery.NextAsync();
                 Console.WriteLine(registrationQueryResult.ToString());
             }


### PR DESCRIPTION
The sample query against the enrollment group does not have code to enumerate the results. This adds a loop to do so.

<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `main` branch.
<!-- If not against main, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
