### PR TITLE
Delete the created configuration once the test is finished

### DIFF
--- a/e2e/test/iothub/service/ConfigurationsClientE2ETests.cs
+++ b/e2e/test/iothub/service/ConfigurationsClientE2ETests.cs
@@ -232,6 +232,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                     TargetCondition = "deviceId='fakeDevice'",
                 };
                 Configuration addResult = await sc.Configurations.CreateAsync(expected).ConfigureAwait(false);
+                configCreated = true;
 
                 // act
 
@@ -273,6 +274,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                     TargetCondition = "deviceId='fakeDevice'",
                 };
                 Configuration addResult = await sc.Configurations.CreateAsync(expected).ConfigureAwait(false);
+                configCreated = true;
 
                 // act
 

--- a/e2e/test/iothub/service/DevicesClientE2ETests.cs
+++ b/e2e/test/iothub/service/DevicesClientE2ETests.cs
@@ -306,7 +306,16 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString, options);
             var device = new Device(deviceId);
-            await serviceClient.Devices.CreateAsync(device).ConfigureAwait(false);
+            try
+            {
+                await serviceClient.Devices.CreateAsync(device).ConfigureAwait(false);
+            }
+            finally
+            {
+                // clean up
+                // If this fails, we shall let it throw an exception and fail the test
+                await serviceClient.Devices.DeleteAsync(deviceId).ConfigureAwait(false);
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
After creating a configuration in an e2e test, ensure that the configCreated var is set to 'true'. Otherwise, it will not be cleaned up after the test is finished.