### PR TITLE
Decouple client open-close semaphore from callback subscription semaphore

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -217,7 +217,7 @@ Function BuildPackage($path, $message)
         SignDotNetBinary $filesToSign
     }
 
-    & dotnet pack --verbosity $verbosity --configuration $configuration --no-build --include-symbols --include-source --output $localPackages
+    & dotnet pack --verbosity $verbosity --configuration $configuration --no-build --include-symbols --include-source --property:PackageOutputPath=$localPackages
 
     if ($LASTEXITCODE -ne 0)
     {

--- a/e2e/test/iothub/FileUploadE2ETests.cs
+++ b/e2e/test/iothub/FileUploadE2ETests.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
+        [TestCategory("Proxy")]
         public async Task FileUpload_SmallFile_Http_GranularSteps_Proxy()
         {
             string filename = await GetTestFileNameAsync(FileSizeSmall).ConfigureAwait(false);

--- a/e2e/test/iothub/service/RegistryManagerE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryManagerE2ETests.cs
@@ -328,6 +328,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
+        [TestCategory("Proxy")]
         public async Task RegistryManager_AddDeviceWithProxy()
         {
             string deviceId = _idPrefix + Guid.NewGuid();

--- a/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 {
     internal abstract class DefaultDelegatingHandler : IDelegatingHandler
     {
-        protected const string ClientDisposedMessage = "The client has already been disposed and is no longer usable.";
+        protected const string ClientDisposedMessage = "The client has been disposed and is no longer usable.";
         protected volatile bool _isDisposed;
         private volatile IDelegatingHandler _innerHandler;
 

--- a/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
@@ -11,8 +11,9 @@ namespace Microsoft.Azure.Devices.Client.Transport
 {
     internal abstract class DefaultDelegatingHandler : IDelegatingHandler
     {
-        private volatile IDelegatingHandler _innerHandler;
+        protected const string ClientDisposedMessage = "The client has already been disposed and is no longer usable.";
         protected volatile bool _isDisposed;
+        private volatile IDelegatingHandler _innerHandler;
 
         protected DefaultDelegatingHandler(PipelineContext context, IDelegatingHandler innerHandler)
         {
@@ -209,7 +210,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             if (_isDisposed)
             {
-                throw new ObjectDisposedException("IoT hub client");
+                throw new ObjectDisposedException("IoT client", ClientDisposedMessage);
             }
         }
 

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -788,7 +788,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     Logging.Enter(this, cancellationToken, nameof(CloseAsync));
 
                 _handleDisconnectCts.Cancel();
-                _cancelPendingOperationsCts.Cancel();
+                _cancelPendingOperationsCts.Cancel(); // Is it possible that this is already disposed by the time close was still waiting to acquire the semaphore?
                 await base.CloseAsync(cancellationToken).ConfigureAwait(false);
             }
             finally

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         private bool _twinEnabled;
         private bool _eventsEnabled;
         private bool _deviceReceiveMessageEnabled;
+        private bool _isDisposing;
         private bool _isAnEdgeModule = true;
 
         private Task _transportClosedTask;
@@ -246,7 +247,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _cloudToDeviceMessageSubscriptionSemaphore?.Release();
+                                try
+                                {
+                                    _cloudToDeviceMessageSubscriptionSemaphore?.Release();
+                                }
+                                catch (ObjectDisposedException) when (_isDisposing)
+                                {
+                                    if (Logging.IsEnabled)
+                                        Logging.Error(this, "Tried releasing cloud-to-device message subscription semaphore but it has already been disposed by client disposal on a separate thread." +
+                                            "Ignoring this exception and continuing with client cleanup.");
+                                }
                             }
                         },
                         operationCts.Token)
@@ -287,7 +297,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _cloudToDeviceMessageSubscriptionSemaphore?.Release();
+                                try
+                                {
+                                    _cloudToDeviceMessageSubscriptionSemaphore?.Release();
+                                }
+                                catch (ObjectDisposedException) when (_isDisposing)
+                                {
+                                    if (Logging.IsEnabled)
+                                        Logging.Error(this, "Tried releasing cloud-to-device message subscription semaphore but it has already been disposed by client disposal on a separate thread." +
+                                            "Ignoring this exception and continuing with client cleanup.");
+                                }
                             }
                         },
                         operationCts.Token)
