### PR TITLE
added subclient test coverage (serviceClient)

### DIFF
--- a/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
@@ -106,10 +106,9 @@ namespace Microsoft.Azure.Devices
                 }
                 throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (Logging.IsEnabled)
             {
-                if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting digital twin with Id {digitalTwinId} threw an exception: {ex}", nameof(GetAsync));
+                Logging.Error(this, $"Getting digital twin with Id {digitalTwinId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
@@ -206,10 +205,9 @@ namespace Microsoft.Azure.Devices
                 }
                 throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (Logging.IsEnabled)
             {
-                if (Logging.IsEnabled)
-                    Logging.Error(this, $"Updating digital twin with Id {digitalTwinId} threw an exception: {ex}", nameof(UpdateAsync));
+                Logging.Error(this, $"Updating digital twin with Id {digitalTwinId} threw an exception: {ex}", nameof(UpdateAsync));
                 throw;
             }
             finally
@@ -292,10 +290,9 @@ namespace Microsoft.Azure.Devices
                 }
                 throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (Logging.IsEnabled)
             {
-                if (Logging.IsEnabled)
-                    Logging.Error(this, $"Invoking command on digital twin with Id {digitalTwinId} threw an exception: {ex}", nameof(InvokeCommandAsync));
+                Logging.Error(this, $"Invoking command on digital twin with Id {digitalTwinId} threw an exception: {ex}", nameof(InvokeCommandAsync));
                 throw;
             }
             finally
@@ -381,10 +378,9 @@ namespace Microsoft.Azure.Devices
                 }
                 throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (Logging.IsEnabled)
             {
-                if (Logging.IsEnabled)
-                    Logging.Error(this, $"Invoking component command on digital twin with Id {digitalTwinId} threw an exception: {ex}", nameof(InvokeComponentCommandAsync));
+                Logging.Error(this, $"Invoking component command on digital twin with Id {digitalTwinId} threw an exception: {ex}", nameof(InvokeComponentCommandAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/Jobs/ScheduledJobsClient.cs
+++ b/iothub/service/src/Jobs/ScheduledJobsClient.cs
@@ -97,10 +97,9 @@ namespace Microsoft.Azure.Devices
                 }
                 throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (Logging.IsEnabled)
             {
-                if (Logging.IsEnabled)
-                    Logging.Error(this, $"Getting job {jobId} threw an exception: {ex}", nameof(GetAsync));
+                Logging.Error(this, $"Getting job {jobId} threw an exception: {ex}", nameof(GetAsync));
                 throw;
             }
             finally
@@ -182,10 +181,9 @@ namespace Microsoft.Azure.Devices
                 }
                 throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (Logging.IsEnabled)
             {
-                if (Logging.IsEnabled)
-                    Logging.Error(this, $"Canceling job {jobId} threw an exception: {ex}", nameof(CancelAsync));
+                Logging.Error(this, $"Canceling job {jobId} threw an exception: {ex}", nameof(CancelAsync));
                 throw;
             }
             finally
@@ -264,10 +262,9 @@ namespace Microsoft.Azure.Devices
                 }
                 throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (Logging.IsEnabled)
             {
-                if (Logging.IsEnabled)
-                    Logging.Error(this, $"Scheduling direct method job {scheduledJobsOptions.JobId} threw an exception: {ex}", nameof(ScheduleDirectMethodAsync));
+                Logging.Error(this, $"Scheduling direct method job {scheduledJobsOptions.JobId} threw an exception: {ex}", nameof(ScheduleDirectMethodAsync));
                 throw;
             }
             finally
@@ -354,10 +351,9 @@ namespace Microsoft.Azure.Devices
                 }
                 throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (Logging.IsEnabled)
             {
-                if (Logging.IsEnabled)
-                    Logging.Error(this, $"Scheduling twin update {scheduledJobsOptions.JobId} threw an exception: {ex}", nameof(ScheduleTwinUpdateAsync));
+                Logging.Error(this, $"Scheduling twin update {scheduledJobsOptions.JobId} threw an exception: {ex}", nameof(ScheduleTwinUpdateAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/Query/QueryClient.cs
+++ b/iothub/service/src/Query/QueryClient.cs
@@ -144,10 +144,9 @@ namespace Microsoft.Azure.Devices
                 }
                 throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (Logging.IsEnabled)
             {
-                if (Logging.IsEnabled)
-                    Logging.Error(this, $"Creating query threw an exception: {ex}", nameof(CreateAsync));
+                Logging.Error(this, $"Creating query threw an exception: {ex}", nameof(CreateAsync));
                 throw;
             }
             finally
@@ -228,10 +227,9 @@ namespace Microsoft.Azure.Devices
                 }
                 throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (Logging.IsEnabled)
             {
-                if (Logging.IsEnabled)
-                    Logging.Error(this, $"Creating query with jobType: {options?.JobType}, jobStatus: {options?.JobStatus}, pageSize: {options?.PageSize} threw an exception: {ex}", nameof(CreateAsync));
+                Logging.Error(this, $"Creating query with jobType: {options?.JobType}, jobStatus: {options?.JobStatus}, pageSize: {options?.PageSize} threw an exception: {ex}", nameof(CreateAsync));
                 throw;
             }
             finally

--- a/iothub/service/src/RetryPolicies/IotHubServiceRetryPolicyBase.cs
+++ b/iothub/service/src/RetryPolicies/IotHubServiceRetryPolicyBase.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Devices
             lock (_rngLock)
             {
                 // A random double from 95% to 105% of the baseTimeMs
-                jitterMs = _rng.Next(95, 106);
+                jitterMs = _rng.Next(95, 105);
             }
 
             jitterMs *= baseTimeMs / 100.0;

--- a/iothub/service/src/RetryPolicies/IotHubServiceRetryPolicyBase.cs
+++ b/iothub/service/src/RetryPolicies/IotHubServiceRetryPolicyBase.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Devices
             lock (_rngLock)
             {
                 // A random double from 95% to 105% of the baseTimeMs
-                jitterMs = _rng.Next(95, 105);
+                jitterMs = _rng.Next(95, 106);
             }
 
             jitterMs *= baseTimeMs / 100.0;

--- a/iothub/service/tests/DigitalTwinsClientTests.cs
+++ b/iothub/service/tests/DigitalTwinsClientTests.cs
@@ -1,0 +1,245 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.Devices.Tests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class DigitalTwinsClientTests
+    {
+        private const string HostName = "contoso.azure-devices.net";
+        private static readonly string s_validMockAuthenticationHeaderValue = $"SharedAccessSignature sr={HostName}&sig=thisIsFake&se=000000&skn=registryRead";
+        private static readonly string s_connectionString = $"HostName={HostName};SharedAccessKeyName=iothubowner;SharedAccessKey=dGVzdFN0cmluZzE=";
+
+        private static readonly Uri s_httpUri = new($"https://{HostName}");
+        private static readonly RetryHandler s_retryHandler = new(new IotHubServiceNoRetry());
+        private static IotHubServiceClientOptions s_options = new()
+        {
+            Protocol = IotHubTransportProtocol.Tcp,
+            RetryPolicy = new IotHubServiceNoRetry()
+        };
+
+        [TestMethod]
+        public async Task DigitalTwinsClient_GetAsync()
+        {
+            // arrange
+            string digitalTwinId = "foo";
+            var digitalTwin = new BasicDigitalTwin
+            {
+                Id = digitalTwinId,
+            };
+
+            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
+            mockCredentialProvider
+                .Setup(getCredential => getCredential.GetAuthorizationHeader())
+                .Returns(s_validMockAuthenticationHeaderValue);
+            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
+
+            using var mockHttpResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = HttpMessageHelper.SerializePayload(digitalTwin),
+            };
+            mockHttpResponse.Headers.Add("ETag", "1234");
+            //mockHttpResponse.Headers.Add("ETag", new ETag("test");
+
+            var mockHttpClient = new Mock<HttpClient>();
+            mockHttpClient
+                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockHttpResponse);
+
+            var digitalTwinsClient = new DigitalTwinsClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                s_retryHandler);
+
+            // act
+            Func<Task> act = async () => await digitalTwinsClient.GetAsync<BasicDigitalTwin>(digitalTwinId).ConfigureAwait(false);
+
+            // assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [TestMethod]
+        public async Task DigitalTwinsClient_GetAsync_NullTwinIdThrows()
+        {
+            // arrange
+            string digitalTwinId = "";
+            using var serviceClient = new IotHubServiceClient(s_connectionString);
+            DigitalTwinsClient digitalTwinsClient = serviceClient.DigitalTwins;
+
+            // act
+            Func<Task> act = async () => await digitalTwinsClient.GetAsync<BasicDigitalTwin>(digitalTwinId);
+
+            // assert
+            await act.Should().ThrowAsync<ArgumentException>();
+        }
+
+        [TestMethod]
+        public async Task DigitalTwinsClient_GetAsync_HttpException()
+        {
+            // arrange
+            string digitalTwinId = Guid.NewGuid().ToString();
+            using var serviceClient = new IotHubServiceClient(s_connectionString);
+            DigitalTwinsClient digitalTwinsClient = serviceClient.DigitalTwins;
+
+            // act
+            // deliberately throw http exception by searching for twin that does not exist
+            Func<Task> act = async () => await digitalTwinsClient.GetAsync<string>(digitalTwinId);
+
+            // assert
+            await act.Should().ThrowAsync<IotHubServiceException>();
+        }
+
+        [TestMethod]
+        public async Task DigitalTwinsClient_UpdateAsync()
+        {
+            // arrange
+            string digitalTwinId = "foo";
+            var digitalTwin = new BasicDigitalTwin
+            {
+                Id = digitalTwinId,
+            };
+            var contents = new Dictionary<string, object>
+            {
+                { "temperature", 8 }
+            };
+            var jsonPatch = new JsonPatchDocument();
+            jsonPatch.AppendAdd("bar", contents);
+
+            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
+            mockCredentialProvider
+                .Setup(getCredential => getCredential.GetAuthorizationHeader())
+                .Returns(s_validMockAuthenticationHeaderValue);
+            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
+
+            using var mockHttpResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = HttpMessageHelper.SerializePayload(digitalTwin),
+            };
+
+            var mockHttpClient = new Mock<HttpClient>();
+            mockHttpClient
+                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockHttpResponse);
+
+            var digitalTwinsClient = new DigitalTwinsClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                s_retryHandler);
+
+            // act
+            Func<Task> act = async () => await digitalTwinsClient.UpdateAsync(digitalTwinId, jsonPatch.ToString());
+
+            // assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [TestMethod]
+        public async Task DigitalTwinsClient_UpdateAsync_HttpException()
+        {
+            // arrange
+            string cs = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;SharedAccessKey=dGVzdFN0cmluZzE=";
+            string digitalTwinId = Guid.NewGuid().ToString();
+            string jsonPatch = "test";
+            using var serviceClient = new IotHubServiceClient(cs);
+            DigitalTwinsClient digialTwinsClient = serviceClient.DigitalTwins;
+
+            // act
+            // deliberately throw http exception by searching for twin that does not exist
+            Func<Task> act = async () => await digialTwinsClient.UpdateAsync(digitalTwinId, jsonPatch);
+
+            // assert
+            await act.Should().ThrowAsync<IotHubServiceException>();
+        }
+
+        [TestMethod]
+        public async Task DigitalTwinsClient_InvokeCommandAsync()
+        {
+            // arrange
+            var digitalTwinsClient = new Mock<DigitalTwinsClient>();
+            string digitalTwinId = Guid.NewGuid().ToString();
+            string commandName = "test";
+
+            // act
+            Func<Task> act = async () => await digitalTwinsClient.Object.InvokeCommandAsync(digitalTwinId, commandName);
+
+            // assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [TestMethod]
+        public async Task DigitalTwinsClient_InvokeCommandAysnc_HttpException()
+        {
+            // arrange
+            string cs = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;SharedAccessKey=dGVzdFN0cmluZzE=";
+            string digitalTwinId = Guid.NewGuid().ToString();
+            string commandName = "test";
+            using var serviceClient = new IotHubServiceClient(cs);
+            DigitalTwinsClient digialTwinsClient = serviceClient.DigitalTwins;
+
+            // act
+            // deliberately throw http exception by searching for twin that does not exist
+            Func<Task> act = async () => await digialTwinsClient.InvokeCommandAsync(digitalTwinId, commandName);
+
+            // assert
+            await act.Should().ThrowAsync<IotHubServiceException>();
+        }
+
+        [TestMethod]
+        public async Task DigitalTwinsClient_InvokeComponentCommandAsync()
+        {
+            // arrange
+            var digitalTwinsClient = new Mock<DigitalTwinsClient>();
+            string digitalTwinId = Guid.NewGuid().ToString();
+            string commandName = "test";
+            string componentName = "test";
+
+            // act
+            Func<Task> act = async () => await digitalTwinsClient.Object.InvokeComponentCommandAsync(digitalTwinId, componentName, commandName);
+
+            // assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [TestMethod]
+        public async Task DigitalTwinsClient_InvokeComponentCommandAsync_HttpException()
+        {
+            // arrange
+            string cs = "HostName=acme.azure-devices.net;SharedAccessKeyName=AllAccessKey;SharedAccessKey=dGVzdFN0cmluZzE=";
+            string digitalTwinId = Guid.NewGuid().ToString();
+            string commandName = "test";
+            string componentName = "test";
+            using var serviceClient = new IotHubServiceClient(cs);
+            DigitalTwinsClient digialTwinsClient = serviceClient.DigitalTwins;
+
+            // act
+            // deliberately throw http exception by searching for twin that does not exist
+            Func<Task> act = async () => await digialTwinsClient.InvokeComponentCommandAsync(digitalTwinId, componentName, commandName);
+
+            // assert
+            await act.Should().ThrowAsync<IotHubServiceException>();
+        }
+    }
+}

