### PR TITLE
Using IAsyncDisposable to cleanup test devices

### DIFF
--- a/e2e/test/helpers/TestModule.cs
+++ b/e2e/test/helpers/TestModule.cs
@@ -6,56 +6,51 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Devices.E2ETests.Helpers
 {
-    public class TestModule
+    internal class TestModule : IAsyncDisposable
     {
-        private readonly Module _module;
+        private Module _module;
+        private TestDevice _testDevice;
 
-        private TestModule(Module module)
-        {
-            _module = module;
-        }
+        /// <summary>
+        /// Used in conjunction with ModuleClient.CreateFromConnectionString()
+        /// </summary>
+        public string ConnectionString =>
+            $"HostName={TestConfiguration.IotHub.GetIotHubHostName()};DeviceId={_module.DeviceId};ModuleId={_module.Id};SharedAccessKey={_module.Authentication.SymmetricKey.PrimaryKey}";
+
+        /// <summary>
+        /// Module Id
+        /// </summary>
+        public string Id => _module.Id;
+
+        /// <summary>
+        /// Device Id
+        /// </summary>
+        public string DeviceId => _testDevice.Id;
 
         /// <summary>
         /// Factory method.
         /// </summary>
         public static async Task<TestModule> GetTestModuleAsync(string deviceNamePrefix, string moduleNamePrefix)
         {
-            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(deviceNamePrefix).ConfigureAwait(false);
+            var testModule = new TestModule
+            {
+                _testDevice = await TestDevice.GetTestDeviceAsync(deviceNamePrefix).ConfigureAwait(false)
+            };
 
-            string deviceName = testDevice.Id;
+            string deviceName = testModule._testDevice.Id;
             string moduleName = $"E2E_{moduleNamePrefix}_{Guid.NewGuid()}";
 
             IotHubServiceClient sc = TestDevice.ServiceClient;
-            VerboseTestLogger.WriteLine($"{nameof(GetTestModuleAsync)}: Creating module for device {deviceName}.");
+            testModule._module = await sc.Modules.CreateAsync(new Module(deviceName, moduleName)).ConfigureAwait(false);
+            VerboseTestLogger.WriteLine($"{nameof(GetTestModuleAsync)}: Using device {testModule.DeviceId} with module {testModule.Id}.");
 
-            Module module = await sc.Modules.CreateAsync(new Module(deviceName, moduleName)).ConfigureAwait(false);
-
-            var ret = new TestModule(module);
-
-            VerboseTestLogger.WriteLine($"{nameof(GetTestModuleAsync)}: Using device {ret.DeviceId} with module {ret.Id}.");
-            return ret;
+            return testModule;
         }
 
-        /// <summary>
-        /// Used in conjunction with ModuleClient.CreateFromConnectionString()
-        /// </summary>
-        public string ConnectionString
+        public async ValueTask DisposeAsync()
         {
-            get
-            {
-                string iotHubHostName = TestConfiguration.IotHub.GetIotHubHostName();
-                return $"HostName={iotHubHostName};DeviceId={_module.DeviceId};ModuleId={_module.Id};SharedAccessKey={_module.Authentication.SymmetricKey.PrimaryKey}";
-            }
+            await _testDevice.DisposeAsync().ConfigureAwait(false);
+            GC.SuppressFinalize(this);
         }
-
-        /// <summary>
-        /// Module ID
-        /// </summary>
-        public string Id => _module.Id;
-
-        /// <summary>
-        /// Device ID
-        /// </summary>
-        public string DeviceId => _module.DeviceId;
     }
 }

--- a/e2e/test/helpers/TestModule.cs
+++ b/e2e/test/helpers/TestModule.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-using static Microsoft.Azure.Devices.E2ETests.Helpers.HostNameHelper;
 
 namespace Microsoft.Azure.Devices.E2ETests.Helpers
 {
@@ -21,16 +20,15 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         /// </summary>
         public static async Task<TestModule> GetTestModuleAsync(string deviceNamePrefix, string moduleNamePrefix)
         {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(deviceNamePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(deviceNamePrefix).ConfigureAwait(false);
 
             string deviceName = testDevice.Id;
-            string moduleName = "E2E_" + moduleNamePrefix + Guid.NewGuid();
+            string moduleName = $"E2E_{moduleNamePrefix}_{Guid.NewGuid()}";
 
-            using var sc = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
+            IotHubServiceClient sc = TestDevice.ServiceClient;
             VerboseTestLogger.WriteLine($"{nameof(GetTestModuleAsync)}: Creating module for device {deviceName}.");
 
-            var requestModule = new Module(deviceName, moduleName);
-            Module module = await sc.Modules.CreateAsync(requestModule).ConfigureAwait(false);
+            Module module = await sc.Modules.CreateAsync(new Module(deviceName, moduleName)).ConfigureAwait(false);
 
             var ret = new TestModule(module);
 
@@ -45,7 +43,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         {
             get
             {
-                string iotHubHostName = GetHostName(TestConfiguration.IotHub.ConnectionString);
+                string iotHubHostName = TestConfiguration.IotHub.GetIotHubHostName();
                 return $"HostName={iotHubHostName};DeviceId={_module.DeviceId};ModuleId={_module.Id};SharedAccessKey={_module.Authentication.SymmetricKey.PrimaryKey}";
             }
         }

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
             Func<IotHubDeviceClient, TestDevice, Task> testOperation,
             Func<Task> cleanupOperation)
         {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(devicePrefix, type).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(devicePrefix, type).ConfigureAwait(false);
 
             await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSettings));
 
@@ -198,8 +198,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                     }
                     sw.Reset();
                 }
-
-                await deviceClient.CloseAsync().ConfigureAwait(false);
             }
             finally
             {
@@ -207,7 +205,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                 {
                     await cleanupOperation().ConfigureAwait(false);
                 }
-                await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
 
                 if (!FaultShouldDisconnect(faultType))
                 {

--- a/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
@@ -164,17 +164,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                         await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
                     }
                 }
-
-                // Close all the device clients.
-                await Task.WhenAll(deviceClients.Select(x => x.CloseAsync())).ConfigureAwait(false);
             }
             finally
             {
                 await cleanupOperation(deviceClients, testDeviceCallbackHandlers).ConfigureAwait(false);
 
                 testDeviceCallbackHandlers.ForEach(x => x.Dispose());
-                await Task.WhenAll(deviceClients.Select(x => x.DisposeAsync().AsTask())).ConfigureAwait(false);
-                await Task.WhenAll(testDevices.Select(x => x.RemoveDeviceAsync())).ConfigureAwait(false);
+                await Task.WhenAll(testDevices.Select(x => x.DisposeAsync().AsTask())).ConfigureAwait(false);
 
                 if (!FaultInjection.FaultShouldDisconnect(faultType))
                 {

--- a/e2e/test/helpers/templates/PoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/PoolingOverAmqp.cs
@@ -83,13 +83,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                     await cleanupOperation().ConfigureAwait(false);
                 }
 
-                await Task.WhenAll(deviceClients.Select(x => x.DisposeAsync().AsTask())).ConfigureAwait(false);
                 testDeviceCallbackHandlers.ForEach(testDeviceCallbackHandler => testDeviceCallbackHandler.Dispose());
-
-                // Clean up the local lists
-                testDevices.Clear();
-                deviceClients.Clear();
-                amqpConnectionStatuses.Clear();
+                await Task.WhenAll(testDevices.Select(x => x.DisposeAsync().AsTask())).ConfigureAwait(false);
             }
         }
 
