### PR TITLE
Fix amqp objects closure event handlers

### DIFF
--- a/e2e/test/helpers/TestDeviceCallbackHandler.cs
+++ b/e2e/test/helpers/TestDeviceCallbackHandler.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
             set => Volatile.Write(ref _expectedMessageSentByService, value);
         }
 
-        public async Task SetDeviceReceiveMethodAsync<T>(string methodName, object deviceResponseJson, T expectedServiceRequestJson)
+        public async Task SetDeviceReceiveMethodAsync<T>(string methodName, object deviceResponse, T expectedServiceRequestJson)
         {
             await _deviceClient.OpenAsync().ConfigureAwait(false);
             await _deviceClient.SetDirectMethodCallbackAsync(
@@ -58,9 +58,9 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
                         request.TryGetPayload(out T actualRequestPayload).Should().BeTrue();
                         actualRequestPayload.Should().BeEquivalentTo(expectedServiceRequestJson, "The expected method data should match what was sent from service");
 
-                        var response = new Client.DirectMethodResponse(200)
+                        var response = new DirectMethodResponse(200)
                         {
-                            Payload = deviceResponseJson,
+                            Payload = deviceResponse,
                         };
                         return Task.FromResult(response);
                     }

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
         {
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(devicePrefix, type).ConfigureAwait(false);
 
-            IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSettings));
+            await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSettings));
 
             int connectionStatusChangeCount = 0;
 
@@ -207,7 +207,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                 {
                     await cleanupOperation().ConfigureAwait(false);
                 }
-                await deviceClient.DisposeAsync();
                 await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
 
                 if (!FaultShouldDisconnect(faultType))

--- a/e2e/test/iothub/device/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/device/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;

--- a/e2e/test/iothub/device/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/device/MessageReceiveE2ETests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
     [TestCategory("E2E")]
     [TestCategory("IoTHub")]
     [TestCategory("LongRunning")]