--- a/iothub/service/tests/DigitalTwinsClientTests.cs
+++ b/iothub/service/tests/DigitalTwinsClientTests.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Azure.Devices.Tests
         private const string HostName = "contoso.azure-devices.net";
         private static readonly string s_validMockAuthenticationHeaderValue = $"SharedAccessSignature sr={HostName}&sig=thisIsFake&se=000000&skn=registryRead";
         private static readonly string s_connectionString = $"HostName={HostName};SharedAccessKeyName=iothubowner;SharedAccessKey=dGVzdFN0cmluZzE=";
+        private static readonly string s_Etag = "\"AAAAAAAAAAE=\"";
+
 
         private static readonly Uri s_httpUri = new($"https://{HostName}");
         private static readonly RetryHandler s_retryHandler = new(new IotHubServiceNoRetry());
@@ -57,7 +59,7 @@ namespace Microsoft.Azure.Devices.Tests
                 StatusCode = HttpStatusCode.OK,
                 Content = HttpMessageHelper.SerializePayload(digitalTwin),
             };
-            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
+            mockHttpResponse.Headers.Add("ETag", s_Etag);
             
             var mockHttpClient = new Mock<HttpClient>();
             mockHttpClient
@@ -76,6 +78,7 @@ namespace Microsoft.Azure.Devices.Tests
 
             // assert
             result.DigitalTwin.Id.Should().Be(digitalTwinId);
+            result.ETag.ToString().Should().Be(s_Etag);
         }
 
         [TestMethod]
@@ -135,7 +138,9 @@ namespace Microsoft.Azure.Devices.Tests
             Func<Task> act = async () => await digitalTwinsClient.GetAsync<string>(digitalTwinId);
 
             // assert
-            await act.Should().ThrowAsync<IotHubServiceException>();
+            var error = await act.Should().ThrowAsync<IotHubServiceException>();
+            error.And.IsTransient.Should().BeFalse();
+            error.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
 
         [TestMethod]
@@ -165,7 +170,7 @@ namespace Microsoft.Azure.Devices.Tests
                 StatusCode = HttpStatusCode.Accepted,
                 Content = HttpMessageHelper.SerializePayload(digitalTwin),
             };
-            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
+            mockHttpResponse.Headers.Add("ETag", s_Etag);
             mockHttpResponse.Headers.Add("Location", s_expectedLocation);
 
             var mockHttpClient = new Mock<HttpClient>();
@@ -185,6 +190,7 @@ namespace Microsoft.Azure.Devices.Tests
 
             // assert
             response.Location.Should().Be(s_expectedLocation);
+            response.ETag.ToString().Should().Be(s_Etag);
         }
 
         [TestMethod]
@@ -247,7 +253,9 @@ namespace Microsoft.Azure.Devices.Tests
             Func<Task> act = async () => await digitalTwinsClient.UpdateAsync(digitalTwinId, jsonPatch);
 
             // assert
-            await act.Should().ThrowAsync<IotHubServiceException>();
+            var error = await act.Should().ThrowAsync<IotHubServiceException>();
+            error.And.IsTransient.Should().BeFalse();
+            error.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
 
         [TestMethod]
@@ -273,7 +281,7 @@ namespace Microsoft.Azure.Devices.Tests
                 Content = HttpMessageHelper.SerializePayload(digitalTwin),
             };
             mockHttpResponse.Headers.Add("x-ms-command-statuscode", "200");
-            mockHttpResponse.Headers.Add("x-ms-request-id", "200");
+            mockHttpResponse.Headers.Add("x-ms-request-id", "201");
 
             var mockHttpClient = new Mock<HttpClient>();
             mockHttpClient
@@ -354,7 +362,9 @@ namespace Microsoft.Azure.Devices.Tests
             Func<Task> act = async () => await digitalTwinsClient.InvokeCommandAsync(digitalTwinId, commandName);
 
             // assert
-            await act.Should().ThrowAsync<IotHubServiceException>();
+            var error = await act.Should().ThrowAsync<IotHubServiceException>();
+            error.And.IsTransient.Should().BeFalse();
+            error.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
 
         [TestMethod]
@@ -381,7 +391,7 @@ namespace Microsoft.Azure.Devices.Tests
                 Content = HttpMessageHelper.SerializePayload(digitalTwin),
             };
             mockHttpResponse.Headers.Add("x-ms-command-statuscode", "200");
-            mockHttpResponse.Headers.Add("x-ms-request-id", "200");
+            mockHttpResponse.Headers.Add("x-ms-request-id", "201");
 
             var mockHttpClient = new Mock<HttpClient>();
             mockHttpClient
@@ -464,7 +474,9 @@ namespace Microsoft.Azure.Devices.Tests
             Func<Task> act = async () => await digitalTwinsClient.InvokeComponentCommandAsync(digitalTwinId, componentName, commandName);
 
             // assert
-            await act.Should().ThrowAsync<IotHubServiceException>();
+            var error = await act.Should().ThrowAsync<IotHubServiceException>();
+            error.And.IsTransient.Should().BeFalse();
+            error.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
     }
 }