@@ -103,7 +98,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
             public void ConnectionStatusChangeHandler(ConnectionStatusInfo connectionStatusInfo)
             {
                 ConnectionStatusChangeHandlerCount++;
-                VerboseTestLogger.WriteLine($"{nameof(PoolingOverAmqp)}.{nameof(ConnectionStatusChangeHandler)}: status={connectionStatusInfo.Status} statusChangeReason={connectionStatusInfo.ChangeReason} count={ConnectionStatusChangeHandlerCount}");
+                VerboseTestLogger.WriteLine(
+                    $"{nameof(PoolingOverAmqp)}.{nameof(ConnectionStatusChangeHandler)}: status={connectionStatusInfo.Status} statusChangeReason={connectionStatusInfo.ChangeReason} count={ConnectionStatusChangeHandlerCount}");
             }
 
             public int ConnectionStatusChangeHandlerCount { get; set; }

--- a/e2e/test/iothub/device/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
+++ b/e2e/test/iothub/device/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         private async Task TestSecurityMessageModuleAsync(IotHubClientTransportSettings transportSettings)
         {
-            TestModule testModule = await TestModule.GetTestModuleAsync(_devicePrefix, _modulePrefix).ConfigureAwait(false);
+            await using TestModule testModule = await TestModule.GetTestModuleAsync(_devicePrefix, _modulePrefix).ConfigureAwait(false);
 
             await using var moduleClient = new IotHubModuleClient(testModule.ConnectionString, new IotHubClientOptions(transportSettings));
             await moduleClient.OpenAsync().ConfigureAwait(false);

--- a/e2e/test/iothub/device/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
+++ b/e2e/test/iothub/device/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
@@ -123,8 +123,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         private async Task TestSecurityMessageAsync(IotHubClientTransportSettings transportSettings)
         {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
-            await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSettings));
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
+            IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSettings));
             await testDevice.OpenWithRetryAsync().ConfigureAwait(false);
             await SendSingleSecurityMessageAsync(deviceClient).ConfigureAwait(false);
         }

--- a/e2e/test/iothub/device/DeviceClientX509AuthenticationE2ETests.cs
+++ b/e2e/test/iothub/device/DeviceClientX509AuthenticationE2ETests.cs
@@ -173,9 +173,8 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         private static async Task SendMessageTestAsync(IotHubClientTransportSettings transportSetting)
         {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(s_devicePrefix, TestDeviceType.X509).ConfigureAwait(false);
-
-            await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSetting));
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(s_devicePrefix, TestDeviceType.X509).ConfigureAwait(false);
+            IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSetting));
             await testDevice.OpenWithRetryAsync().ConfigureAwait(false);
             TelemetryMessage message = TelemetryE2ETests.ComposeD2cTestMessage(out string _, out string _);
             await deviceClient.SendTelemetryAsync(message).ConfigureAwait(false);

--- a/e2e/test/iothub/device/FileUploadE2ETests.cs
+++ b/e2e/test/iothub/device/FileUploadE2ETests.cs
@@ -96,9 +96,11 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         private async Task UploadFileGranularAsync(Stream source, string filename, IotHubClientHttpSettings fileUploadTransportSettings, bool isCorrelationIdValid, bool useX509auth = false)
         {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(
-                _devicePrefix,
-                useX509auth ? TestDeviceType.X509 : TestDeviceType.Sasl).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice
+                .GetTestDeviceAsync(
+                    _devicePrefix,
+                    useX509auth ? TestDeviceType.X509 : TestDeviceType.Sasl)
+                .ConfigureAwait(false);
 
             IotHubDeviceClient deviceClient;
             var clientOptions = new IotHubClientOptions
@@ -157,7 +159,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             string blobName,
             bool useX509auth = false)
         {
-            using TestDevice testDevice = await TestDevice
+            await using TestDevice testDevice = await TestDevice
                 .GetTestDeviceAsync(
                     _devicePrefix,
                     useX509auth
@@ -189,7 +191,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 FileUploadSasUriResponse sasUriResponse = await deviceClient
                     .GetFileUploadSasUriAsync(new FileUploadSasUriRequest(blobName))
                     .ConfigureAwait(false);
-                await deviceClient.CloseAsync().ConfigureAwait(false);
             }
         }
 

