### PR TITLE
Utilize retry policy when retrying to send SAS token in CBS auth in AMQP

### DIFF
--- a/iothub/device/samples/how to guides/DeviceReconnectionSample/Parameters.cs
+++ b/iothub/device/samples/how to guides/DeviceReconnectionSample/Parameters.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         [Option(
             't',
             "Transport",
-            Default = Transport.Amqp,
+            Default = Transport.Mqtt,
             Required = false,
             HelpText = "The transport to use for the connection.")]
         public Transport Transport { get; set; }

--- a/iothub/device/samples/how to guides/DeviceReconnectionSample/Parameters.cs
+++ b/iothub/device/samples/how to guides/DeviceReconnectionSample/Parameters.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         [Option(
             't',
             "Transport",
-            Default = Transport.Mqtt,
+            Default = Transport.Amqp,
             Required = false,
             HelpText = "The transport to use for the connection.")]
         public Transport Transport { get; set; }

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -409,8 +409,7 @@ namespace Microsoft.Azure.Devices.Client
 
             await InnerHandler.CloseAsync(cancellationToken).ConfigureAwait(false);
 
-            if (_clientOptions.TransportSettings is IotHubClientAmqpSettings iotHubClientAmqpSettings
-                && IotHubConnectionCredentials.AuthenticationModel == AuthenticationModel.SasIndividual)
+            if (_clientOptions.TransportSettings is IotHubClientAmqpSettings)
             {
                 await InnerHandler.StopSasTokenLoopAsync().ConfigureAwait(false);
             }

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -117,9 +117,7 @@ namespace Microsoft.Azure.Devices.Client
             cancellationToken.ThrowIfCancellationRequested();
 
             await InnerHandler.OpenAsync(cancellationToken).ConfigureAwait(false);
-
-            if (_clientOptions.TransportSettings is IotHubClientAmqpSettings iotHubClientAmqpSettings
-                && IotHubConnectionCredentials.AuthenticationModel == AuthenticationModel.SasIndividual)
+            if (_clientOptions.TransportSettings is IotHubClientAmqpSettings)
             {
                 InnerHandler.SetSasTokenRefreshesOn();
             }

--- a/iothub/device/src/Pipeline/ClientPipelineBuilder.cs
+++ b/iothub/device/src/Pipeline/ClientPipelineBuilder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Devices.Client
             return this;
         }
 
-        public IDelegatingHandler Build(PipelineContext context, IIotHubClientRetryPolicy retryPolicy)
+        public IDelegatingHandler Build(PipelineContext context)
         {
             if (_pipeline.Count == 0)
             {
@@ -34,10 +34,6 @@ namespace Microsoft.Azure.Devices.Client
             {
                 ContinuationFactory<IDelegatingHandler> currentFactory = _pipeline[i];
                 currentHandler = currentFactory(context, nextHandler);
-                if (currentHandler is RetryDelegatingHandler retryHandler)
-                {
-                    retryHandler.SetRetryPolicy(retryPolicy ?? new IotHubClientNoRetry());
-                }
                 currentHandler.ContinuationFactory = nextFactory;
 
                 nextHandler = currentHandler;

--- a/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
@@ -138,13 +138,13 @@ namespace Microsoft.Azure.Devices.Client.Transport
         public virtual Task<DateTime> RefreshSasTokenAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
-            return NextHandler?.RefreshSasTokenAsync(cancellationToken) ?? Task.FromResult(DateTime.Now);
+            return NextHandler?.RefreshSasTokenAsync(cancellationToken) ?? Task.FromResult(DateTime.UtcNow);
         }
 
         public virtual DateTime GetSasTokenRefreshesOn()
         {
             ThrowIfDisposed();
-            return NextHandler?.GetSasTokenRefreshesOn() ?? DateTime.MaxValue;
+            return NextHandler?.GetSasTokenRefreshesOn() ?? DateTime.UtcNow;
         }
 
         public virtual void SetSasTokenRefreshesOn()

--- a/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
@@ -135,6 +135,29 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return NextHandler?.UpdateReportedPropertiesAsync(reportedProperties, cancellationToken) ?? Task.FromResult(0L);
         }
 
+        public virtual Task<DateTime> RefreshSasTokenAsync(CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            return NextHandler?.RefreshSasTokenAsync(cancellationToken) ?? Task.FromResult(DateTime.Now);
+        }
+
+        public virtual DateTime GetSasTokenRefreshesOn()
+        {
+            ThrowIfDisposed();
+            return NextHandler?.GetSasTokenRefreshesOn() ?? DateTime.MaxValue;
+        }
+
+        public virtual void SetSasTokenRefreshesOn()
+        {
+            ThrowIfDisposed();
+        }
+
+        public virtual Task StopSasTokenLoopAsync()
+        {
+            ThrowIfDisposed();
+            return NextHandler?.StopSasTokenLoopAsync() ?? Task.CompletedTask;
+        }
+
         public virtual bool IsUsable => NextHandler?.IsUsable ?? true;
 
         public virtual void Dispose()

--- a/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/ErrorDelegatingHandler.cs
@@ -73,6 +73,11 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return ExecuteWithErrorHandlingAsync(() => base.GetTwinAsync(cancellationToken));
         }
 