--- a/iothub/service/tests/DigitalTwinsClientTests.cs
+++ b/iothub/service/tests/DigitalTwinsClientTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task DigitalTwinsClient_GetAsync_HttpException()
+        public async Task DigitalTwinsClient_GetAsync_DigitalTwinNotFound_ThrowsIotHubServiceException()
         {
             // arrange
             string digitalTwinId = "foo";
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task DigitalTwinsClient_InvokeCommandAysnc_HttpException()
+        public async Task DigitalTwinsClient_InvokeCommandAysnc_DigitalTwinNotFound_ThrowsIotHubServiceException()
         {
             // arrange
             string commandName = "test";
@@ -420,7 +420,7 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task DigitalTwinsClient_InvokeComponentCommandAsync_HttpException()
+        public async Task DigitalTwinsClient_InvokeComponentCommandAsync_DigitalTwinNotFound_ThrowsIotHubServiceException()
         {
             // arrange
             string commandName = "test";

--- a/iothub/service/tests/DigitalTwinsClientTests.cs
+++ b/iothub/service/tests/DigitalTwinsClientTests.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.Devices.Tests
             DigitalTwinUpdateResponse response = await digitalTwinsClient.UpdateAsync(digitalTwinId, jsonPatch.ToString());
 
             // assert
-            response.Should().BeOfType<DigitalTwinUpdateResponse>();
+            response.Location.Should().Be(digitalTwinId);
         }
 
         [TestMethod]

--- a/iothub/service/tests/DigitalTwinsClientTests.cs
+++ b/iothub/service/tests/DigitalTwinsClientTests.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Azure.Devices.Tests
             RetryPolicy = new IotHubServiceNoRetry()
         };
 
+        private static readonly string s_expectedLocation = "https://contoso.azure-devices.net/digitaltwins/foo?api-version=2021-04-12";
+
         [TestMethod]
         public async Task DigitalTwinsClient_GetAsync()
         {
@@ -164,8 +166,8 @@ namespace Microsoft.Azure.Devices.Tests
                 Content = HttpMessageHelper.SerializePayload(digitalTwin),
             };
             mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
-            mockHttpResponse.Headers.Add("Location", "foo");
-            
+            mockHttpResponse.Headers.Add("Location", s_expectedLocation);
+
             var mockHttpClient = new Mock<HttpClient>();
             mockHttpClient
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
@@ -182,7 +184,7 @@ namespace Microsoft.Azure.Devices.Tests
             DigitalTwinUpdateResponse response = await digitalTwinsClient.UpdateAsync(digitalTwinId, jsonPatch.ToString());
 
             // assert
-            response.Location.Should().Be(digitalTwinId);
+            response.Location.Should().Be(s_expectedLocation);
         }
 
         [TestMethod]

--- a/iothub/service/tests/DigitalTwinsClientTests.cs
+++ b/iothub/service/tests/DigitalTwinsClientTests.cs
@@ -82,10 +82,9 @@ namespace Microsoft.Azure.Devices.Tests
             // arrange
             string digitalTwinId = null;
             using var serviceClient = new IotHubServiceClient(s_connectionString);
-            DigitalTwinsClient digitalTwinsClient = serviceClient.DigitalTwins;
 
             // act
-            Func<Task> act = async () => await digitalTwinsClient.GetAsync<BasicDigitalTwin>(digitalTwinId);
+            Func<Task> act = async () => await serviceClient.DigitalTwins.GetAsync<BasicDigitalTwin>(digitalTwinId);
 
             // assert
             await act.Should().ThrowAsync<ArgumentException>();
@@ -198,11 +197,12 @@ namespace Microsoft.Azure.Devices.Tests
             // act
             Func<Task> act = async () => await serviceClient.DigitalTwins.UpdateAsync(digitalTwinId, jsonPatch);
 
+            // assert
             await act.Should().ThrowAsync<ArgumentNullException>();
         }
 
         [TestMethod]
-        public async Task DigitalTwinsClient_UpdateAsync_OnHttpRequestException_ThrowsIotHubServiceException()
+        public async Task DigitalTwinsClient_UpdateAsync_DigitalTwinNotFound_ThrowsIotHubServiceException()
         {
             // arrange
             string jsonPatch = "test";
@@ -302,9 +302,9 @@ namespace Microsoft.Azure.Devices.Tests
             using var serviceClient = new IotHubServiceClient(s_connectionString);
 
             // act
-            // deliberately throw http exception by searching for twin that does not exist
             Func<Task> act = async () => await serviceClient.DigitalTwins.InvokeCommandAsync(digitalTwinId, commandName);
 
+            // assert
             await act.Should().ThrowAsync<ArgumentNullException>();
         }
 
@@ -409,11 +409,11 @@ namespace Microsoft.Azure.Devices.Tests
         {
             // arrange
             using var serviceClient = new IotHubServiceClient(s_connectionString);
-            DigitalTwinsClient digialTwinsClient = serviceClient.DigitalTwins;
 
             // act
-            Func<Task> act = async () => await digialTwinsClient.InvokeComponentCommandAsync(digitalTwinId, componentName, commandName);
+            Func<Task> act = async () => await serviceClient.DigitalTwins.InvokeComponentCommandAsync(digitalTwinId, componentName, commandName);
 
+            // assert
             await act.Should().ThrowAsync<ArgumentNullException>();
         }
 

--- a/iothub/service/tests/DigitalTwinsClientTests.cs
+++ b/iothub/service/tests/DigitalTwinsClientTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -204,7 +202,7 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task DigitalTwinsClient_UpdateAsync_HttpException()
+        public async Task DigitalTwinsClient_UpdateAsync_OnHttpRequestException_ThrowsIotHubServiceException()
         {
             // arrange
             string jsonPatch = "test";
@@ -302,11 +300,10 @@ namespace Microsoft.Azure.Devices.Tests
         {
             // arrange
             using var serviceClient = new IotHubServiceClient(s_connectionString);
-            DigitalTwinsClient digialTwinsClient = serviceClient.DigitalTwins;
 
             // act
             // deliberately throw http exception by searching for twin that does not exist
-            Func<Task> act = async () => await digialTwinsClient.InvokeCommandAsync(digitalTwinId, commandName);
+            Func<Task> act = async () => await serviceClient.DigitalTwins.InvokeCommandAsync(digitalTwinId, commandName);
 
             await act.Should().ThrowAsync<ArgumentNullException>();
         }

--- a/iothub/service/tests/QueryClientTests.cs
+++ b/iothub/service/tests/QueryClientTests.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net;
+using System.Threading;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using FluentAssertions;
+
+namespace Microsoft.Azure.Devices.Tests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class QueryClientTests
+    {
+        private const string HostName = "contoso.azure-devices.net";
+        private static readonly string s_validMockAuthenticationHeaderValue = $"SharedAccessSignature sr={HostName}&sig=thisIsFake&se=000000&skn=registryRead";
+        private static readonly string s_connectionString = $"HostName={HostName};SharedAccessKeyName=iothubowner;SharedAccessKey=dGVzdFN0cmluZzE=";
+
+        private static readonly Uri s_httpUri = new($"https://{HostName}");
+        private static readonly RetryHandler s_retryHandler = new(new IotHubServiceNoRetry());
+        private static IotHubServiceClientOptions s_options = new()
+        {
+            Protocol = IotHubTransportProtocol.Tcp,
+            RetryPolicy = new IotHubServiceNoRetry()
+        };
+
+        [TestMethod]
+        public async Task QueryClient_CreateAsync()
+        {
+            // arrange
+            string query = "SELECT * FROM devices";
+            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
+            mockCredentialProvider
+                .Setup(getCredential => getCredential.GetAuthorizationHeader())
+                .Returns(s_validMockAuthenticationHeaderValue);
+            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
+
+            using var mockHttpResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = HttpMessageHelper.SerializePayload(query),
+            };
+            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
+
+            var mockHttpClient = new Mock<HttpClient>();
+            mockHttpClient
+                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockHttpResponse);
+
+            var queryClient = new QueryClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                s_retryHandler);
+
+            // act
+            Func<Task> act = async () => await queryClient.CreateAsync<ClientTwin>(query);
+
+            // assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [TestMethod]
+        public async Task QueryClient_CreateAsync_NullParamterThrows()
+        {
+            // arrange
+            using var serviceClient = new IotHubServiceClient(s_connectionString);
+            QueryClient queryClient = serviceClient.Query;
+
+            // act
+            Func<Task> act = async () => await queryClient.CreateAsync<ClientTwin>(null);
+
+            // assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public async Task QueryClient_CreateAsync_HttpException()
+        {
+            // arrange
+            using var serviceClient = new IotHubServiceClient(s_connectionString);
+            QueryClient queryClient = serviceClient.Query;
+
+            // act
+            // query from a Hub that does not exist
+            Func<Task> act = async () => await queryClient.CreateAsync<ClientTwin>("SELECT * FROM devices");
+
+            // assert
+            await act.Should().ThrowAsync<IotHubServiceException>();
+        }
+
+        [TestMethod]
+        public async Task QueryClient_CreateJobsQueryAsync()
+        {
+            // arrange
+            string query = "SELECT * FROM devices";
+            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
+            mockCredentialProvider
+                .Setup(getCredential => getCredential.GetAuthorizationHeader())
+                .Returns(s_validMockAuthenticationHeaderValue);
+            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
+
+            using var mockHttpResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = HttpMessageHelper.SerializePayload(query),
+            };
+            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
+
+            var mockHttpClient = new Mock<HttpClient>();
+            mockHttpClient
+                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockHttpResponse);
+
+            var queryClient = new QueryClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                s_retryHandler);
+
+            // act
+            Func<Task> act = async () => await queryClient.CreateJobsQueryAsync();
+
+            // assert
+            await act.Should().NotThrowAsync();
+        }
+    }
+}

--- a/iothub/service/tests/QueryClientTests.cs
+++ b/iothub/service/tests/QueryClientTests.cs
@@ -87,7 +87,8 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task QueryClient_CreateAsync_HttpException()
+        // NOT FOUND returns exception
+        public async Task QueryClient_CreateAsync_IotHubNotFound_ThrowsIotHubServiceException()
         {
             // arrange
             var responseMessage = new ResponseMessage2
@@ -119,6 +120,7 @@ namespace Microsoft.Azure.Devices.Tests
                 mockHttpClient.Object,
                 mockHttpRequestFactory,
                 s_retryHandler);
+
             // act
             // query returns HttpStatusCode.NotFound
             Func<Task> act = async () => await queryClient.CreateAsync<ClientTwin>("SELECT * FROM devices");
@@ -165,7 +167,7 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task QueryClient_CreateJobsQuery_HttpException()
+        public async Task QueryClient_CreateJobsQuery_IotHubNotFound_ThrowsIotHubServiceException()
         {
             // arrange
             var responseMessage = new ResponseMessage2
@@ -197,6 +199,7 @@ namespace Microsoft.Azure.Devices.Tests
                 mockHttpClient.Object,
                 mockHttpRequestFactory,
                 s_retryHandler);