--- a/e2e/test/iothub/device/IotHubDeviceClientTests.cs
+++ b/e2e/test/iothub/device/IotHubDeviceClientTests.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.Devices.E2ETests
         public async Task IotHubDeviceClient_SendTelemetryAsync_AfterExplicitOpenAsync_DoesNotThrow()
         {
             // arrange
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(nameof(IotHubDeviceClientTests));
-            await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient();
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(nameof(IotHubDeviceClientTests));
+            IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient();
             await testDevice.OpenWithRetryAsync().ConfigureAwait(false);
 
             // act

--- a/e2e/test/iothub/device/MethodE2ECustomPayloadTests.cs
+++ b/e2e/test/iothub/device/MethodE2ECustomPayloadTests.cs
@@ -111,10 +111,10 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             TimeSpan responseTimeout = default,
             IotHubServiceClientOptions serviceClientTransportSettings = default)
         {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
             var options = new IotHubClientOptions(transportSettings);
             await using var deviceClient = new IotHubDeviceClient(testDevice.ConnectionString, options);
-            await deviceClient.OpenAsync().ConfigureAwait(false);
+            await TestDevice.OpenWithRetryAsync(deviceClient).ConfigureAwait(false);
 
             Task methodReceivedTask = await setDeviceReceiveMethod(deviceClient, MethodName).ConfigureAwait(false);
             Task serviceSendTask = ServiceSendMethodAndVerifyResponseAsync(
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             TimeSpan responseTimeout = default,
             IotHubServiceClientOptions serviceClientTransportSettings = default)
         {
-            using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
+            var serviceClient = TestDevice.ServiceClient;
             TimeSpan methodTimeout = responseTimeout == default ? s_defaultMethodTimeoutMinutes : responseTimeout;
             VerboseTestLogger.WriteLine($"{nameof(ServiceSendMethodAndVerifyResponseAsync)}: Invoke method {methodName}.");
 

--- a/e2e/test/iothub/device/MethodE2ETests.cs
+++ b/e2e/test/iothub/device/MethodE2ETests.cs
@@ -594,7 +594,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             TimeSpan responseTimeout = default,
             IotHubServiceClientOptions serviceClientTransportSettings = default)
         {
-            TestModule testModule = await TestModule.GetTestModuleAsync(_devicePrefix, _modulePrefix).ConfigureAwait(false);
+            await using TestModule testModule = await TestModule.GetTestModuleAsync(_devicePrefix, _modulePrefix).ConfigureAwait(false);
             var options = new IotHubClientOptions(transportSettings);
             await using var moduleClient = new IotHubModuleClient(testModule.ConnectionString, options);
             await moduleClient.OpenAsync().ConfigureAwait(false);

--- a/e2e/test/iothub/device/NoRetryE2ETests.cs
+++ b/e2e/test/iothub/device/NoRetryE2ETests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestCategory("FaultInjection")]
         public async Task FaultInjection_NoRetry_NoRecovery_OpenAsync()
         {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix, TestDeviceType.Sasl).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix, TestDeviceType.Sasl).ConfigureAwait(false);
             
             var options = new IotHubClientOptions(new IotHubClientAmqpSettings())
             {

--- a/e2e/test/iothub/device/TelemetryE2eTests.cs
+++ b/e2e/test/iothub/device/TelemetryE2eTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         private async Task SendSingleMessageAsync(TestDeviceType type, IotHubClientTransportSettings transportSettings, int messageSize = 0)
         {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_idPrefix, type).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_idPrefix, type).ConfigureAwait(false);
             var options = new IotHubClientOptions(transportSettings);
             await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(options);
             await testDevice.OpenWithRetryAsync().ConfigureAwait(false);
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         private async Task SendBatchMessages(TestDeviceType type, IotHubClientTransportSettings transportSettings)
         {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_idPrefix, type).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_idPrefix, type).ConfigureAwait(false);
             var options = new IotHubClientOptions(transportSettings);
             await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(options);
             await testDevice.OpenWithRetryAsync().ConfigureAwait(false);
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         private async Task OpenCloseOpenThenSendSingleMessage(TestDeviceType type, IotHubClientTransportSettings transportSettings, int messageSize = 0)
         {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_idPrefix, type).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_idPrefix, type).ConfigureAwait(false);
             var options = new IotHubClientOptions(transportSettings);
             await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(options);
             await testDevice.OpenWithRetryAsync().ConfigureAwait(false);

--- a/e2e/test/iothub/device/TelemetryE2eTests.cs
+++ b/e2e/test/iothub/device/TelemetryE2eTests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         private async Task SendSingleMessageModule(IotHubClientTransportSettings transportSettings)
         {
-            TestModule testModule = await TestModule.GetTestModuleAsync(_idPrefix, _idPrefix).ConfigureAwait(false);
+            await using TestModule testModule = await TestModule.GetTestModuleAsync(_idPrefix, _idPrefix).ConfigureAwait(false);
             var options = new IotHubClientOptions(transportSettings);
             await using var moduleClient = new IotHubModuleClient(testModule.ConnectionString, options);
 

--- a/e2e/test/iothub/device/TwinE2ETests.cs
+++ b/e2e/test/iothub/device/TwinE2ETests.cs
@@ -758,41 +758,34 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
             await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
 
-            try
-            {
-                var options = new IotHubClientOptions(transportSettings);
-                await using var deviceClient = new IotHubDeviceClient(testDevice.ConnectionString, options);
-                await deviceClient.OpenAsync().ConfigureAwait(false);
+            var options = new IotHubClientOptions(transportSettings);
+            await using var deviceClient = new IotHubDeviceClient(testDevice.ConnectionString, options);
+            await deviceClient.OpenAsync().ConfigureAwait(false);
 
-                await deviceClient
-                    .UpdateReportedPropertiesAsync(
-                        new ReportedProperties
-                        {
-                            [propName1] = null
-                        })
-                    .ConfigureAwait(false);
-                ClientTwin serviceTwin = await s_serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
-                Assert.IsFalse(serviceTwin.Properties.Reported.Contains(propName1));
+            await deviceClient
+                .UpdateReportedPropertiesAsync(
+                    new ReportedProperties
+                    {
+                        [propName1] = null
+                    })
+                .ConfigureAwait(false);
+            ClientTwin serviceTwin = await s_serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
+            Assert.IsFalse(serviceTwin.Properties.Reported.Contains(propName1));
 
-                await deviceClient
-                    .UpdateReportedPropertiesAsync(
-                        new ReportedProperties
+            await deviceClient
+                .UpdateReportedPropertiesAsync(
+                    new ReportedProperties
+                    {
+                        [propName1] = new Dictionary<string, object>
                         {
-                            [propName1] = new Dictionary<string, object>
-                            {
-                                [propName2] = null
-                            }
-                        })
-                    .ConfigureAwait(false);
-                serviceTwin = await s_serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
-                serviceTwin.Properties.Reported.Contains(propName1).Should().BeTrue();
-                serviceTwin.Properties.Reported.TryGetValue(propName1, out Dictionary<string, object> value1).Should().BeTrue();
-                value1.Count.Should().Be(0);
-            }
-            finally
-            {
-                await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
-            }
+                            [propName2] = null
+                        }
+                    })
+                .ConfigureAwait(false);
+            serviceTwin = await s_serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
+            serviceTwin.Properties.Reported.Contains(propName1).Should().BeTrue();
+            serviceTwin.Properties.Reported.TryGetValue(propName1, out Dictionary<string, object> value1).Should().BeTrue();
+            value1.Count.Should().Be(0);
         }
 
         [DataTestMethod, Timeout(LongRunningTestTimeoutMilliseconds)]

--- a/e2e/test/iothub/service/BulkOperationsE2ETests.cs
+++ b/e2e/test/iothub/service/BulkOperationsE2ETests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             string tagName = Guid.NewGuid().ToString();
             string tagValue = Guid.NewGuid().ToString();
 
-            TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix).ConfigureAwait(false);
+            await using TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix).ConfigureAwait(false);
             IotHubServiceClient serviceClient = TestDevice.ServiceClient;
 
             ClientTwin twin = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);

--- a/e2e/test/iothub/service/BulkOperationsE2ETests.cs
+++ b/e2e/test/iothub/service/BulkOperationsE2ETests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             string tagName = Guid.NewGuid().ToString();
             string tagValue = Guid.NewGuid().ToString();
 
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
 
             ClientTwin twin = await serviceClient.Twins.GetAsync(testDevice.Id).ConfigureAwait(false);
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             string tagName = Guid.NewGuid().ToString();
             string tagValue = Guid.NewGuid().ToString();
 
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
 
             var twin = new ClientTwin(testDevice.Id);
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             string tagValue = Guid.NewGuid().ToString();
 
             TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix).ConfigureAwait(false);