+        public override Task<DateTime> RefreshSasTokenAsync(CancellationToken cancellationToken)
+        {
+            return ExecuteWithErrorHandlingAsync(() => base.RefreshSasTokenAsync(cancellationToken));
+        }
+
         public override Task<long> UpdateReportedPropertiesAsync(ReportedProperties reportedProperties, CancellationToken cancellationToken)
         {
             return ExecuteWithErrorHandlingAsync(() => base.UpdateReportedPropertiesAsync(reportedProperties, cancellationToken));

--- a/iothub/device/src/Pipeline/IDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/IDelegatingHandler.cs
@@ -35,6 +35,14 @@ namespace Microsoft.Azure.Devices.Client
 
         Task SendMethodResponseAsync(DirectMethodResponse methodResponse, CancellationToken cancellationToken);
 
+        Task<DateTime> RefreshSasTokenAsync(CancellationToken cancellationToken);
+
+        DateTime GetSasTokenRefreshesOn();
+
+        void SetSasTokenRefreshesOn();
+
+        Task StopSasTokenLoopAsync();
+
         // Twin.
         Task<TwinProperties> GetTwinAsync(CancellationToken cancellationToken);
 
@@ -43,5 +51,6 @@ namespace Microsoft.Azure.Devices.Client
         Task EnableTwinPatchAsync(CancellationToken cancellationToken);
 
         Task DisableTwinPatchAsync(CancellationToken cancellationToken);
+
     }
 }

--- a/iothub/device/src/Pipeline/PipelineContext.cs
+++ b/iothub/device/src/Pipeline/PipelineContext.cs
@@ -25,5 +25,7 @@ namespace Microsoft.Azure.Devices.Client
         internal Func<DirectMethodRequest, Task> MethodCallback { get; set; }
 
         internal Func<IncomingMessage, Task<MessageAcknowledgement>> MessageEventCallback { get; set; }
+
+        internal IIotHubClientRetryPolicy RetryPolicy { get; set; }
     }
 }

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -487,7 +487,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             await VerifyIsOpenAsync(cancellationToken).ConfigureAwait(false);
                             return await base.RefreshSasTokenAsync(cancellationToken).ConfigureAwait(false);
                         },
-                        (Exception ex) => ex is IotHubClientException iex && iex.ErrorCode == IotHubClientErrorCode.NetworkErrors,
                         cancellationToken)
                     .ConfigureAwait(false);
             }
@@ -602,14 +601,13 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     
                     refreshesOn = await RefreshSasTokenAsync(cancellationToken).ConfigureAwait(false);
 
-                    // what happens if refreshesOn is DateTime.MaxValue ?
-
                     if (Logging.IsEnabled)
                         Logging.Info(this, refreshesOn, "Token has been refreshed.");
 
                     waitTime = refreshesOn - DateTime.UtcNow;
                 }
             }