+
             // act
             Func<Task> act = async () => await queryClient.CreateJobsQueryAsync();
 

--- a/iothub/service/tests/QueryClientTests.cs
+++ b/iothub/service/tests/QueryClientTests.cs
@@ -38,8 +38,9 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task QueryClient_CreateAsync()
         {
             // arrange
-            string query = "SELECT * FROM devices";
-            var querySerialization = new RawQuerySerializationClass();
+            string query = "select * from devices where deviceId = 'foo'";
+            var twin = new ClientTwin("foo");
+
 
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider
@@ -50,7 +51,7 @@ namespace Microsoft.Azure.Devices.Tests
             using var mockHttpResponse = new HttpResponseMessage
             {
                 StatusCode = HttpStatusCode.OK,
-                Content = HttpMessageHelper.SerializePayload(querySerialization),
+                Content = HttpMessageHelper.SerializePayload(new List<ClientTwin> { twin }),
             };
             mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
 
@@ -67,7 +68,7 @@ namespace Microsoft.Azure.Devices.Tests
                 s_retryHandler);
 
             // act
-            Func<Task> act = async () => await queryClient.CreateAsync<RawQuerySerializationClass>(query);
+            Func<Task> act = async () => await queryClient.CreateAsync<ClientTwin>(query);
 
             // assert
             await act.Should().NotThrowAsync();
@@ -106,7 +107,7 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task QueryClient_CreateJobsQueryAsync()
         {
             // arrange
-            string query = "SELECT * FROM devices";
+            var job = new ScheduledJob();
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider
                 .Setup(getCredential => getCredential.GetAuthorizationHeader())
@@ -116,7 +117,7 @@ namespace Microsoft.Azure.Devices.Tests
             using var mockHttpResponse = new HttpResponseMessage
             {
                 StatusCode = HttpStatusCode.OK,
-                Content = HttpMessageHelper.SerializePayload(query),
+                Content = HttpMessageHelper.SerializePayload(new List<ScheduledJob> { job }),
             };
             mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
 
@@ -152,14 +153,6 @@ namespace Microsoft.Azure.Devices.Tests
 
             // assert
             await act.Should().ThrowAsync<IotHubServiceException>();
-        }
-
-        [JsonObjectAttribute]
-        [JsonArray]
-        public class RawQuerySerializationClass
-        {
-            [JsonProperty("TotalNumberOfDevices")]
-            public JArray TotalNumberOfDevices { get; set; }
         }
     }
 }

--- a/iothub/service/tests/QueryClientTests.cs
+++ b/iothub/service/tests/QueryClientTests.cs
@@ -67,10 +67,10 @@ namespace Microsoft.Azure.Devices.Tests
                 s_retryHandler);
 
             // act
-            Func<Task> act = async () => await queryClient.CreateAsync<ClientTwin>(query);
+            QueryResponse<ClientTwin> response = await queryClient.CreateAsync<ClientTwin>(query);
 
             // assert
-            await act.Should().NotThrowAsync();
+            response.CurrentPage.First().DeviceId.Should().Be("foo");
         }
 
         [TestMethod]
@@ -87,7 +87,6 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        // NOT FOUND returns exception
         public async Task QueryClient_CreateAsync_IotHubNotFound_ThrowsIotHubServiceException()
         {
             // arrange
@@ -126,7 +125,9 @@ namespace Microsoft.Azure.Devices.Tests
             Func<Task> act = async () => await queryClient.CreateAsync<ClientTwin>("SELECT * FROM devices");
 
             // assert
-            await act.Should().ThrowAsync<IotHubServiceException>();
+            var error = await act.Should().ThrowAsync<IotHubServiceException>();
+            error.And.IsTransient.Should().BeFalse();
+            error.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
 
         [TestMethod]
@@ -204,7 +205,9 @@ namespace Microsoft.Azure.Devices.Tests
             Func<Task> act = async () => await queryClient.CreateJobsQueryAsync();
 
             // assert
-            await act.Should().ThrowAsync<IotHubServiceException>();
+            var error = await act.Should().ThrowAsync<IotHubServiceException>();
+            error.And.IsTransient.Should().BeFalse();
+            error.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
     }
 }