-            using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
+            IotHubServiceClient serviceClient = TestDevice.ServiceClient;
 
             ClientTwin twin = await serviceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
             twin.Tags[tagName] = tagValue;
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix).ConfigureAwait(false);
 
-            using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
+            var serviceClient = TestDevice.ServiceClient;
             var twin = new ClientTwin(testModule.DeviceId)
             {
                 ModuleId = testModule.Id

--- a/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
+++ b/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Azure;
 using FluentAssertions;
@@ -23,89 +22,80 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         private const string TemperatureControllerModelId = "dtmi:com:example:TemperatureController;1";
 
         private readonly string _devicePrefix = $"{nameof(DigitalTwinClientE2ETests)}_";
-        private static readonly string s_connectionString = TestConfiguration.IotHub.ConnectionString;
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task DigitalTwinWithOnlyRootComponentOperationsAsync()
         {
             // Create a new test device instance.
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
             string deviceId = testDevice.Id;
 
-            try
+            // Create a device client instance over Mqtt, initializing it with the "Thermostat" model which has only a root component.
+            var options = new IotHubClientOptions(new IotHubClientMqttSettings())
             {
-                // Create a device client instance over Mqtt, initializing it with the "Thermostat" model which has only a root component.
-                var options = new IotHubClientOptions(new IotHubClientMqttSettings())
+                ModelId = ThermostatModelId,
+            };
+            // Call openAsync() to open the device's connection, so that the ModelId is sent over Mqtt CONNECT packet.
+            IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(options);
+            await testDevice.OpenWithRetryAsync().ConfigureAwait(false);
+
+            // Perform operations on the digital twin.
+            var serviceClient = TestDevice.ServiceClient;
+
+            // Retrieve the digital twin.
+            DigitalTwinGetResponse<ThermostatTwin> response = await serviceClient.DigitalTwins
+                .GetAsync<ThermostatTwin>(deviceId)
+                .ConfigureAwait(false);
+
+            ThermostatTwin twin = response.DigitalTwin;
+            twin.Metadata.ModelId.Should().Be(ThermostatModelId);
+            response.ETag.Should().NotBeNull();
+
+            // Set callback handler for receiving root-level twin property updates.
+            await deviceClient.SetDesiredPropertyUpdateCallbackAsync((patch) =>
+            {
+                VerboseTestLogger.WriteLine($"{nameof(DigitalTwinWithComponentOperationsAsync)}: DesiredProperty update received: {patch}.");
+                return Task.FromResult(true);
+            });
+
+            // Update the root-level property "targetTemperature".
+            string propertyName = "targetTemperature";
+            double propertyValue = new Random().Next(0, 100);
+            var patchDocument = new JsonPatchDocument();
+            patchDocument.AppendAdd($"/{propertyName}", propertyValue);
+            string patch = patchDocument.ToString();
+            DigitalTwinUpdateResponse updateResponse = await serviceClient.DigitalTwins.UpdateAsync(deviceId, patch);
+
+            // Set callback to handle root-level command invocation request.
+            int expectedCommandStatus = 200;
+            string commandName = "getMaxMinReport";
+            await deviceClient.SetDirectMethodCallbackAsync(
+                (request) =>
                 {
-                    ModelId = ThermostatModelId,
-                };
-                // Call openAsync() to open the device's connection, so that the ModelId is sent over Mqtt CONNECT packet.
-                await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(options);
-                await testDevice.OpenWithRetryAsync().ConfigureAwait(false);
+                    VerboseTestLogger.WriteLine($"{nameof(DigitalTwinWithOnlyRootComponentOperationsAsync)}: Digital twin command received: {request.MethodName}.");
+                    var response = new Client.DirectMethodResponse(404);
 
-                // Perform operations on the digital twin.
-                using var serviceClient = new IotHubServiceClient(s_connectionString);
+                    if (request.MethodName == commandName)
+                    {
+                        response.Status = expectedCommandStatus;
+                        response.Payload = request.MethodName;
+                    }
 
-                // Retrieve the digital twin.
-                DigitalTwinGetResponse<ThermostatTwin> response = await serviceClient.DigitalTwins
-                    .GetAsync<ThermostatTwin>(deviceId)
-                    .ConfigureAwait(false);
-
-                ThermostatTwin twin = response.DigitalTwin;
-                twin.Metadata.ModelId.Should().Be(ThermostatModelId);
-                response.ETag.Should().NotBeNull();
-
-                // Set callback handler for receiving root-level twin property updates.
-                await deviceClient.SetDesiredPropertyUpdateCallbackAsync((patch) =>
-                {
-                    VerboseTestLogger.WriteLine($"{nameof(DigitalTwinWithComponentOperationsAsync)}: DesiredProperty update received: {patch}.");
-                    return Task.FromResult(true);
+                    return Task.FromResult(response);
                 });
 
-                // Update the root-level property "targetTemperature".
-                string propertyName = "targetTemperature";
-                double propertyValue = new Random().Next(0, 100);
-                var patchDocument = new JsonPatchDocument();
-                patchDocument.AppendAdd($"/{propertyName}", propertyValue);
-                string patch = patchDocument.ToString();
-                DigitalTwinUpdateResponse updateResponse = await serviceClient.DigitalTwins.UpdateAsync(deviceId, patch);
-
-                // Set callback to handle root-level command invocation request.
-                int expectedCommandStatus = 200;
-                string commandName = "getMaxMinReport";
-                await deviceClient.SetDirectMethodCallbackAsync(
-                    (request) =>
-                    {
-                        VerboseTestLogger.WriteLine($"{nameof(DigitalTwinWithOnlyRootComponentOperationsAsync)}: Digital twin command received: {request.MethodName}.");
-                        var response = new Client.DirectMethodResponse(404);
-
-                        if (request.MethodName == commandName)
-                        {
-                            response.Status = expectedCommandStatus;
-                            response.Payload = request.MethodName;
-                        }
-
-                        return Task.FromResult(response);
-                    });
-
-                // Invoke the root-level command "getMaxMinReport" on the digital twin.
-                DateTimeOffset since = DateTimeOffset.Now.Subtract(TimeSpan.FromMinutes(1));
-                var requestOptions = new InvokeDigitalTwinCommandOptions
-                {
-                    Payload = JsonConvert.SerializeObject(since)
-                };
-                InvokeDigitalTwinCommandResponse commandResponse = await serviceClient.DigitalTwins
-                    .InvokeCommandAsync(deviceId, commandName, requestOptions)
-                    .ConfigureAwait(false);
-                commandResponse.Status.Should().Be(expectedCommandStatus);
-                commandResponse.Payload.Should().Be(JsonConvert.SerializeObject(commandName));
-            }
-            finally
+            // Invoke the root-level command "getMaxMinReport" on the digital twin.
+            DateTimeOffset since = DateTimeOffset.Now.Subtract(TimeSpan.FromMinutes(1));
+            var requestOptions = new InvokeDigitalTwinCommandOptions
             {
-                // Delete the device.
-                await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
-            }
+                Payload = JsonConvert.SerializeObject(since)
+            };
+            InvokeDigitalTwinCommandResponse commandResponse = await serviceClient.DigitalTwins
+                .InvokeCommandAsync(deviceId, commandName, requestOptions)
+                .ConfigureAwait(false);
+            commandResponse.Status.Should().Be(expectedCommandStatus);
+            commandResponse.Payload.Should().Be(JsonConvert.SerializeObject(commandName));
         }
 
         [TestMethod]
