### PR TITLE
Make CertificateInstaller unit testable by turning X509Store into an injectable dependency

### DIFF
--- a/provisioning/device/src/Utilities/CertificateInstaller.cs
+++ b/provisioning/device/src/Utilities/CertificateInstaller.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
+using Microsoft.Azure.Devices.Provisioning.Client.Utilities;
 
 namespace Microsoft.Azure.Devices.Provisioning.Client
 {
@@ -20,7 +21,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// for more information.
         /// </remarks>
         /// <param name="certificates">The certificate chain to ensure is installed.</param>
-        public static void EnsureChainIsInstalled(X509Certificate2Collection certificates)
+        /// <param name="certStore">For unit testing to allow for mocking.</param>
+        internal static void EnsureChainIsInstalled(
+            X509Certificate2Collection certificates,
+            ICertificiateStore certStore = default)
         {
             if (certificates == null
                 || certificates.Count == 0)
@@ -31,27 +35,25 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                 return;
             }
 
+
             // Certificate install on Windows is a multi-step process, and in the case that someone might have more than one
             // DPS client we'll want to ensure these actions (get certs, install certs) are atomic.
             lock (s_certOperationsLock)
             {
                 try
                 {
-                    using var store = new X509Store(StoreName.CertificateAuthority, StoreLocation.CurrentUser);
-                    store.Open(OpenFlags.ReadWrite);
+#pragma warning disable CA2000 // Disposed in finally block
+                    certStore ??= new X509CertificateStore();
+#pragma warning restore CA2000
 
                     foreach (X509Certificate2 certificate in certificates)
                     {
-                        X509Certificate2Collection results = store.Certificates.Find(
-                            X509FindType.FindByThumbprint,
-                            certificate.Thumbprint,
-                            false);
-                        if (results.Count == 0)
+                        if (!certStore.Find(certificate))
                         {
+                            certStore.Add(certificate);
+
                             if (Logging.IsEnabled)
                                 Logging.Info(null, $"{nameof(CertificateInstaller)} adding cert with thumbprint {certificate.Thumbprint} to X509 store.");
-
-                            store.Add(certificate);
                         }
                     }
                 }
@@ -59,6 +61,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
                 {
                     if (Logging.IsEnabled)
                         Logging.Error(null, $"{nameof(CertificateInstaller)} failed to read or write to cert store due to: {ex}");
+                }
+                finally
+                {
+                    if (certStore is IDisposable disposableCertStore)
+                    {
+                        disposableCertStore.Dispose();
+                    }
                 }
             }
         }

--- a/provisioning/device/src/Utilities/ICertficiateStore.cs
+++ b/provisioning/device/src/Utilities/ICertficiateStore.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace Microsoft.Azure.Devices.Provisioning.Client.Utilities
+{
+    internal interface ICertificiateStore
+    {
+        internal bool Find(X509Certificate2 certificate);
+        internal void Add(X509Certificate2 certificate);
+    }
+}

--- a/provisioning/device/src/Utilities/X509CertificateStore.cs
+++ b/provisioning/device/src/Utilities/X509CertificateStore.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Microsoft.Azure.Devices.Provisioning.Client.Utilities
+{
+    internal class X509CertificateStore : ICertificiateStore, IDisposable
+    {
+        private readonly X509Store _store;
+
+        public X509CertificateStore()
+        {
+            _store = new X509Store(StoreName.CertificateAuthority, StoreLocation.CurrentUser);
+            _store.Open(OpenFlags.ReadWrite);
+        }
+
+        bool ICertificiateStore.Find(X509Certificate2 certificate)
+        {
+            X509Certificate2Collection results = _store.Certificates.Find(
+                X509FindType.FindByThumbprint,
+                certificate.Thumbprint,
+                false);
+            return results.Count > 0;
+        }
+
+        void ICertificiateStore.Add(X509Certificate2 certificate)
+        {
+            _store.Add(certificate);
+        }
+
+        public void Dispose()
+        {
+            _store?.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
In a 1:1 with Nate talking about how to unit test some methods that seem hard, this is an example of dependency injection.