--- a/iothub/service/tests/QueryClientTests.cs
+++ b/iothub/service/tests/QueryClientTests.cs
@@ -90,11 +90,6 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task QueryClient_CreateAsync_HttpException()
         {
             // arrange
-            string digitalTwinId = "foo";
-            var digitalTwin = new BasicDigitalTwin
-            {
-                Id = digitalTwinId,
-            };
             var responseMessage = new ResponseMessage2
             {
                 Message = "test",
@@ -125,7 +120,7 @@ namespace Microsoft.Azure.Devices.Tests
                 mockHttpRequestFactory,
                 s_retryHandler);
             // act
-            // query from a Hub that does not exist
+            // query returns HttpStatusCode.NotFound
             Func<Task> act = async () => await queryClient.CreateAsync<ClientTwin>("SELECT * FROM devices");
 
             // assert
@@ -173,11 +168,6 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task QueryClient_CreateJobsQuery_HttpException()
         {
             // arrange
-            string digitalTwinId = "foo";
-            var digitalTwin = new BasicDigitalTwin
-            {
-                Id = digitalTwinId,
-            };
             var responseMessage = new ResponseMessage2
             {
                 Message = "test",

--- a/iothub/service/tests/QueryClientTests.cs
+++ b/iothub/service/tests/QueryClientTests.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Azure.Devices.Tests
             string query = "select * from devices where deviceId = 'foo'";
             var twin = new ClientTwin("foo");
 
-
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider
                 .Setup(getCredential => getCredential.GetAuthorizationHeader())

--- a/iothub/service/tests/RetryPolicies/IotHubServiceRetryPolicyBaseTests.cs
+++ b/iothub/service/tests/RetryPolicies/IotHubServiceRetryPolicyBaseTests.cs
@@ -106,8 +106,8 @@ namespace Microsoft.Azure.Devices.Tests
             // arrange
             var retryPolicy = new IotHubServiceTestRetryPolicy(0);
             var duration = TimeSpan.FromSeconds(seconds);
-            double min = duration.TotalMilliseconds * .95d;
-            double max = duration.TotalMilliseconds * 1.05d;
+            double min = duration.TotalMilliseconds * .9d;
+            double max = duration.TotalMilliseconds * 1.1d;
 
             // act
             TimeSpan actual = retryPolicy.UpdateWithJitter(duration.TotalMilliseconds);

--- a/iothub/service/tests/RetryPolicies/IotHubServiceRetryPolicyBaseTests.cs
+++ b/iothub/service/tests/RetryPolicies/IotHubServiceRetryPolicyBaseTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Devices.Tests
             var retryPolicy = new IotHubServiceTestRetryPolicy(0);
             var duration = TimeSpan.FromSeconds(seconds);
             double min = duration.TotalMilliseconds * .95d;
-            double max = duration.TotalMilliseconds * 1.05d;
+            double max = duration.TotalMilliseconds * 1.06d;
 
             // act
             TimeSpan actual = retryPolicy.UpdateWithJitter(duration.TotalMilliseconds);

--- a/iothub/service/tests/RetryPolicies/IotHubServiceRetryPolicyBaseTests.cs
+++ b/iothub/service/tests/RetryPolicies/IotHubServiceRetryPolicyBaseTests.cs
@@ -106,8 +106,8 @@ namespace Microsoft.Azure.Devices.Tests
             // arrange
             var retryPolicy = new IotHubServiceTestRetryPolicy(0);
             var duration = TimeSpan.FromSeconds(seconds);
-            double min = duration.TotalMilliseconds * .9d;
-            double max = duration.TotalMilliseconds * 1.1d;
+            double min = duration.TotalMilliseconds * .95d;
+            double max = duration.TotalMilliseconds * 1.05d;
 
             // act
             TimeSpan actual = retryPolicy.UpdateWithJitter(duration.TotalMilliseconds);

--- a/iothub/service/tests/ScheduledJobsClientTests.cs
+++ b/iothub/service/tests/ScheduledJobsClientTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Tests
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var qureyClient = new QueryClient(
+            var queryClient = new Mock<QueryClient>(
                 HostName,
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices.Tests
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
                 mockHttpRequestFactory,
-                qureyClient,
+                queryClient.Object,
                 s_retryHandler);
 
             // act
@@ -81,7 +81,24 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task ScheduledJobsClient_GetAsync_NullArgumentThrows()
         {
             // arrange
-            var scheduledJob = new ScheduledJob();
+            using var serviceClient = new IotHubServiceClient(s_connectionString);
+
+            // act
+            Func<Task> act = async () => await serviceClient.ScheduledJobs.GetAsync(null);
+
+            // assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_GetAsync_HttpException()
+        {
+            var responseMessage = new ResponseMessage2
+            {
+                Message = "test",
+                ExceptionMessage = "test"
+            };
+
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider
                 .Setup(getCredential => getCredential.GetAuthorizationHeader())
@@ -90,17 +107,16 @@ namespace Microsoft.Azure.Devices.Tests
 
             using var mockHttpResponse = new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.OK,
-                Content = HttpMessageHelper.SerializePayload(scheduledJob),
+                StatusCode = HttpStatusCode.NotFound,
+                Content = HttpMessageHelper.SerializePayload(responseMessage),
             };
-            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
 
             var mockHttpClient = new Mock<HttpClient>();
             mockHttpClient
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var qureyClient = new QueryClient(
+            var queryClient = new Mock<QueryClient>(
                 HostName,
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
@@ -112,25 +128,10 @@ namespace Microsoft.Azure.Devices.Tests
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
                 mockHttpRequestFactory,
-                qureyClient,
+                queryClient.Object,
                 s_retryHandler);
 
             // act
-            Func<Task> act = async () => await scheduledJobsClient.GetAsync(null);
-
-            // assert
-            await act.Should().ThrowAsync<ArgumentNullException>();
-        }
-
-        [TestMethod]
-        public async Task ScheduledJobsClient_GetAsync_HttpException()
-        {
-            // arrange
-            using var serviceClient = new IotHubServiceClient(s_connectionString);
-            ScheduledJobsClient scheduledJobsClient = serviceClient.ScheduledJobs;
-
-            // act
-            // query from a Hub that does not exist
             Func<Task> act = async() => await scheduledJobsClient.GetAsync("foo");
 
             // assert
@@ -160,7 +161,7 @@ namespace Microsoft.Azure.Devices.Tests
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var qureyClient = new QueryClient(
+            var queryClient = new Mock<QueryClient>(
                 HostName,
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
@@ -172,7 +173,7 @@ namespace Microsoft.Azure.Devices.Tests
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
                 mockHttpRequestFactory,
-                qureyClient,
+                queryClient.Object,
                 s_retryHandler);
 
             // act
@@ -186,7 +187,25 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task ScheduledJobsClient_CancelAsync_NullParameterThrows()
         {
             // arrange
-            var scheduledJob = new ScheduledJob();
+            using var serviceClient = new IotHubServiceClient(s_connectionString);
+
+            // act
+            Func<Task> act = async () => await serviceClient.ScheduledJobs.CancelAsync(null);
+
+            // assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_CancelAsync_HttpException()
+        {
+            // arrange
+            var responseMessage = new ResponseMessage2
+            {
+                Message = "test",
+                ExceptionMessage = "test"
+            };
+
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider
                 .Setup(getCredential => getCredential.GetAuthorizationHeader())
@@ -195,17 +214,16 @@ namespace Microsoft.Azure.Devices.Tests
 
             using var mockHttpResponse = new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.OK,
-                Content = HttpMessageHelper.SerializePayload(scheduledJob),
+                StatusCode = HttpStatusCode.NotFound,
+                Content = HttpMessageHelper.SerializePayload(responseMessage),
             };
-            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
 
             var mockHttpClient = new Mock<HttpClient>();
             mockHttpClient
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var qureyClient = new QueryClient(
+            var queryClient = new Mock<QueryClient>(
                 HostName,
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
@@ -217,25 +235,10 @@ namespace Microsoft.Azure.Devices.Tests
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
                 mockHttpRequestFactory,
-                qureyClient,
+                queryClient.Object,
                 s_retryHandler);
 
             // act
-            Func<Task> act = async () => await scheduledJobsClient.CancelAsync(null);
-
-            // assert
-            await act.Should().ThrowAsync<ArgumentNullException>();
-        }
-
-        [TestMethod]
-        public async Task ScheduledJobsClient_CancelAsync_HttpException()
-        {
-            // arrange
-            using var serviceClient = new IotHubServiceClient(s_connectionString);
-            ScheduledJobsClient scheduledJobsClient = serviceClient.ScheduledJobs;
-
-            // act
-            // query from Hub that does not exist
             Func<Task> act = async() => await scheduledJobsClient.CancelAsync("foo");
 
             // assert
@@ -269,7 +272,7 @@ namespace Microsoft.Azure.Devices.Tests
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var qureyClient = new QueryClient(
+            var queryClient = new Mock<QueryClient>(
                 HostName,
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
@@ -281,7 +284,7 @@ namespace Microsoft.Azure.Devices.Tests
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
                 mockHttpRequestFactory,
-                qureyClient,
+                queryClient.Object,
                 s_retryHandler);
 
             // act
@@ -299,8 +302,28 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task ScheduledJobsClient_ScheduleDirectMethodAsync_NullParamterThrows()
         {
             // arrange
-            var scheduledJob = new ScheduledJob();
-            var scheduledJobsOptions = new ScheduledJobsOptions();
+            using var serviceClient = new IotHubServiceClient(s_connectionString);
+
+            // act
+            Func<Task> act = async () => await serviceClient.ScheduledJobs.ScheduleDirectMethodAsync(
+               null,
+               null,
+               new DateTimeOffset(DateTime.UtcNow),
+               new ScheduledJobsOptions());
+
+            // assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_ScheduleDirectMethodAsync_HttpException()
+        {
+            // arrange
+            var responseMessage = new ResponseMessage2
+            {
+                Message = "test",
+                ExceptionMessage = "test"
+            };
 
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider
@@ -310,17 +333,16 @@ namespace Microsoft.Azure.Devices.Tests
 
             using var mockHttpResponse = new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.OK,
-                Content = HttpMessageHelper.SerializePayload(scheduledJob),
+                StatusCode = HttpStatusCode.NotFound,
+                Content = HttpMessageHelper.SerializePayload(responseMessage),
             };
-            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
 
             var mockHttpClient = new Mock<HttpClient>();
             mockHttpClient
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var qureyClient = new QueryClient(
+            var queryClient = new Mock<QueryClient>(
                 HostName,
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
@@ -332,29 +354,10 @@ namespace Microsoft.Azure.Devices.Tests
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
                 mockHttpRequestFactory,
-                qureyClient,
+                queryClient.Object,
                 s_retryHandler);
 
             // act
-            Func<Task> act = async () => await scheduledJobsClient.ScheduleDirectMethodAsync(
-               null,
-               null,
-               new DateTimeOffset(DateTime.UtcNow),
-               scheduledJobsOptions);
-
-            // assert
-            await act.Should().ThrowAsync<ArgumentNullException>();
-        }
-
-        [TestMethod]
-        public async Task ScheduledJobsClient_ScheduleDirectMethodAsync_HttpException()
-        {
-            // arrange
-            using var serviceClient = new IotHubServiceClient(s_connectionString);
-            ScheduledJobsClient scheduledJobsClient = serviceClient.ScheduledJobs;
-
-            // act
-            // schedule method to Hub that does not exist
             Func<Task> act = async () => await scheduledJobsClient.ScheduleDirectMethodAsync(
                 "foo",
                 new DirectMethodServiceRequest("bar"),
@@ -389,7 +392,7 @@ namespace Microsoft.Azure.Devices.Tests
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var qureyClient = new QueryClient(
+            var queryClient = new Mock<QueryClient>(
                 HostName,
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
@@ -401,7 +404,7 @@ namespace Microsoft.Azure.Devices.Tests
                 mockCredentialProvider.Object,
                 mockHttpClient.Object,
                 mockHttpRequestFactory,
-                qureyClient,
+                queryClient.Object,
                 s_retryHandler);
 
             // act
@@ -418,43 +421,10 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task ScheduledJobsClient_ScheduleTwinUpdateAysnc_NullParamterThrows()
         {
             // arrange
-            var scheduledJob = new ScheduledJob();
-
-            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
-            mockCredentialProvider
-                .Setup(getCredential => getCredential.GetAuthorizationHeader())
-                .Returns(s_validMockAuthenticationHeaderValue);
-            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
-
-            using var mockHttpResponse = new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = HttpMessageHelper.SerializePayload(scheduledJob),
-            };
-            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
-
-            var mockHttpClient = new Mock<HttpClient>();
-            mockHttpClient
-                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(mockHttpResponse);
-
-            var qureyClient = new QueryClient(
-                HostName,
-                mockCredentialProvider.Object,
-                mockHttpClient.Object,
-                mockHttpRequestFactory,
-                s_retryHandler);
-
-            var scheduledJobsClient = new ScheduledJobsClient(
-                HostName,
-                mockCredentialProvider.Object,
-                mockHttpClient.Object,
-                mockHttpRequestFactory,
-                qureyClient,
-                s_retryHandler);
+            using var serviceClient = new IotHubServiceClient(s_connectionString);
 
             // act
-            Func<Task> act = async () => await scheduledJobsClient.ScheduleTwinUpdateAsync(
+            Func<Task> act = async () => await serviceClient.ScheduledJobs.ScheduleTwinUpdateAsync(
                 "foo",
                 null,
                 new DateTimeOffset(DateTime.UtcNow));
@@ -467,11 +437,45 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task ScheduledJobsClient_ScheduleTwinUpdateAysnc_HttpException()
         {
             // arrange
-            using var serviceClient = new IotHubServiceClient(s_connectionString);
-            ScheduledJobsClient scheduledJobsClient = serviceClient.ScheduledJobs;
+            var responseMessage = new ResponseMessage2
+            {
+                Message = "test",
+                ExceptionMessage = "test"
+            };
+
+            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
+            mockCredentialProvider
+                .Setup(getCredential => getCredential.GetAuthorizationHeader())
+                .Returns(s_validMockAuthenticationHeaderValue);
+            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
+
+            using var mockHttpResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.NotFound,
+                Content = HttpMessageHelper.SerializePayload(responseMessage),
+            };
+
+            var mockHttpClient = new Mock<HttpClient>();
+            mockHttpClient
+                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockHttpResponse);
+
+            var queryClient = new Mock<QueryClient>(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                s_retryHandler);
+
+            var scheduledJobsClient = new ScheduledJobsClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                queryClient.Object,
+                s_retryHandler);
 
             // act
-            // schedule twin update from Hub that doesn't exist
             Func<Task> act = async () => await scheduledJobsClient.ScheduleTwinUpdateAsync(
                 "foo",
                 new ClientTwin(),

--- a/iothub/service/tests/ScheduledJobsClientTests.cs
+++ b/iothub/service/tests/ScheduledJobsClientTests.cs
@@ -1,0 +1,484 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using FluentAssertions;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Azure.Devices.Tests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class ScheduledJobsClientTests
+    {
+        private const string HostName = "contoso.azure-devices.net";
+        private static readonly string s_validMockAuthenticationHeaderValue = $"SharedAccessSignature sr={HostName}&sig=thisIsFake&se=000000&skn=registryRead";
+        private static readonly string s_connectionString = $"HostName={HostName};SharedAccessKeyName=iothubowner;SharedAccessKey=dGVzdFN0cmluZzE=";
+
+        private static readonly Uri s_httpUri = new($"https://{HostName}");
+        private static readonly RetryHandler s_retryHandler = new(new IotHubServiceNoRetry());
+        private static IotHubServiceClientOptions s_options = new()
+        {
+            Protocol = IotHubTransportProtocol.Tcp,
+            RetryPolicy = new IotHubServiceNoRetry()
+        };
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_GetAsync()
+        {
+            // arrange
+            var scheduledJob = new ScheduledJob();
+            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
+            mockCredentialProvider
+                .Setup(getCredential => getCredential.GetAuthorizationHeader())
+                .Returns(s_validMockAuthenticationHeaderValue);
+            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
+
+            using var mockHttpResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = HttpMessageHelper.SerializePayload(scheduledJob),
+            };
+            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
+
+            var mockHttpClient = new Mock<HttpClient>();
+            mockHttpClient
+                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockHttpResponse);
+
+            var qureyClient = new QueryClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                s_retryHandler);
+
+            var scheduledJobsClient = new ScheduledJobsClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                qureyClient,
+                s_retryHandler);
+
+            // act
+            Func<Task> act = async () => await scheduledJobsClient.GetAsync("foo");
+
+            // assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_GetAsync_NullArgumentThrows()
+        {
+            // arrange
+            var scheduledJob = new ScheduledJob();
+            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
+            mockCredentialProvider
+                .Setup(getCredential => getCredential.GetAuthorizationHeader())
+                .Returns(s_validMockAuthenticationHeaderValue);
+            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
+
+            using var mockHttpResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = HttpMessageHelper.SerializePayload(scheduledJob),
+            };
+            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
+
+            var mockHttpClient = new Mock<HttpClient>();
+            mockHttpClient
+                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockHttpResponse);
+
+            var qureyClient = new QueryClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                s_retryHandler);
+
+            var scheduledJobsClient = new ScheduledJobsClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                qureyClient,
+                s_retryHandler);
+
+            // act
+            Func<Task> act = async () => await scheduledJobsClient.GetAsync(null);
+
+            // assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_GetAsync_HttpException()
+        {
+            // arrange
+            using var serviceClient = new IotHubServiceClient(s_connectionString);
+            ScheduledJobsClient scheduledJobsClient = serviceClient.ScheduledJobs;
+
+            // act
+            // query from a Hub that does not exist
+            Func<Task> act = async() => await scheduledJobsClient.GetAsync("foo");
+
+            // assert
+            await act.Should().ThrowAsync<IotHubServiceException>();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_CancelAsync()
+        {
+            // arrange
+            var scheduledJob = new ScheduledJob();
+            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
+            mockCredentialProvider
+                .Setup(getCredential => getCredential.GetAuthorizationHeader())
+                .Returns(s_validMockAuthenticationHeaderValue);
+            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
+
+            using var mockHttpResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = HttpMessageHelper.SerializePayload(scheduledJob),
+            };
+            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
+
+            var mockHttpClient = new Mock<HttpClient>();
+            mockHttpClient
+                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockHttpResponse);
+
+            var qureyClient = new QueryClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                s_retryHandler);
+
+            var scheduledJobsClient = new ScheduledJobsClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                qureyClient,
+                s_retryHandler);
+
+            // act
+            Func<Task> act = async () => await scheduledJobsClient.CancelAsync("foo");
+
+            // assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_CancelAsync_NullParameterThrows()
+        {
+            // arrange
+            var scheduledJob = new ScheduledJob();
+            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
+            mockCredentialProvider
+                .Setup(getCredential => getCredential.GetAuthorizationHeader())
+                .Returns(s_validMockAuthenticationHeaderValue);
+            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
+
+            using var mockHttpResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = HttpMessageHelper.SerializePayload(scheduledJob),
+            };
+            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
+
+            var mockHttpClient = new Mock<HttpClient>();
+            mockHttpClient
+                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockHttpResponse);
+
+            var qureyClient = new QueryClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                s_retryHandler);
+
+            var scheduledJobsClient = new ScheduledJobsClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                qureyClient,
+                s_retryHandler);
+
+            // act
+            Func<Task> act = async () => await scheduledJobsClient.CancelAsync(null);
+
+            // assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_CancelAsync_HttpException()
+        {
+            // arrange
+            using var serviceClient = new IotHubServiceClient(s_connectionString);
+            ScheduledJobsClient scheduledJobsClient = serviceClient.ScheduledJobs;
+
+            // act
+            // query from Hub that does not exist
+            Func<Task> act = async() => await scheduledJobsClient.CancelAsync("foo");
+
+            // assert
+            await act.Should().ThrowAsync<IotHubServiceException>();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_ScheduleDirectMethodAsync()
+        {
+            // arrange
+            var scheduledJob = new ScheduledJob();
+            var directMethodRequest = new DirectMethodServiceRequest("foo");
+            var startTime = new DateTimeOffset();
+            var scheduledJobsOptions = new ScheduledJobsOptions();
+
+            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
+            mockCredentialProvider
+                .Setup(getCredential => getCredential.GetAuthorizationHeader())
+                .Returns(s_validMockAuthenticationHeaderValue);
+            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
+
+            using var mockHttpResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = HttpMessageHelper.SerializePayload(scheduledJob),
+            };
+            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
+
+            var mockHttpClient = new Mock<HttpClient>();
+            mockHttpClient
+                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockHttpResponse);
+
+            var qureyClient = new QueryClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                s_retryHandler);
+
+            var scheduledJobsClient = new ScheduledJobsClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                qureyClient,
+                s_retryHandler);
+
+            // act
+            Func<Task> act = async () => await scheduledJobsClient.ScheduleDirectMethodAsync(
+                "foo",
+                directMethodRequest, 
+               startTime,
+               scheduledJobsOptions);
+
+            // assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_ScheduleDirectMethodAsync_NullParamterThrows()
+        {
+            // arrange
+            var scheduledJob = new ScheduledJob();
+            var scheduledJobsOptions = new ScheduledJobsOptions();
+
+            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
+            mockCredentialProvider
+                .Setup(getCredential => getCredential.GetAuthorizationHeader())
+                .Returns(s_validMockAuthenticationHeaderValue);
+            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
+
+            using var mockHttpResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = HttpMessageHelper.SerializePayload(scheduledJob),
+            };
+            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
+
+            var mockHttpClient = new Mock<HttpClient>();
+            mockHttpClient
+                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockHttpResponse);
+
+            var qureyClient = new QueryClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                s_retryHandler);
+
+            var scheduledJobsClient = new ScheduledJobsClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                qureyClient,
+                s_retryHandler);
+
+            // act
+            Func<Task> act = async () => await scheduledJobsClient.ScheduleDirectMethodAsync(
+               null,
+               null,
+               new DateTimeOffset(DateTime.UtcNow),
+               scheduledJobsOptions);
+
+            // assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_ScheduleDirectMethodAsync_HttpException()
+        {
+            // arrange
+            using var serviceClient = new IotHubServiceClient(s_connectionString);
+            ScheduledJobsClient scheduledJobsClient = serviceClient.ScheduledJobs;
+
+            // act
+            // schedule method to Hub that does not exist
+            Func<Task> act = async () => await scheduledJobsClient.ScheduleDirectMethodAsync(
+                "foo",
+                new DirectMethodServiceRequest("bar"),
+                new DateTimeOffset(DateTime.UtcNow),
+                new ScheduledJobsOptions());
+
+            // assert
+            await act.Should().ThrowAsync<IotHubServiceException>();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_ScheduleTwinUpdateAsync()
+        {
+            // arrange
+            var scheduledJob = new ScheduledJob();
+
+            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
+            mockCredentialProvider
+                .Setup(getCredential => getCredential.GetAuthorizationHeader())
+                .Returns(s_validMockAuthenticationHeaderValue);
+            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
+
+            using var mockHttpResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = HttpMessageHelper.SerializePayload(scheduledJob),
+            };
+            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
+
+            var mockHttpClient = new Mock<HttpClient>();
+            mockHttpClient
+                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockHttpResponse);
+
+            var qureyClient = new QueryClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                s_retryHandler);
+
+            var scheduledJobsClient = new ScheduledJobsClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                qureyClient,
+                s_retryHandler);
+
+            // act
+            Func<Task> act = async () => await scheduledJobsClient.ScheduleTwinUpdateAsync(
+                "foo",
+                new ClientTwin(),
+                new DateTimeOffset(DateTime.UtcNow));
+
+            // assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_ScheduleTwinUpdateAysnc_NullParamterThrows()
+        {
+            // arrange
+            var scheduledJob = new ScheduledJob();
+
+            var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
+            mockCredentialProvider
+                .Setup(getCredential => getCredential.GetAuthorizationHeader())
+                .Returns(s_validMockAuthenticationHeaderValue);
+            var mockHttpRequestFactory = new HttpRequestMessageFactory(s_httpUri, "");
+
+            using var mockHttpResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = HttpMessageHelper.SerializePayload(scheduledJob),
+            };
+            mockHttpResponse.Headers.Add("ETag", "\"AAAAAAAAAAE=\"");
+
+            var mockHttpClient = new Mock<HttpClient>();
+            mockHttpClient
+                .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockHttpResponse);
+
+            var qureyClient = new QueryClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                s_retryHandler);
+
+            var scheduledJobsClient = new ScheduledJobsClient(
+                HostName,
+                mockCredentialProvider.Object,
+                mockHttpClient.Object,
+                mockHttpRequestFactory,
+                qureyClient,
+                s_retryHandler);
+
+            // act
+            Func<Task> act = async () => await scheduledJobsClient.ScheduleTwinUpdateAsync(
+                "foo",
+                null,
+                new DateTimeOffset(DateTime.UtcNow));
+
+            // assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public async Task ScheduledJobsClient_ScheduleTwinUpdateAysnc_HttpException()
+        {
+            // arrange
+            using var serviceClient = new IotHubServiceClient(s_connectionString);
+            ScheduledJobsClient scheduledJobsClient = serviceClient.ScheduledJobs;
+
+            // act
+            // schedule twin update from Hub that doesn't exist
+            Func<Task> act = async () => await scheduledJobsClient.ScheduleTwinUpdateAsync(
+                "foo",
+                new ClientTwin(),
+                new DateTimeOffset(DateTime.UtcNow));
+
+            // assert
+            await act.Should().ThrowAsync<IotHubServiceException>();
+        }
+    }
+}