@@ -113,111 +103,103 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         public async Task DigitalTwinWithComponentOperationsAsync()
         {
             // Create a new test device instance.
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
+            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
             string deviceId = testDevice.Id;
 
-            try
+            // Create a device client instance over Mqtt, initializing it with the "TemperatureController" model which has "Thermostat" components.
+            var options = new IotHubClientOptions(new IotHubClientMqttSettings())
             {
-                // Create a device client instance over Mqtt, initializing it with the "TemperatureController" model which has "Thermostat" components.
-                var options = new IotHubClientOptions(new IotHubClientMqttSettings())
+                ModelId = TemperatureControllerModelId,
+            };
+            // Call openAsync() to open the device's connection, so that the ModelId is sent over Mqtt CONNECT packet.
+            IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(options);
+            await testDevice.OpenWithRetryAsync().ConfigureAwait(false);
+
+            // Perform operations on the digital twin.
+            var serviceClient = TestDevice.ServiceClient;
+
+            // Retrieve the digital twin.
+            DigitalTwinGetResponse<TemperatureControllerTwin> response = await serviceClient.DigitalTwins
+                .GetAsync<TemperatureControllerTwin>(deviceId)
+                .ConfigureAwait(false);
+
+            TemperatureControllerTwin twin = response.DigitalTwin;
+            twin.Metadata.ModelId.Should().Be(TemperatureControllerModelId);
+            response.ETag.Should().NotBeNull();
+
+            string componentName = "thermostat1";
+
+            // Set callback handler for receiving twin property updates.
+            await deviceClient.SetDesiredPropertyUpdateCallbackAsync((patch) =>
+            {
+                VerboseTestLogger.WriteLine($"{nameof(DigitalTwinWithComponentOperationsAsync)}: DesiredProperty update received: {patch}.");
+                return Task.FromResult(true);
+            });
+
+            // Update the property "targetTemperature" under component "thermostat1" on the digital twin.
+            // NOTE: since this is the first operation on the digital twin, the component "thermostat1" doesn't exist on it yet.
+            // So we will create a property patch that "adds" a component, and updates the property in it.
+            string propertyName = "targetTemperature";
+            double propertyValue = new Random().Next(0, 100);
+            var propertyValues = new Dictionary<string, object> { { propertyName, propertyValue } };
+
+            var patchDocument = new JsonPatchDocument();
+            patchDocument.AppendAdd($"/{componentName}", propertyValues);
+            string patch = patchDocument.ToString();
+            DigitalTwinUpdateResponse updateResponse = await serviceClient.DigitalTwins
+                .UpdateAsync(deviceId, patch)
+                .ConfigureAwait(false);
+
+            // Set callbacks to handle command requests.
+            int expectedCommandStatus = 200;
+
+            // Set callback to handle both root-level and component-level command invocation requests.
+            // For a component-level command, the command name is in the format "<component-name>*<command-name>".
+
+            string rootCommandName = "reboot";
+            string componentCommandName = "getMaxMinReport";
+            string componentCommandNamePnp = $"{componentName}*{componentCommandName}";
+            await deviceClient.SetDirectMethodCallbackAsync(
+                (request) =>
                 {
-                    ModelId = TemperatureControllerModelId,
-                };
-                // Call openAsync() to open the device's connection, so that the ModelId is sent over Mqtt CONNECT packet.
-                await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(options);
-                await testDevice.OpenWithRetryAsync().ConfigureAwait(false);
+                    VerboseTestLogger.WriteLine($"{nameof(DigitalTwinWithOnlyRootComponentOperationsAsync)}: Digital twin command received: {request.MethodName}.");
+                    var response = new Client.DirectMethodResponse(404);
 
-                // Perform operations on the digital twin.
-                var serviceClient = TestDevice.ServiceClient;
+                    if (request.MethodName == rootCommandName
+                        || request.MethodName == componentCommandNamePnp)
+                    {
+                        response.Status = expectedCommandStatus;
+                        response.Payload = request.MethodName;
+                    }
 
-                // Retrieve the digital twin.
-                DigitalTwinGetResponse<TemperatureControllerTwin> response = await serviceClient.DigitalTwins
-                    .GetAsync<TemperatureControllerTwin>(deviceId)
-                    .ConfigureAwait(false);
-
-                TemperatureControllerTwin twin = response.DigitalTwin;
-                twin.Metadata.ModelId.Should().Be(TemperatureControllerModelId);
-                response.ETag.Should().NotBeNull();
-
-                string componentName = "thermostat1";
-
-                // Set callback handler for receiving twin property updates.
-                await deviceClient.SetDesiredPropertyUpdateCallbackAsync((patch) =>
-                {
-                    VerboseTestLogger.WriteLine($"{nameof(DigitalTwinWithComponentOperationsAsync)}: DesiredProperty update received: {patch}.");
-                    return Task.FromResult(true);
+                    return Task.FromResult(response);
                 });
 
-                // Update the property "targetTemperature" under component "thermostat1" on the digital twin.
-                // NOTE: since this is the first operation on the digital twin, the component "thermostat1" doesn't exist on it yet.
-                // So we will create a property patch that "adds" a component, and updates the property in it.
-                string propertyName = "targetTemperature";
-                double propertyValue = new Random().Next(0, 100);
-                var propertyValues = new Dictionary<string, object> { { propertyName, propertyValue } };
-
-                var patchDocument = new JsonPatchDocument();
-                patchDocument.AppendAdd($"/{componentName}", propertyValues);
-                string patch = patchDocument.ToString();
-                DigitalTwinUpdateResponse updateResponse = await serviceClient.DigitalTwins
-                    .UpdateAsync(deviceId, patch)
-                    .ConfigureAwait(false);
-
-                // Set callbacks to handle command requests.
-                int expectedCommandStatus = 200;
-
-                // Set callback to handle both root-level and component-level command invocation requests.
-                // For a component-level command, the command name is in the format "<component-name>*<command-name>".
-
-                string rootCommandName = "reboot";
-                string componentCommandName = "getMaxMinReport";
-                string componentCommandNamePnp = $"{componentName}*{componentCommandName}";
-                await deviceClient.SetDirectMethodCallbackAsync(
-                    (request) =>
-                    {
-                        VerboseTestLogger.WriteLine($"{nameof(DigitalTwinWithOnlyRootComponentOperationsAsync)}: Digital twin command received: {request.MethodName}.");
-                        var response = new Client.DirectMethodResponse(404);
-
-                        if (request.MethodName == rootCommandName
-                            || request.MethodName == componentCommandNamePnp)
-                        {
-                            response.Status = expectedCommandStatus;
-                            response.Payload = request.MethodName;
-                        }
-
-                        return Task.FromResult(response);
-                    });
-
-                // Invoke the root-level command "reboot" on the digital twin.
-                int delay = 1;
-                var requestOptions = new InvokeDigitalTwinCommandOptions()
-                {
-                    Payload = JsonConvert.SerializeObject(delay)
-                };
-                InvokeDigitalTwinCommandResponse rootCommandResponse = await serviceClient.DigitalTwins
-                    .InvokeCommandAsync(deviceId, rootCommandName, requestOptions)
-                    .ConfigureAwait(false);
-
-                rootCommandResponse.Status.Should().Be(expectedCommandStatus);
-                rootCommandResponse.Payload.Should().Be(JsonConvert.SerializeObject(rootCommandName));
-
-                // Invoke the command "getMaxMinReport" under component "thermostat1" on the digital twin.
-                DateTimeOffset since = DateTimeOffset.Now.Subtract(TimeSpan.FromMinutes(1));
-                requestOptions = new InvokeDigitalTwinCommandOptions()
-                {
-                    Payload = JsonConvert.SerializeObject(since)
-                };
-                InvokeDigitalTwinCommandResponse componentCommandResponse = await serviceClient.DigitalTwins
-                    .InvokeComponentCommandAsync(deviceId, componentName, componentCommandName, requestOptions)
-                    .ConfigureAwait(false);
-
-                componentCommandResponse.Status.Should().Be(expectedCommandStatus);
-                componentCommandResponse.Payload.Should().Be(JsonConvert.SerializeObject(componentCommandNamePnp));
-            }
-            finally
+            // Invoke the root-level command "reboot" on the digital twin.
+            int delay = 1;
+            var requestOptions = new InvokeDigitalTwinCommandOptions()
             {
-                // Delete the device.
-                await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
-            }
+                Payload = JsonConvert.SerializeObject(delay)
+            };
+            InvokeDigitalTwinCommandResponse rootCommandResponse = await serviceClient.DigitalTwins
+                .InvokeCommandAsync(deviceId, rootCommandName, requestOptions)
+                .ConfigureAwait(false);
+
+            rootCommandResponse.Status.Should().Be(expectedCommandStatus);
+            rootCommandResponse.Payload.Should().Be(JsonConvert.SerializeObject(rootCommandName));
+
+            // Invoke the command "getMaxMinReport" under component "thermostat1" on the digital twin.
+            DateTimeOffset since = DateTimeOffset.Now.Subtract(TimeSpan.FromMinutes(1));
+            requestOptions = new InvokeDigitalTwinCommandOptions()
+            {
+                Payload = JsonConvert.SerializeObject(since)
+            };
+            InvokeDigitalTwinCommandResponse componentCommandResponse = await serviceClient.DigitalTwins
+                .InvokeComponentCommandAsync(deviceId, componentName, componentCommandName, requestOptions)
+                .ConfigureAwait(false);
+
+            componentCommandResponse.Status.Should().Be(expectedCommandStatus);
+            componentCommandResponse.Payload.Should().Be(JsonConvert.SerializeObject(componentCommandNamePnp));
         }
     }
 }

