### PR TITLE
Make Location property from DigitalTwinUpdateResponse internal

### DIFF
--- a/iothub/service/src/DigitalTwin/Models/DigitalTwinUpdateResponse.cs
+++ b/iothub/service/src/DigitalTwin/Models/DigitalTwinUpdateResponse.cs
@@ -34,6 +34,6 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Gets the URI of the digital twin.
         /// </summary>
-        public string Location { get; }
+        internal string Location { get; }
     }
 }

--- a/iothub/service/src/DigitalTwin/Models/DigitalTwinUpdateResponse.cs
+++ b/iothub/service/src/DigitalTwin/Models/DigitalTwinUpdateResponse.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.Devices
 
         /// <summary>
         /// Gets the URI of the digital twin.
+        /// Marked internal as it was added to the service for completeness with guidance and there is no known user use case.
         /// </summary>
         internal string Location { get; }
     }


### PR DESCRIPTION
Location property from DigitialTwinUpdateResponse is marked internal as there is no known use case from users and it was added to be complete with the guidance.