@@ -326,7 +345,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _cloudToDeviceMessageSubscriptionSemaphore?.Release();
+                                try
+                                {
+                                    _cloudToDeviceMessageSubscriptionSemaphore?.Release();
+                                }
+                                catch (ObjectDisposedException) when (_isDisposing)
+                                {
+                                    if (Logging.IsEnabled)
+                                        Logging.Error(this, "Tried releasing cloud-to-device message subscription semaphore but it has already been disposed by client disposal on a separate thread." +
+                                            "Ignoring this exception and continuing with client cleanup.");
+                                }
                             }
                         },
                         operationCts.Token)
@@ -362,7 +390,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _directMethodSubscriptionSemaphore?.Release();
+                                try
+                                {
+                                    _directMethodSubscriptionSemaphore?.Release();
+                                }
+                                catch (ObjectDisposedException) when (_isDisposing)
+                                {
+                                    if (Logging.IsEnabled)
+                                        Logging.Error(this, "Tried releasing direct method subscription semaphore but it has already been disposed by client disposal on a separate thread." +
+                                            "Ignoring this exception and continuing with client cleanup.");
+                                }
                             }
                         },
                         operationCts.Token)
@@ -398,7 +435,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _directMethodSubscriptionSemaphore?.Release();
+                                try
+                                {
+                                    _directMethodSubscriptionSemaphore?.Release();
+                                }
+                                catch (ObjectDisposedException) when (_isDisposing)
+                                {
+                                    if (Logging.IsEnabled)
+                                        Logging.Error(this, "Tried releasing direct method subscription semaphore but it has already been disposed by client disposal on a separate thread." +
+                                            "Ignoring this exception and continuing with client cleanup.");
+                                }
                             }
                         },
                         operationCts.Token)
@@ -435,7 +481,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _cloudToDeviceEventSubscriptionSemaphore?.Release();
+                                try
+                                {
+                                    _cloudToDeviceEventSubscriptionSemaphore?.Release();
+                                }
+                                catch (ObjectDisposedException) when (_isDisposing)
+                                {
+                                    if (Logging.IsEnabled)
+                                        Logging.Error(this, "Tried releasing cloud-to-device event subscription semaphore but it has already been disposed by client disposal on a separate thread." +
+                                            "Ignoring this exception and continuing with client cleanup.");
+                                }
                             }
                         },
                         operationCts.Token)
@@ -472,7 +527,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _cloudToDeviceEventSubscriptionSemaphore?.Release();
+                                try
+                                {
+                                    _cloudToDeviceEventSubscriptionSemaphore?.Release();
+                                }
+                                catch (ObjectDisposedException) when (_isDisposing)
+                                {
+                                    if (Logging.IsEnabled)
+                                        Logging.Error(this, "Tried releasing cloud-to-device event subscription semaphore but it has already been disposed by client disposal on a separate thread." +
+                                            "Ignoring this exception and continuing with client cleanup.");
+                                }
                             }
                         },
                         operationCts.Token)
@@ -508,7 +572,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _twinEventsSubscriptionSemaphore?.Release();
+                                try
+                                {
+                                    _twinEventsSubscriptionSemaphore?.Release();
+                                }
+                                catch (ObjectDisposedException) when (_isDisposing)
+                                {
+                                    if (Logging.IsEnabled)
+                                        Logging.Error(this, "Tried releasing twin event subscription semaphore but it has already been disposed by client disposal on a separate thread." +
+                                            "Ignoring this exception and continuing with client cleanup.");
+                                }
                             }
                         },
                         operationCts.Token)