+            // OperationCanceledException can be thrown when the connection is closing or the cancellationToken is signaled
             catch (OperationCanceledException) { return; }
             finally
             {

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.Devices.Client.Transport.AmqpIot;
 
 namespace Microsoft.Azure.Devices.Client.Transport
 {
@@ -851,13 +850,13 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     {
                         _handleDisconnectCts?.Cancel();
                         _handleDisconnectCts?.Dispose();
+                        _loopCancellationTokenSource?.Dispose();
                         if (_handlerSemaphore != null && _handlerSemaphore.CurrentCount == 0)
                         {
                             _handlerSemaphore.Release();
                         }
                         _handlerSemaphore?.Dispose();
                         _handlerSemaphore = null;
-                        _loopCancellationTokenSource?.Dispose();
                     }
 
                     // the _disposed flag is inherited from the base class DefaultDelegatingHandler and is finally set to null there.

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -533,11 +533,11 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task StopSasTokenLoopAsync()
         {
+            if (Logging.IsEnabled)
+                Logging.Enter(this, nameof(StopSasTokenLoopAsync));
+
             try
             {
-                if (Logging.IsEnabled)
-                    Logging.Enter(this, nameof(StopSasTokenLoopAsync));
-
                 try
                 {
                     _loopCancellationTokenSource?.Cancel();
@@ -579,11 +579,11 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         private async Task RefreshSasTokenLoopAsync(DateTime refreshesOn, CancellationToken cancellationToken)
         {
+            if (Logging.IsEnabled)
+                Logging.Enter(this, refreshesOn, nameof(RefreshSasTokenLoopAsync));
+
             try
             {
-                if (Logging.IsEnabled)
-                    Logging.Enter(this, refreshesOn, nameof(RefreshSasTokenLoopAsync));
-
                 TimeSpan waitTime = refreshesOn - DateTime.UtcNow;
 
                 while (!cancellationToken.IsCancellationRequested)
@@ -601,10 +601,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     
                     refreshesOn = await RefreshSasTokenAsync(cancellationToken).ConfigureAwait(false);
 
-                    if (Logging.IsEnabled)
-                        Logging.Info(this, refreshesOn, "Token has been refreshed.");
-
                     waitTime = refreshesOn - DateTime.UtcNow;
+
+                    if (Logging.IsEnabled)
+                        Logging.Info(this, refreshesOn, $"Token has been refreshed; valid until {refreshesOn}.");
                 }
             }
             // OperationCanceledException can be thrown when the connection is closing or the cancellationToken is signaled

--- a/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -87,34 +86,5 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             // SAS tokens granted to a group SAS authenticated client will scoped to the IoT hub-level; for example, myHub.azure-devices.net
             return connectionCredentials.HostName;
         }
-
-        //public void Dispose()
-        //{
-        //    Dispose(true);
-        //    GC.SuppressFinalize(this);
-        //}
-
-        //private void Dispose(bool disposing)
-        //{
-        //    try
-        //    {
-        //        if (Logging.IsEnabled)
-        //            Logging.Enter(this, $"Disposed={_disposed}; disposing={disposing}", $"{nameof(AmqpAuthenticationRefresher)}.{nameof(Dispose)}");
-
-        //        if (!_disposed)
-        //        {
-        //            if (disposing)
-        //            {
-        //            }
-
-        //            _disposed = true;
-        //        }
-        //    }
-        //    finally
-        //    {
-        //        if (Logging.IsEnabled)
-        //            Logging.Exit(this, $"Disposed={_disposed}; disposing={disposing}", $"{nameof(AmqpAuthenticationRefresher)}.{nameof(Dispose)}");
-        //    }
-        //}
     }
 }

--- a/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
@@ -36,10 +36,10 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
         }
 
-        async Task<DateTime> IAmqpAuthenticationRefresher.SasTokenRefreshTokenAsync(CancellationToken cancellationToken)
+        async Task<DateTime> IAmqpAuthenticationRefresher.RefreshSasTokenAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, nameof(IAmqpAuthenticationRefresher.SasTokenRefreshTokenAsync));
+                Logging.Enter(this, nameof(IAmqpAuthenticationRefresher.RefreshSasTokenAsync));
 
             try
             {
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, nameof(IAmqpAuthenticationRefresher.SasTokenRefreshTokenAsync));
+                    Logging.Exit(this, nameof(IAmqpAuthenticationRefresher.RefreshSasTokenAsync));
             }
         }
 

--- a/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpAuthenticationRefresher.cs
@@ -10,7 +10,7 @@ using Microsoft.Azure.Devices.Client.Transport.AmqpIot;
 
 namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 {
-    internal class AmqpAuthenticationRefresher : IAmqpAuthenticationRefresher, IDisposable
+    internal class AmqpAuthenticationRefresher : IAmqpAuthenticationRefresher
     {
         private static readonly string[] s_accessRightsStringArray = new[] { "DeviceConnect" };
         private readonly Uri _amqpEndpoint;
@@ -18,9 +18,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
         private readonly IConnectionCredentials _connectionCredentials;
         private readonly AmqpIotCbsTokenProvider _amqpIotCbsTokenProvider;
         private readonly string _audience;
-        private CancellationTokenSource _refresherCancellationTokenSource;
-        private Task _refreshLoop;
-        private bool _disposed;
+
+        DateTime IAmqpAuthenticationRefresher.SasTokenRefreshesOn { get; set; }
 
         internal AmqpAuthenticationRefresher(IConnectionCredentials connectionCredentials, AmqpIotCbsLink amqpCbsLink)
         {
@@ -37,150 +36,35 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             }
         }
 
-        async Task IAmqpAuthenticationRefresher.InitLoopAsync(CancellationToken cancellationToken)
+        async Task<DateTime> IAmqpAuthenticationRefresher.SasTokenRefreshTokenAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, nameof(IAmqpAuthenticationRefresher.InitLoopAsync));
+                Logging.Enter(this, nameof(IAmqpAuthenticationRefresher.SasTokenRefreshTokenAsync));
 
