### PR TITLE
Bring semaphore synchronization updates in retry delegating handler to LTS

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -151,7 +151,7 @@ Function BuildPackage($path, $message)
         SignDotNetBinary $filesToSign
     }
 
-    & dotnet pack --verbosity $verbosity --configuration $configuration --no-build --include-symbols --include-source --output $localPackages
+    & dotnet pack --verbosity $verbosity --configuration $configuration --no-build --include-symbols --include-source --property:PackageOutputPath=$localPackages
 
     if ($LASTEXITCODE -ne 0)
     {

--- a/e2e/test/iothub/FileUploadE2ETests.cs
+++ b/e2e/test/iothub/FileUploadE2ETests.cs
@@ -97,6 +97,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         [LoggedTestMethod]
         [TestCategory("LongRunning")]
+        [TestCategory("Proxy")]
         public async Task FileUpload_SmallFile_Http_GranularSteps_Proxy()
         {
             string filename = await GetTestFileNameAsync(FileSizeSmall).ConfigureAwait(false);

--- a/e2e/test/iothub/service/RegistryManagerE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryManagerE2ETests.cs
@@ -117,6 +117,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Iothub.Service
         }
 
         [LoggedTestMethod]
+        [TestCategory("Proxy")]
         public async Task RegistryManager_AddDeviceWithProxy()
         {
             string deviceId = _devicePrefix + Guid.NewGuid();

--- a/iothub/device/src/Transport/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Transport/DefaultDelegatingHandler.cs
@@ -11,8 +11,9 @@ namespace Microsoft.Azure.Devices.Client.Transport
 {
     internal abstract class DefaultDelegatingHandler : IDelegatingHandler
     {
-        private volatile IDelegatingHandler _innerHandler;
+        protected const string ClientDisposedMessage = "The client has been disposed and is no longer usable.";
         protected volatile bool _disposed;
+        private volatile IDelegatingHandler _innerHandler;
 
         protected DefaultDelegatingHandler(IPipelineContext context, IDelegatingHandler innerHandler)
         {
@@ -208,7 +209,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException("IoT Client");
+                throw new ObjectDisposedException("IoT client", ClientDisposedMessage);
             }
         }
 

--- a/iothub/device/src/Transport/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Transport/RetryDelegatingHandler.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
 
                             if (message.IsBodyCalled)
                             {
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
 
                             foreach (Message m in messages)
                             {
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
                             await base.SendMethodResponseAsync(method, cancellationToken).ConfigureAwait(false);
                         },
                         cancellationToken)
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
                             return await base.ReceiveAsync(cancellationToken).ConfigureAwait(false);
                         },
                         cancellationToken)
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(timeoutHelper).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, timeoutHelper).ConfigureAwait(false);
                             return await base.ReceiveAsync(timeoutHelper).ConfigureAwait(false);
                         },
                         cts.Token)
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         async () =>
                         {
                             // Ensure that the connection has been opened, before enabling the callback for receiving messages.
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
 
                             // Wait to acquire the _handlerSemaphore. This ensures that concurrently invoked API calls are invoked in a thread-safe manner.
                             await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         async () =>
                         {
                             // Ensure that the connection has been opened before returning pending messages to the callback.
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
 
                             // Wait to acquire the _handlerSemaphore. This ensures that concurrently invoked API calls are invoked in a thread-safe manner.
                             await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         async () =>
                         {
                             // Ensure that the connection has been opened, before disabling the callback for receiving messages.
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
 
                             // Wait to acquire the _handlerSemaphore. This ensures that concurrently invoked API calls are invoked in a thread-safe manner.
                             await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -313,7 +313,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
 
                             await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
@@ -346,7 +346,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
                             await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
                             {
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
                             await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
                             {
@@ -410,7 +410,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
                             await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
                             {
@@ -442,7 +442,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
                             await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
                             {
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
                             await _handlerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                             try
                             {
@@ -506,7 +506,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
                             return await base.SendTwinGetAsync(cancellationToken).ConfigureAwait(false);
                         },
                         cancellationToken)
@@ -528,7 +528,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
                             await base.SendTwinPatchAsync(reportedProperties, cancellationToken).ConfigureAwait(false);
                         },
                         cancellationToken)
@@ -550,7 +550,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
                             await base.CompleteAsync(lockToken, cancellationToken).ConfigureAwait(false);
                         },
                         cancellationToken)
@@ -572,7 +572,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
                             await base.AbandonAsync(lockToken, cancellationToken).ConfigureAwait(false);
                         },
                         cancellationToken)
@@ -594,7 +594,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     .ExecuteAsync(
                         async () =>
                         {
-                            await EnsureOpenedAsync(cancellationToken).ConfigureAwait(false);
+                            await EnsureOpenedAsync(false, cancellationToken).ConfigureAwait(false);
                             await base.RejectAsync(lockToken, cancellationToken).ConfigureAwait(false);
                         },
                         cancellationToken)
@@ -608,7 +608,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override Task OpenAsync(CancellationToken cancellationToken)
         {
-            return EnsureOpenedAsync(cancellationToken);
+            return EnsureOpenedAsync(true, cancellationToken);
         }
 
         public override async Task CloseAsync(CancellationToken cancellationToken)
