### PR TITLE
BugFix(MQTT): send an event in ReceiveMessageHandler before completin…

### DIFF
--- a/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
@@ -938,6 +938,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 async (message, context) =>
                 {
                     VerboseTestLogger.WriteLine($"Received message over the first message handler: MessageId={message.MessageId}");
+                    var messageD2C = new Client.Message(Encoding.UTF8.GetBytes("DeviceToCloud"));
+                    // sending an event within message handler to make sure its flow is not affected by the event.
+                    await deviceClient.SendEventAsync(messageD2C);
                     await deviceClient.CompleteAsync(message).ConfigureAwait(false);
                     firstHandlerSemaphore.Release();
                 },

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -578,9 +578,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             // We are intentionally not awaiting _deviceMessageReceivedListener callback.
             // This is a user-supplied callback that isn't required to be awaited by us. We can simply invoke it and continue.
             _ = _deviceMessageReceivedListener?.Invoke(message);
-            // Messages with QoS = 1 need to be Acknowledged otherwise it results in mismatched Ack to IoT Hub
-            // causing next message being replayed and all subsequent messages being queued.
-            await CompleteIncomingMessageAsync(message).ConfigureAwait(false);
+            await TaskHelpers.CompletedTask.ConfigureAwait(false);
 
             if (Logging.IsEnabled)
                 Logging.Exit(this, "Process C2D message via callback", nameof(HandleIncomingMessagesAsync));


### PR DESCRIPTION
For MQTT, after receiving C2D message, the implementation was making an additional call to CompleteAsync(). This did not cause an issue if message handler was eventually only making call to Complete/Abandon/RejectAsync() but if an event was sent within message handler, the ACKs within CompleteAsync() get mismatched. The mismatch was due to awaited event call causing delay in ACK for the first lock token. i.e:

**_Flow with no event within message handler:_**
- Add message lock token to queue.
- Remove lock token from queue and complete ACK.
- Add message lock token **again** to the queue.
- Remove lock token from queue and complete ACK.

**_Flow with event within message handler:_**
- Add message lock token to queue.
- Add message lock token **again** to the queue.
- Remove first lock token from queue but expects the second lock token.
- Remove second lock token from queue but expects the first lock token.