### PR TITLE
Test only with project references

### DIFF
--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -34,17 +34,10 @@
     <PackageReference Include="Azure.Identity" Version="1.8.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(AZURE_IOT_LOCALPACKAGES)' == '' ">
+  <ItemGroup>
     <ProjectReference Include="$(RootDir)\iothub\device\src\Microsoft.Azure.Devices.Client.csproj" />
     <ProjectReference Include="$(RootDir)\iothub\service\src\Microsoft.Azure.Devices.csproj" />
     <ProjectReference Include="$(RootDir)\provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj" />
     <ProjectReference Include="$(RootDir)\provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(AZURE_IOT_LOCALPACKAGES)' != '' ">
-    <PackageReference Include="Microsoft.Azure.Devices" Version="2.*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="2.*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="2.*" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Service" Version="2.*" />
   </ItemGroup>
 </Project>

--- a/vsts/build-release-artifacts.yml
+++ b/vsts/build-release-artifacts.yml
@@ -80,7 +80,6 @@ jobs:
   - powershell: |
       . $(Build.StagingDirectory)/build-tools/csharp/new/SignTools.ps1
       md $env:ESRP_LOG_DIR
-      md $env:AZURE_IOT_LOCALPACKAGES
       Set-Location $(Build.SourcesDirectory)
       $(Build.SourcesDirectory)/build.ps1 -configuration Release -build -sign -package -verbosity d
 
@@ -90,7 +89,6 @@ jobs:
         ESRP_POLICY_CONFIG: $(Build.StagingDirectory)/build-tools/csharp/new/json/Policy.json
         ESRP_INPUT_JSON_DIR: $(Build.StagingDirectory)/build-tools/csharp/new/json
         ESRP_LOG_DIR: $(Build.StagingDirectory)/build-tools/csharp/new/logs
-        AZURE_IOT_LOCALPACKAGES: $(Build.StagingDirectory)/build-tools/csharp/nuget_local
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM Generation Task'

--- a/vsts/build-test-nuget.yml
+++ b/vsts/build-test-nuget.yml
@@ -150,7 +150,6 @@ jobs:
           PROXY_SERVER_ADDRESS: 127.0.0.1:3128
           TARGET_BRANCH: $(System.PullRequest.TargetBranch)
           FRAMEWORK: $(FRAMEWORK)
-          AZURE_IOT_LOCALPACKAGES: $(Build.SourcesDirectory)/bin/nuget
           # Environment variables for invalid certificate tests
           IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
           IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
@@ -413,7 +412,6 @@ jobs:
           PROXY_SERVER_ADDRESS: 127.0.0.1:8888
           TARGET_BRANCH: $(System.PullRequest.TargetBranch)
           FRAMEWORK: $(FRAMEWORK)
-          AZURE_IOT_LOCALPACKAGES: $(Build.SourcesDirectory)/bin/nuget
           # Environment variables for invalid certificate tests
           IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
           IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)

--- a/vsts/releaseTest.ps1
+++ b/vsts/releaseTest.ps1
@@ -15,9 +15,6 @@ if (isWindows)
 Write-Host List active docker containers
 docker ps -a
 
-Write-Host Add DevOps artifacts location as local NuGet source
-dotnet nuget add source $env:AZURE_IOT_LOCALPACKAGES -n "LocalPackages"
-
 Write-Host List all NuGet sources
 dotnet nuget list source
 

--- a/vsts/test-release-nuget.yaml
+++ b/vsts/test-release-nuget.yaml
@@ -104,7 +104,6 @@ jobs:
           PROXY_SERVER_ADDRESS: 127.0.0.1:8888
           TARGET_BRANCH: $(System.PullRequest.TargetBranch)
           FRAMEWORK: $(FRAMEWORK)
-          AZURE_IOT_LOCALPACKAGES: $(Build.ArtifactStagingDirectory)/nuget
 
           # Environment variables for invalid certificate tests
           IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
@@ -243,7 +242,6 @@ jobs:
           PROXY_SERVER_ADDRESS: 127.0.0.1:3128
           TARGET_BRANCH: $(System.PullRequest.TargetBranch)
           FRAMEWORK: $(FRAMEWORK)
-          AZURE_IOT_LOCALPACKAGES: $(Build.ArtifactStagingDirectory)/nuget
 
           # Environment variables for invalid certificate tests
           IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)


### PR DESCRIPTION
Simplify our testing process by removing step to test against built NuGet packges as we have not seen this step produce any value in the last several years (at least) and it often costs us some trouble.