--- a/iothub/service/tests/ScheduledJobsClientTests.cs
+++ b/iothub/service/tests/ScheduledJobsClientTests.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Azure.Devices.Tests
         private static readonly string s_connectionString = $"HostName={HostName};SharedAccessKeyName=iothubowner;SharedAccessKey=dGVzdFN0cmluZzE=";
         private static readonly string s_toSelect = "Devices";
         private static readonly string s_jobId = "foo";
+        private static readonly string s_deviceId = "bar";
+        private static readonly TimeSpan s_jobTimeSpan = new(10);
 
         private static readonly Uri s_httpUri = new($"https://{HostName}");
         private static readonly RetryHandler s_retryHandler = new(new IotHubServiceNoRetry());
@@ -40,7 +42,9 @@ namespace Microsoft.Azure.Devices.Tests
             // arrange
             var scheduledJob = new ScheduledJob
             {
-                JobId = s_jobId
+                JobId = s_jobId,
+                DeviceId = s_deviceId,
+                MaxExecutionTime = s_jobTimeSpan,
             };
 
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
@@ -76,6 +80,8 @@ namespace Microsoft.Azure.Devices.Tests
 
             // assert
             jobResponse.JobId.Should().Be(s_jobId);
+            jobResponse.DeviceId.Should().Be(s_deviceId);
+            jobResponse.MaxExecutionTimeInSeconds.Should().Be(s_jobTimeSpan.Seconds);
         }
 
         [TestMethod]
