### PR TITLE
Fix bug in date deserialization of device method response 

### DIFF
--- a/common/src/service/HttpClientHelper.cs
+++ b/common/src/service/HttpClientHelper.cs
@@ -307,12 +307,14 @@ namespace Microsoft.Azure.Devices
                 return (T)(object)message;
             }
 
-#if NET451
-            T entity = await message.Content.ReadAsAsync<T>(token).ConfigureAwait(false);
-#else
+            /*#if NET451
+                        T entity = await message.Content.ReadAsAsync<T>(token).ConfigureAwait(false);
+            #else
+                        string str = await message.Content.ReadHttpContentAsStringAsync(token).ConfigureAwait(false);
+                        T entity = JsonConvert.DeserializeObject<T>(str);
+            #endif*/
             string str = await message.Content.ReadHttpContentAsStringAsync(token).ConfigureAwait(false);
             T entity = JsonConvert.DeserializeObject<T>(str, new JsonSerializerSettings { DateParseHandling = DateParseHandling.None });
-#endif
 
             // Etag in the header is considered authoritative
             var eTagHolder = entity as IETagHolder;

--- a/common/src/service/HttpClientHelper.cs
+++ b/common/src/service/HttpClientHelper.cs
@@ -48,6 +48,8 @@ namespace Microsoft.Azure.Devices
             _defaultErrorMapping = defaultErrorMapping;
             _defaultOperationTimeout = timeout;
 
+            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetJsonSerializerSettingsDelegate();
+
             // We need two types of HttpClients, one with our default operation timeout, and one without. The one without will rely on
             // a cancellation token.
 
@@ -308,7 +310,7 @@ namespace Microsoft.Azure.Devices
             }
 
             string str = await message.Content.ReadHttpContentAsStringAsync(token).ConfigureAwait(false);
-            T entity = JsonConvert.DeserializeObject<T>(str, new JsonSerializerSettings { DateParseHandling = DateParseHandling.None });
+            T entity = JsonConvert.DeserializeObject<T>(str);
 
             // Etag in the header is considered authoritative
             var eTagHolder = entity as IETagHolder;

--- a/common/src/service/HttpClientHelper.cs
+++ b/common/src/service/HttpClientHelper.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Devices
             T entity = await message.Content.ReadAsAsync<T>(token).ConfigureAwait(false);
 #else
             string str = await message.Content.ReadHttpContentAsStringAsync(token).ConfigureAwait(false);
-            T entity = JsonConvert.DeserializeObject<T>(str);
+            T entity = JsonConvert.DeserializeObject<T>(str, new JsonSerializerSettings { DateParseHandling = DateParseHandling.None });
 #endif
 
             // Etag in the header is considered authoritative

--- a/common/src/service/HttpClientHelper.cs
+++ b/common/src/service/HttpClientHelper.cs
@@ -307,12 +307,6 @@ namespace Microsoft.Azure.Devices
                 return (T)(object)message;
             }
 
-            /*#if NET451
-                        T entity = await message.Content.ReadAsAsync<T>(token).ConfigureAwait(false);
-            #else
-                        string str = await message.Content.ReadHttpContentAsStringAsync(token).ConfigureAwait(false);
-                        T entity = JsonConvert.DeserializeObject<T>(str);
-            #endif*/
             string str = await message.Content.ReadHttpContentAsStringAsync(token).ConfigureAwait(false);
             T entity = JsonConvert.DeserializeObject<T>(str, new JsonSerializerSettings { DateParseHandling = DateParseHandling.None });
 

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
 
             var date = new DateTimeOffset(638107582284599400, TimeSpan.FromHours(1));
 
-            string responseJson = JsonConvert.SerializeObject(new DateTime { Iso8601String = date.ToString("o", CultureInfo.InvariantCulture) });
+            string responseJson = JsonConvert.SerializeObject(new TestDateTime { Iso8601String = date.ToString("o", CultureInfo.InvariantCulture) });
             byte[] responseBytes = Encoding.UTF8.GetBytes(responseJson);
 
             const string commandName = "GetDateTime";
@@ -341,7 +341,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
 
                 CloudToDeviceMethodResult result = await serviceClient.InvokeDeviceMethodAsync(testDevice.Id, c2dMethod).ConfigureAwait(false);
                 string actualResultJson = result.GetPayloadAsJson();
-                DateTime myDtoValue = JsonConvert.DeserializeObject<DateTime>(actualResultJson);
+                TestDateTime myDtoValue = JsonConvert.DeserializeObject<TestDateTime>(actualResultJson);
                 string value = myDtoValue.Iso8601String;
 
                 Action act = () => DateTimeOffset.ParseExact(value, "o", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
@@ -679,7 +679,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await moduleClient.CloseAsync().ConfigureAwait(false);
         }
 
-        private class DateTime
+        private class TestDateTime
         {
             public string Iso8601String { get; set; }
         }

--- a/shared/src/JsonSerializerSettingsInitializer.cs
+++ b/shared/src/JsonSerializerSettingsInitializer.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    /// <summary>
+    /// A class to initialize JsonSerializerSettings which can be applied to the project.
+    /// </summary>
+    public static class JsonSerializerSettingsInitializer
+    {
+        /// <summary>
+        /// A static instance of JsonSerializerSettings which sets DateParseHandling to None.
+        /// </summary>
+        /// <remarks>
+        /// By default, serializing/deserializing with Newtonsoft.Json will try to parse date-formatted
+        /// strings to a date type, which drops trailing zeros in the microseconds date portion. By
+        /// specifying DateParseHandling with None, the original string will be read as-is.
+        /// </remarks>
+        public static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+        {
+            DateParseHandling = DateParseHandling.None
+        };
+
+        /// <summary>
+        /// Returns JsonSerializerSettings Func delegate
+        /// </summary>
+        public static Func<JsonSerializerSettings> GetJsonSerializerSettingsDelegate()
+        {
+            return () => Settings;
+        }
+    }
+}


### PR DESCRIPTION
For https://github.com/Azure/azure-iot-sdk-csharp/issues/3093,

Newtonsoft.Json has a known [issue ](https://github.com/JamesNK/Newtonsoft.Json/issues/1511)where date serialization/deserialization drops trailing zeros in the microseconds date portion by default. As a result, a method payload containing date type will be deserialized into an improperly formatted ISO 8601 string and cannot be parsed correctly. 

```c#
{"MyIso8601Date":"2023-01-31T01:37:08.45994-08:00"}

Unhandled exception. System.FormatException: String '2023-01-31T01:37:08.45994-08:00' was not recognized as a valid DateTime.
   at System.DateTimeParse.ParseExact(ReadOnlySpan`1 s, ReadOnlySpan`1 format, DateTimeFormatInfo dtfi, DateTimeStyles style, TimeSpan& offset)
   at System.DateTimeOffset.ParseExact(String input, String format, IFormatProvider formatProvider, DateTimeStyles styles)
```