### PR TITLE
Replace System.Text.Json with Newtonsoft.Json in HubEvents

### DIFF
--- a/e2e/LongHaul/service/HubEvents.cs
+++ b/e2e/LongHaul/service/HubEvents.cs
@@ -41,8 +41,8 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
 
                     try
                     {
-                        var testProperties = JsonConvert.SerializeObject(partitionEvent.Data.SystemProperties);
-                        DeviceEventSystemProperties eventMetadata = JsonConvert.DeserializeObject<DeviceEventSystemProperties>(testProperties);
+                        DeviceEventSystemProperties eventMetadata = JsonConvert.DeserializeObject<DeviceEventSystemProperties>(
+                            JsonConvert.SerializeObject(partitionEvent.Data.SystemProperties));
 
                         switch (eventMetadata.MessageSource)
                         {

--- a/e2e/LongHaul/service/HubEvents.cs
+++ b/e2e/LongHaul/service/HubEvents.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Consumer;
 using Mash.Logging;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.LongHaul.Service
 {
@@ -41,14 +41,14 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
 
                     try
                     {
-                        DeviceEventSystemProperties eventMetadata = JsonSerializer.Deserialize<DeviceEventSystemProperties>(
-                            JsonSerializer.Serialize(partitionEvent.Data.SystemProperties));
+                        var testProperties = JsonConvert.SerializeObject(partitionEvent.Data.SystemProperties);
+                        DeviceEventSystemProperties eventMetadata = JsonConvert.DeserializeObject<DeviceEventSystemProperties>(testProperties);
 
                         switch (eventMetadata.MessageSource)
                         {
                             case DeviceEventMessageSource.DeviceConnectionStateEvents:
-                                DeviceEventProperties deviceEvent = JsonSerializer.Deserialize<DeviceEventProperties>(
-                                    JsonSerializer.Serialize(partitionEvent.Data.Properties));
+                                DeviceEventProperties deviceEvent = JsonConvert.DeserializeObject<DeviceEventProperties>(
+                                    JsonConvert.SerializeObject(partitionEvent.Data.Properties));
                                 TimeSpan timeSince = DateTimeOffset.UtcNow - deviceEvent.OperationOnUtc;
                                 if (timeSince.TotalSeconds < 30)
                                 {
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
                     }
                     catch (Exception ex)
                     {
-                        _logger.Trace($"Failed to convert event [{JsonSerializer.Serialize(partitionEvent.Data.Properties)}] to DeviceEventProperties due to {ex}", TraceSeverity.Warning);
+                        _logger.Trace($"Failed to convert event [{JsonConvert.SerializeObject(partitionEvent.Data.Properties)}] to DeviceEventProperties due to {ex}", TraceSeverity.Warning);
                     }
                 }
             }


### PR DESCRIPTION
`partitionEvent.Data.SystemProperties` is type of "IReadOnlyDictionary". It appears that serializing/deserializing the `ReadOnlyMemory` type of object with `System.Text.Json` would complain the following:

![Untitled](https://user-images.githubusercontent.com/94650966/228942191-ff57d599-6b8b-4442-9ff7-5ecc4419d1b5.png)

`Newtonsoft.Json` doesn't cause such a problem, so replaced.