@@ -92,7 +98,7 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task ScheduledJobsClient_GetAsync_IotHubNotFound_ThrowsIotHubServiceException()
+        public async Task ScheduledJobsClient_GetAsync_JobNotFound_ThrowsIotHubServiceException()
         {
             var responseMessage = new ResponseMessage2
             {
@@ -131,7 +137,9 @@ namespace Microsoft.Azure.Devices.Tests
             Func<Task> act = async() => await scheduledJobsClient.GetAsync("foo");
 
             // assert
-            await act.Should().ThrowAsync<IotHubServiceException>();
+            var error = await act.Should().ThrowAsync<IotHubServiceException>();
+            error.And.IsTransient.Should().BeFalse();
+            error.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
 
         [TestMethod]
@@ -140,7 +148,9 @@ namespace Microsoft.Azure.Devices.Tests
             // arrange
             var scheduledJob = new ScheduledJob
             {
-                JobId = s_jobId
+                JobId = s_jobId,
+                DeviceId = s_deviceId,
+                MaxExecutionTime = s_jobTimeSpan,
             };
 
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
@@ -176,6 +186,8 @@ namespace Microsoft.Azure.Devices.Tests
 
             // assert
             jobResponse.JobId.Should().Be(s_jobId);
+            jobResponse.DeviceId.Should().Be(s_deviceId);
+            jobResponse.MaxExecutionTimeInSeconds.Should().Be(s_jobTimeSpan.Seconds);
         }
 
         [TestMethod]
@@ -192,7 +204,7 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task ScheduledJobsClient_CancelAsync_IotHubNotFound_ThrowsIotHubServiceException()
+        public async Task ScheduledJobsClient_CancelAsync_JobNotFound_ThrowsIotHubServiceException()
         {
             // arrange
             var responseMessage = new ResponseMessage2
@@ -232,7 +244,9 @@ namespace Microsoft.Azure.Devices.Tests
             Func<Task> act = async() => await scheduledJobsClient.CancelAsync("foo");
 
             // assert
-            await act.Should().ThrowAsync<IotHubServiceException>();
+            var error = await act.Should().ThrowAsync<IotHubServiceException>();
+            error.And.IsTransient.Should().BeFalse();
+            error.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
 
         [TestMethod]
@@ -241,8 +255,11 @@ namespace Microsoft.Azure.Devices.Tests
             // arrange
             var scheduledJob = new ScheduledJob
             {
-                JobId = s_jobId 
+                JobId = s_jobId,
+                DeviceId = s_deviceId,
+                MaxExecutionTime = s_jobTimeSpan,
             };
+
             var directMethodRequest = new DirectMethodServiceRequest("foo");
             var startTime = new DateTimeOffset();
             var scheduledJobsOptions = new ScheduledJobsOptions();
@@ -284,6 +301,8 @@ namespace Microsoft.Azure.Devices.Tests
 
             // assert
             returnedJob.JobId.Should().Be(s_jobId);
+            returnedJob.DeviceId.Should().Be(s_deviceId);
+            returnedJob.MaxExecutionTimeInSeconds.Should().Be(s_jobTimeSpan.Seconds);
         }
 
         [TestMethod]
@@ -304,7 +323,7 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task ScheduledJobsClient_ScheduleDirectMethodAsync_IotHubNotFound_ThrowsIotHubServiceException()
+        public async Task ScheduledJobsClient_ScheduleDirectMethodAsync_JobNotFound_ThrowsIotHubServiceException()
         {
             // arrange
             var responseMessage = new ResponseMessage2
@@ -348,7 +367,9 @@ namespace Microsoft.Azure.Devices.Tests
                 new ScheduledJobsOptions());
 
             // assert
-            await act.Should().ThrowAsync<IotHubServiceException>();
+            var error = await act.Should().ThrowAsync<IotHubServiceException>();
+            error.And.IsTransient.Should().BeFalse();
+            error.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
 
         [TestMethod]
@@ -357,7 +378,9 @@ namespace Microsoft.Azure.Devices.Tests
             // arrange
             var scheduledJob = new ScheduledJob
             {
-                JobId = s_jobId
+                JobId = s_jobId,
+                DeviceId = s_deviceId,
+                MaxExecutionTime = s_jobTimeSpan,
             };
 
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
@@ -396,6 +419,8 @@ namespace Microsoft.Azure.Devices.Tests
 
             // assert
             jobResponse.JobId.Should().Be(s_jobId);
+            jobResponse.DeviceId.Should().Be(s_deviceId);
+            jobResponse.MaxExecutionTimeInSeconds.Should().Be(s_jobTimeSpan.Seconds);
         }
 
         [TestMethod]
@@ -415,7 +440,7 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task ScheduledJobsClient_ScheduleTwinUpdateAysnc_IotHubNotFound_ThrowsIotHubServiceException()
+        public async Task ScheduledJobsClient_ScheduleTwinUpdateAysnc_JobNotFound_ThrowsIotHubServiceException()
         {
             // arrange
             var responseMessage = new ResponseMessage2
@@ -458,7 +483,9 @@ namespace Microsoft.Azure.Devices.Tests
                 new DateTimeOffset(DateTime.UtcNow));
 
             // assert
-            await act.Should().ThrowAsync<IotHubServiceException>();
+            var error = await act.Should().ThrowAsync<IotHubServiceException>();
+            error.And.IsTransient.Should().BeFalse();
+            error.And.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
     }
 }

--- a/iothub/service/tests/ScheduledJobsClientTests.cs
+++ b/iothub/service/tests/ScheduledJobsClientTests.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Azure.Devices.Tests
         private const string HostName = "contoso.azure-devices.net";
         private static readonly string s_validMockAuthenticationHeaderValue = $"SharedAccessSignature sr={HostName}&sig=thisIsFake&se=000000&skn=registryRead";
         private static readonly string s_connectionString = $"HostName={HostName};SharedAccessKeyName=iothubowner;SharedAccessKey=dGVzdFN0cmluZzE=";
+        private static readonly string s_toSelect = "Devices";
+        private static readonly string s_jobId = "foo";
 
         private static readonly Uri s_httpUri = new($"https://{HostName}");
         private static readonly RetryHandler s_retryHandler = new(new IotHubServiceNoRetry());
@@ -38,7 +40,7 @@ namespace Microsoft.Azure.Devices.Tests
             // arrange
             var scheduledJob = new ScheduledJob
             {
-                JobId = "foo"
+                JobId = s_jobId
             };
 
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
@@ -70,10 +72,10 @@ namespace Microsoft.Azure.Devices.Tests
                 s_retryHandler);
 
             // act
-            Func<Task> act = async () => await scheduledJobsClient.GetAsync("foo");
+            ScheduledJob jobResponse = await scheduledJobsClient.GetAsync(s_jobId);
 
             // assert
-            await act.Should().NotThrowAsync();
+            jobResponse.JobId.Should().Be(s_jobId);
         }
 
         [TestMethod]
@@ -138,7 +140,7 @@ namespace Microsoft.Azure.Devices.Tests
             // arrange
             var scheduledJob = new ScheduledJob
             {
-                JobId = "foo"
+                JobId = s_jobId
             };
 
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
@@ -170,10 +172,10 @@ namespace Microsoft.Azure.Devices.Tests
                 s_retryHandler);
 
             // act
-            Func<Task> act = async () => await scheduledJobsClient.CancelAsync("foo");
+            ScheduledJob jobResponse = await scheduledJobsClient.CancelAsync("foo");
 
             // assert
-            await act.Should().NotThrowAsync();
+            jobResponse.JobId.Should().Be(s_jobId);
         }
 
         [TestMethod]
@@ -239,7 +241,7 @@ namespace Microsoft.Azure.Devices.Tests
             // arrange
             var scheduledJob = new ScheduledJob
             {
-                JobId = "foo" 
+                JobId = s_jobId 
             };
             var directMethodRequest = new DirectMethodServiceRequest("foo");
             var startTime = new DateTimeOffset();
@@ -274,14 +276,14 @@ namespace Microsoft.Azure.Devices.Tests
                 s_retryHandler);
 
             // act
