### PR TITLE
Longhaul - Updated how we collect system metrics

### DIFF
--- a/e2e/LongHaul/device/IIotHub.cs
+++ b/e2e/LongHaul/device/IIotHub.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/e2e/LongHaul/device/IotHub.cs
+++ b/e2e/LongHaul/device/IotHub.cs
@@ -1,7 +1,6 @@
-﻿using Azure.Storage.Blobs.Models;
-using Azure.Storage.Blobs.Specialized;
-using Mash.Logging;
-using Microsoft.Azure.Devices.Client;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -12,6 +11,10 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+using Mash.Logging;
+using Microsoft.Azure.Devices.Client;
 using static Microsoft.Azure.Devices.LongHaul.Device.LoggingConstants;
 
 namespace Microsoft.Azure.Devices.LongHaul.Device
@@ -158,7 +161,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
                     {
                         { "TotalTelemetryMessagesSent", _totalTelemetryMessagesSent },
                     };
-                    await _deviceClient.UpdateReportedPropertiesAsync(reported ,ct).ConfigureAwait(false);
+                    await _deviceClient.UpdateReportedPropertiesAsync(reported, ct).ConfigureAwait(false);
 
                     ++_totalTwinUpdatesReported;
                     _logger.Metric(TotalTwinUpdatesReported, _totalTwinUpdatesReported);

--- a/e2e/LongHaul/device/IotHub.cs
+++ b/e2e/LongHaul/device/IotHub.cs
@@ -124,10 +124,14 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
                 }
 
                 // If not connected, skip the work below this round
-                if (!IsConnected && !loggedDisconnection)
+                if (!IsConnected)
                 {
-                    loggedDisconnection = true;
-                    _logger.Trace($"Waiting for connection before sending telemetry", TraceSeverity.Warning);
+                    if (!loggedDisconnection)
+                    {
+                        loggedDisconnection = true;
+                        _logger.Trace($"Waiting for connection before sending telemetry", TraceSeverity.Warning);
+                    }
+                    continue;
                 }
 
                 // Make get a message to send, unless we're retrying a previous message
@@ -167,7 +171,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
                     ++_totalTwinUpdatesReported;
                     _logger.Metric(TotalTwinUpdatesReported, _totalTwinUpdatesReported);
                 }
