### PR TITLE
Edge module created from env vars

### DIFF
--- a/iothub/device/src/Authentication/HsmAuthentication/HttpClientHelper.cs
+++ b/iothub/device/src/Authentication/HsmAuthentication/HttpClientHelper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication
             throw new InvalidOperationException("ProviderUri scheme is not supported");
         }
 
-        internal static string GetBaseUrl(Uri providerUri)
+        internal static string GetBaseUri(Uri providerUri)
         {
             return providerUri.Scheme.Equals(UnixScheme, StringComparison.OrdinalIgnoreCase)
                 ? $"{HttpScheme}://{providerUri.Segments.Last()}"

--- a/iothub/device/src/Authentication/HsmAuthentication/HttpHsmSignatureProvider.cs
+++ b/iothub/device/src/Authentication/HsmAuthentication/HttpHsmSignatureProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication
             {
                 var hsmHttpClient = new HttpHsmClient(httpClient)
                 {
-                    BaseUrl = HttpClientHelper.GetBaseUrl(_providerUri)
+                    BaseUrl = HttpClientHelper.GetBaseUri(_providerUri)
                 };
 
                 SignResponse response = await SignWithRetryAsync(

--- a/iothub/device/src/Authentication/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
+++ b/iothub/device/src/Authentication/HsmAuthentication/Transport/HttpUdsMessageHandler.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication.Transport
             // around unix sockets in the BCL. For older versions of the framework we will continue to use the existing class since it works
             // fine. For netcore 2.1 and greater as well as .NET 5.0 and greater the native framework version can be an alternatve.
 
-            var endpoint = new Microsoft.Azure.Devices.Client.HsmAuthentication.Transport.UnixDomainSocketEndPoint(_providerUri.LocalPath);
+            var endpoint = new UnixDomainSocketEndPoint(_providerUri.LocalPath);
             await socket.ConnectAsync(endpoint).ConfigureAwait(false);
             return socket;
         }

--- a/iothub/device/src/Authentication/HsmAuthentication/Transport/UnixDomainSocketEndPoint.cs
+++ b/iothub/device/src/Authentication/HsmAuthentication/Transport/UnixDomainSocketEndPoint.cs
@@ -5,13 +5,22 @@
 using System;
 using System.Text;
 using System.Net;
+using System.Net.Sockets;
+using System.Diagnostics;
 
 namespace Microsoft.Azure.Devices.Client.HsmAuthentication.Transport
 {
     internal sealed class UnixDomainSocketEndPoint : EndPoint
     {
-        private const int NativePathLength = 91; // sockaddr_un.sun_path at http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_un.h.html, -1 for terminator
+        private const AddressFamily EndPointAddressFamily = AddressFamily.Unix;
+
         private static readonly Encoding s_pathEncoding = Encoding.UTF8;
+
+        private const int NativePathOffset = 2; // = offset of(struct sockaddr_un, sun_path). It's the same on Linux and OSX
+
+        private const int NativePathLength = 91; // sockaddr_un.sun_path at http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_un.h.html, -1 for terminator
+
+        private const int NativeAddressSize = NativePathOffset + NativePathLength;
 
         private readonly string _path;
         private readonly byte[] _encodedPath;
@@ -27,5 +36,70 @@ namespace Microsoft.Azure.Devices.Client.HsmAuthentication.Transport
                 throw new ArgumentOutOfRangeException(nameof(path), path);
             }
         }
+
+        internal UnixDomainSocketEndPoint(SocketAddress socketAddress)
+        {
+            if (socketAddress == null)
+            {
+                throw new ArgumentNullException(nameof(socketAddress));
+            }
+
+            if (socketAddress.Family != EndPointAddressFamily
+                || socketAddress.Size > NativeAddressSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(socketAddress));
+            }
+
+            if (socketAddress.Size > NativePathOffset)
+            {
+                _encodedPath = new byte[socketAddress.Size - NativePathOffset];
+                for (int i = 0; i < _encodedPath.Length; i++)
+                {
+                    _encodedPath[i] = socketAddress[NativePathOffset + i];
+                }
+
+                _path = s_pathEncoding.GetString(_encodedPath, 0, _encodedPath.Length);
+            }
+            else
+            {
+                _encodedPath = Array.Empty<byte>();
+                _path = string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Do not remove. Even though there are no references, it will be called by System.Net.HttpClient.
+        /// </summary>
+        public override SocketAddress Serialize()
+        {
+            var result = new SocketAddress(AddressFamily.Unix, NativeAddressSize);
+            Debug.Assert(_encodedPath.Length + NativePathOffset <= result.Size, "Expected path to fit in address");
+
+            for (int index = 0; index < _encodedPath.Length; index++)
+            {
+                result[NativePathOffset + index] = _encodedPath[index];
+            }
+            result[NativePathOffset + _encodedPath.Length] = 0; // path must be null-terminated
+
+            return result;
+        }
+
+
+        /// <summary>
+        /// Do not remove. Even though there are no references, it will be called by System.Net.HttpClient.
+        /// </summary>
+        public override EndPoint Create(SocketAddress socketAddress) => new UnixDomainSocketEndPoint(socketAddress);
+
+
+        /// <summary>
+        /// Do not remove. Even though there are no references, it will be called by System.Net.HttpClient.
+        /// </summary>
+        public override AddressFamily AddressFamily => EndPointAddressFamily;
+
+
+        /// <summary>
+        /// Do not remove. Even though there are no references, it will be called by System.Net.HttpClient.
+        /// </summary>
+        public override string ToString() => _path;
     }
 }

--- a/iothub/device/src/Edge/TrustBundleProvider.cs
+++ b/iothub/device/src/Edge/TrustBundleProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Client.Edge
                 using HttpClient httpClient = HttpClientHelper.GetHttpClient(providerUri);
                 var hsmHttpClient = new HttpHsmClient(httpClient)
                 {
-                    BaseUrl = HttpClientHelper.GetBaseUrl(providerUri)
+                    BaseUrl = HttpClientHelper.GetBaseUri(providerUri)
                 };
                 TrustBundleResponse response = await GetTrustBundleWithRetryAsync(hsmHttpClient, apiVersion).ConfigureAwait(false);
 


### PR DESCRIPTION
We were too aggressive about deleting some "dead code" which turned out to be called by HttpClient. That caused an error:

```
Unhandled exception. System.AggregateException: One or more errors occurred. (This property is not implemented by this class.)
 ---> System.NotImplementedException: This property is not implemented by this class.
   at System.Net.EndPoint.get_AddressFamily()
   at System.Net.Sockets.Socket.ConnectAsync(SocketAsyncEventArgs e, Boolean userSocket, Boolean saeaCancelable)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ConnectAsync(Socket socket)
   at System.Net.Sockets.Socket.ConnectAsync(EndPoint remoteEP, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.ConnectAsync(EndPoint remoteEP)
   at System.Net.Sockets.SocketTaskExtensions.ConnectAsync(Socket socket, EndPoint remoteEP)
   at Microsoft.Azure.Devices.Client.HsmAuthentication.Transport.HttpUdsMessageHandler.GetConnectedSocketAsync()
   at Microsoft.Azure.Devices.Client.HsmAuthentication.Transport.HttpUdsMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at Microsoft.Azure.Devices.Client.HsmAuthentication.GeneratedCode.HttpHsmClient.TrustBundleAsync(String apiVersion, CancellationToken cancellationToken)
   at Microsoft.Azure.Devices.Client.RetryHandler.RunWithRetryAsync[T](Func`1 taskFunc, Func`2 transientErrorCheck, CancellationToken cancellationToken)
   at Microsoft.Azure.Devices.Client.Edge.TrustBundleProvider.GetTrustBundleWithRetryAsync(HttpHsmClient hsmHttpClient, String apiVersion)
   at Microsoft.Azure.Devices.Client.Edge.TrustBundleProvider.GetTrustBundleAsync(Uri providerUri, String apiVersion)
   at Microsoft.Azure.Devices.Client.EdgeModuleClientHelper.CreateCertificateValidatorFromEnvironmentAsync(ITrustBundleProvider trustBundleProvider, IotHubClientOptions options)
   at Microsoft.Azure.Devices.Client.IotHubModuleClient.CreateFromEnvironmentAsync(IotHubClientOptions options)
   at FilterModule.Program.Init() in /app/Program.cs:line 52
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at FilterModule.Program.Main(String[] args) in /app/Program.cs:line 22
Unhandled exception. System.AggregateException: One or more errors occurred. (This property is not implemented by this class.)
 ---> System.NotImplementedException: This property is not implemented by this class.
   at System.Net.EndPoint.get_AddressFamily()
   at System.Net.Sockets.Socket.ConnectAsync(SocketAsyncEventArgs e, Boolean userSocket, Boolean saeaCancelable)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ConnectAsync(Socket socket)
   at System.Net.Sockets.Socket.ConnectAsync(EndPoint remoteEP, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.ConnectAsync(EndPoint remoteEP)
   at System.Net.Sockets.SocketTaskExtensions.ConnectAsync(Socket socket, EndPoint remoteEP)
   at Microsoft.Azure.Devices.Client.HsmAuthentication.Transport.HttpUdsMessageHandler.GetConnectedSocketAsync()
   at Microsoft.Azure.Devices.Client.HsmAuthentication.Transport.HttpUdsMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at Microsoft.Azure.Devices.Client.HsmAuthentication.GeneratedCode.HttpHsmClient.TrustBundleAsync(String apiVersion, CancellationToken cancellationToken)
   at Microsoft.Azure.Devices.Client.RetryHandler.RunWithRetryAsync[T](Func`1 taskFunc, Func`2 transientErrorCheck, CancellationToken cancellationToken)
   at Microsoft.Azure.Devices.Client.Edge.TrustBundleProvider.GetTrustBundleWithRetryAsync(HttpHsmClient hsmHttpClient, String apiVersion)
   at Microsoft.Azure.Devices.Client.Edge.TrustBundleProvider.GetTrustBundleAsync(Uri providerUri, String apiVersion)
   at Microsoft.Azure.Devices.Client.EdgeModuleClientHelper.CreateCertificateValidatorFromEnvironmentAsync(ITrustBundleProvider trustBundleProvider, IotHubClientOptions options)
   at Microsoft.Azure.Devices.Client.IotHubModuleClient.CreateFromEnvironmentAsync(IotHubClientOptions options)
```

Also, we updated the API version to latest, but that results in an error as well, so I reverted it back to a 2018 one for use by this HSM path only.