-            DateTime refreshOn = await _amqpIotCbsLink
-                .SendTokenAsync(
-                    _amqpIotCbsTokenProvider,
-                    _amqpEndpoint,
-                    _audience,
-                    _audience,
-                    s_accessRightsStringArray,
-                    cancellationToken)
-                .ConfigureAwait(false);
-
-            // This cancellation token source is disposed when the authentication refresher is disposed
-            // or if this code block is executed more than once per instance of AmqpAuthenticationRefresher (not expected).
-
-            if (_refresherCancellationTokenSource != null)
-            {
-                if (Logging.IsEnabled)
-                    Logging.Info(this, "_refresherCancellationTokenSource was already initialized, which was unexpected. Canceling and disposing the previous instance.", nameof(IAmqpAuthenticationRefresher.InitLoopAsync));
-
-                try
-                {
-                    _refresherCancellationTokenSource.Cancel();
-                }
-                catch (ObjectDisposedException)
-                {
-                }
-                _refresherCancellationTokenSource.Dispose();
-            }
-            _refresherCancellationTokenSource = new CancellationTokenSource();
-
-            // AmqpAuthenticationRefresher.StartLoop is implemented as an explicit interface implementation. 
-            // This is because we do not wish to make the interface and its methods public.
-            // Implicit interface implementation requires the interface and its methods to be public.
-            // Since StartLoop can only be accessed through an AmqpAuthenticationRefresher instance, we have to add the instance check.
-            if (refreshOn < DateTime.MaxValue
-                && this is IAmqpAuthenticationRefresher refresher)
-            {
-                refresher.StartLoop(refreshOn, _refresherCancellationTokenSource.Token);
-            }
-
-            if (Logging.IsEnabled)
-                Logging.Exit(this, nameof(IAmqpAuthenticationRefresher.InitLoopAsync));
-        }
-
-        void IAmqpAuthenticationRefresher.StartLoop(DateTime refreshOn, CancellationToken cancellationToken)
-        {
-            if (Logging.IsEnabled)
-                Logging.Enter(this, refreshOn, nameof(IAmqpAuthenticationRefresher.StartLoop));
-
-            // This task runs in the background and is unmonitored.
-            // When this refresher is disposed it signals this task to be cancelled.
-            _refreshLoop = RefreshLoopAsync(refreshOn, cancellationToken);
-
-            if (Logging.IsEnabled)
-                Logging.Exit(this, refreshOn, nameof(IAmqpAuthenticationRefresher.StartLoop));
-        }
-
-        async Task IAmqpAuthenticationRefresher.StopLoopAsync()
-        {
             try
             {
-                if (Logging.IsEnabled)
-                    Logging.Enter(this, nameof(IAmqpAuthenticationRefresher.StopLoopAsync));
+                DateTime refreshesOn = await _amqpIotCbsLink
+                    .SendTokenAsync(
+                        _amqpIotCbsTokenProvider,
+                        _amqpEndpoint,
+                        _audience,
+                        _audience,
+                        s_accessRightsStringArray,
+                        cancellationToken)
+                    .ConfigureAwait(false);
 
-                try
+                if (refreshesOn < DateTime.MaxValue
+                    && this is IAmqpAuthenticationRefresher refresher)
                 {
-                    _refresherCancellationTokenSource?.Cancel();
-                }
-                catch (ObjectDisposedException)
-                {
-                    if (Logging.IsEnabled)
-                        Logging.Error(this, "The cancellation token source has already been canceled and disposed", nameof(IAmqpAuthenticationRefresher.StopLoopAsync));
+                    refresher.SasTokenRefreshesOn = refreshesOn;
                 }
 
-                // Await the completion of _refreshLoop.
-                // This will ensure that when StopLoopAsync has been exited then no more token refresh attempts are in-progress.
-                await _refreshLoop.ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                if (Logging.IsEnabled)
-                    Logging.Error(this, $"Caught exception when stopping token refresh loop: {ex}");
+                return refreshesOn;
             }
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, nameof(IAmqpAuthenticationRefresher.StopLoopAsync));
-            }
-        }
-
-        private async Task RefreshLoopAsync(DateTime refreshesOn, CancellationToken cancellationToken)
-        {
-            TimeSpan waitTime = refreshesOn - DateTime.UtcNow;
-            Debug.Assert(_connectionCredentials.SasTokenRefresher != null);
-
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                if (Logging.IsEnabled)
-                    Logging.Info(this, refreshesOn, $"{_amqpIotCbsTokenProvider} before {nameof(RefreshLoopAsync)} with wait time {waitTime}.");
-
-                if (waitTime > TimeSpan.Zero)
-                {
-                    if (Logging.IsEnabled)
-                        Logging.Info(this, refreshesOn, $"{_amqpIotCbsTokenProvider} waiting {waitTime} {nameof(RefreshLoopAsync)}.");
-
-                    await Task.Delay(waitTime, cancellationToken).ConfigureAwait(false);
-                }
-
-                if (!cancellationToken.IsCancellationRequested)
-                {
-                    try
-                    {
-                        refreshesOn = await _amqpIotCbsLink
-                            .SendTokenAsync(
-                                _amqpIotCbsTokenProvider,
-                                _amqpEndpoint,
-                                _audience,
-                                _audience,
-                                s_accessRightsStringArray,
-                                cancellationToken)
-                            .ConfigureAwait(false);
-                    }
-                    catch (IotHubClientException ex) when (ex.ErrorCode is IotHubClientErrorCode.NetworkErrors)
-                    {
-                        if (Logging.IsEnabled)
-                            Logging.Error(this, refreshesOn, $"{_amqpIotCbsTokenProvider} refresh token failed {ex}");
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // close gracefully
-                        return;
-                    }
-                    finally
-                    {
-                        if (Logging.IsEnabled)
-                            Logging.Info(this, refreshesOn, $"After {nameof(RefreshLoopAsync)}");
-                    }
-
-                    waitTime = refreshesOn - DateTime.UtcNow;
-                }
+                    Logging.Exit(this, nameof(IAmqpAuthenticationRefresher.SasTokenRefreshTokenAsync));
             }
         }
 