--- a/e2e/test/iothub/service/FileUploadNotificationE2ETest.cs
+++ b/e2e/test/iothub/service/FileUploadNotificationE2ETest.cs
@@ -155,8 +155,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
         private async Task UploadFile()
         {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
-            await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(new IotHubClientAmqpSettings()));
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
+            IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(new IotHubClientAmqpSettings()));
             await testDevice.OpenWithRetryAsync().ConfigureAwait(false);
             const string filePath = "TestPayload.txt";
             using FileStream fileStreamSource = File.Create(filePath);

--- a/e2e/test/iothub/service/IoTHubServiceProxyE2ETests.cs
+++ b/e2e/test/iothub/service/IoTHubServiceProxyE2ETests.cs
@@ -35,14 +35,13 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 Proxy = new WebProxy(TestConfiguration.IotHub.ProxyServerAddress),
             };
 
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(s_devicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(s_devicePrefix).ConfigureAwait(false);
             await using var deviceClient = new IotHubDeviceClient(testDevice.ConnectionString);
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString, options);
             (Message testMessage, string messageId, string payload, string p1Value) = ComposeTelemetryMessage();
             await serviceClient.Messages.OpenAsync().ConfigureAwait(false);
             await serviceClient.Messages.SendAsync(testDevice.Id, testMessage).ConfigureAwait(false);
 
-            await deviceClient.CloseAsync().ConfigureAwait(false);
             await serviceClient.Messages.CloseAsync().ConfigureAwait(false);
         }
 