@@ -638,7 +638,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         /// <summary>
         /// Implicit open handler.
         /// </summary>
-        private async Task EnsureOpenedAsync(CancellationToken cancellationToken)
+        private async Task EnsureOpenedAsync(bool withRetry, CancellationToken cancellationToken)
         {
             // If this object has already been disposed, we will throw an exception indicating that.
             // This is the entry point for interacting with the client and this safety check should be done here.
@@ -664,7 +664,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     // we are returning the corresponding connection status change event => disconnected: retry_expired.
                     try
                     {
-                        await OpenInternalAsync(cancellationToken).ConfigureAwait(false);
+                        await OpenInternalAsync(withRetry, cancellationToken).ConfigureAwait(false);
                     }
                     catch (Exception ex) when (!ex.IsFatal())
                     {
@@ -694,7 +694,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
-        private async Task EnsureOpenedAsync(TimeoutHelper timeoutHelper)
+        private async Task EnsureOpenedAsync(bool withRetry, TimeoutHelper timeoutHelper)
         {
             if (Volatile.Read(ref _opened))
             {
@@ -717,7 +717,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     // we are returning the corresponding connection status change event => disconnected: retry_expired.
                     try
                     {
-                        await OpenInternalAsync(timeoutHelper).ConfigureAwait(false);
+                        await OpenInternalAsync(withRetry, timeoutHelper).ConfigureAwait(false);
                     }
                     catch (Exception ex) when (!ex.IsFatal())
                     {
@@ -747,37 +747,63 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
-        private Task OpenInternalAsync(CancellationToken cancellationToken)
+        private async Task OpenInternalAsync(bool withRetry, CancellationToken cancellationToken)
         {
-            return _internalRetryPolicy
-                .ExecuteAsync(
-                    async () =>
-                    {
-                        try
+            if (withRetry)
+            {
+                await _internalRetryPolicy
+                    .ExecuteAsync(
+                        async () =>
                         {
-                            Logging.Enter(this, cancellationToken, nameof(OpenAsync));
+                            try
+                            {
+                                Logging.Enter(this, cancellationToken, nameof(OpenAsync));
 
-                            // Will throw on error.
-                            await base.OpenAsync(cancellationToken).ConfigureAwait(false);
-                            _onConnectionStatusChanged(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
-                        }
-                        catch (Exception ex) when (!ex.IsFatal())
-                        {
-                            HandleConnectionStatusExceptions(ex);
-                            throw;
-                        }
-                        finally
-                        {
-                            Logging.Exit(this, cancellationToken, nameof(OpenAsync));
-                        }
-                    },
-                    cancellationToken);
+                                // Will throw on error.
+                                await base.OpenAsync(cancellationToken).ConfigureAwait(false);
+                                _onConnectionStatusChanged(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
+                            }
+                            catch (Exception ex) when (!ex.IsFatal())
+                            {
+                                HandleConnectionStatusExceptions(ex);
+                                throw;
+                            }
+                            finally
+                            {
+                                Logging.Exit(this, cancellationToken, nameof(OpenAsync));
+                            }
+                        },
+                        cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                try
+                {
+                    Logging.Enter(this, cancellationToken, nameof(OpenAsync));
+
+                    // Will throw on error.
+                    await base.OpenAsync(cancellationToken).ConfigureAwait(false);
+                    _onConnectionStatusChanged(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
+                }
+                catch (Exception ex) when (!ex.IsFatal())
+                {
+                    HandleConnectionStatusExceptions(ex);
+                    throw;
+                }
+                finally
+                {
+                    Logging.Exit(this, cancellationToken, nameof(OpenAsync));
+                }
+            }
         }
 
-        private async Task OpenInternalAsync(TimeoutHelper timeoutHelper)
+        private async Task OpenInternalAsync(bool withRetry, TimeoutHelper timeoutHelper)
         {
             using var cts = new CancellationTokenSource(timeoutHelper.GetRemainingTime());
-            await _internalRetryPolicy
+
+            if (withRetry)
+            {
+                await _internalRetryPolicy
                 .ExecuteAsync(
                     async () =>
                     {
@@ -801,6 +827,29 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     },
                     cts.Token)
                 .ConfigureAwait(false);
+            }
+            else
+            {
+                try
+                {
+                    Logging.Enter(this, timeoutHelper, nameof(OpenAsync));
+
+                // Will throw on error.
+                await base.OpenAsync(timeoutHelper).ConfigureAwait(false);
+                    _onConnectionStatusChanged(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
+                }
+                catch (Exception ex) when (!ex.IsFatal())
+                {
+                    HandleConnectionStatusExceptions(ex);
+                    throw;
+                }
+                finally
+                {
+                    Logging.Exit(this, timeoutHelper, nameof(OpenAsync));
+                }
+            }
+
+                
         }
 
         // Triggered from connection loss event

--- a/iothub/device/src/Transport/RetryDelegatingHandler.cs
+++ b/iothub/device/src/Transport/RetryDelegatingHandler.cs
@@ -20,11 +20,17 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         private RetryPolicy _internalRetryPolicy;
 
+#pragma warning disable CA2213
+        // The semaphores are getting disposed in the Dispose() block below but it seems like
+        // Microsoft.CodeAnalysis.FxCopAnalyzers isn't able to analyze and interpret our code successfully.
+        // We've moved to Microsoft.CodeAnalysis.NetAnalyzers in main and it understands the below disposal block successfully.
         private readonly SemaphoreSlim _clientOpenSemaphore = new SemaphoreSlim(1, 1);
         private readonly SemaphoreSlim _cloudToDeviceMessageSubscriptionSemaphore = new SemaphoreSlim(1, 1);
         private readonly SemaphoreSlim _cloudToDeviceEventSubscriptionSemaphore = new SemaphoreSlim(1, 1);
         private readonly SemaphoreSlim _directMethodSubscriptionSemaphore = new SemaphoreSlim(1, 1);
         private readonly SemaphoreSlim _twinEventsSubscriptionSemaphore = new SemaphoreSlim(1, 1);
+#pragma warning restore CA2213
+
         private bool _openCalled;
         private bool _methodsEnabled;
         private bool _twinEnabled;
@@ -34,8 +40,14 @@ namespace Microsoft.Azure.Devices.Client.Transport
         private long _isOpened; // store the opened status in an int which can be accessed via Interlocked class. opened = 1, closed = 0.
 
         private Task _transportClosedTask;
+
+#pragma warning disable CA2213
+        // The cancellation token sources are getting canceled and disposed in the Dispose() block below but it seems like
+        // Microsoft.CodeAnalysis.FxCopAnalyzers isn't able to analyze and interpret our code successfully.
+        // We've moved to Microsoft.CodeAnalysis.NetAnalyzers in main and it understands the below disposal block successfully.
         private readonly CancellationTokenSource _handleDisconnectCts = new CancellationTokenSource();
         private readonly CancellationTokenSource _cancelPendingOperationsCts = new CancellationTokenSource();
+#pragma warning restore CA2213
 
         private readonly ConnectionStatusChangesHandler _onConnectionStatusChanged;
 

--- a/iothub/device/tests/RetryDelegatingHandlerTests.cs
+++ b/iothub/device/tests/RetryDelegatingHandlerTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             // arrange
             int callCounter = 0;
 
-            PipelineContext contextMock = Substitute.For<PipelineContext>();
+            IPipelineContext contextMock = Substitute.For<IPipelineContext>();
             IDelegatingHandler innerHandlerMock = Substitute.For<IDelegatingHandler>();
 
             innerHandlerMock
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             // arrange
             int callCounter = 0;
 
-            PipelineContext contextMock = Substitute.For<PipelineContext>();
+            IPipelineContext contextMock = Substitute.For<IPipelineContext>();
             IDelegatingHandler innerHandlerMock = Substitute.For<IDelegatingHandler>();
             using var message = new Message(new MemoryStream(new byte[] { 1, 2, 3 }));
             innerHandlerMock
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             // arrange
             int callCounter = 0;
 
-            PipelineContext contextMock = Substitute.For<PipelineContext>();
+            IPipelineContext contextMock = Substitute.For<IPipelineContext>();
             IDelegatingHandler innerHandlerMock = Substitute.For<IDelegatingHandler>();
             var memoryStream = new NotSeekableStream(new byte[] { 1, 2, 3 });
             using var message = new Message(memoryStream);
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             // arrange
             int callCounter = 0;
 
-            var contextMock = Substitute.For<PipelineContext>();
+            var contextMock = Substitute.For<IPipelineContext>();
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
             using var message = new Message(new MemoryStream(new byte[] { 1, 2, 3 }));
             IEnumerable<Message> messages = new[] { message };
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             // arrange
             int callCounter = 0;
 
-            var contextMock = Substitute.For<PipelineContext>();
+            var contextMock = Substitute.For<IPipelineContext>();
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
             using var message = new Message(new MemoryStream(new byte[] { 1, 2, 3 }));
             innerHandlerMock
@@ -191,7 +191,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             // arrange
             int callCounter = 0;
 
-            var contextMock = Substitute.For<PipelineContext>();
+            var contextMock = Substitute.For<IPipelineContext>();
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
             innerHandlerMock
                 .OpenAsync(Arg.Any<CancellationToken>())
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         public async Task DeviceNotFoundExceptionReturnsDeviceDisabledStatus()
         {
             // arrange
-            var contextMock = Substitute.For<PipelineContext>();
+            var contextMock = Substitute.For<IPipelineContext>();
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
             innerHandlerMock.OpenAsync(Arg.Any<CancellationToken>()).Returns(t => throw new DeviceNotFoundException());
 
@@ -228,6 +228,8 @@ namespace Microsoft.Azure.Devices.Client.Test
                 status = s;
                 statusChangeReason = r;
             };
+
+            contextMock.Get<ConnectionStatusChangesHandler>().Returns(statusChangeHandler);
 
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
@@ -247,7 +249,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             // arrange
             using var cts = new CancellationTokenSource(1000);
-            var contextMock = Substitute.For<PipelineContext>();
+            var contextMock = Substitute.For<IPipelineContext>();
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
             innerHandlerMock
                 .OpenAsync(Arg.Any<CancellationToken>())
@@ -274,7 +276,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             cts.Cancel();
             innerHandlerMock.OpenAsync(Arg.Any<CancellationToken>()).Returns(TaskHelpers.CompletedTask);
 
-            var contextMock = Substitute.For<PipelineContext>();
+            var contextMock = Substitute.For<IPipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             // act and assert
@@ -288,7 +290,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
             innerHandlerMock.SendEventAsync((Message)null, CancellationToken.None).ReturnsForAnyArgs(TaskHelpers.CompletedTask);
 
-            var contextMock = Substitute.For<PipelineContext>();
+            var contextMock = Substitute.For<IPipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
             using var cts = new CancellationTokenSource();
             cts.Cancel();
@@ -304,7 +306,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
             innerHandlerMock.SendEventAsync((IEnumerable<Message>)null, CancellationToken.None).ReturnsForAnyArgs(TaskHelpers.CompletedTask);
 
-            var contextMock = Substitute.For<PipelineContext>();
+            var contextMock = Substitute.For<IPipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
             using var cts = new CancellationTokenSource();
             cts.Cancel();
@@ -325,7 +327,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             cts.Cancel();
             innerHandlerMock.ReceiveAsync(cts.Token).Returns(new Task<Message>(() => new Message(new byte[0])));
-            var contextMock = Substitute.For<PipelineContext>();
+            var contextMock = Substitute.For<IPipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             // act and assert
@@ -337,7 +339,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             // arrange
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
-            var contextMock = Substitute.For<PipelineContext>();
+            var contextMock = Substitute.For<IPipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             var retryPolicy = new TestRetryPolicyRetryTwice();
@@ -373,7 +375,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             cts.Cancel();
             innerHandlerMock.CompleteAsync(Arg.Any<string>(), cts.Token).Returns(TaskHelpers.CompletedTask);
 
-            var contextMock = Substitute.For<PipelineContext>();
+            var contextMock = Substitute.For<IPipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             // act and assert
@@ -387,7 +389,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
             innerHandlerMock.AbandonAsync(null, Arg.Any<CancellationToken>()).ReturnsForAnyArgs(TaskHelpers.CompletedTask);
 
-            var contextMock = Substitute.For<PipelineContext>();
+            var contextMock = Substitute.For<IPipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
             using var cts = new CancellationTokenSource();
             cts.Cancel();
@@ -406,7 +408,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
             innerHandlerMock.RejectAsync(null, Arg.Any<CancellationToken>()).ReturnsForAnyArgs(TaskHelpers.CompletedTask);
 
-            var contextMock = Substitute.For<PipelineContext>();
+            var contextMock = Substitute.For<IPipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
             using var cts = new CancellationTokenSource();
             cts.Cancel();

--- a/iothub/device/tests/RetryDelegatingHandlerTests.cs
+++ b/iothub/device/tests/RetryDelegatingHandlerTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.Devices.Client.Exceptions;
 using Microsoft.Azure.Devices.Client.Transport;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
+using FluentAssertions;
 
 namespace Microsoft.Azure.Devices.Client.Test
 {
@@ -26,24 +27,26 @@ namespace Microsoft.Azure.Devices.Client.Test
             // arrange
             int callCounter = 0;
 
-            IPipelineContext contextMock = Substitute.For<IPipelineContext>();
+            PipelineContext contextMock = Substitute.For<PipelineContext>();
             IDelegatingHandler innerHandlerMock = Substitute.For<IDelegatingHandler>();
 
-            innerHandlerMock.OpenAsync(Arg.Any<CancellationToken>()).Returns(t =>
-            {
-                return ++callCounter == 1
-                    ? throw new IotHubException("Test transient exception", isTransient: true)
-                    : TaskHelpers.CompletedTask;
-            });
+            innerHandlerMock
+                .OpenAsync(Arg.Any<CancellationToken>())
+                .Returns(t =>
+                    {
+                        return ++callCounter == 1
+                            ? throw new IotHubException("Test transient exception", isTransient: true)
+                            : TaskHelpers.CompletedTask;
+                    });
             innerHandlerMock.WaitForTransportClosedAsync().Returns(Task.Delay(TimeSpan.FromSeconds(10)));
 
             var retryDelegatingHandler = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             // act
-            await retryDelegatingHandler.OpenAsync(new CancellationToken()).ConfigureAwait(false);
+            await retryDelegatingHandler.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
-            Assert.AreEqual(2, callCounter);
+            callCounter.Should().Be(2);
         }
 
         [TestMethod]
@@ -52,31 +55,33 @@ namespace Microsoft.Azure.Devices.Client.Test
             // arrange
             int callCounter = 0;
 
-            IPipelineContext contextMock = Substitute.For<IPipelineContext>();
+            PipelineContext contextMock = Substitute.For<PipelineContext>();
             IDelegatingHandler innerHandlerMock = Substitute.For<IDelegatingHandler>();
-            var message = new Message(new MemoryStream(new byte[] { 1, 2, 3 }));
-            innerHandlerMock.SendEventAsync(Arg.Is(message), Arg.Any<CancellationToken>()).Returns(t =>
-            {
-                callCounter++;
+            using var message = new Message(new MemoryStream(new byte[] { 1, 2, 3 }));
+            innerHandlerMock
+                .SendEventAsync(Arg.Is(message), Arg.Any<CancellationToken>())
+                .Returns(t =>
+                    {
+                        callCounter++;
 
-                Message m = t.Arg<Message>();
-                Stream stream = m.GetBodyStream();
-                if (callCounter == 1)
-                {
-                    throw new IotHubException(TestExceptionMessage, isTransient: true);
-                }
-                byte[] buffer = new byte[3];
-                stream.Read(buffer, 0, 3);
-                return TaskHelpers.CompletedTask; ;
-            });
+                        Message m = t.Arg<Message>();
+                        Stream stream = m.GetBodyStream();
+                        if (callCounter == 1)
+                        {
+                            throw new IotHubException(TestExceptionMessage, isTransient: true);
+                        }
+                        byte[] buffer = new byte[3];
+                        stream.Read(buffer, 0, 3);
+                        return TaskHelpers.CompletedTask;
+                    });
 
             var retryDelegatingHandler = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             // act
-            await retryDelegatingHandler.SendEventAsync(message, new CancellationToken()).ConfigureAwait(false);
+            await retryDelegatingHandler.SendEventAsync(message, CancellationToken.None).ConfigureAwait(false);
 
             // assert
-            Assert.AreEqual(2, callCounter);
+            callCounter.Should().Be(2);
         }
 
         [TestMethod]
@@ -85,118 +90,134 @@ namespace Microsoft.Azure.Devices.Client.Test
             // arrange
             int callCounter = 0;
 
-            IPipelineContext contextMock = Substitute.For<IPipelineContext>();
+            PipelineContext contextMock = Substitute.For<PipelineContext>();
             IDelegatingHandler innerHandlerMock = Substitute.For<IDelegatingHandler>();
             var memoryStream = new NotSeekableStream(new byte[] { 1, 2, 3 });
-            var message = new Message(memoryStream);
-            innerHandlerMock.SendEventAsync(Arg.Is(message), Arg.Any<CancellationToken>()).Returns(t =>
-            {
-                callCounter++;
-                Message m = t.Arg<Message>();
-                Stream stream = m.GetBodyStream();
-                byte[] buffer = new byte[3];
-                stream.Read(buffer, 0, 3);
-                throw new IotHubException(TestExceptionMessage, isTransient: true);
-            });
+            using var message = new Message(memoryStream);
+            innerHandlerMock
+                .SendEventAsync(Arg.Is(message), Arg.Any<CancellationToken>())
+                .Returns(t =>
+                    {
+                        callCounter++;
+                        Message m = t.Arg<Message>();
+                        Stream stream = m.GetBodyStream();
+                        byte[] buffer = new byte[3];
+                        stream.Read(buffer, 0, 3);
+                        throw new IotHubException(TestExceptionMessage, isTransient: true);
+                    });
 
             var retryDelegatingHandler = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
             // act
-            NotSupportedException exception = await retryDelegatingHandler.SendEventAsync(message, new CancellationToken()).ExpectedAsync<NotSupportedException>().ConfigureAwait(false);
+            NotSupportedException exception = await retryDelegatingHandler
+                .SendEventAsync(message, CancellationToken.None)
+                .ExpectedAsync<NotSupportedException>()
+                .ConfigureAwait(false);
 
             // assert
-            Assert.AreEqual(callCounter, 1);
+            callCounter.Should().Be(1);
         }
 
         [TestMethod]
         public async Task RetryOneMessageHasBeenTouchedTransientExceptionOccuredSuccess()
         {
+            // arrange
             int callCounter = 0;
 
-            var contextMock = Substitute.For<IPipelineContext>();
+            var contextMock = Substitute.For<PipelineContext>();
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
-            var message = new Message(new MemoryStream(new byte[] { 1, 2, 3 }));
+            using var message = new Message(new MemoryStream(new byte[] { 1, 2, 3 }));
             IEnumerable<Message> messages = new[] { message };
-            innerHandlerMock.SendEventAsync(Arg.Is(messages), Arg.Any<CancellationToken>()).Returns(t =>
-            {
-                callCounter++;
-
-                Message m = t.Arg<IEnumerable<Message>>().First();
-                Stream stream = m.GetBodyStream();
-                if (callCounter == 1)
-                {
-                    throw new IotHubException(TestExceptionMessage, isTransient: true);
-                }
-                var buffer = new byte[3];
-                stream.Read(buffer, 0, 3);
-                return TaskHelpers.CompletedTask; ;
-            });
+            innerHandlerMock
+                .SendEventAsync(Arg.Is(messages), Arg.Any<CancellationToken>())
+                .Returns(t =>
+                    {
+                        Message m = t.Arg<IEnumerable<Message>>().First();
+                        Stream stream = m.GetBodyStream();
+                        if (++callCounter == 1)
+                        {
+                            throw new IotHubException(TestExceptionMessage, isTransient: true);
+                        }
+                        var buffer = new byte[3];
+                        stream.Read(buffer, 0, 3);
+                        return TaskHelpers.CompletedTask;
+                    });
 
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
-            var cancellationToken = new CancellationToken();
-            await sut.SendEventAsync(messages, cancellationToken).ConfigureAwait(false);
 
-            Assert.AreEqual(2, callCounter);
+            // act
+            await sut.SendEventAsync(messages, CancellationToken.None).ConfigureAwait(false);
+
+            // assert
+            callCounter.Should().Be(2);
         }
 
         [TestMethod]
         public async Task RetryMessageWithSeekableStreamHasBeenReadTransientExceptionOccuredThrows()
         {
+            // arrange
             int callCounter = 0;
 
-            var contextMock = Substitute.For<IPipelineContext>();
+            var contextMock = Substitute.For<PipelineContext>();
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
-            var message = new Message(new MemoryStream(new byte[] { 1, 2, 3 }));
-            innerHandlerMock.SendEventAsync(Arg.Is(message), Arg.Any<CancellationToken>()).Returns(t =>
-            {
-                callCounter++;
-                var m = t.Arg<Message>();
-                Stream stream = m.GetBodyStream();
-                var buffer = new byte[3];
-                stream.Read(buffer, 0, 3);
-                if (callCounter == 1)
-                {
-                    throw new IotHubException(TestExceptionMessage, isTransient: true);
-                }
-                return TaskHelpers.CompletedTask; ;
-            });
+            using var message = new Message(new MemoryStream(new byte[] { 1, 2, 3 }));
+            innerHandlerMock
+                .SendEventAsync(Arg.Is(message), Arg.Any<CancellationToken>())
+                .Returns(t =>
+                    {
+                        var m = t.Arg<Message>();
+                        Stream stream = m.GetBodyStream();
+                        var buffer = new byte[3];
+                        stream.Read(buffer, 0, 3);
+                        if (++callCounter == 1)
+                        {
+                            throw new IotHubException(TestExceptionMessage, isTransient: true);
+                        }
+                        return TaskHelpers.CompletedTask;
+                    });
 
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
-            var cancellationToken = new CancellationToken();
-            await sut.SendEventAsync(message, cancellationToken).ConfigureAwait(false);
 
-            Assert.AreEqual(callCounter, 2);
+            // act
+            await sut.SendEventAsync(message, CancellationToken.None).ConfigureAwait(false);
+
+            // assert
+            callCounter.Should().Be(2);
         }
 
         [TestMethod]
         public async Task RetryNonTransientErrorThrownThrows()
         {
+            // arrange
             int callCounter = 0;
 
-            var contextMock = Substitute.For<IPipelineContext>();
+            var contextMock = Substitute.For<PipelineContext>();
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
-            innerHandlerMock.OpenAsync(Arg.Any<CancellationToken>()).Returns(t =>
-            {
-                callCounter++;
-
-                if (callCounter == 1)
+            innerHandlerMock
+                .OpenAsync(Arg.Any<CancellationToken>())
+                .Returns(t =>
                 {
-                    throw new InvalidOperationException("");
-                }
-                return TaskHelpers.CompletedTask; ;
-            });
+                    if (++callCounter == 1)
+                    {
+                        throw new InvalidOperationException("");
+                    }
+                    return TaskHelpers.CompletedTask;
+                });
 
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
-            var cancellationToken = new CancellationToken();
-            await sut.OpenAsync(cancellationToken).ExpectedAsync<InvalidOperationException>().ConfigureAwait(false);
 
-            Assert.AreEqual(callCounter, 1);
+            // arrange
+            await sut.OpenAsync(CancellationToken.None).ExpectedAsync<InvalidOperationException>().ConfigureAwait(false);
+
+            // act
+            callCounter.Should().Be(1);
         }
 
         [TestMethod]
         public async Task DeviceNotFoundExceptionReturnsDeviceDisabledStatus()
         {
-            var contextMock = Substitute.For<IPipelineContext>();
+            // arrange
+            var contextMock = Substitute.For<PipelineContext>();
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
             innerHandlerMock.OpenAsync(Arg.Any<CancellationToken>()).Returns(t => throw new DeviceNotFoundException());
 
@@ -208,118 +229,118 @@ namespace Microsoft.Azure.Devices.Client.Test
                 statusChangeReason = r;
             };
 
-            contextMock.Get<ConnectionStatusChangesHandler>().Returns(statusChangeHandler);
+            var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
-            var cancellationToken = new CancellationToken();
-            var testee = new RetryDelegatingHandler(contextMock, innerHandlerMock);
-            await ((Func<Task>)(() => testee.OpenAsync(cancellationToken))).ExpectedAsync<DeviceNotFoundException>().ConfigureAwait(false);
+            // act
+            await ((Func<Task>)(() => sut
+                .OpenAsync(CancellationToken.None)))
+                .ExpectedAsync<DeviceNotFoundException>()
+                .ConfigureAwait(false);
 
-            Assert.AreEqual(ConnectionStatus.Disconnected, status);
-            Assert.AreEqual(ConnectionStatusChangeReason.Device_Disabled, statusChangeReason);
+            // assert
+            status.Should().Be(ConnectionStatus.Disconnected);
+            statusChangeReason.Should().Be(ConnectionStatusChangeReason.Device_Disabled);
         }
 
         [TestMethod]
         public async Task RetryTransientErrorThrownAfterNumberOfRetriesThrows()
         {
-            var contextMock = Substitute.For<IPipelineContext>();
+            // arrange
+            using var cts = new CancellationTokenSource(1000);
+            var contextMock = Substitute.For<PipelineContext>();
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
-            innerHandlerMock.OpenAsync(Arg.Any<CancellationToken>()).Returns(t =>
-            {
-                throw new IotHubException(TestExceptionMessage, isTransient: true);
-            });
+            innerHandlerMock
+                .OpenAsync(Arg.Any<CancellationToken>())
+                .Returns(t => throw new IotHubException(TestExceptionMessage, isTransient: true));
 
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
-            using (var cts = new CancellationTokenSource(100))
-            {
-                IotHubException exception = await sut.OpenAsync(cts.Token).ExpectedAsync<IotHubException>().ConfigureAwait(false);
-                Assert.AreEqual(TestExceptionMessage, exception.Message);
-            }
+            IotHubException exception = await sut
+                .OpenAsync(cts.Token)
+                .ExpectedAsync<IotHubException>()
+                .ConfigureAwait(false);
+
+            // act
+
+            // assert
+            exception.Message.Should().Be(TestExceptionMessage);
         }
 
         [TestMethod]
         public async Task RetryCancellationTokenCanceledOpen()
         {
+            // arrange
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
-            using var cancellationTokenSource = new CancellationTokenSource();
-
-            cancellationTokenSource.Cancel();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
             innerHandlerMock.OpenAsync(Arg.Any<CancellationToken>()).Returns(TaskHelpers.CompletedTask);
 
-            var contextMock = Substitute.For<IPipelineContext>();
+            var contextMock = Substitute.For<PipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
-            await sut.OpenAsync(cancellationTokenSource.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+            // act and assert
+            await sut.OpenAsync(cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task RetryCancellationTokenCanceledSendEvent()
         {
+            // arrange
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
             innerHandlerMock.SendEventAsync((Message)null, CancellationToken.None).ReturnsForAnyArgs(TaskHelpers.CompletedTask);
 
-            var contextMock = Substitute.For<IPipelineContext>();
+            var contextMock = Substitute.For<PipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
-            using var cancellationTokenSource = new CancellationTokenSource();
-            cancellationTokenSource.Cancel();
-            await sut.SendEventAsync(Arg.Any<Message>(), cancellationTokenSource.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // act and assert
+            await sut.SendEventAsync(Arg.Any<Message>(), cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task RetryCancellationTokenCanceledSendEventWithIEnumMessage()
         {
+            // arrange
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
             innerHandlerMock.SendEventAsync((IEnumerable<Message>)null, CancellationToken.None).ReturnsForAnyArgs(TaskHelpers.CompletedTask);
 
-            var contextMock = Substitute.For<IPipelineContext>();
+            var contextMock = Substitute.For<PipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
-            using var cancellationTokenSource = new CancellationTokenSource();
-            cancellationTokenSource.Cancel();
-            await sut.SendEventAsync(new List<Message>(), cancellationTokenSource.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
 
+            // act
+            await sut.SendEventAsync(new List<Message>(), cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+
+            // assert
             await innerHandlerMock.Received(0).SendEventAsync(new List<Message>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task RetryCancellationTokenCanceledReceive()
         {
+            // arrange
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
-            using var cancellationTokenSource = new CancellationTokenSource();
+            using var cts = new CancellationTokenSource();
 
-            cancellationTokenSource.Cancel();
-            innerHandlerMock.ReceiveAsync(cancellationTokenSource.Token).Returns(new Task<Message>(() => new Message(new byte[0])));
-            var contextMock = Substitute.For<IPipelineContext>();
+            cts.Cancel();
+            innerHandlerMock.ReceiveAsync(cts.Token).Returns(new Task<Message>(() => new Message(new byte[0])));
+            var contextMock = Substitute.For<PipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
-            await sut.ReceiveAsync(cancellationTokenSource.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
-        }
-
-        private class TestRetryPolicy : IRetryPolicy
-        {
-            public int Counter
-            {
-                get;
-                private set;
-            }
-
-            public bool ShouldRetry(int currentRetryCount, Exception lastException, out TimeSpan retryInterval)
-            {
-                Counter++;
-                Assert.IsInstanceOfType(lastException, typeof(IotHubCommunicationException));
-
-                retryInterval = TimeSpan.MinValue;
-                if (Counter < 2) return true;
-                return false;
-            }
+            // act and assert
+            await sut.ReceiveAsync(cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task RetrySetRetryPolicyVerifyInternalsSuccess()
         {
+            // arrange
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
-            var contextMock = Substitute.For<IPipelineContext>();
+            var contextMock = Substitute.For<PipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
-            var retryPolicy = new TestRetryPolicy();
+            var retryPolicy = new TestRetryPolicyRetryTwice();
             sut.SetRetryPolicy(retryPolicy);
 
             int innerHandlerCallCounter = 0;
@@ -330,57 +351,82 @@ namespace Microsoft.Azure.Devices.Client.Test
                    throw new IotHubCommunicationException();
                });
 
+            // act and assert
             await sut.OpenAsync(CancellationToken.None).ExpectedAsync<IotHubCommunicationException>().ConfigureAwait(false);
-            Assert.AreEqual(2, innerHandlerCallCounter);
-            Assert.AreEqual(2, retryPolicy.Counter);
+            innerHandlerCallCounter.Should().Be(2);
+            retryPolicy.Counter.Should().Be(2);
 
             var noretry = new NoRetry();
             sut.SetRetryPolicy(noretry);
             await sut.OpenAsync(CancellationToken.None).ExpectedAsync<IotHubCommunicationException>().ConfigureAwait(false);
 
-            Assert.AreEqual(3, innerHandlerCallCounter);
-            Assert.AreEqual(2, retryPolicy.Counter);
+            innerHandlerCallCounter.Should().Be(3);
+            retryPolicy.Counter.Should().Be(2);
         }
 
         [TestMethod]
         public async Task RetryCancellationTokenCanceledComplete()
         {
+            // arrange
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
-            using var cancellationTokenSource = new CancellationTokenSource();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            innerHandlerMock.CompleteAsync(Arg.Any<string>(), cts.Token).Returns(TaskHelpers.CompletedTask);
 
-            cancellationTokenSource.Cancel();
-            innerHandlerMock.CompleteAsync(Arg.Any<string>(), cancellationTokenSource.Token).Returns(TaskHelpers.CompletedTask);
-
-            var contextMock = Substitute.For<IPipelineContext>();
+            var contextMock = Substitute.For<PipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
 
-            await sut.CompleteAsync("", cancellationTokenSource.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+            // act and assert
+            await sut.CompleteAsync("", cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task RetryCancellationTokenCanceledAbandon()
         {
+            // arrange
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
-            innerHandlerMock.AbandonAsync(null, CancellationToken.None).ReturnsForAnyArgs(TaskHelpers.CompletedTask);
+            innerHandlerMock.AbandonAsync(null, Arg.Any<CancellationToken>()).ReturnsForAnyArgs(TaskHelpers.CompletedTask);
 
-            var contextMock = Substitute.For<IPipelineContext>();
+            var contextMock = Substitute.For<PipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
-            using var cancellationTokenSource = new CancellationTokenSource();
-            cancellationTokenSource.Cancel();
-            await sut.AbandonAsync(Arg.Any<string>(), cancellationTokenSource.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // act and assert
+            await sut
+                .AbandonAsync(Arg.Any<string>(), cts.Token)
+                .ExpectedAsync<TaskCanceledException>()
+                .ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task RetryCancellationTokenCanceledReject()
         {
+            // arrange
             var innerHandlerMock = Substitute.For<IDelegatingHandler>();
-            innerHandlerMock.RejectAsync(null, CancellationToken.None).ReturnsForAnyArgs(TaskHelpers.CompletedTask);
+            innerHandlerMock.RejectAsync(null, Arg.Any<CancellationToken>()).ReturnsForAnyArgs(TaskHelpers.CompletedTask);
 
-            var contextMock = Substitute.For<IPipelineContext>();
+            var contextMock = Substitute.For<PipelineContext>();
             var sut = new RetryDelegatingHandler(contextMock, innerHandlerMock);
-            using var cancellationTokenSource = new CancellationTokenSource();
-            cancellationTokenSource.Cancel();
-            await sut.RejectAsync(Arg.Any<string>(), cancellationTokenSource.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // act and assert
+            await sut.RejectAsync(Arg.Any<string>(), cts.Token).ExpectedAsync<TaskCanceledException>().ConfigureAwait(false);
+        }
+
+        private class TestRetryPolicyRetryTwice : IRetryPolicy
+        {
+            public int Counter { get; private set; }
+
+            public bool ShouldRetry(int currentRetryCount, Exception lastException, out TimeSpan retryInterval)
+            {
+                Counter++;
+                lastException.Should().BeOfType(typeof(IotHubCommunicationException));
+
+                retryInterval = TimeSpan.MinValue;
+                return Counter < 2;
+            }
         }
 
         private class NotSeekableStream : MemoryStream
@@ -393,7 +439,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             public override long Length
             {
-                get { throw new NotSupportedException(); }
+                get => throw new NotSupportedException();
             }
 
             public override void SetLength(long value)
@@ -403,14 +449,8 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             public override long Position
             {
-                get
-                {
-                    throw new NotSupportedException();
-                }
-                set
-                {
-                    throw new NotSupportedException();
-                }
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
             }
 
             public override long Seek(long offset, SeekOrigin loc)

--- a/iothub/service/src/IoTHubExceptionResult.cs
+++ b/iothub/service/src/IoTHubExceptionResult.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices
@@ -10,6 +11,8 @@ namespace Microsoft.Azure.Devices
     /// </summary>
     internal class IoTHubExceptionResult
     {
+        [SuppressMessage("Usage", "CA1507: Use nameof in place of string literal 'Message'",
+            Justification = "This JsonProperty annotation depends on service-defined contract (name) and is independent of the property name selected by the SDK.")]
         [JsonProperty("Message")]
         internal string Message { get; set; }
     }

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -532,13 +532,8 @@ jobs:
     pool:
       vmImage: windows-2022
     steps:
-      - script: |
-          rem Run dotnet first experience.
-          dotnet new
-          rem Start build
-          build.cmd -clean -build -configuration Debug -package
-
-        displayName: build
+      - powershell: .\build.ps1 -clean -build -configutaion Debug -package
+        displayName: Build Package
 
       - task: ComponentGovernanceComponentDetection@0
         displayName: "Component Detection"


### PR DESCRIPTION
#2209 : fix(iot-dev): Fix bug where client's retry policy applied n^2 times rather than n times
#3135 : Decouple client open-close semaphore from callback subscription semaphore