@@ -204,34 +88,33 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
             return connectionCredentials.HostName;
         }
 
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
+        //public void Dispose()
+        //{
+        //    Dispose(true);
+        //    GC.SuppressFinalize(this);
+        //}
 
-        private void Dispose(bool disposing)
-        {
-            try
-            {
-                if (Logging.IsEnabled)
-                    Logging.Enter(this, $"Disposed={_disposed}; disposing={disposing}", $"{nameof(AmqpAuthenticationRefresher)}.{nameof(Dispose)}");
+        //private void Dispose(bool disposing)
+        //{
+        //    try
+        //    {
+        //        if (Logging.IsEnabled)
+        //            Logging.Enter(this, $"Disposed={_disposed}; disposing={disposing}", $"{nameof(AmqpAuthenticationRefresher)}.{nameof(Dispose)}");
 
-                if (!_disposed)
-                {
-                    if (disposing)
-                    {
-                        _refresherCancellationTokenSource?.Dispose();
-                    }
+        //        if (!_disposed)
+        //        {
+        //            if (disposing)
+        //            {
+        //            }
 
-                    _disposed = true;
-                }
-            }
-            finally
-            {
-                if (Logging.IsEnabled)
-                    Logging.Exit(this, $"Disposed={_disposed}; disposing={disposing}", $"{nameof(AmqpAuthenticationRefresher)}.{nameof(Dispose)}");
-            }
-        }
+        //            _disposed = true;
+        //        }
+        //    }
+        //    finally
+        //    {
+        //        if (Logging.IsEnabled)
+        //            Logging.Exit(this, $"Disposed={_disposed}; disposing={disposing}", $"{nameof(AmqpAuthenticationRefresher)}.{nameof(Dispose)}");
+        //    }
+        //}
     }
 }

--- a/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpConnectionHolder.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                 Logging.Enter(this, connectionCredentials, nameof(CreateRefresherAsync));
 
             AmqpIotConnection amqpIotConnection = await EnsureConnectionAsync(cancellationToken).ConfigureAwait(false);
-            IAmqpAuthenticationRefresher amqpAuthenticator = amqpIotConnection.CreateRefresher(connectionCredentials, cancellationToken);
+            IAmqpAuthenticationRefresher amqpAuthenticator = await amqpIotConnection.CreateRefresherAsync(connectionCredentials, cancellationToken);
 
             if (Logging.IsEnabled)
                 Logging.Exit(this, connectionCredentials, nameof(CreateRefresherAsync));
@@ -170,8 +170,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
                             Logging.Info(this, "Creating connection wide AmqpAuthenticationRefresher", nameof(EnsureConnectionAsync));
 
                         amqpAuthenticationRefresher = new AmqpAuthenticationRefresher(_connectionCredentials, amqpIotConnection.GetCbsLink());
-                        await amqpAuthenticationRefresher.SasTokenRefreshTokenAsync(cancellationToken).ConfigureAwait(false);
-                        //await amqpAuthenticationRefresher.InitLoopAsync(cancellationToken).ConfigureAwait(false);
+                        await amqpAuthenticationRefresher.RefreshSasTokenAsync(cancellationToken).ConfigureAwait(false);
                     }
 
                     _amqpIotConnection = amqpIotConnection;

--- a/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpTransportHandler.cs
@@ -98,6 +98,28 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         public override bool IsUsable => !_isDisposed;
 
+        public override DateTime GetSasTokenRefreshesOn()
+        {
+            return _amqpUnit.GetSasTokenRefreshesOn();
+        }
+
+        public override async Task<DateTime> RefreshSasTokenAsync(CancellationToken cancellationToken)
+        {
+            if (Logging.IsEnabled)
+                Logging.Enter(this, cancellationToken, nameof(RefreshSasTokenAsync));
+
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return await _amqpUnit.RefreshSasTokenAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (Logging.IsEnabled)
+                    Logging.Exit(this, cancellationToken, nameof(RefreshSasTokenAsync));
+            }
+        }
+
         public override async Task OpenAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)