-                else if(!loggedDisconnection)
+                else if (!loggedDisconnection)
                 {
                     loggedDisconnection = true;
                     _logger.Trace($"Waiting for connection before any other operations.", TraceSeverity.Warning);

--- a/e2e/LongHaul/device/LoggingConstants.cs
+++ b/e2e/LongHaul/device/LoggingConstants.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Azure.Devices.LongHaul.Device
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.LongHaul.Device
 {
     internal static class LoggingConstants
     {
@@ -28,7 +31,7 @@
         public const string RunId = "runId";
         public const string SdkLanguage = "sdkLanguage";
         public const string SdkVersion = "sdkVersion";
-        
+
         public const string Hub = "hub";
         public const string DeviceId = "deviceId";
         public const string Transport = "transport";

--- a/e2e/LongHaul/device/MessageHelpers.cs
+++ b/e2e/LongHaul/device/MessageHelpers.cs
@@ -1,6 +1,9 @@
-﻿using Microsoft.Azure.Devices.Client;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
+using Microsoft.Azure.Devices.Client;
 
 namespace Microsoft.Azure.Devices.LongHaul.Device
 {

--- a/e2e/LongHaul/device/Program.cs
+++ b/e2e/LongHaul/device/Program.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
     {
         private static readonly IDictionary<string, string> s_commonProperties = new Dictionary<string, string>();
         private static Logger s_logger;
+        private static int s_port;
         private static ApplicationInsightsLoggingProvider s_aiLoggingProvider;
         internal static readonly string _runId = Guid.NewGuid().ToString();
 
@@ -42,6 +43,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
                 });
 
             s_logger = InitializeLogging(parameters);
+            s_port = PortFilter(parameters);
 
             // Log system health before initializing hub
             SystemHealthMonitor.BuildAndLogSystemHealth(s_logger);
@@ -77,7 +79,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
 
             await iotHub.SetPropertiesAsync(LoggingConstants.RunId, _runId, cancellationTokenSource.Token).ConfigureAwait(false);
 
-            var systemHealthMonitor = new SystemHealthMonitor(iotHub, s_logger.Clone());
+            var systemHealthMonitor = new SystemHealthMonitor(iotHub, s_port, s_logger.Clone());
 
             try
             {
@@ -126,6 +128,18 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
 
             Logger logger = logBuilder.BuildLogger();
             return logger;
+        }
+
+        private static int PortFilter(Parameters parameters)
+        {
+            return parameters.TransportProtocol == IotHubClientTransportProtocol.WebSocket
+                ? 443
+                : parameters.Transport switch
+                {
+                    TransportType.Mqtt => 8883,
+                    TransportType.Amqp => 5671,
+                    _ => throw new NotSupportedException($"Unsupported transport type {parameters.Transport}/{parameters.TransportProtocol}"),
+                };
         }
 
         private static IotHubClientTransportSettings GetTransportSettings(Parameters parameters)

--- a/e2e/LongHaul/device/Program.cs
+++ b/e2e/LongHaul/device/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;

--- a/e2e/LongHaul/device/SystemHealthMonitor.cs
+++ b/e2e/LongHaul/device/SystemHealthMonitor.cs
@@ -1,9 +1,11 @@
-﻿using Mash.Logging;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Mash.Logging;
 
 namespace Microsoft.Azure.Devices.LongHaul.Device
 {

--- a/e2e/LongHaul/device/SystemHealthMonitor.cs
+++ b/e2e/LongHaul/device/SystemHealthMonitor.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
         {
             var telemetry = new SystemHealthTelemetry(s_port);
             logger.Metric(nameof(telemetry.TotalAssignedMemoryBytes), telemetry.TotalAssignedMemoryBytes);
-            logger.Metric(nameof(telemetry.ProcessCpu), telemetry.ProcessCpu);
+            logger.Metric(nameof(telemetry.ProcessCpuUsagePercent), telemetry.ProcessCpuUsagePercent);
             logger.Metric(nameof(telemetry.TotalGCBytes), telemetry.TotalGCBytes);
-            logger.Metric(nameof(telemetry.TcpConnections), telemetry.TcpConnections);
+            logger.Metric(nameof(telemetry.ActiveTcpConnections), telemetry.ActiveTcpConnections);
 
             return telemetry;
         }

--- a/e2e/LongHaul/device/SystemHealthMonitor.cs
+++ b/e2e/LongHaul/device/SystemHealthMonitor.cs
@@ -1,6 +1,8 @@
 ﻿using Mash.Logging;
+using Microsoft.Diagnostics.Runtime;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -52,10 +54,10 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
         internal static SystemHealthTelemetry BuildAndLogSystemHealth(Logger logger)
         {
             var telemetry = new SystemHealthTelemetry(s_port);
-            logger.Metric(nameof(telemetry.totalAssignedMemoryBytes), telemetry.totalAssignedMemoryBytes);
-            logger.Metric(nameof(telemetry.processCpu), telemetry.processCpu);
-            logger.Metric(nameof(telemetry.totalGCBytes), telemetry.totalGCBytes);
-            logger.Metric(nameof(telemetry.tcpConnections), telemetry.tcpConnections);
+            logger.Metric(nameof(telemetry.TotalAssignedMemoryBytes), telemetry.TotalAssignedMemoryBytes);
+            logger.Metric(nameof(telemetry.ProcessCpu), telemetry.ProcessCpu);
+            logger.Metric(nameof(telemetry.TotalGCBytes), telemetry.TotalGCBytes);
+            logger.Metric(nameof(telemetry.TcpConnections), telemetry.TcpConnections);
 
             return telemetry;
         }

--- a/e2e/LongHaul/device/SystemHealthMonitor.cs
+++ b/e2e/LongHaul/device/SystemHealthMonitor.cs
@@ -15,11 +15,13 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
     {
         private readonly IIotHub _iotHub;
         private readonly Logger _logger;
+        private static int s_port;
         private static readonly TimeSpan s_interval = TimeSpan.FromSeconds(3);
 
-        public SystemHealthMonitor(IIotHub iotHub, Logger logger)
+        public SystemHealthMonitor(IIotHub iotHub, int portFilter, Logger logger)
         {
             _iotHub = iotHub;
+            s_port = portFilter;
             _logger = logger;
             _logger.LoggerContext.Add("Component", nameof(SystemHealthMonitor));
         }
@@ -49,15 +51,11 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
 
         internal static SystemHealthTelemetry BuildAndLogSystemHealth(Logger logger)
         {
-            var telemetry = new SystemHealthTelemetry();
-            logger.Metric(nameof(telemetry.ProcessCpuUsagePercent), telemetry.ProcessCpuUsagePercent);
-            logger.Metric(nameof(telemetry.ProcessWorkingSet), telemetry.ProcessWorkingSet);
-            logger.Metric(nameof(telemetry.ProcessWorkingSetPrivate), telemetry.ProcessWorkingSetPrivate);
-            logger.Metric(nameof(telemetry.ProcessPrivateBytes), telemetry.ProcessPrivateBytes);
-            if (telemetry.ProcessBytesInAllHeaps.HasValue)
-            {
-                logger.Metric(nameof(telemetry.ProcessBytesInAllHeaps), telemetry.ProcessBytesInAllHeaps.Value);
-            }
+            var telemetry = new SystemHealthTelemetry(s_port);
+            logger.Metric(nameof(telemetry.totalAssignedMemoryBytes), telemetry.totalAssignedMemoryBytes);
+            logger.Metric(nameof(telemetry.processCpu), telemetry.processCpu);
+            logger.Metric(nameof(telemetry.totalGCBytes), telemetry.totalGCBytes);
+            logger.Metric(nameof(telemetry.tcpConnections), telemetry.tcpConnections);
 
             return telemetry;
         }

--- a/e2e/LongHaul/device/SystemHealthMonitor.cs
+++ b/e2e/LongHaul/device/SystemHealthMonitor.cs
@@ -1,5 +1,4 @@
 ﻿using Mash.Logging;
-using Microsoft.Diagnostics.Runtime;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/e2e/LongHaul/device/SystemHealthTelemetry.cs
+++ b/e2e/LongHaul/device/SystemHealthTelemetry.cs
@@ -1,25 +1,29 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Net.NetworkInformation;
+using Microsoft.Diagnostics.Runtime;
 
 namespace Microsoft.Azure.Devices.LongHaul.Device
 {
     internal class SystemHealthTelemetry : TelemetryBase
     {
-        public SystemHealthTelemetry(int port) 
-        {
-            s_tcpPortFilter = port;
-        }
+        
 
         private static readonly Process s_currentProcess = Process.GetCurrentProcess();
-        public static long s_tcpPortFilter;
-        public double processCpu { get; set; } = s_currentProcess.TotalProcessorTime.TotalMilliseconds / Environment.ProcessorCount;
-        public long totalAssignedMemoryBytes { get; set; } = s_currentProcess.WorkingSet64;
-        public long totalGCBytes { get; set; } = GC.GetTotalMemory(false);
-        public long tcpConnections { get; set; } = updateTCPConnections();
+        public static long TcpPortFilter;
+        public double ProcessCpu { get; set; } = s_currentProcess.TotalProcessorTime.TotalMilliseconds / Environment.ProcessorCount;
+        public long TotalAssignedMemoryBytes { get; set; } = s_currentProcess.WorkingSet64;
+        public long TotalGCBytes { get; set; } = GC.GetTotalMemory(false);
+        public long TcpConnections { get; set; } = UpdateTCPConnections();
+
+        public SystemHealthTelemetry(int port)
+        {
+            TcpPortFilter = port;
+        }
 
 
-        private static long updateTCPConnections()
+        private static long UpdateTCPConnections()
         {
             IPGlobalProperties properties = IPGlobalProperties.GetIPGlobalProperties();
             TcpConnectionInformation[] connections = properties.GetActiveTcpConnections();
@@ -27,7 +31,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
             long n = 0;
             foreach (TcpConnectionInformation conn in connections)
             {
-                if (s_tcpPortFilter != 0 && conn.RemoteEndPoint.Port != s_tcpPortFilter)
+                if (TcpPortFilter != 0 && conn.RemoteEndPoint.Port != TcpPortFilter)
                     continue;
                 if (conn.State == TcpState.Established) 
                     n++;

--- a/e2e/LongHaul/device/SystemHealthTelemetry.cs
+++ b/e2e/LongHaul/device/SystemHealthTelemetry.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
         // always include HTTPS port.
         public static HashSet<int> TcpPortFilter = new() { 443 };
 
+        public SystemHealthTelemetry(int port)
+        {
+            TcpPortFilter.Add(port);
+        }
+
         [JsonPropertyName("processCpuUsagePercent")]
         public double ProcessCpuUsagePercent { get; set; } = UpdateCpuUsage();
 
@@ -29,12 +34,6 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
 
         [JsonPropertyName("activeTcpConnections")]
         public long ActiveTcpConnections { get; set; } = UpdateTcpConnections();
-
-        public SystemHealthTelemetry(int port)
-        {
-            TcpPortFilter.Add(port);
-        }
-
 
         private static long UpdateTcpConnections()
         {

--- a/e2e/LongHaul/device/SystemHealthTelemetry.cs
+++ b/e2e/LongHaul/device/SystemHealthTelemetry.cs
@@ -1,14 +1,15 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Net.NetworkInformation;
-using Microsoft.Diagnostics.Runtime;
 
 namespace Microsoft.Azure.Devices.LongHaul.Device
 {
     internal class SystemHealthTelemetry : TelemetryBase
     {
-        
+
 
         private static readonly Process s_currentProcess = Process.GetCurrentProcess();
         public static long TcpPortFilter;
@@ -33,7 +34,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
             {
                 if (TcpPortFilter != 0 && conn.RemoteEndPoint.Port != TcpPortFilter)
                     continue;
-                if (conn.State == TcpState.Established) 
+                if (conn.State == TcpState.Established)
                     n++;
             }
             return n;

--- a/e2e/LongHaul/device/SystemHealthTelemetry.cs
+++ b/e2e/LongHaul/device/SystemHealthTelemetry.cs
@@ -2,42 +2,71 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net.NetworkInformation;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Azure.Devices.LongHaul.Device
 {
     internal class SystemHealthTelemetry : TelemetryBase
     {
-
-
         private static readonly Process s_currentProcess = Process.GetCurrentProcess();
-        public static long TcpPortFilter;
-        public double ProcessCpu { get; set; } = s_currentProcess.TotalProcessorTime.TotalMilliseconds / Environment.ProcessorCount;
+        private static DateTime? s_previousCpuStartTime = null;
+        private static TimeSpan? s_previousTotalProcessorTime = null;
+        // always include HTTPS port.
+        public static HashSet<int> TcpPortFilter = new() { 443 };
+
+        [JsonPropertyName("processCpuUsagePercent")]
+        public double ProcessCpuUsagePercent { get; set; } = UpdateCpuUsage();
+
+        [JsonPropertyName("totalAssignedMemoryBytes")]
         public long TotalAssignedMemoryBytes { get; set; } = s_currentProcess.WorkingSet64;
+
+        [JsonPropertyName("totalGCBytes")]
         public long TotalGCBytes { get; set; } = GC.GetTotalMemory(false);
-        public long TcpConnections { get; set; } = UpdateTCPConnections();
+
+        [JsonPropertyName("activeTcpConnections")]
+        public long ActiveTcpConnections { get; set; } = UpdateTcpConnections();
 
         public SystemHealthTelemetry(int port)
         {
-            TcpPortFilter = port;
+            TcpPortFilter.Add(port);
         }
 
 
-        private static long UpdateTCPConnections()
+        private static long UpdateTcpConnections()
         {
-            IPGlobalProperties properties = IPGlobalProperties.GetIPGlobalProperties();
+            var properties = IPGlobalProperties.GetIPGlobalProperties();
             TcpConnectionInformation[] connections = properties.GetActiveTcpConnections();
+            return connections
+                .Where(c => TcpPortFilter.Contains(c.RemoteEndPoint.Port))
+                .Where(c => c.State == TcpState.Established)
+                .Count();
+        }
 
-            long n = 0;
-            foreach (TcpConnectionInformation conn in connections)
+        private static double UpdateCpuUsage()
+        {
+            DateTime currentCpuStartTime = DateTime.UtcNow;
+            TimeSpan currentCpuUsage = s_currentProcess.TotalProcessorTime;
+
+            // If no start time set then set to now
+            if (!s_previousCpuStartTime.HasValue)
             {
-                if (TcpPortFilter != 0 && conn.RemoteEndPoint.Port != TcpPortFilter)
-                    continue;
-                if (conn.State == TcpState.Established)
-                    n++;
+                s_previousCpuStartTime = currentCpuStartTime;
+                s_previousTotalProcessorTime = currentCpuUsage;
             }
-            return n;
+
+            double cpuUsedMs = (currentCpuUsage - s_previousTotalProcessorTime.Value).TotalMilliseconds;
+            double totalMsPassed = (currentCpuStartTime - s_previousCpuStartTime.Value).TotalMilliseconds;
+            double cpuUsageTotal = cpuUsedMs / (Environment.ProcessorCount * totalMsPassed);
+
+            // Set previous times.
+            s_previousCpuStartTime = currentCpuStartTime;
+            s_previousTotalProcessorTime = currentCpuUsage;
+
+            return cpuUsageTotal * 100.0;
         }
     }
 }

--- a/e2e/LongHaul/device/SystemProperties.cs
+++ b/e2e/LongHaul/device/SystemProperties.cs
@@ -1,4 +1,7 @@
-﻿using System.Runtime.InteropServices;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Azure.Devices.LongHaul.Device

--- a/e2e/LongHaul/device/TelemetryBase.cs
+++ b/e2e/LongHaul/device/TelemetryBase.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Azure.Devices.LongHaul.Device

--- a/e2e/LongHaul/service/IotHub.cs
+++ b/e2e/LongHaul/service/IotHub.cs
@@ -111,6 +111,10 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
                             {
                                 _logger.Trace($"Operations on [{deviceId}] have been canceled as the device goes offline.", TraceSeverity.Information);
                             }
+                            catch (Exception ex)
+                            {
+                                _logger.Trace($"Service app failed with exception {ex}", TraceSeverity.Error);
+                            }
                         }
 
                         // Passing in "Operations()" as Task so we don't need to manually call "Invoke()" on it.

--- a/e2e/LongHaul/service/Program.cs
+++ b/e2e/LongHaul/service/Program.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
     {
         private static readonly IDictionary<string, string> s_commonProperties = new Dictionary<string, string>();
         private static Logger s_logger;
+        private static int s_port;
         private static ApplicationInsightsLoggingProvider s_aiLoggingProvider;
 
         private static async Task Main(string[] args)
@@ -49,6 +50,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
             }
 
             s_logger = InitializeLogging(parameters);
+            s_port = PortFilter(parameters);
 
             // Log system health before initializing hub
             SystemHealthMonitor.BuildAndLogSystemHealth(s_logger);
@@ -74,7 +76,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
                 Console.WriteLine("Exiting ...");
             };
 
-            var systemHealthMonitor = new SystemHealthMonitor(s_logger.Clone());
+            var systemHealthMonitor = new SystemHealthMonitor(s_port, s_logger.Clone());
             var hubEvents = new HubEvents(iotHub, s_logger.Clone());
 
             try
@@ -100,6 +102,11 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
 
             s_logger.Flush();
             s_aiLoggingProvider.Dispose();
+        }
+
+        private static int PortFilter(Parameters parameters)
+        {
+            return parameters.TransportProtocol == IotHubTransportProtocol.WebSocket? 443 : 5671;
         }
 
         private static Logger InitializeLogging(Parameters parameters)

--- a/e2e/LongHaul/service/Program.cs
+++ b/e2e/LongHaul/service/Program.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
 
         private static int PortFilter(Parameters parameters)
         {
-            return parameters.TransportProtocol == IotHubTransportProtocol.WebSocket? 443 : 5671;
+            return parameters.TransportProtocol == IotHubTransportProtocol.WebSocket ? 443 : 5671;
         }
 
         private static Logger InitializeLogging(Parameters parameters)

--- a/e2e/LongHaul/service/SystemHealthMessage.cs
+++ b/e2e/LongHaul/service/SystemHealthMessage.cs
@@ -2,40 +2,70 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net.NetworkInformation;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Azure.Devices.LongHaul.Service
 {
     internal class SystemHealthMessage : MessageBase
     {
-        public SystemHealthMessage(int port) 
+        private static readonly Process s_currentProcess = Process.GetCurrentProcess();
+        private static DateTime? s_previousCpuStartTime = null;
+        private static TimeSpan? s_previousTotalProcessorTime = null;
+        // always include HTTPS and AMQP port.
+        public static HashSet<int> TcpPortFilter = new() { 443, 5671 };
+
+        [JsonPropertyName("processCpuUsagePercent")]
+        public double ProcessCpuUsagePercent { get; set; } = UpdateCpuUsage();
+        
+        [JsonPropertyName("totalAssignedMemoryBytes")]
+        public long TotalAssignedMemoryBytes { get; set; } = s_currentProcess.WorkingSet64;
+        
+        [JsonPropertyName("totalGCBytes")]
+        public long TotalGCBytes { get; set; } = GC.GetTotalMemory(false);
+        
+        [JsonPropertyName("activeTcpConnections")] 
+        public long ActiveTcpConnections { get; set; } = UpdateTcpConnections();
+
+        public SystemHealthMessage(int port)
         {
-            TcpPortFilter = port;
+            TcpPortFilter.Add(port);
         }
 
-        private static readonly Process s_currentProcess = Process.GetCurrentProcess();
-        public static long TcpPortFilter;
-        public double ProcessCpu { get; set; } = s_currentProcess.TotalProcessorTime.TotalMilliseconds / Environment.ProcessorCount;
-        public long TotalAssignedMemoryBytes { get; set; } = s_currentProcess.WorkingSet64;
-        public long TotalGCBytes { get; set; } = GC.GetTotalMemory(false);
-        public long TcpConnections { get; set; } = UpdateTCPConnections();
-
-
-        private static long UpdateTCPConnections()
+        private static long UpdateTcpConnections()
         {
-            IPGlobalProperties properties = IPGlobalProperties.GetIPGlobalProperties();
+            var properties = IPGlobalProperties.GetIPGlobalProperties();
             TcpConnectionInformation[] connections = properties.GetActiveTcpConnections();
+            return connections
+                .Where(c => TcpPortFilter.Contains(c.RemoteEndPoint.Port))
+                .Where(c => c.State == TcpState.Established)
+                .Count();
+        }
 
-            long n = 0;
-            foreach (TcpConnectionInformation conn in connections)
+        private static double UpdateCpuUsage()
+        {
+            DateTime currentCpuStartTime = DateTime.UtcNow;
+            TimeSpan currentCpuUsage = s_currentProcess.TotalProcessorTime;
+
+            // If no start time set then set to now
+            if (!s_previousCpuStartTime.HasValue)
             {
-                if (TcpPortFilter != 0 && conn.RemoteEndPoint.Port != TcpPortFilter)
-                    continue;
-                if (conn.State == TcpState.Established)
-                    n++;
+                s_previousCpuStartTime = currentCpuStartTime;
+                s_previousTotalProcessorTime = currentCpuUsage;
             }
-            return n;
+
+            double cpuUsedMs = (currentCpuUsage - s_previousTotalProcessorTime.Value).TotalMilliseconds;
+            double totalMsPassed = (currentCpuStartTime - s_previousCpuStartTime.Value).TotalMilliseconds;
+            double cpuUsageTotal = cpuUsedMs / (Environment.ProcessorCount * totalMsPassed);
+
+            // Set previous times.
+            s_previousCpuStartTime = currentCpuStartTime;
+            s_previousTotalProcessorTime = currentCpuUsage;
+
+            return cpuUsageTotal * 100.0;
         }
     }
 }

--- a/e2e/LongHaul/service/SystemHealthMessage.cs
+++ b/e2e/LongHaul/service/SystemHealthMessage.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
         // always include HTTPS and AMQP port.
         public static HashSet<int> TcpPortFilter = new() { 443, 5671 };
 
+        public SystemHealthMessage(int port)
+        {
+            TcpPortFilter.Add(port);
+        }
+
         [JsonPropertyName("processCpuUsagePercent")]
         public double ProcessCpuUsagePercent { get; set; } = UpdateCpuUsage();
         
@@ -29,11 +34,6 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
         
         [JsonPropertyName("activeTcpConnections")] 
         public long ActiveTcpConnections { get; set; } = UpdateTcpConnections();
-
-        public SystemHealthMessage(int port)
-        {
-            TcpPortFilter.Add(port);
-        }
 
         private static long UpdateTcpConnections()
         {

--- a/e2e/LongHaul/service/SystemHealthMessage.cs
+++ b/e2e/LongHaul/service/SystemHealthMessage.cs
@@ -1,56 +1,42 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics;
+using System.Net.NetworkInformation;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Azure.Devices.LongHaul.Service
 {
     internal class SystemHealthMessage : MessageBase
     {
+        public SystemHealthMessage(int port) 
+        {
+            s_tcpPortFilter = port;
+        }
+
         private static readonly Process s_currentProcess = Process.GetCurrentProcess();
-        private static readonly string s_processName = s_currentProcess.ProcessName;
+        public static long s_tcpPortFilter;
+        public double processCpu { get; set; } = s_currentProcess.TotalProcessorTime.TotalMilliseconds / Environment.ProcessorCount;
+        public long totalAssignedMemoryBytes { get; set; } = s_currentProcess.WorkingSet64;
+        public long totalGCBytes { get; set; } = GC.GetTotalMemory(false);
+        public long tcpConnections { get; set; } = updateTCPConnections();
 
-        private static readonly PerformanceCounter s_processCpuCounter = new(
-            "Process",
-            "% Processor Time",
-            s_processName,
-            true);
-        private static readonly PerformanceCounter s_processWorkingSet = new(
-            "Process",
-            "Working Set",
-            s_processName,
-            true);
-        private static readonly PerformanceCounter s_processWorkingSetPrivate = new(
-            "Process",
-            "Working Set - Private",
-            s_processName,
-            true);
-        private static readonly PerformanceCounter s_processPrivateBytes = new(
-            "Process",
-            "Private bytes",
-            s_processName,
-            true);
-        private static readonly PerformanceCounter s_processBytesInAllHeaps = null;
-        //new PerformanceCounter(
-        //    ".NET CLR Memory",
-        //    "# Bytes in all Heaps",
-        //    _processName,
-        //    true);
 
-        [JsonPropertyName("processCpuUsagePercent")]
-        public float ProcessCpuUsagePercent { get; set; } = s_processCpuCounter.NextValue();
+        private static long updateTCPConnections()
+        {
+            IPGlobalProperties properties = IPGlobalProperties.GetIPGlobalProperties();
+            TcpConnectionInformation[] connections = properties.GetActiveTcpConnections();
 
-        [JsonPropertyName("processWorkingSet")]
-        public float ProcessWorkingSet { get; set; } = s_processWorkingSet.NextValue();
-
-        [JsonPropertyName("processWorkingSetPrivate")]
-        public float ProcessWorkingSetPrivate { get; set; } = s_processWorkingSetPrivate.NextValue();
-
-        [JsonPropertyName("processPrivateBytes")]
-        public float ProcessPrivateBytes { get; set; } = s_processPrivateBytes.NextValue();
-
-        [JsonPropertyName("processBytesInAllHeaps")]
-        public float? ProcessBytesInAllHeaps { get; set; } = s_processBytesInAllHeaps?.NextValue();
+            long n = 0;
+            foreach (TcpConnectionInformation conn in connections)
+            {
+                if (s_tcpPortFilter != 0 && conn.RemoteEndPoint.Port != s_tcpPortFilter)
+                    continue;
+                if (conn.State == TcpState.Established)
+                    n++;
+            }
+            return n;
+        }
     }
 }

--- a/e2e/LongHaul/service/SystemHealthMessage.cs
+++ b/e2e/LongHaul/service/SystemHealthMessage.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.Net.NetworkInformation;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.Azure.Devices.LongHaul.Service
 {
@@ -12,18 +11,18 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
     {
         public SystemHealthMessage(int port) 
         {
-            s_tcpPortFilter = port;
+            TcpPortFilter = port;
         }
 
         private static readonly Process s_currentProcess = Process.GetCurrentProcess();
-        public static long s_tcpPortFilter;
-        public double processCpu { get; set; } = s_currentProcess.TotalProcessorTime.TotalMilliseconds / Environment.ProcessorCount;
-        public long totalAssignedMemoryBytes { get; set; } = s_currentProcess.WorkingSet64;
-        public long totalGCBytes { get; set; } = GC.GetTotalMemory(false);
-        public long tcpConnections { get; set; } = updateTCPConnections();
+        public static long TcpPortFilter;
+        public double ProcessCpu { get; set; } = s_currentProcess.TotalProcessorTime.TotalMilliseconds / Environment.ProcessorCount;
+        public long TotalAssignedMemoryBytes { get; set; } = s_currentProcess.WorkingSet64;
+        public long TotalGCBytes { get; set; } = GC.GetTotalMemory(false);
+        public long TcpConnections { get; set; } = UpdateTCPConnections();
 
 
-        private static long updateTCPConnections()
+        private static long UpdateTCPConnections()
         {
             IPGlobalProperties properties = IPGlobalProperties.GetIPGlobalProperties();
             TcpConnectionInformation[] connections = properties.GetActiveTcpConnections();
@@ -31,7 +30,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
             long n = 0;
             foreach (TcpConnectionInformation conn in connections)
             {
-                if (s_tcpPortFilter != 0 && conn.RemoteEndPoint.Port != s_tcpPortFilter)
+                if (TcpPortFilter != 0 && conn.RemoteEndPoint.Port != TcpPortFilter)
                     continue;
                 if (conn.State == TcpState.Established)
                     n++;

--- a/e2e/LongHaul/service/SystemHealthMonitor.cs
+++ b/e2e/LongHaul/service/SystemHealthMonitor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Mash.Logging;
+using Microsoft.ApplicationInsights.Channel;
 
 namespace Microsoft.Azure.Devices.LongHaul.Service
 {
@@ -16,10 +17,12 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
     internal class SystemHealthMonitor
     {
         private readonly Logger _logger;
+        private static int s_port;
         private static readonly TimeSpan s_interval = TimeSpan.FromSeconds(3);
 
-        public SystemHealthMonitor(Logger logger)
+        public SystemHealthMonitor(int port, Logger logger)
         {
+            s_port = port;
             _logger = logger;
             _logger.LoggerContext.Add("Component", nameof(SystemHealthMonitor));
         }
@@ -35,15 +38,11 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
 
         internal static SystemHealthMessage BuildAndLogSystemHealth(Logger logger)
         {
-            var message = new SystemHealthMessage();
-            logger.Metric(nameof(message.ProcessCpuUsagePercent), message.ProcessCpuUsagePercent);
-            logger.Metric(nameof(message.ProcessWorkingSet), message.ProcessWorkingSet);
-            logger.Metric(nameof(message.ProcessWorkingSetPrivate), message.ProcessWorkingSetPrivate);
-            logger.Metric(nameof(message.ProcessPrivateBytes), message.ProcessPrivateBytes);
-            if (message.ProcessBytesInAllHeaps.HasValue)
-            {
-                logger.Metric(nameof(message.ProcessBytesInAllHeaps), message.ProcessBytesInAllHeaps.Value);
-            }
+            var message = new SystemHealthMessage(s_port);
+            logger.Metric(nameof(message.totalAssignedMemoryBytes), message.totalAssignedMemoryBytes);
+            logger.Metric(nameof(message.processCpu), message.processCpu);
+            logger.Metric(nameof(message.totalGCBytes), message.totalGCBytes);
+            logger.Metric(nameof(message.tcpConnections), message.tcpConnections);
 
             return message;
         }

--- a/e2e/LongHaul/service/SystemHealthMonitor.cs
+++ b/e2e/LongHaul/service/SystemHealthMonitor.cs
@@ -39,9 +39,9 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
         {
             var message = new SystemHealthMessage(s_port);
             logger.Metric(nameof(message.TotalAssignedMemoryBytes), message.TotalAssignedMemoryBytes);
-            logger.Metric(nameof(message.ProcessCpu), message.ProcessCpu);
+            logger.Metric(nameof(message.ProcessCpuUsagePercent), message.ProcessCpuUsagePercent);
             logger.Metric(nameof(message.TotalGCBytes), message.TotalGCBytes);
-            logger.Metric(nameof(message.TcpConnections), message.TcpConnections);
+            logger.Metric(nameof(message.ActiveTcpConnections), message.ActiveTcpConnections);
 
             return message;
         }

--- a/e2e/LongHaul/service/SystemHealthMonitor.cs
+++ b/e2e/LongHaul/service/SystemHealthMonitor.cs
@@ -39,10 +39,10 @@ namespace Microsoft.Azure.Devices.LongHaul.Service
         internal static SystemHealthMessage BuildAndLogSystemHealth(Logger logger)
         {
             var message = new SystemHealthMessage(s_port);
-            logger.Metric(nameof(message.totalAssignedMemoryBytes), message.totalAssignedMemoryBytes);
-            logger.Metric(nameof(message.processCpu), message.processCpu);
-            logger.Metric(nameof(message.totalGCBytes), message.totalGCBytes);
-            logger.Metric(nameof(message.tcpConnections), message.tcpConnections);
+            logger.Metric(nameof(message.TotalAssignedMemoryBytes), message.TotalAssignedMemoryBytes);
+            logger.Metric(nameof(message.ProcessCpu), message.ProcessCpu);
+            logger.Metric(nameof(message.TotalGCBytes), message.TotalGCBytes);
+            logger.Metric(nameof(message.TcpConnections), message.TcpConnections);
 
             return message;
         }

--- a/e2e/LongHaul/service/SystemHealthMonitor.cs
+++ b/e2e/LongHaul/service/SystemHealthMonitor.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Mash.Logging;
-using Microsoft.ApplicationInsights.Channel;
 
 namespace Microsoft.Azure.Devices.LongHaul.Service
 {

--- a/iothub/device/src/Exceptions/IotHubClientException.cs
+++ b/iothub/device/src/Exceptions/IotHubClientException.cs
@@ -98,7 +98,9 @@ namespace Microsoft.Azure.Devices.Client
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"{Message}\nError code: {ErrorCode}\n{StackTrace}n";
+            return $"Message: {Message}\n" +
+                   $"ErrorCode: {ErrorCode}, TrackingId: {TrackingId}, IsTransient: {IsTransient}\n" +
+                   $"StackTrace: {StackTrace}";
         }
 
         private static bool DetermineIfTransient(IotHubClientErrorCode errorCode)

--- a/iothub/device/src/Exceptions/IotHubClientException.cs
+++ b/iothub/device/src/Exceptions/IotHubClientException.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+using System.Text;
 
 namespace Microsoft.Azure.Devices.Client
 {
@@ -98,9 +99,12 @@ namespace Microsoft.Azure.Devices.Client
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"Message: {Message}\n" +
-                   $"ErrorCode: {ErrorCode}, TrackingId: {TrackingId}, IsTransient: {IsTransient}\n" +
-                   $"StackTrace: {StackTrace}";
+            var sb = new StringBuilder();
+            sb.Append($"Message: {Message}\nErrorCode: {ErrorCode}, IsTransient: {IsTransient}");
+            if (!string.IsNullOrEmpty(TrackingId))
+                sb.Append($", TrackingId: {TrackingId}");
+            sb.Append($"\n{StackTrace}");
+            return sb.ToString();
         }
 
         private static bool DetermineIfTransient(IotHubClientErrorCode errorCode)

--- a/iothub/service/src/Exceptions/IotHubServiceException.cs
+++ b/iothub/service/src/Exceptions/IotHubServiceException.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Net;
 using System.Runtime.Serialization;
+using System.Text;
 
 namespace Microsoft.Azure.Devices
 {
@@ -107,9 +108,12 @@ namespace Microsoft.Azure.Devices
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"Message: {Message}\n" +
-                   $"ErrorCode: {ErrorCode}, TrackingId: {TrackingId}, IsTransient: {IsTransient}\n" +
-                   $"StackTrace: {StackTrace}";
+            var sb = new StringBuilder();
+            sb.Append($"Message: {Message}\nErrorCode: {ErrorCode}, IsTransient: {IsTransient}");
+            if (!string.IsNullOrEmpty(TrackingId))
+                sb.Append($", TrackingId: {TrackingId}");
+            sb.Append($"\n{StackTrace}");
+            return sb.ToString();
         }
 
         private static bool DetermineIfTransient(HttpStatusCode statusCode, IotHubServiceErrorCode errorCode)

--- a/iothub/service/src/Exceptions/IotHubServiceException.cs
+++ b/iothub/service/src/Exceptions/IotHubServiceException.cs
@@ -104,6 +104,14 @@ namespace Microsoft.Azure.Devices
             info.AddValue(TrackingIdValueSerializationStoreName, TrackingId);
         }
 
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"Message: {Message}\n" +
+                   $"ErrorCode: {ErrorCode}, TrackingId: {TrackingId}, IsTransient: {IsTransient}\n" +
+                   $"StackTrace: {StackTrace}";
+        }
+
         private static bool DetermineIfTransient(HttpStatusCode statusCode, IotHubServiceErrorCode errorCode)
         {
             return errorCode switch


### PR DESCRIPTION
Using implementation from https://github.com/Azure/azure-iot-sdk-csharp/blob/main/e2e/stress/IoTClientPerf/Reporting/SystemMetrics.cs  as performance counters do not work with Linux and performance counters for .NET CLR were not working as expected.