@@ -544,7 +617,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             }
                             finally
                             {
-                                _twinEventsSubscriptionSemaphore?.Release();
+                                try
+                                {
+                                    _twinEventsSubscriptionSemaphore?.Release();
+                                }
+                                catch (ObjectDisposedException) when (_isDisposing)
+                                {
+                                    if (Logging.IsEnabled)
+                                        Logging.Error(this, "Tried releasing twin event subscription semaphore but it has already been disposed by client disposal on a separate thread." +
+                                            "Ignoring this exception and continuing with client cleanup.");
+                                }
                             }
                         },
                         operationCts.Token)
@@ -714,7 +796,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Exit(this, cancellationToken, nameof(CloseAsync));
 
-                _clientOpenCloseSemaphore?.Release();
+                try
+                {
+                    _clientOpenCloseSemaphore?.Release();
+                }
+                catch (ObjectDisposedException) when (_isDisposing)
+                {
+                    if (Logging.IsEnabled)
+                        Logging.Error(this, "Tried releasing twin event subscription semaphore but it has already been disposed by client disposal on a separate thread." +
+                            "Ignoring this exception and continuing with client cleanup.");
+                }
                 Dispose(true);
             }
         }
@@ -776,7 +867,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
             finally
             {
-                _clientOpenCloseSemaphore?.Release();
+                try
+                {
+                    _clientOpenCloseSemaphore?.Release();
+                }
+                catch (ObjectDisposedException) when (_isDisposing)
+                {
+                    if (Logging.IsEnabled)
+                        Logging.Error(this, "Tried releasing twin event subscription semaphore but it has already been disposed by client disposal on a separate thread." +
+                            "Ignoring this exception and continuing with client cleanup.");
+                }
             }
         }
 
@@ -831,7 +931,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
             finally
             {
-                _clientOpenCloseSemaphore?.Release();
+                try
+                {
+                    _clientOpenCloseSemaphore?.Release();
+                }
+                catch (ObjectDisposedException) when (_isDisposing)
+                {
+                    if (Logging.IsEnabled)
+                        Logging.Error(this, "Tried releasing twin event subscription semaphore but it has already been disposed by client disposal on a separate thread." +
+                            "Ignoring this exception and continuing with client cleanup.");
+                }
             }
         }
 
@@ -1064,7 +1173,16 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
             finally
             {
-                _clientOpenCloseSemaphore?.Release();
+                try
+                {
+                    _clientOpenCloseSemaphore?.Release();
+                }
+                catch (ObjectDisposedException) when (_isDisposing)
+                {
+                    if (Logging.IsEnabled)
+                        Logging.Error(this, "Tried releasing twin event subscription semaphore but it has already been disposed by client disposal on a separate thread." +
+                            "Ignoring this exception and continuing with client cleanup.");
+                }
             }
         }
 