--- a/iothub/device/src/Transport/Amqp/AmqpUnit.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnit.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
 
             try
             {
-                return await _amqpAuthenticationRefresher.SasTokenRefreshTokenAsync(cancellationToken).ConfigureAwait(false);
+                return await _amqpAuthenticationRefresher.RefreshSasTokenAsync(cancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/iothub/device/src/Transport/Amqp/IAmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/IAmqpAuthenticationRefresher.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 {
     internal interface IAmqpAuthenticationRefresher
     {
-        Task<DateTime> SasTokenRefreshTokenAsync(CancellationToken cancellationToken);
+        Task<DateTime> RefreshSasTokenAsync(CancellationToken cancellationToken);
         DateTime SasTokenRefreshesOn { get; set; }
     }
 }

--- a/iothub/device/src/Transport/Amqp/IAmqpAuthenticationRefresher.cs
+++ b/iothub/device/src/Transport/Amqp/IAmqpAuthenticationRefresher.cs
@@ -9,8 +9,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 {
     internal interface IAmqpAuthenticationRefresher
     {
-        Task InitLoopAsync(CancellationToken cancellationToken);
-        void StartLoop(DateTime refreshOn, CancellationToken cancellationToken);
-        Task StopLoopAsync();
+        Task<DateTime> SasTokenRefreshTokenAsync(CancellationToken cancellationToken);
+        DateTime SasTokenRefreshesOn { get; set; }
     }
 }

--- a/iothub/device/src/Transport/Amqp/IAmqpConnectionHolder.cs
+++ b/iothub/device/src/Transport/Amqp/IAmqpConnectionHolder.cs
@@ -16,6 +16,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
 
         Task<IAmqpAuthenticationRefresher> CreateRefresherAsync(IConnectionCredentials connectionCredentials, CancellationToken cancellationToken);
 
-        Task ShutdownAsync();
+        void Shutdown();
     }
 }

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotConnection.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotConnection.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
             }
         }
 
-        internal IAmqpAuthenticationRefresher CreateRefresher(IConnectionCredentials connectionCredentials, CancellationToken cancellationToken)
+        internal async Task<IAmqpAuthenticationRefresher> CreateRefresherAsync(IConnectionCredentials connectionCredentials, CancellationToken cancellationToken)
         {
             if (_amqpConnection.IsClosing())
             {
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
             try
             {
                 IAmqpAuthenticationRefresher amqpAuthenticator = new AmqpAuthenticationRefresher(connectionCredentials, _amqpIotCbsLink);
-                amqpAuthenticator.SasTokenRefreshTokenAsync(cancellationToken).ConfigureAwait(false);
+                await amqpAuthenticator.RefreshSasTokenAsync(cancellationToken).ConfigureAwait(false);
 
                 return amqpAuthenticator;
             }

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotConnection.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotConnection.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
             }
         }
 