--- a/e2e/test/iothub/service/MessageFeedbackReceiverE2ETest.cs
+++ b/e2e/test/iothub/service/MessageFeedbackReceiverE2ETest.cs
@@ -34,8 +34,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 Protocol = protocol,
             };
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString, options);
-
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
 
             try
             {

--- a/e2e/test/iothub/service/MessagingClientE2ETests.cs
+++ b/e2e/test/iothub/service/MessagingClientE2ETests.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
         private async Task TestTimeout(CancellationToken cancellationToken)
         {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
-            using var sender = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            IotHubServiceClient sender = TestDevice.ServiceClient;
 
             // don't pass in cancellation token here. This test is for seeing how SendAsync reacts with an valid or expired token.
             await sender.Messages.OpenAsync(CancellationToken.None).ConfigureAwait(false);
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             {
                 Protocol = protocol
             };
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             using var sender = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString, options);
             await sender.Messages.OpenAsync().ConfigureAwait(false);
 
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             {
                 Protocol = protocol
             };
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             using var sender = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString, options);
 
             // Open, close, then re-open the client
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             {
                 Protocol = protocol
             };
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             using var sender = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString, options);
             await sender.Messages.OpenAsync().ConfigureAwait(false);
 
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         public async Task MessageIdDefaultNotSet_SendEventDoesNotSetMessageId()
         {
             // arrange
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             using var sender = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
             await sender.Messages.OpenAsync().ConfigureAwait(false);
             string messageId = Guid.NewGuid().ToString();
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         public async Task MessageIdDefaultSetToNull_SendEventDoesNotSetMessageId()
         {
             // arrange
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             var options = new IotHubServiceClientOptions
             {
                 SdkAssignsMessageId = SdkAssignsMessageId.Never,
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         public async Task MessageIdDefaultSetToGuid_SendEventSetMessageIdIfNotSet()
         {
             // arrange
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             var options = new IotHubServiceClientOptions
             {
                 SdkAssignsMessageId = SdkAssignsMessageId.WhenUnset,
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             {
                 Protocol = protocol
             };
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(DevicePrefix).ConfigureAwait(false);
             using var sender = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString, options);
             await sender.Messages.OpenAsync().ConfigureAwait(false);
 

--- a/e2e/test/iothub/service/PnpServiceTests.cs
+++ b/e2e/test/iothub/service/PnpServiceTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             // Setup
 
             // Create a module.
-            TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix).ConfigureAwait(false);
+            await using TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix).ConfigureAwait(false);
 
             // Send model ID with MQTT connect packet to make the module plug and play.
             var options = new IotHubClientOptions(new IotHubClientMqttSettings())

--- a/e2e/test/iothub/service/PnpServiceTests.cs
+++ b/e2e/test/iothub/service/PnpServiceTests.cs
@@ -96,29 +96,23 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             // Create a module.
             TestModule testModule = await TestModule.GetTestModuleAsync(DevicePrefix, ModulePrefix).ConfigureAwait(false);
 
-            try
+            // Send model ID with MQTT connect packet to make the module plug and play.
+            var options = new IotHubClientOptions(new IotHubClientMqttSettings())
             {
-                // Send model ID with MQTT connect packet to make the module plug and play.
-                var options = new IotHubClientOptions(new IotHubClientMqttSettings())
-                {
-                    ModelId = TestModelId,
-                };
-                await using var moduleClient = new IotHubModuleClient(testModule.ConnectionString, options);
-                await moduleClient.OpenAsync().ConfigureAwait(false);
+                ModelId = TestModelId,
+            };
+            await using var moduleClient = new IotHubModuleClient(testModule.ConnectionString, options);
+            await moduleClient.OpenAsync().ConfigureAwait(false);
 
-                // Act
+            // Act
 
-                // Get module twin.
-                ClientTwin twin = await TestDevice.ServiceClient.Twins.GetAsync(testModule.DeviceId, testModule.Id).ConfigureAwait(false);
+            // Get module twin.
+            ClientTwin twin = await TestDevice.ServiceClient.Twins
+                .GetAsync(testModule.DeviceId, testModule.Id)
+                .ConfigureAwait(false);
 
-                // Assert
-                twin.ModelId.Should().Be(TestModelId, "because the module was created as plug and play");
-            }
-            finally
-            {
-                // Cleanup
-                await TestDevice.ServiceClient.Devices.DeleteAsync(testModule.DeviceId).ConfigureAwait(false);
-            }
+            // Assert
+            twin.ModelId.Should().Be(TestModelId, "because the module was created as plug and play");
         }
     }
 }

--- a/e2e/test/iothub/service/PurgeMessageQueueE2ETests.cs
+++ b/e2e/test/iothub/service/PurgeMessageQueueE2ETests.cs
@@ -24,12 +24,12 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         [Timeout(TestTimeoutMilliseconds)]
         public async Task PurgeMessageQueueOperation()
         {
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
             string expectedDeviceId = testDevice.Device.Id;
             using var sc = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
             PurgeMessageQueueResult result = await sc.Messages.PurgeMessageQueueAsync(expectedDeviceId, CancellationToken.None).ConfigureAwait(false); // making sure the queue is empty
 
-            Message testMessage = ComposeD2CTestMessage();
+            var testMessage = new Message(Encoding.UTF8.GetBytes("some payload"));
 
             await sc.Messages.OpenAsync().ConfigureAwait(false);
             const int numberOfSends = 3;
@@ -41,11 +41,6 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             result = await sc.Messages.PurgeMessageQueueAsync(expectedDeviceId, CancellationToken.None).ConfigureAwait(false);
             result.DeviceId.Should().Be(expectedDeviceId);
             result.TotalMessagesPurged.Should().Be(numberOfSends);
-        }
-
-        private static Message ComposeD2CTestMessage()
-        {
-            return new Message(Encoding.UTF8.GetBytes("some payload"));
         }
     }
 }

--- a/e2e/test/iothub/service/QueryClientE2ETests.cs
+++ b/e2e/test/iothub/service/QueryClientE2ETests.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             // arrange
 
             using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            using TestDevice testDevice1 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
-            using TestDevice testDevice2 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            await using TestDevice testDevice1 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            await using TestDevice testDevice2 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
 
             string queryText = $"select * from devices where deviceId = '{testDevice1.Id}' OR deviceId = '{testDevice2.Id}'";
 
