### PR TITLE
{AzureIOT} fixes Azure/azure-sdk-for-net#33498 Add the deprecation info

### DIFF
--- a/iothub/service/src/Messaging/ServiceClient.cs
+++ b/iothub/service/src/Messaging/ServiceClient.cs
@@ -123,7 +123,8 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <summary>
-        /// Creates ServiceClient from an IoT hub connection string.
+        /// Creates ServiceClient from an IoT hub connection string. This method is deprecated because this method declares a thrown IOException
+        /// even though it never throws an IOException.
         /// </summary>
         /// <param name="connectionString">Connection string for the IoT hub.</param>
         /// <param name="options">The <see cref="ServiceClientOptions"/> that allow configuration of the service client instance during initialization.</param>
@@ -246,7 +247,8 @@ namespace Microsoft.Azure.Devices
         }
 
         /// <summary>
-        /// Create an instance of ServiceClient from the specified IoT hub connection string using specified Transport Type.
+        /// Create an instance of ServiceClient from the specified IoT hub connection string using specified Transport Type. This method is deprecated
+        /// because this method declares a thrown IOException even though it never throws an IOException.
         /// </summary>
         /// <param name="connectionString">Connection string for the IoT hub.</param>
         /// <param name="transportType">The <see cref="TransportType"/> used (Amqp or Amqp_WebSocket_Only).</param>
@@ -259,6 +261,7 @@ namespace Microsoft.Azure.Devices
 
         /// <summary>
         /// Create an instance of ServiceClient from the specified IoT hub connection string using specified Transport Type and transport settings.
+        /// This method is deprecated because this method declares a thrown IOException even though it never throws an IOException.
         /// </summary>
         /// <param name="connectionString">Connection string for the IoT hub.</param>
         /// <param name="transportType">The <see cref="TransportType"/> used (Amqp or Amqp_WebSocket_Only).</param>


### PR DESCRIPTION
fixes Azure/azure-sdk-for-net#33498 Add the deprecation info about ServiceClient

In the Java SDK we see this info. But in .NET SDK for IOT this info seems to be missing.

More Info here: https://learn.microsoft.com/en-us/java/api/com.microsoft.azure.sdk.iot.service.serviceclient?view=azure-java-stable

<!--
Thank you for helping us improve the Azure IoT C# SDK!

Need support?
- Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag “azure-iot-hub”
- Need Support? Every customer with an active Azure subscription has access to support with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub (C, Java, .NET, Node.js, Python).
-->

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `main` branch.
<!-- If not against main, please add the reason. -->

## Description of the changes
<!-- Itemized list of changes. -->

## Reference/Link to the issue solved with this PR (if any)
<!-- Use Fixes #nnnn to automatically close the issue. -->