@@ -1123,6 +1241,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
                 if (!_isDisposed)
                 {
+                    _isDisposing = true;
+
                     base.Dispose(disposing);
                     if (disposing)
                     {
@@ -1132,83 +1252,14 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         _cancelPendingOperations?.Cancel();
                         _cancelPendingOperations?.Dispose();
 
-                        if (_clientOpenCloseSemaphore != null && _clientOpenCloseSemaphore.CurrentCount == 0)
-                        {
-                            try
-                            {
-                                _clientOpenCloseSemaphore.Release();
-                            }
-                            catch (SemaphoreFullException)
-                            {
-                                if (Logging.IsEnabled)
-                                    Logging.Error(this, $"Tried releasing the close-open semaphore before disposing it but its count was already at maximum." +
-                                        $" Will ignore the exception and dispose the semaphore.");
-                            }
-                        }
                         _clientOpenCloseSemaphore?.Dispose();
-
-                        if (_cloudToDeviceMessageSubscriptionSemaphore != null && _cloudToDeviceMessageSubscriptionSemaphore.CurrentCount == 0)
-                        {
-                            try
-                            {
-                                _cloudToDeviceMessageSubscriptionSemaphore.Release();
-                            }
-                            catch (SemaphoreFullException)
-                            {
-                                if (Logging.IsEnabled)
-                                    Logging.Error(this, $"Tried releasing the cloud-to-device message subscription semaphore before disposing it but its count was already at maximum." +
-                                        $" Will ignore the exception and dispose the semaphore.");
-                            }
-                        }
                         _cloudToDeviceMessageSubscriptionSemaphore?.Dispose();
-
-                        if (_cloudToDeviceEventSubscriptionSemaphore != null && _cloudToDeviceEventSubscriptionSemaphore.CurrentCount == 0)
-                        {
-                            try
-                            {
-                                _cloudToDeviceEventSubscriptionSemaphore.Release();
-                            }
-                            catch (SemaphoreFullException)
-                            {
-                                if (Logging.IsEnabled)
-                                    Logging.Error(this, $"Tried releasing the cloud-to-device event subscription sepmaphore before disposing it but its count was already at maximum." +
-                                        $" Will ignore the exception and dispose the semaphore.");
-                            }
-                        }
                         _cloudToDeviceEventSubscriptionSemaphore?.Dispose();
-
-                        if (_directMethodSubscriptionSemaphore != null && _directMethodSubscriptionSemaphore.CurrentCount == 0)
-                        {
-                            try
-                            {
-                                _directMethodSubscriptionSemaphore.Release();
-                            }
-                            catch (SemaphoreFullException)
-                            {
-                                if (Logging.IsEnabled)
-                                    Logging.Error(this, $"Tried releasing the direct method subscription semaphore before disposing it but its count was already at maximum." +
-                                        $" Will ignore the exception and dispose the semaphore.");
-                            }
-                        }
                         _directMethodSubscriptionSemaphore?.Dispose();
-
-                        if (_twinEventsSubscriptionSemaphore != null && _twinEventsSubscriptionSemaphore.CurrentCount == 0)
-                        {
-                            try
-                            {
-                                _twinEventsSubscriptionSemaphore.Release();
-                            }
-                            catch (SemaphoreFullException)
-                            {
-                                if (Logging.IsEnabled)
-                                    Logging.Error(this, $"Tried releasing the twin events subscription semaphore before disposing it but its count was already at maximum." +
-                                        $" Will ignore the exception and dispose the semaphore.");
-                            }
-                        }
                         _twinEventsSubscriptionSemaphore?.Dispose();
                     }
 
-                    // the _disposed flag is inherited from the base class DefaultDelegatingHandler and is finally set to null there.
+                    // the _disposed flag is inherited from the base class DefaultDelegatingHandler and is finally set to true there.
                 }
             }
             finally

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -77,6 +77,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task SendEventAsync(Message message, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -109,6 +111,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task SendEventAsync(IEnumerable<Message> messages, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -144,6 +148,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task SendMethodResponseAsync(MethodResponseInternal method, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -170,6 +176,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task<Message> ReceiveAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -223,6 +231,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task EnableReceiveMessageAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -273,6 +283,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
         // then any message sent while the device was disconnected is delivered on the callback.
         public override async Task EnsurePendingMessagesAreDeliveredAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -321,6 +333,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task DisableReceiveMessageAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -369,6 +383,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task EnableMethodsAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -414,6 +430,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task DisableMethodsAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -459,6 +477,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task EnableEventReceiveAsync(bool isAnEdgeModule, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -505,6 +525,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task DisableEventReceiveAsync(bool isAnEdgeModule, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -551,6 +573,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task EnableTwinPatchAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -596,6 +620,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task DisableTwinPatchAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -641,6 +667,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task<Twin> SendTwinGetAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -667,6 +695,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -693,6 +723,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task CompleteAsync(string lockToken, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -719,6 +751,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task AbandonAsync(string lockToken, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -745,6 +779,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task RejectAsync(string lockToken, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 if (Logging.IsEnabled)
@@ -776,6 +812,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task CloseAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             await _clientOpenCloseSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
@@ -815,6 +853,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
         /// </summary>
         private async Task EnsureOpenedAsync(bool withRetry, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             // If this object has already been disposed, we will throw an exception indicating that.
             // This is the entry point for interacting with the client and this safety check should be done here.
             // The current behavior does not support open->close->open
@@ -946,6 +986,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         private async Task OpenInternalAsync(bool withRetry, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (withRetry)
             {
                 await _internalRetryPolicy

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -77,8 +77,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task SendEventAsync(Message message, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -111,8 +109,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task SendEventAsync(IEnumerable<Message> messages, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -148,8 +144,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task SendMethodResponseAsync(MethodResponseInternal method, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -176,8 +170,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task<Message> ReceiveAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -231,8 +223,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task EnableReceiveMessageAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -283,8 +273,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
         // then any message sent while the device was disconnected is delivered on the callback.
         public override async Task EnsurePendingMessagesAreDeliveredAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -333,8 +321,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task DisableReceiveMessageAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -383,8 +369,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task EnableMethodsAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -430,8 +414,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task DisableMethodsAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -477,8 +459,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task EnableEventReceiveAsync(bool isAnEdgeModule, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -525,8 +505,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task DisableEventReceiveAsync(bool isAnEdgeModule, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -573,8 +551,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task EnableTwinPatchAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -620,8 +596,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task DisableTwinPatchAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -667,8 +641,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task<Twin> SendTwinGetAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -695,8 +667,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task SendTwinPatchAsync(TwinCollection reportedProperties, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -723,8 +693,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task CompleteAsync(string lockToken, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -751,8 +719,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task AbandonAsync(string lockToken, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -779,8 +745,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task RejectAsync(string lockToken, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
                 if (Logging.IsEnabled)
@@ -812,8 +776,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task CloseAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             await _clientOpenCloseSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
@@ -853,8 +815,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
         /// </summary>
         private async Task EnsureOpenedAsync(bool withRetry, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             // If this object has already been disposed, we will throw an exception indicating that.
             // This is the entry point for interacting with the client and this safety check should be done here.
             // The current behavior does not support open->close->open
@@ -986,8 +946,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         private async Task OpenInternalAsync(bool withRetry, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             if (withRetry)
             {
                 await _internalRetryPolicy

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -776,7 +776,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task CloseAsync(CancellationToken cancellationToken)
         {
-            await _clientOpenCloseSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 if (!_openCalled)
@@ -793,20 +792,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
             finally
             {
+                Dispose(true);
+
                 if (Logging.IsEnabled)
                     Logging.Exit(this, cancellationToken, nameof(CloseAsync));
-
-                try
-                {
-                    _clientOpenCloseSemaphore?.Release();
-                }
-                catch (ObjectDisposedException) when (_isDisposing)
-                {
-                    if (Logging.IsEnabled)
-                        Logging.Error(this, "Tried releasing twin event subscription semaphore but it has already been disposed by client disposal on a separate thread." +
-                            "Ignoring this exception and continuing with client cleanup.");
-                }
-                Dispose(true);
             }
         }
 

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             // Ensure that the connection has been opened before returning pending messages to the callback.
                             await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
 
-                            // Wait to acquire the _cloudToDeviceSubscriptionSemaphore. This ensures that concurrently invoked API calls are invoked in a thread-safe manner.
+                            // Wait to acquire the _cloudToDeviceMessageSubscriptionSemaphore. This ensures that concurrently invoked API calls are invoked in a thread-safe manner.
                             await _cloudToDeviceMessageSubscriptionSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
                             try

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             // Ensure that the connection has been opened, before disabling the callback for receiving messages.
                             await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
 
-                            // Wait to acquire the _cloudToDeviceSubscriptionSemaphore. This ensures that concurrently invoked API calls are invoked in a thread-safe manner.
+                            // Wait to acquire the _cloudToDeviceMessageSubscriptionSemaphore. This ensures that concurrently invoked API calls are invoked in a thread-safe manner.
                             await _cloudToDeviceMessageSubscriptionSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
                             {

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -788,7 +788,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     Logging.Enter(this, cancellationToken, nameof(CloseAsync));
 
                 _handleDisconnectCts.Cancel();
-                _cancelPendingOperationsCts.Cancel(); // Is it possible that this is already disposed by the time close was still waiting to acquire the semaphore?
+                _cancelPendingOperationsCts.Cancel();
                 await base.CloseAsync(cancellationToken).ConfigureAwait(false);
             }
             finally

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         private Task _transportClosedTask;
         private readonly CancellationTokenSource _handleDisconnectCts = new CancellationTokenSource();
-        private readonly CancellationTokenSource _cancelPendingOperations = new CancellationTokenSource();
+        private readonly CancellationTokenSource _cancelPendingOperationsCts = new CancellationTokenSource();
 
         private readonly ConnectionStatusChangesHandler _onConnectionStatusChanged;
 
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, message, cancellationToken, nameof(SendEventAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, messages, cancellationToken, nameof(SendEventAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, method, cancellationToken, nameof(SendMethodResponseAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, cancellationToken, nameof(ReceiveAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 return await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     Logging.Enter(this, timeoutHelper, nameof(ReceiveAsync));
 
                 using var cts = new CancellationTokenSource(timeoutHelper.GetRemainingTime());
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, _cancelPendingOperationsCts.Token);
 
                 return await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, cancellationToken, nameof(EnableReceiveMessageAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, cancellationToken, nameof(EnsurePendingMessagesAreDeliveredAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -326,7 +326,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, cancellationToken, nameof(DisableReceiveMessageAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -374,7 +374,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, cancellationToken, nameof(EnableMethodsAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -419,7 +419,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, cancellationToken, nameof(DisableMethodsAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -465,7 +465,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     Logging.Enter(this, cancellationToken, nameof(EnableEventReceiveAsync));
 
                 _isAnEdgeModule = isAnEdgeModule;
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -511,7 +511,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     Logging.Enter(this, cancellationToken, nameof(DisableEventReceiveAsync));
 
                 _isAnEdgeModule = isAnEdgeModule;
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -556,7 +556,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, cancellationToken, nameof(EnableTwinPatchAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -601,7 +601,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, cancellationToken, nameof(DisableTwinPatchAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -646,7 +646,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, cancellationToken, nameof(SendTwinGetAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 return await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -672,7 +672,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, reportedProperties, cancellationToken, nameof(SendTwinPatchAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -698,7 +698,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, lockToken, cancellationToken, nameof(CompleteAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -724,7 +724,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, lockToken, cancellationToken, nameof(AbandonAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -750,7 +750,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Logging.IsEnabled)
                     Logging.Enter(this, lockToken, cancellationToken, nameof(RejectAsync));
 
-                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperations.Token);
+                using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancelPendingOperationsCts.Token);
 
                 await _internalRetryPolicy
                     .RunWithRetryAsync(
@@ -788,7 +788,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     Logging.Enter(this, cancellationToken, nameof(CloseAsync));
 
                 _handleDisconnectCts.Cancel();
-                _cancelPendingOperations.Cancel();
+                _cancelPendingOperationsCts.Cancel();
                 await base.CloseAsync(cancellationToken).ConfigureAwait(false);
             }
             finally
@@ -1246,17 +1246,33 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     base.Dispose(disposing);
                     if (disposing)
                     {
+                        var disposables = new List<IDisposable>
+                        {
+                            _handleDisconnectCts,
+                            _cancelPendingOperationsCts,
+                            _clientOpenCloseSemaphore,
+                            _cloudToDeviceMessageSubscriptionSemaphore,
+                            _cloudToDeviceEventSubscriptionSemaphore,
+                            _directMethodSubscriptionSemaphore,
+                            _twinEventsSubscriptionSemaphore,
+                        };
+
                         _handleDisconnectCts?.Cancel();
-                        _handleDisconnectCts?.Dispose();
+                        _cancelPendingOperationsCts?.Cancel();
 
-                        _cancelPendingOperations?.Cancel();
-                        _cancelPendingOperations?.Dispose();
-
-                        _clientOpenCloseSemaphore?.Dispose();
-                        _cloudToDeviceMessageSubscriptionSemaphore?.Dispose();
-                        _cloudToDeviceEventSubscriptionSemaphore?.Dispose();
-                        _directMethodSubscriptionSemaphore?.Dispose();
-                        _twinEventsSubscriptionSemaphore?.Dispose();
+                        foreach (IDisposable disposable in disposables)
+                        {
+                            try
+                            {
+                                disposable?.Dispose();
+                            }
+                            catch (ObjectDisposedException)
+                            {
+                                if (Logging.IsEnabled)
+                                    Logging.Error(this, $"Tried disposing the IDisposable {disposable} but it has already been disposed by client disposal on a separate thread." +
+                                        "Ignoring this exception and continuing with client cleanup.");
+                            }
+                        }
                     }
 
                     // the _disposed flag is inherited from the base class DefaultDelegatingHandler and is finally set to true there.

--- a/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/RetryDelegatingHandler.cs
@@ -1097,35 +1097,30 @@ namespace Microsoft.Azure.Devices.Client.Transport
                             _clientOpenCloseSemaphore.Release();
                         }
                         _clientOpenCloseSemaphore?.Dispose();
-                        _clientOpenCloseSemaphore = null;
 
                         if (_cloudToDeviceMessageSubscriptionSemaphore != null && _cloudToDeviceMessageSubscriptionSemaphore.CurrentCount == 0)
                         {
                             _cloudToDeviceMessageSubscriptionSemaphore.Release();
                         }
                         _cloudToDeviceMessageSubscriptionSemaphore?.Dispose();
-                        _cloudToDeviceMessageSubscriptionSemaphore = null;
 
                         if (_cloudToDeviceEventSubscriptionSemaphore != null && _cloudToDeviceEventSubscriptionSemaphore.CurrentCount == 0)
                         {
                             _cloudToDeviceEventSubscriptionSemaphore.Release();
                         }
                         _cloudToDeviceEventSubscriptionSemaphore?.Dispose();
-                        _cloudToDeviceEventSubscriptionSemaphore = null;
 
                         if (_directMethodSubscriptionSemaphore != null && _directMethodSubscriptionSemaphore.CurrentCount == 0)
                         {
                             _directMethodSubscriptionSemaphore.Release();
                         }
                         _directMethodSubscriptionSemaphore?.Dispose();
-                        _directMethodSubscriptionSemaphore = null;
 
                         if (_twinEventsSubscriptionSemaphore != null && _twinEventsSubscriptionSemaphore.CurrentCount == 0)
                         {
                             _twinEventsSubscriptionSemaphore.Release();
                         }
                         _twinEventsSubscriptionSemaphore?.Dispose();
-                        _twinEventsSubscriptionSemaphore = null;
                     }
 
                     // the _disposed flag is inherited from the base class DefaultDelegatingHandler and is finally set to null there.

--- a/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
+++ b/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             // act and assert
-            await sut.OpenAsync(cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+            await sut.OpenAsync(cts.Token).ExpectedAsync<OperationCanceledException>().ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             cts.Cancel();
 
             // act and assert
-            await sut.SendEventAsync(Arg.Any<Message>(), cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+            await sut.SendEventAsync(Arg.Any<Message>(), cts.Token).ExpectedAsync<OperationCanceledException>().ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -320,7 +320,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             cts.Cancel();
 
             // act
-            await sut.SendEventAsync(new List<Message>(), cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+            await sut.SendEventAsync(new List<Message>(), cts.Token).ExpectedAsync<OperationCanceledException>().ConfigureAwait(false);
 
             // assert
             await innerHandlerMock.Received(0).SendEventAsync(new List<Message>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             // act and assert
-            await sut.ReceiveAsync(cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+            await sut.ReceiveAsync(cts.Token).ExpectedAsync<OperationCanceledException>().ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -389,7 +389,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             // act and assert
-            await sut.CompleteAsync("", cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+            await sut.CompleteAsync("", cts.Token).ExpectedAsync<OperationCanceledException>().ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -407,7 +407,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             // act and assert
             await sut
                 .AbandonAsync(Arg.Any<string>(), cts.Token)
-                .ExpectedAsync<TaskCanceledException>()
+                .ExpectedAsync<OperationCanceledException>()
                 .ConfigureAwait(false);
         }
 
@@ -424,7 +424,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             cts.Cancel();
 
             // act and assert
-            await sut.RejectAsync(Arg.Any<string>(), cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+            await sut.RejectAsync(Arg.Any<string>(), cts.Token).ExpectedAsync<OperationCanceledException>().ConfigureAwait(false);
         }
 
         private class TestRetryPolicy : IRetryPolicy

--- a/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
+++ b/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             // act and assert
-            await sut.OpenAsync(cts.Token).ExpectedAsync<OperationCanceledException>().ConfigureAwait(false);
+            await sut.OpenAsync(cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             cts.Cancel();
 
             // act and assert
-            await sut.SendEventAsync(Arg.Any<Message>(), cts.Token).ExpectedAsync<OperationCanceledException>().ConfigureAwait(false);
+            await sut.SendEventAsync(Arg.Any<Message>(), cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -320,7 +320,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             cts.Cancel();
 
             // act
-            await sut.SendEventAsync(new List<Message>(), cts.Token).ExpectedAsync<OperationCanceledException>().ConfigureAwait(false);
+            await sut.SendEventAsync(new List<Message>(), cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
 
             // assert
             await innerHandlerMock.Received(0).SendEventAsync(new List<Message>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             // act and assert
-            await sut.ReceiveAsync(cts.Token).ExpectedAsync<OperationCanceledException>().ConfigureAwait(false);
+            await sut.ReceiveAsync(cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -389,7 +389,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             // act and assert
-            await sut.CompleteAsync("", cts.Token).ExpectedAsync<OperationCanceledException>().ConfigureAwait(false);
+            await sut.CompleteAsync("", cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -407,7 +407,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             // act and assert
             await sut
                 .AbandonAsync(Arg.Any<string>(), cts.Token)
-                .ExpectedAsync<OperationCanceledException>()
+                .ExpectedAsync<TaskCanceledException>()
                 .ConfigureAwait(false);
         }
 
@@ -424,7 +424,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             cts.Cancel();
 
             // act and assert
-            await sut.RejectAsync(Arg.Any<string>(), cts.Token).ExpectedAsync<OperationCanceledException>().ConfigureAwait(false);
+            await sut.RejectAsync(Arg.Any<string>(), cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
         }
 
         private class TestRetryPolicy : IRetryPolicy

--- a/iothub/device/tests/Transport/Amqp/AmqpConnectionPoolTests.cs
+++ b/iothub/device/tests/Transport/Amqp/AmqpConnectionPoolTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,6 +16,7 @@ using Moq;
 namespace Microsoft.Azure.Devices.Client.Tests.Amqp
 {
     [TestClass]
+    [TestCategory("Unit")]
     public class AmqpConnectionPoolTests
     {
         internal class AmqpConnectionPoolTest : AmqpConnectionPool

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -548,11 +548,7 @@ jobs:
     pool:
       vmImage: windows-2022
     steps:
-      - script: |
-          rem Run dotnet first experience.
-          dotnet new
-          rem Start build
-          build.cmd -clean -build -configuration Debug -package
+      - powershell: .\build.ps1 -clean -build -configutaion Debug -package
         displayName: Build Package
 
       - task: ComponentGovernanceComponentDetection@0


### PR DESCRIPTION
The sepmaphores associated with enabling and disabling subscriptions for callbacks should not be dependent on the Semaphore used for opening or closing the client.
The only purpose of the enable-disable events semaphore is to ensure that requests to enable and disable the subscription invoked by parallel threads are executed in a thread-safe manner.