-            Func<Task> act = async () => await scheduledJobsClient.ScheduleDirectMethodAsync(
-                "foo",
-                directMethodRequest, 
+            ScheduledJob returnedJob = await scheduledJobsClient.ScheduleDirectMethodAsync(
+                $"SELECT * FROM {s_toSelect}",
+                directMethodRequest,
                 startTime,
                 scheduledJobsOptions);
 
             // assert
-            await act.Should().NotThrowAsync();
+            returnedJob.JobId.Should().Be(s_jobId);
         }
 
         [TestMethod]
@@ -340,7 +342,7 @@ namespace Microsoft.Azure.Devices.Tests
 
             // act
             Func<Task> act = async () => await scheduledJobsClient.ScheduleDirectMethodAsync(
-                "foo",
+                $"SELECT * FROM {s_toSelect}",
                 new DirectMethodServiceRequest("bar"),
                 new DateTimeOffset(DateTime.UtcNow),
                 new ScheduledJobsOptions());
@@ -355,7 +357,7 @@ namespace Microsoft.Azure.Devices.Tests
             // arrange
             var scheduledJob = new ScheduledJob
             {
-                JobId = "foo"
+                JobId = s_jobId
             };
 
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
@@ -387,13 +389,13 @@ namespace Microsoft.Azure.Devices.Tests
                 s_retryHandler);
 
             // act
-            Func<Task> act = async () => await scheduledJobsClient.ScheduleTwinUpdateAsync(
-                "foo",
+            ScheduledJob jobResponse = await scheduledJobsClient.ScheduleTwinUpdateAsync(
+                $"SELECT * FROM {s_toSelect}",
                 new ClientTwin(),
                 new DateTimeOffset(DateTime.UtcNow));
 
             // assert
-            await act.Should().NotThrowAsync();
+            jobResponse.JobId.Should().Be(s_jobId);
         }
 
         [TestMethod]
@@ -404,7 +406,7 @@ namespace Microsoft.Azure.Devices.Tests
 
             // act
             Func<Task> act = async () => await serviceClient.ScheduledJobs.ScheduleTwinUpdateAsync(
-                "foo",
+                $"SELECT * FROM {s_toSelect}",
                 null,
                 new DateTimeOffset(DateTime.UtcNow));
 
@@ -451,7 +453,7 @@ namespace Microsoft.Azure.Devices.Tests
 
             // act
             Func<Task> act = async () => await scheduledJobsClient.ScheduleTwinUpdateAsync(
-                "foo",
+                $"SELECT * FROM {s_toSelect}",
                 new ClientTwin(),
                 new DateTimeOffset(DateTime.UtcNow));
 

--- a/iothub/service/tests/ScheduledJobsClientTests.cs
+++ b/iothub/service/tests/ScheduledJobsClientTests.cs
@@ -36,7 +36,11 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task ScheduledJobsClient_GetAsync()
         {
             // arrange
-            var scheduledJob = new ScheduledJob();
+            var scheduledJob = new ScheduledJob
+            {
+                JobId = "foo"
+            };
+
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider
                 .Setup(getCredential => getCredential.GetAuthorizationHeader())
@@ -132,7 +136,11 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task ScheduledJobsClient_CancelAsync()
         {
             // arrange
-            var scheduledJob = new ScheduledJob();
+            var scheduledJob = new ScheduledJob
+            {
+                JobId = "foo"
+            };
+
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider
                 .Setup(getCredential => getCredential.GetAuthorizationHeader())
@@ -229,7 +237,10 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task ScheduledJobsClient_ScheduleDirectMethodAsync()
         {
             // arrange
-            var scheduledJob = new ScheduledJob();
+            var scheduledJob = new ScheduledJob
+            {
+                JobId = "foo" 
+            };
             var directMethodRequest = new DirectMethodServiceRequest("foo");
             var startTime = new DateTimeOffset();
             var scheduledJobsOptions = new ScheduledJobsOptions();
@@ -266,8 +277,8 @@ namespace Microsoft.Azure.Devices.Tests
             Func<Task> act = async () => await scheduledJobsClient.ScheduleDirectMethodAsync(
                 "foo",
                 directMethodRequest, 
-               startTime,
-               scheduledJobsOptions);
+                startTime,
+                scheduledJobsOptions);
 
             // assert
             await act.Should().NotThrowAsync();
@@ -342,7 +353,10 @@ namespace Microsoft.Azure.Devices.Tests
         public async Task ScheduledJobsClient_ScheduleTwinUpdateAsync()
         {
             // arrange
-            var scheduledJob = new ScheduledJob();
+            var scheduledJob = new ScheduledJob
+            {
+                JobId = "foo"
+            };
 
             var mockCredentialProvider = new Mock<IotHubConnectionProperties>();
             mockCredentialProvider

--- a/iothub/service/tests/ScheduledJobsClientTests.cs
+++ b/iothub/service/tests/ScheduledJobsClientTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task ScheduledJobsClient_GetAsync_HttpException()
+        public async Task ScheduledJobsClient_GetAsync_IotHubNotFound_ThrowsIotHubServiceException()
         {
             var responseMessage = new ResponseMessage2
             {
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task ScheduledJobsClient_CancelAsync_HttpException()
+        public async Task ScheduledJobsClient_CancelAsync_IotHubNotFound_ThrowsIotHubServiceException()
         {
             // arrange
             var responseMessage = new ResponseMessage2
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task ScheduledJobsClient_ScheduleDirectMethodAsync_HttpException()
+        public async Task ScheduledJobsClient_ScheduleDirectMethodAsync_IotHubNotFound_ThrowsIotHubServiceException()
         {
             // arrange
             var responseMessage = new ResponseMessage2
@@ -415,7 +415,7 @@ namespace Microsoft.Azure.Devices.Tests
         }
 
         [TestMethod]
-        public async Task ScheduledJobsClient_ScheduleTwinUpdateAysnc_HttpException()
+        public async Task ScheduledJobsClient_ScheduleTwinUpdateAysnc_IotHubNotFound_ThrowsIotHubServiceException()
         {
             // arrange
             var responseMessage = new ResponseMessage2

--- a/iothub/service/tests/ScheduledJobsClientTests.cs
+++ b/iothub/service/tests/ScheduledJobsClientTests.cs
@@ -55,12 +55,7 @@ namespace Microsoft.Azure.Devices.Tests
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var queryClient = new Mock<QueryClient>(
-                HostName,
-                mockCredentialProvider.Object,
-                mockHttpClient.Object,
-                mockHttpRequestFactory,
-                s_retryHandler);
+            var queryClient = new Mock<QueryClient>();
 
             var scheduledJobsClient = new ScheduledJobsClient(
                 HostName,
@@ -116,12 +111,7 @@ namespace Microsoft.Azure.Devices.Tests
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var queryClient = new Mock<QueryClient>(
-                HostName,
-                mockCredentialProvider.Object,
-                mockHttpClient.Object,
-                mockHttpRequestFactory,
-                s_retryHandler);
+            var queryClient = new Mock<QueryClient>();
 
             var scheduledJobsClient = new ScheduledJobsClient(
                 HostName,
@@ -161,12 +151,7 @@ namespace Microsoft.Azure.Devices.Tests
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var queryClient = new Mock<QueryClient>(
-                HostName,
-                mockCredentialProvider.Object,
-                mockHttpClient.Object,
-                mockHttpRequestFactory,
-                s_retryHandler);
+            var queryClient = new Mock<QueryClient>();
 
             var scheduledJobsClient = new ScheduledJobsClient(
                 HostName,
@@ -223,12 +208,7 @@ namespace Microsoft.Azure.Devices.Tests
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var queryClient = new Mock<QueryClient>(
-                HostName,
-                mockCredentialProvider.Object,
-                mockHttpClient.Object,
-                mockHttpRequestFactory,
-                s_retryHandler);
+            var queryClient = new Mock<QueryClient>();
 
             var scheduledJobsClient = new ScheduledJobsClient(
                 HostName,
@@ -272,12 +252,7 @@ namespace Microsoft.Azure.Devices.Tests
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var queryClient = new Mock<QueryClient>(
-                HostName,
-                mockCredentialProvider.Object,
-                mockHttpClient.Object,
-                mockHttpRequestFactory,
-                s_retryHandler);
+            var queryClient = new Mock<QueryClient>();
 
             var scheduledJobsClient = new ScheduledJobsClient(
                 HostName,
@@ -342,12 +317,7 @@ namespace Microsoft.Azure.Devices.Tests
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var queryClient = new Mock<QueryClient>(
-                HostName,
-                mockCredentialProvider.Object,
-                mockHttpClient.Object,
-                mockHttpRequestFactory,
-                s_retryHandler);
+            var queryClient = new Mock<QueryClient>();
 
             var scheduledJobsClient = new ScheduledJobsClient(
                 HostName,
@@ -392,12 +362,7 @@ namespace Microsoft.Azure.Devices.Tests
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var queryClient = new Mock<QueryClient>(
-                HostName,
-                mockCredentialProvider.Object,
-                mockHttpClient.Object,
-                mockHttpRequestFactory,
-                s_retryHandler);
+            var queryClient = new Mock<QueryClient>();
 
             var scheduledJobsClient = new ScheduledJobsClient(
                 HostName,
@@ -460,12 +425,7 @@ namespace Microsoft.Azure.Devices.Tests
                 .Setup(restOp => restOp.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockHttpResponse);
 
-            var queryClient = new Mock<QueryClient>(
-                HostName,
-                mockCredentialProvider.Object,
-                mockHttpClient.Object,
-                mockHttpRequestFactory,
-                s_retryHandler);
+            var queryClient = new Mock<QueryClient>();
 
             var scheduledJobsClient = new ScheduledJobsClient(
                 HostName,


### PR DESCRIPTION
DigitalTwinsClient: 0% => 80%
QueryClient: 0 => 73%
ScheduledJobsClient: 0 => 67%

Remaining lines to be covered are either logging or partially covered and not included in total count.