### PR TITLE
Remove ClientRuntime dependency and add Newtonsoft.Json package

### DIFF
--- a/e2e/test/iothub/service/TokenCredentialAuthenticationTests.cs
+++ b/e2e/test/iothub/service/TokenCredentialAuthenticationTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
-using Microsoft.Rest;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ClientOptions = Microsoft.Azure.Devices.Client.IotHubClientOptions;
 

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -64,10 +64,11 @@
     <PackageReference Include="Azure.Core" Version="1.26.0" />
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.5.12" />
     <PackageReference Include="MQTTnet" Version="4.1.2.350" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0-preview1.22518.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
+    
   </ItemGroup>
 </Project>

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -69,6 +69,5 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    
   </ItemGroup>
 </Project>


### PR DESCRIPTION
As part of the v2 migration, HTTP has been removed as a transport option, resulting in Microsoft.Rest.ClientRuntime no longer being required as a dependency of Provisioning Client SDK. However, its dependency is still utilized, so this change has been introduced. 