### PR TITLE
Bump versions for LTS 03/21/23 release

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.1;netstandard2.0;net472;net451</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.36.7</Version>
+    <Version>1.36.8</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net472;net451</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.31.4</Version>
+    <Version>1.31.5</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,6 +1,6 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.36.7
-iothub\service\src\Microsoft.Azure.Devices.csproj, 1.31.4
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 1.36.8
+iothub\service\src\Microsoft.Azure.Devices.csproj, 1.31.5
 shared\src\Microsoft.Azure.Devices.Shared.csproj, 1.27.2
 provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 1.16.5
 provisioning\transport\amqp\src\Microsoft.Azure.Devices.Provisioning.Transport.Amqp.csproj, 1.13.8


### PR DESCRIPTION
**Release Notes:**

Microsoft Azure IoT SDKs for .NET LTS patch Release 2023-03-21

This release is a patch for the [Microsoft Azure IoT Hub SDK for .NET LTS patch Release 2023-01-24](https://github.com/Azure/azure-iot-sdk-csharp/releases/tag/lts_2021-3-18_patch7) LTS release.

## Microsoft.Azure.Devices.Client 1.36.8
- Fix bug where client's retry policy applied n^2 times rather than n times (#3148)
- Decouple client open-close semaphore from callback subscription semaphore (#3148)
- Set transport state to 'closed' when CloseAsync() is called (#3160)

## Microsoft.Azure.Devices  1.31.5
- Address fix for FxCop analyzer issue (#3148)