-        internal async Task<IAmqpAuthenticationRefresher> CreateRefresherAsync(IConnectionCredentials connectionCredentials, CancellationToken cancellationToken)
+        internal IAmqpAuthenticationRefresher CreateRefresher(IConnectionCredentials connectionCredentials, CancellationToken cancellationToken)
         {
             if (_amqpConnection.IsClosing())
             {
@@ -86,7 +86,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
             try
             {
                 IAmqpAuthenticationRefresher amqpAuthenticator = new AmqpAuthenticationRefresher(connectionCredentials, _amqpIotCbsLink);
-                await amqpAuthenticator.InitLoopAsync(cancellationToken).ConfigureAwait(false);
+                amqpAuthenticator.SasTokenRefreshTokenAsync(cancellationToken).ConfigureAwait(false);
+
                 return amqpAuthenticator;
             }
             catch (Exception ex) when (!Fx.IsFatal(ex))

--- a/iothub/device/tests/Pipeline/RetryDelegatingHandlerImplicitOpenTests.cs
+++ b/iothub/device/tests/Pipeline/RetryDelegatingHandlerImplicitOpenTests.cs
@@ -20,8 +20,11 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public async Task OpenAsyncNextCompletedSubjIsOpen()
         {
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (connectionStatusInfo) => { };
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(1),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
             var nextHandlerMock = new Mock<IDelegatingHandler>();
             nextHandlerMock.Setup(x => x.OpenAsync(It.IsAny<CancellationToken>())).Returns(() => Task.CompletedTask);
 
@@ -32,8 +35,11 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public async Task NoImplicitOpenByClientMethods()
         {
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (connectionStatusInfo) => { };
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(2),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
             var nextHandlerMock = new Mock<IDelegatingHandler>();
             nextHandlerMock.Setup(x => x.OpenAsync(It.IsAny<CancellationToken>())).Returns(() => Task.CompletedTask);
             nextHandlerMock.Setup(x => x.SendTelemetryAsync(It.IsAny<TelemetryMessage>(), It.IsAny<CancellationToken>())).Returns(() => Task.CompletedTask);
@@ -58,8 +64,13 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public async Task Retry_CloseAsyncBeforeOpen_Ok()
         {
-            var contextMock = new PipelineContext();
             var nextHandlerMock = new Mock<IDelegatingHandler>();
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(1),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
+
             nextHandlerMock.Setup(x => x.CloseAsync(CancellationToken.None)).Returns(() => Task.CompletedTask);
 
             using var sut = new RetryDelegatingHandler(contextMock, nextHandlerMock.Object);
@@ -69,8 +80,11 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public async Task OpenAsync_SynchronizesToOneInnerCallToOpen()
         {
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (csi) => { }; // avoid NRE
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(2),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
 
             int callCounter = 0;
             var nextHandlerMock = new Mock<IDelegatingHandler>();
@@ -97,7 +111,12 @@ namespace Microsoft.Azure.Devices.Client.Test
         [TestMethod]
         public async Task OpenAsyncNextFailedSutIsOpenAndCanBeReopen()
         {
-            var contextMock = new PipelineContext();
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(2),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
+
             contextMock.ConnectionStatusChangeHandler = (connectionStatusInfo) => { };
             var nextHandlerMock = new Mock<IDelegatingHandler>();
             bool shouldThrow = true;
@@ -123,9 +142,11 @@ namespace Microsoft.Azure.Devices.Client.Test
         public async Task OpenAsync_AfterCancelled_CanBeReopened()
         {
             // arrange
-
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (csi) => { }; // avoid NRE
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(1),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
 
             var nextHandlerMock = new Mock<IDelegatingHandler>();
             nextHandlerMock

--- a/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
+++ b/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
@@ -28,8 +28,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             int callCounter = 0;
 
             var ct = CancellationToken.None;
-            PipelineContext contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (connectionStatusInfo) => { };
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(2),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
 
             var nextHandlerMock = new Mock<IDelegatingHandler>();
 
@@ -63,8 +66,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             // arrange
             int callCounter = 0;
 
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (connectionStatusInfo) => { };
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(2),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
 
             var nextHandlerMock = new Mock<IDelegatingHandler>();
             var message = new TelemetryMessage(new byte[] { 1, 2, 3 });
@@ -105,8 +111,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             int callCounter = 0;
             var message = new TelemetryMessage(new byte[] { 1, 2, 3 });
 
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (connectionStatusInfo) => { }; // avoid NRE
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(2),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
 
             var nextHandlerMock = new Mock<IDelegatingHandler>();
 
@@ -140,8 +149,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             // arrange
             int callCounter = 0;
 
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (connectionStatusInfo) => { };
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(2),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
             var nextHandlerMock = new Mock<IDelegatingHandler>();
             var message = new TelemetryMessage(new byte[] { 1, 2, 3 });
             IEnumerable<TelemetryMessage> messages = new[] { message };
@@ -181,6 +193,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             var contextMock = new PipelineContext
             {
+                RetryPolicy = new IotHubClientTestRetryPolicy(2),
                 ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
             };
             var nextHandlerMock = new Mock<IDelegatingHandler>();
@@ -212,8 +225,11 @@ namespace Microsoft.Azure.Devices.Client.Test
             // arrange
             int callCounter = 0;
 
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (connectionStatusInfo) => { };
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(2),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
             var nextHandlerMock = new Mock<IDelegatingHandler>();
             nextHandlerMock
                 .Setup(x => x.OpenAsync(CancellationToken.None))
@@ -243,8 +259,11 @@ namespace Microsoft.Azure.Devices.Client.Test
         public async Task DeviceNotFoundExceptionReturnsDeviceDisabledStatus()
         {
             // arrange
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (connectionInfo) => { };
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(1),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
             var nextHandlerMock = new Mock<IDelegatingHandler>();
             nextHandlerMock
                 .Setup(x => x.OpenAsync(It.IsAny<CancellationToken>()))
@@ -280,8 +299,11 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             // arrange
             using var cts = new CancellationTokenSource(100);
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (connectionStatusInfo) => { };
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientExponentialBackoffRetryPolicy(0, TimeSpan.FromHours(12), true),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
             var nextHandlerMock = new Mock<IDelegatingHandler>();
             nextHandlerMock
                 .Setup(x => x.OpenAsync(cts.Token))
@@ -304,8 +326,11 @@ namespace Microsoft.Azure.Devices.Client.Test
         public async Task RetryCancellationTokenCanceledOpen()
         {
             // arrange
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (connectionInfo) => { };
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(2),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
             var nextHandlerMock = new Mock<IDelegatingHandler>();
             var ct = new CancellationToken(true);
             nextHandlerMock
@@ -326,8 +351,11 @@ namespace Microsoft.Azure.Devices.Client.Test
         public async Task RetryCancellationTokenCanceledSendEvent()
         {
             // arrange
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (connectionInfo) => { };
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(2),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
             var nextHandlerMock = new Mock<IDelegatingHandler>();
             nextHandlerMock
                 .Setup(x => x.OpenAsync(It.IsAny<CancellationToken>()))
@@ -352,8 +380,11 @@ namespace Microsoft.Azure.Devices.Client.Test
         public async Task RetryCancellationTokenCanceledSendEventWithIEnumMessage()
         {
             // arrange
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (connectionInfo) => { }; // avoid NRE
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(2),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
 
             var nextHandlerMock = new Mock<IDelegatingHandler>();
             nextHandlerMock
@@ -384,8 +415,11 @@ namespace Microsoft.Azure.Devices.Client.Test
         public async Task RetrySetRetryPolicyVerifyInternalsSuccess()
         {
             // arrange
-            var contextMock = new PipelineContext();
-            contextMock.ConnectionStatusChangeHandler = (connectionStatusInfo) => { }; // avoid NRE
+            var contextMock = new PipelineContext
+            {
+                RetryPolicy = new IotHubClientTestRetryPolicy(2),
+                ConnectionStatusChangeHandler = (connectionStatusInfo) => { }
+            };
 
             var nextHandlerMock = new Mock<IDelegatingHandler>();
 

--- a/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
+++ b/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
@@ -483,14 +483,14 @@ namespace Microsoft.Azure.Devices.Client.Test
                     return Task.FromResult(DateTime.UtcNow);
                 });
 
-            var retryDelegatingHandler = new RetryDelegatingHandler(contextMock, nextHandlerMock.Object);
+            using var retryDelegatingHandler = new RetryDelegatingHandler(contextMock, nextHandlerMock.Object);
 
             // act
             await retryDelegatingHandler.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Func<Task> refreshToken = () => retryDelegatingHandler.RefreshSasTokenAsync(CancellationToken.None);
 
             // assert
-            var exception = await refreshToken.Should()
+            await refreshToken.Should()
                 .ThrowAsync<IotHubClientException>()
                 .ConfigureAwait(false);
             callCounter.Should().Be(1);
@@ -525,7 +525,7 @@ namespace Microsoft.Azure.Devices.Client.Test
                     return Task.FromResult(DateTime.UtcNow);
                 });
 
-            var retryDelegatingHandler = new RetryDelegatingHandler(contextMock, nextHandlerMock.Object);
+            using var retryDelegatingHandler = new RetryDelegatingHandler(contextMock, nextHandlerMock.Object);
 
             // act
             await retryDelegatingHandler.OpenAsync(CancellationToken.None).ConfigureAwait(false);

--- a/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
+++ b/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         [DataRow(IotHubClientErrorCode.ServerError)]
         [DataRow(IotHubClientErrorCode.ServerBusy)]
         [DataRow(IotHubClientErrorCode.Timeout)]
-        public async Task RetryDelegatingHandler_RefreshTokenAsync_RetriesOnTransientErrors(IotHubClientErrorCode errorCode)
+        public async Task RetryDelegatingHandler_RefreshSasTokenAsync_RetriesOnTransientErrors(IotHubClientErrorCode errorCode)
         {
             // arrange
             int callCounter = 0;
@@ -508,7 +508,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         [DataRow(IotHubClientErrorCode.Unauthorized)]
         [DataRow(IotHubClientErrorCode.TlsAuthenticationError)]
         [DataRow(IotHubClientErrorCode.ArgumentInvalid)]
-        public async Task RetryDelegatingHandler_RefreshTokenAsync_NoRetriesOnNonTransientErrors(IotHubClientErrorCode errorCode)
+        public async Task RetryDelegatingHandler_RefreshSasTokenAsync_NoRetriesOnNonTransientErrors(IotHubClientErrorCode errorCode)
         {
             // arrange
             int callCounter = 0;


### PR DESCRIPTION
Refactored how retryPolicy is set in RetryDelegatingHandler. It is passed as a PipelineContext property. This change eliminates the need for setting it with a default RetryPolicy and updating it later.
AMQP implements proactive SAS token renewal support. This logic has been moved from AmqpAuthenticationRefresher to RetryDelegatingHandler to utilize retryHandler. When deviceClient calls OpenAsync(), AmqpIoTConnection creates amqpAuthenticationRefresher and amqpAuthenticationRefresher.refreshTokenAsync() sends a token to AmqpIotCbsTokenProvider for the first time and then gets a dateTime variable. This variable represents the token expiry time in UTC.