@@ -65,10 +65,10 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         {
             // arrange
 
-            using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            using TestDevice testDevice1 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
-            using TestDevice testDevice2 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
-            using TestDevice testDevice3 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            var serviceClient = TestDevice.ServiceClient;
+            await using TestDevice testDevice1 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            await using TestDevice testDevice2 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            await using TestDevice testDevice3 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
 
             string queryText = $"select * from devices where deviceId = '{testDevice1.Id}' OR deviceId = '{testDevice2.Id}' OR deviceId = '{testDevice3.Id}'";
             var firstPageOptions = new QueryOptions
@@ -119,10 +119,10 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         {
             // arrange
 
-            using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            using TestDevice testDevice1 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
-            using TestDevice testDevice2 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
-            using TestDevice testDevice3 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            var serviceClient = TestDevice.ServiceClient;
+            await using TestDevice testDevice1 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            await using TestDevice testDevice2 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            await using TestDevice testDevice3 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
 
             string queryText = $"select * from devices where deviceId = '{testDevice1.Id}' OR deviceId = '{testDevice2.Id}' OR deviceId = '{testDevice3.Id}'";
 
@@ -160,10 +160,10 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         {
             // arrange
 
-            using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            using TestDevice testDevice1 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
-            using TestDevice testDevice2 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
-            using TestDevice testDevice3 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            var serviceClient = TestDevice.ServiceClient;
+            await using TestDevice testDevice1 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            await using TestDevice testDevice2 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            await using TestDevice testDevice3 = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
 
             string queryText = $"select * from devices where deviceId = '{testDevice1.Id}' OR deviceId = '{testDevice2.Id}' OR deviceId = '{testDevice3.Id}'";
 
@@ -199,8 +199,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         [Timeout(TestTimeoutMilliseconds)]
         public async Task JobQuery_QueryWorks()
         {
-            using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            var serviceClient = TestDevice.ServiceClient;
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
 
             await QueryClientE2ETests.ScheduleJobToBeQueriedAsync(serviceClient.ScheduledJobs, testDevice.Id).ConfigureAwait(false);
 
@@ -237,8 +237,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         [Timeout(TestTimeoutMilliseconds)]
         public async Task JobQuery_QueryByTypeWorks()
         {
-            using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            var serviceClient = TestDevice.ServiceClient;
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
 
             await QueryClientE2ETests.ScheduleJobToBeQueriedAsync(serviceClient.ScheduledJobs, testDevice.Id).ConfigureAwait(false);
             await WaitForJobToBeQueryableAsync(serviceClient.Query, 1, null, null).ConfigureAwait(false);
@@ -261,8 +261,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         [Timeout(TestTimeoutMilliseconds)]
         public async Task RawQuery_QueryWorks()
         {
-            using var serviceClient = new IotHubServiceClient(TestConfiguration.IotHub.ConnectionString);
-            using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
+            var serviceClient = TestDevice.ServiceClient;
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_idPrefix).ConfigureAwait(false);
 
             string query = "SELECT COUNT() as TotalNumberOfDevices FROM devices";
 

--- a/e2e/test/iothub/service/SasCredentialAuthenticationTests.cs
+++ b/e2e/test/iothub/service/SasCredentialAuthenticationTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         public async Task DigitalTwinClient_Http_SasCredentialAuth_Success()
         {
             // arrange
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
             string thermostatModelId = "dtmi:com:example:TemperatureController;1";
 
             // Create a device client instance initializing it with the "Thermostat" model.
@@ -145,9 +145,6 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             ThermostatTwin twin = response.DigitalTwin;
             // assert
             twin.Metadata.ModelId.Should().Be(thermostatModelId);
-
-            // cleanup
-            await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -155,8 +152,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         public async Task Service_Amqp_SasCredentialAuth_Success()
         {
             // arrange
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
-            await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(new IotHubClientMqttSettings()));
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
+            IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(new IotHubClientMqttSettings()));
             await testDevice.OpenWithRetryAsync().ConfigureAwait(false);
 
             string signature = TestConfiguration.IotHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(1));
@@ -173,7 +170,6 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             // cleanup
             await serviceClient.Messages.CloseAsync().ConfigureAwait(false);
-            await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -181,8 +177,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         public async Task Service_Amqp_SasCredentialAuth_Renewed_Success()
         {
             // arrange
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
-            await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(new IotHubClientMqttSettings()));
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
+            IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(new IotHubClientMqttSettings()));
             await testDevice.OpenWithRetryAsync().ConfigureAwait(false);
 
             string signature = TestConfiguration.IotHub.GetIotHubSharedAccessSignature(TimeSpan.FromHours(-1));
@@ -209,9 +205,6 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             var message = new Message(Encoding.ASCII.GetBytes("Hello, Cloud!"));
             await serviceClient.Messages.SendAsync(testDevice.Id, message);
             await serviceClient.Messages.CloseAsync().ConfigureAwait(false);
-
-            // cleanup
-            await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
         }
     }
 }

--- a/e2e/test/iothub/service/TokenCredentialAuthenticationTests.cs
+++ b/e2e/test/iothub/service/TokenCredentialAuthenticationTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         public async Task DigitalTwinClient_Http_TokenCredentialAuth_Success()
         {
             // arrange
-            TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
             string thermostatModelId = "dtmi:com:example:TemperatureController;1";
 
             // Create a device client instance initializing it with the "Thermostat" model.
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 ModelId = thermostatModelId,
             };
             // Call openAsync() to open the device's connection, so that the ModelId is sent over Mqtt CONNECT packet.
-            await using IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(options);
+            IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(options);
             await testDevice.OpenWithRetryAsync().ConfigureAwait(false);
 
             using var serviceClient = new IotHubServiceClient(
@@ -108,9 +108,6 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
             // assert
             twin.Metadata.ModelId.Should().Be(thermostatModelId);
-
-            // cleanup
-            await testDevice.RemoveDeviceAsync().ConfigureAwait(false);
         }
 
         [TestMethod]

--- a/e2e/test/iothub/service/TwinsClientE2ETests.cs
+++ b/e2e/test/iothub/service/TwinsClientE2ETests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
@@ -25,7 +24,7 @@ namespace Microsoft.Azure.Devices.E2ETests.iothub.service
         public async Task TwinsClient_DeviceTwinLifecycle()
         {
             IotHubServiceClient serviceClient = TestDevice.ServiceClient;
-            TestModule module = await TestModule.GetTestModuleAsync(_idPrefix, _idPrefix).ConfigureAwait(false);
+            await using TestModule module = await TestModule.GetTestModuleAsync(_idPrefix, _idPrefix).ConfigureAwait(false);
 
             // Get the module twin
             ClientTwin moduleTwin = await serviceClient.Twins.GetAsync(module.DeviceId, module.Id).ConfigureAwait(false);

--- a/e2e/test/iothub/service/TwinsClientE2ETests.cs
+++ b/e2e/test/iothub/service/TwinsClientE2ETests.cs
@@ -27,28 +27,19 @@ namespace Microsoft.Azure.Devices.E2ETests.iothub.service
             IotHubServiceClient serviceClient = TestDevice.ServiceClient;
             TestModule module = await TestModule.GetTestModuleAsync(_idPrefix, _idPrefix).ConfigureAwait(false);
 
-            try
-            {
-                // Get the module twin
-                ClientTwin moduleTwin = await serviceClient.Twins.GetAsync(module.DeviceId, module.Id).ConfigureAwait(false);
+            // Get the module twin
+            ClientTwin moduleTwin = await serviceClient.Twins.GetAsync(module.DeviceId, module.Id).ConfigureAwait(false);
 
-                moduleTwin.ModuleId.Should().Be(module.Id, "ModuleId on the Twin should match that of the module identity.");
+            moduleTwin.ModuleId.Should().Be(module.Id, "ModuleId on the Twin should match that of the module identity.");
 
-                // Update device twin
-                string propName = "username";
-                string propValue = "userA";
-                moduleTwin.Properties.Desired[propName] = propValue;
+            // Update device twin
+            string propName = "username";
+            string propValue = "userA";
+            moduleTwin.Properties.Desired[propName] = propValue;
 
-                ClientTwin updatedModuleTwin = await serviceClient.Twins.UpdateAsync(module.DeviceId, module.Id, moduleTwin).ConfigureAwait(false);
+            ClientTwin updatedModuleTwin = await serviceClient.Twins.UpdateAsync(module.DeviceId, module.Id, moduleTwin).ConfigureAwait(false);
 
-                ((string)updatedModuleTwin.Properties.Desired[propName]).Should().Be(propValue);
-
-                // Deleting the module happens in the finally block as cleanup.
-            }
-            finally
-            {
-                await CleanupAsync(serviceClient, module.DeviceId).ConfigureAwait(false);
-            }
+            ((string)updatedModuleTwin.Properties.Desired[propName]).Should().Be(propValue);
         }
 
         [TestMethod]


### PR DESCRIPTION
Instead of each test method having to have a try/finally to remove the test device, we can use IAsyncDisposable to remove it when the variable goes out of scope.