-    public partial class MessageReceiveE2ETests : E2EMsTestBase
+    public class MessageReceiveE2ETests : E2EMsTestBase
     {
         private static readonly string s_devicePrefix = $"{nameof(MessageReceiveE2ETests)}_";
 

--- a/e2e/test/iothub/device/MessageReceiveFaultInjectionTests.cs
+++ b/e2e/test/iothub/device/MessageReceiveFaultInjectionTests.cs
@@ -188,10 +188,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         {
             TestDeviceCallbackHandler testDeviceCallbackHandler = null;
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            await serviceClient.Messages.OpenAsync().ConfigureAwait(false);
 
             async Task InitOperationAsync(IotHubDeviceClient deviceClient, TestDevice testDevice)
             {
+                await serviceClient.Messages.OpenAsync().ConfigureAwait(false);
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
                 await deviceClient.OpenAsync(cts.Token).ConfigureAwait(false);
 

--- a/e2e/test/iothub/device/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/iothub/device/MessageSendFaultInjectionTests.cs
@@ -190,50 +190,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
         [DoNotParallelize]
-        public async Task Message_ThrottledConnectionLongTimeNoRecovery_Amqp()
-        {
-            // act
-            Func<Task> act = async () =>
-            {
-                await SendMessageRecoveryAsync(
-                        new IotHubClientAmqpSettings(),
-                        FaultInjectionConstants.FaultType_Throttle,
-                        FaultInjectionConstants.FaultCloseReason_Boom,
-                        FaultInjection.ShortRetryDuration)
-                .ConfigureAwait(false);
-            };
-
-            // assert
-            var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.ErrorCode.Should().Be(IotHubClientErrorCode.Throttled);
-            error.And.IsTransient.Should().BeTrue();
-        }
-
-        [TestMethod]
-        [Timeout(TestTimeoutMilliseconds)]
-        [DoNotParallelize]
-        public async Task Message_ThrottledConnectionLongTimeNoRecovery_AmqpWs()
-        {
-            // act
-            Func<Task> act = async () =>
-            {
-                await SendMessageRecoveryAsync(
-                        new IotHubClientAmqpSettings(IotHubClientTransportProtocol.WebSocket),
-                        FaultInjectionConstants.FaultType_Throttle,
-                        FaultInjectionConstants.FaultCloseReason_Boom,
-                        FaultInjection.ShortRetryDuration)
-                    .ConfigureAwait(false);
-            };
-
-            // assert
-            var error = await act.Should().ThrowAsync<IotHubClientException>();
-            error.And.ErrorCode.Should().Be(IotHubClientErrorCode.Throttled);
-            error.And.IsTransient.Should().BeTrue();
-        }
-
-        [TestMethod]
-        [Timeout(TestTimeoutMilliseconds)]
-        [DoNotParallelize]
         public async Task Message_QuotaExceededRecovery_Amqp()
         {
             await SendMessageRecoveryAsync(

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -687,7 +687,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             catch (OperationCanceledException)
             {
                 // Canceled when the transport is being closed by the application.
-                if (Logging.IsEnabled) 
+                if (Logging.IsEnabled)
                     Logging.Info(this, "Transport disconnected: closed by application.", nameof(HandleDisconnectAsync));
 
                 connectionStatusInfo = new ConnectionStatusInfo(ConnectionStatus.Closed, ConnectionStatusChangeReason.ClientClosed);

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -598,7 +598,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
                         await Task.Delay(waitTime, cancellationToken).ConfigureAwait(false);
                     }
-                    
+
                     refreshesOn = await RefreshSasTokenAsync(cancellationToken).ConfigureAwait(false);
 
                     waitTime = refreshesOn - DateTime.UtcNow;
@@ -687,7 +687,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             catch (OperationCanceledException)
             {
                 // Canceled when the transport is being closed by the application.
-                if (Logging.IsEnabled)
+                if (Logging.IsEnabled) 
                     Logging.Info(this, "Transport disconnected: closed by application.", nameof(HandleDisconnectAsync));
 
                 connectionStatusInfo = new ConnectionStatusInfo(ConnectionStatus.Closed, ConnectionStatusChangeReason.ClientClosed);

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotConnection.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotConnection.cs
@@ -28,12 +28,19 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
             return _amqpIotCbsLink;
         }
 
+        // This event handler is not invoked by the AMQP library in an async fashion.
+        // This also co-relates with the fact that AmqpConnection.SafeClose() is a sync method.
+
         internal void AmqpConnectionClosed(object sender, EventArgs e)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, nameof(AmqpConnectionClosed));
 
             Closed?.Invoke(this, e);
+
+            // After the Closed event handler has been invoked, the AmqpConnection has now been effectively cleaned up.
+            // This is a good point for us to detach the Closed event handler from the AmqpConnection instance.
+            _amqpConnection.Closed -= AmqpConnectionClosed;
 
             if (Logging.IsEnabled)
                 Logging.Exit(this, nameof(AmqpConnectionClosed));
@@ -104,7 +111,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
 
         internal void SafeClose()
         {
-            _amqpConnection.Closed -= AmqpConnectionClosed;
             _amqpConnection.SafeClose();
         }
 

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotConnection.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotConnection.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
 
         // This event handler is not invoked by the AMQP library in an async fashion.
         // This also co-relates with the fact that AmqpConnection.SafeClose() is a sync method.
-
         internal void AmqpConnectionClosed(object sender, EventArgs e)
         {
             if (Logging.IsEnabled)

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotReceivingLink.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotReceivingLink.cs
@@ -171,9 +171,9 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
 
             try
             {
-                DirectMethodRequest DirectMethodRequest = AmqpIotMessageConverter.ConstructMethodRequestFromAmqpMessage(amqpMessage, _payloadConvention);
+                DirectMethodRequest directMethodRequest = AmqpIotMessageConverter.ConstructMethodRequestFromAmqpMessage(amqpMessage, _payloadConvention);
                 DisposeDelivery(amqpMessage, true, AmqpConstants.AcceptedOutcome);
-                _onMethodReceived?.Invoke(DirectMethodRequest);
+                _onMethodReceived?.Invoke(directMethodRequest);
             }
             finally
             {

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotSendingLink.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotSendingLink.cs
@@ -24,12 +24,18 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
             _sendingAmqpLink.Closed += SendingAmqpLinkClosed;
         }
 
+        // This event handler is not invoked by the AMQP library in an async fashion.
+        // This also co-relates with the fact that SendingAmqpLink.SafeClose() is a sync method.
         private void SendingAmqpLinkClosed(object sender, EventArgs e)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, nameof(SendingAmqpLinkClosed));
 
             Closed?.Invoke(this, e);
+
+            // After the Closed event handler has been invoked, the SendingAmqpLink has now been effectively cleaned up.
+            // This is a good point for us to detach the Closed event handler from the SendingAmqpLink instance.
+            _sendingAmqpLink.Closed -= SendingAmqpLinkClosed;
 
             if (Logging.IsEnabled)
                 Logging.Exit(this, nameof(SendingAmqpLinkClosed));
@@ -48,7 +54,6 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
             if (Logging.IsEnabled)
                 Logging.Enter(this, nameof(SafeClose));
 
-            _sendingAmqpLink.Closed -= SendingAmqpLinkClosed;
             _sendingAmqpLink.SafeClose();
 
             if (Logging.IsEnabled)

--- a/iothub/service/src/Amqp/AmqpSendingLinkHandler.cs
+++ b/iothub/service/src/Amqp/AmqpSendingLinkHandler.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Amqp
             // By using a unique guid in the link's name, it becomes possible to correlate logs where a user
             // may have multiple instances of this type of link open. It also makes it easier to correlate
             // the state of this link with the service side logs if need be.
-            _linkName = "CloudToDevieMessageSenderLink-" + Guid.NewGuid();
+            _linkName = "CloudToDeviceMessageSenderLink-" + Guid.NewGuid();
 
             if (Logging.IsEnabled)
                 Logging.Enter(this, $"Opening sending link with address {_linkAddress} and link name {_linkName}", nameof(OpenAsync));


### PR DESCRIPTION
Remove the AMQP object closure event handlers only after the objects themselves have been cleaned up by the AMQP library.