### PR TITLE
Fix some ErrorCode in IotHubServiceException

### DIFF
--- a/e2e/Tests/iothub/service/DevicesClientE2ETests.cs
+++ b/e2e/Tests/iothub/service/DevicesClientE2ETests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             // assert
             var error = await act.Should().ThrowAsync<IotHubServiceException>();
             error.And.StatusCode.Should().Be(HttpStatusCode.RequestTimeout);
-            error.And.ErrorCode.Should().Be(IotHubServiceErrorCode.Unknown);
+            error.And.ErrorCode.Should().Be(IotHubServiceErrorCode.GenericRequestTimeout);
             error.And.IsTransient.Should().BeTrue();
         }
 

--- a/e2e/Tests/iothub/service/DevicesClientE2ETests.cs
+++ b/e2e/Tests/iothub/service/DevicesClientE2ETests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             // assert
             var error = await act.Should().ThrowAsync<IotHubServiceException>();
             error.And.StatusCode.Should().Be(HttpStatusCode.RequestTimeout);
-            error.And.ErrorCode.Should().Be(IotHubServiceErrorCode.GenericRequestTimeout);
+            error.And.ErrorCode.Should().Be(IotHubServiceErrorCode.RequestTimeout);
             error.And.IsTransient.Should().BeTrue();
         }
 

--- a/iothub/device/src/Fx/Fx.cs
+++ b/iothub/device/src/Fx/Fx.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Client
 
             if (ex is IotHubClientException hex)
             {
-                return hex.IsTransient;
+                return !hex.IsTransient;
             }
 
             // These exceptions aren't themselves fatal, but since the CLR uses them to wrap other exceptions,

--- a/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
+++ b/iothub/device/tests/Pipeline/RetryDelegatingHandlerTests.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Azure.Devices.Client.Test
 
             // assert for connection status
             connectionStatusInfo.Status.Should().Be(ConnectionStatus.Disconnected);
-            connectionStatusInfo.ChangeReason.Should().Be(ConnectionStatusChangeReason.DeviceDisabled);
+            connectionStatusInfo.ChangeReason.Should().Be(ConnectionStatusChangeReason.ClientClosed);
         }
 
         [TestMethod]

--- a/iothub/service/src/Amqp/AmqpClientHelper.cs
+++ b/iothub/service/src/Amqp/AmqpClientHelper.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Amqp
                 TimeoutException => new IotHubServiceException(
                     exception.Message,
                     HttpStatusCode.RequestTimeout,
-                    IotHubServiceErrorCode.GenericRequestTimeout),
+                    IotHubServiceErrorCode.RequestTimeout),
                 UnauthorizedAccessException => new IotHubServiceException(
                     exception.Message,
                     HttpStatusCode.Unauthorized,
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Amqp
 
             if (error.Condition.Equals(IotHubAmqpErrorCode.TimeoutError))
             {
-                retException = new IotHubServiceException(message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, innerException);
+                retException = new IotHubServiceException(message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, innerException);
             }
             else if (error.Condition.Equals(AmqpErrorCode.NotFound))
             {

--- a/iothub/service/src/Amqp/AmqpClientHelper.cs
+++ b/iothub/service/src/Amqp/AmqpClientHelper.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Amqp
                 TimeoutException => new IotHubServiceException(
                     exception.Message,
                     HttpStatusCode.RequestTimeout,
-                    IotHubServiceErrorCode.Unknown),
+                    IotHubServiceErrorCode.GenericRequestTimeout),
                 UnauthorizedAccessException => new IotHubServiceException(
                     exception.Message,
                     HttpStatusCode.Unauthorized,
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Amqp
 
             if (error.Condition.Equals(IotHubAmqpErrorCode.TimeoutError))
             {
-                retException = new IotHubServiceException(message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, innerException);
+                retException = new IotHubServiceException(message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, innerException);
             }
             else if (error.Condition.Equals(AmqpErrorCode.NotFound))
             {

--- a/iothub/service/src/Amqp/AmqpConnectionHandler.cs
+++ b/iothub/service/src/Amqp/AmqpConnectionHandler.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.Devices.Amqp
             }
             catch (SocketException socketException)
             {
-                throw new IotHubServiceException(socketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, socketException);
+                throw new IotHubServiceException(socketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, socketException);
             }
             catch (WebSocketException webSocketException)
             {
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.Devices.Amqp
                 {
                     throw new IotHubServiceException(webSocketException.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, webSocketException);
                 }
-                throw new IotHubServiceException(webSocketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, webSocketException);
+                throw new IotHubServiceException(webSocketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, webSocketException);
             }
             finally
             {
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.Devices.Amqp
             }
             catch (SocketException socketException)
             {
-                throw new IotHubServiceException(socketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, socketException);
+                throw new IotHubServiceException(socketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, socketException);
             }
             catch (WebSocketException webSocketException)
             {
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.Devices.Amqp
                 {
                     throw new IotHubServiceException(webSocketException.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, webSocketException);
                 }
-                throw new IotHubServiceException(webSocketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, webSocketException);
+                throw new IotHubServiceException(webSocketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, webSocketException);
             }
             finally
             {

--- a/iothub/service/src/Amqp/AmqpConnectionHandler.cs
+++ b/iothub/service/src/Amqp/AmqpConnectionHandler.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.Devices.Amqp
             }
             catch (SocketException socketException)
             {
-                throw new IotHubServiceException(socketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, socketException);
+                throw new IotHubServiceException(socketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, socketException);
             }
             catch (WebSocketException webSocketException)
             {
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.Devices.Amqp
                 {
                     throw new IotHubServiceException(webSocketException.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, webSocketException);
                 }
-                throw new IotHubServiceException(webSocketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, webSocketException);
+                throw new IotHubServiceException(webSocketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, webSocketException);
             }
             finally
             {
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.Devices.Amqp
             }
             catch (SocketException socketException)
             {
-                throw new IotHubServiceException(socketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, socketException);
+                throw new IotHubServiceException(socketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, socketException);
             }
             catch (WebSocketException webSocketException)
             {
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.Devices.Amqp
                 {
                     throw new IotHubServiceException(webSocketException.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, webSocketException);
                 }
-                throw new IotHubServiceException(webSocketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, webSocketException);
+                throw new IotHubServiceException(webSocketException.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, webSocketException);
             }
             finally
             {

--- a/iothub/service/src/Configurations/ConfigurationsClient.cs
+++ b/iothub/service/src/Configurations/ConfigurationsClient.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex)
             {
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex)
             {
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex)
             {
@@ -287,7 +287,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex)
             {
@@ -376,7 +376,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -443,7 +443,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex)
             {

--- a/iothub/service/src/Configurations/ConfigurationsClient.cs
+++ b/iothub/service/src/Configurations/ConfigurationsClient.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex)
             {
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex)
             {
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex)
             {
@@ -287,7 +287,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex)
             {
@@ -376,7 +376,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -443,7 +443,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex)
             {

--- a/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinsClient.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/src/DirectMethod/DirectMethodsClient.cs
+++ b/iothub/service/src/DirectMethod/DirectMethodsClient.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/src/DirectMethod/DirectMethodsClient.cs
+++ b/iothub/service/src/DirectMethod/DirectMethodsClient.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/src/Exceptions/IotHubServiceErrorCode.cs
+++ b/iothub/service/src/Exceptions/IotHubServiceErrorCode.cs
@@ -159,6 +159,13 @@ namespace Microsoft.Azure.Devices
         /// </summary>
         ConfigurationNotFound = 404301,
 
+        // Request Timeout - 408
+
+        /// <summary>
+        /// The client did not send a request within the time the server was expecting the request.
+        /// </summary>
+        GenericRequestTimeout,
+
         // Conflict - 409
 
         /// <summary>

--- a/iothub/service/src/Exceptions/IotHubServiceErrorCode.cs
+++ b/iothub/service/src/Exceptions/IotHubServiceErrorCode.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// The client did not send a request within the time the server was expecting the request.
         /// </summary>
-        GenericRequestTimeout,
+        GenericRequestTimeout = 408000,
 
         // Conflict - 409
 

--- a/iothub/service/src/Exceptions/IotHubServiceErrorCode.cs
+++ b/iothub/service/src/Exceptions/IotHubServiceErrorCode.cs
@@ -164,7 +164,10 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// The client did not send a request within the time the server was expecting the request.
         /// </summary>
-        GenericRequestTimeout = 408000,
+        /// <remarks>
+        /// We define this error code ourselves as the client wouldn't actually receive response from the service.
+        /// </remarks>
+        RequestTimeout = 408000,
 
         // Conflict - 409
 

--- a/iothub/service/src/Exceptions/IotHubServiceException.cs
+++ b/iothub/service/src/Exceptions/IotHubServiceException.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices
                     or IotHubServiceErrorCode.ThrottlingBacklogTimeout
                     or IotHubServiceErrorCode.ServerError
                     or IotHubServiceErrorCode.ServiceUnavailable
-                    or IotHubServiceErrorCode.GenericRequestTimeout
+                    or IotHubServiceErrorCode.RequestTimeout
                     => true,
                 IotHubServiceErrorCode.Unknown
                     => statusCode == (HttpStatusCode)429,

--- a/iothub/service/src/Exceptions/IotHubServiceException.cs
+++ b/iothub/service/src/Exceptions/IotHubServiceException.cs
@@ -126,9 +126,10 @@ namespace Microsoft.Azure.Devices
                     or IotHubServiceErrorCode.ThrottlingBacklogTimeout
                     or IotHubServiceErrorCode.ServerError
                     or IotHubServiceErrorCode.ServiceUnavailable
+                    or IotHubServiceErrorCode.GenericRequestTimeout
                     => true,
-                IotHubServiceErrorCode.Unknown => statusCode == HttpStatusCode.RequestTimeout
-                    || statusCode == (HttpStatusCode)429,
+                IotHubServiceErrorCode.Unknown
+                    => statusCode == (HttpStatusCode)429,
                 _ => false,
             };
         }

--- a/iothub/service/src/Jobs/ScheduledJobsClient.cs
+++ b/iothub/service/src/Jobs/ScheduledJobsClient.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -287,7 +287,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/src/Jobs/ScheduledJobsClient.cs
+++ b/iothub/service/src/Jobs/ScheduledJobsClient.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -287,7 +287,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/src/Messaging/MessagesClient.cs
+++ b/iothub/service/src/Messaging/MessagesClient.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/src/Messaging/MessagesClient.cs
+++ b/iothub/service/src/Messaging/MessagesClient.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/src/Query/QueryClient.cs
+++ b/iothub/service/src/Query/QueryClient.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -293,7 +293,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
 
             await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.OK, response).ConfigureAwait(false);

--- a/iothub/service/src/Query/QueryClient.cs
+++ b/iothub/service/src/Query/QueryClient.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -293,7 +293,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
 
             await HttpMessageHelper.ValidateHttpResponseStatusAsync(HttpStatusCode.OK, response).ConfigureAwait(false);

--- a/iothub/service/src/Registry/DevicesClient.cs
+++ b/iothub/service/src/Registry/DevicesClient.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -320,7 +320,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -385,7 +385,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -445,7 +445,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -497,7 +497,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -552,7 +552,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -607,7 +607,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -653,7 +653,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -700,7 +700,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -760,7 +760,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -815,7 +815,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -874,7 +874,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -929,7 +929,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -984,7 +984,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/src/Registry/DevicesClient.cs
+++ b/iothub/service/src/Registry/DevicesClient.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -320,7 +320,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -385,7 +385,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -445,7 +445,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -497,7 +497,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -552,7 +552,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -607,7 +607,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -653,7 +653,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -700,7 +700,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -760,7 +760,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -815,7 +815,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -874,7 +874,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -929,7 +929,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -984,7 +984,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/src/Registry/ModulesClient.cs
+++ b/iothub/service/src/Registry/ModulesClient.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -312,7 +312,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/src/Registry/ModulesClient.cs
+++ b/iothub/service/src/Registry/ModulesClient.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -312,7 +312,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/src/Twin/TwinsClient.cs
+++ b/iothub/service/src/Twin/TwinsClient.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -313,7 +313,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -431,7 +431,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -490,7 +490,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/src/Twin/TwinsClient.cs
+++ b/iothub/service/src/Twin/TwinsClient.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -313,7 +313,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -431,7 +431,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {
@@ -490,7 +490,7 @@ namespace Microsoft.Azure.Devices
                 {
                     throw new IotHubServiceException(ex.Message, HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess, null, ex);
                 }
-                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown, null, ex);
+                throw new IotHubServiceException(ex.Message, HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout, null, ex);
             }
             catch (Exception ex) when (Logging.IsEnabled)
             {

--- a/iothub/service/tests/Amqp/AmqpClientHelperTests.cs
+++ b/iothub/service/tests/Amqp/AmqpClientHelperTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Tests.Amqp
             returnedException.Message.Should().Be(timeoutExceptionMessage);
             returnedException.IsTransient.Should().BeTrue();
             returnedException.StatusCode.Should().Be(HttpStatusCode.RequestTimeout);
-            returnedException.ErrorCode.Should().Be(IotHubServiceErrorCode.Unknown);
+            returnedException.ErrorCode.Should().Be(IotHubServiceErrorCode.GenericRequestTimeout);
         }
 
         [TestMethod]
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Tests.Amqp
 
         [TestMethod]
         [DataRow("amqp:not-found", HttpStatusCode.NotFound, IotHubServiceErrorCode.DeviceNotFound)]
-        [DataRow(AmqpConstants.Vendor + ":timeout", HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.Unknown)]
+        [DataRow(AmqpConstants.Vendor + ":timeout", HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout)]
         [DataRow("amqp:unauthorized-access", HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess)]
         [DataRow("amqp:link:message-size-exceeded", HttpStatusCode.RequestEntityTooLarge, IotHubServiceErrorCode.MessageTooLarge)]
         [DataRow("amqp:resource-limit-exceeded", HttpStatusCode.Forbidden, IotHubServiceErrorCode.DeviceMaximumQueueDepthExceeded)]

--- a/iothub/service/tests/Amqp/AmqpClientHelperTests.cs
+++ b/iothub/service/tests/Amqp/AmqpClientHelperTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Tests.Amqp
             returnedException.Message.Should().Be(timeoutExceptionMessage);
             returnedException.IsTransient.Should().BeTrue();
             returnedException.StatusCode.Should().Be(HttpStatusCode.RequestTimeout);
-            returnedException.ErrorCode.Should().Be(IotHubServiceErrorCode.GenericRequestTimeout);
+            returnedException.ErrorCode.Should().Be(IotHubServiceErrorCode.RequestTimeout);
         }
 
         [TestMethod]
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Tests.Amqp
 
         [TestMethod]
         [DataRow("amqp:not-found", HttpStatusCode.NotFound, IotHubServiceErrorCode.DeviceNotFound)]
-        [DataRow(AmqpConstants.Vendor + ":timeout", HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.GenericRequestTimeout)]
+        [DataRow(AmqpConstants.Vendor + ":timeout", HttpStatusCode.RequestTimeout, IotHubServiceErrorCode.RequestTimeout)]
         [DataRow("amqp:unauthorized-access", HttpStatusCode.Unauthorized, IotHubServiceErrorCode.IotHubUnauthorizedAccess)]
         [DataRow("amqp:link:message-size-exceeded", HttpStatusCode.RequestEntityTooLarge, IotHubServiceErrorCode.MessageTooLarge)]
         [DataRow("amqp:resource-limit-exceeded", HttpStatusCode.Forbidden, IotHubServiceErrorCode.DeviceMaximumQueueDepthExceeded)]

--- a/iothub/service/tests/Exceptions/IotHubServiceExceptionTests.cs
+++ b/iothub/service/tests/Exceptions/IotHubServiceExceptionTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Devices.Tests.Exceptions
         [TestMethod]
         [DataRow(IotHubServiceErrorCode.DeviceNotFound)]
         [DataRow(IotHubServiceErrorCode.InvalidProtocolVersion)]
+        [DataRow(IotHubServiceErrorCode.Unknown)]
         [DataRow(IotHubServiceErrorCode.InvalidOperation)]
         [DataRow(IotHubServiceErrorCode.ArgumentInvalid)]
         [DataRow(IotHubServiceErrorCode.ArgumentNull)]

--- a/iothub/service/tests/Exceptions/IotHubServiceExceptionTests.cs
+++ b/iothub/service/tests/Exceptions/IotHubServiceExceptionTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Devices.Tests.Exceptions
             var exception = new IotHubServiceException(
                 Message,
                 statusCode,
-                IotHubServiceErrorCode.GenericRequestTimeout);
+                IotHubServiceErrorCode.RequestTimeout);
             var sctx = new StreamingContext();
 
             // act
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Devices.Tests.Exceptions
             var exception = new IotHubServiceException(
                 Message,
                 statusCode,
-                IotHubServiceErrorCode.GenericRequestTimeout);
+                IotHubServiceErrorCode.RequestTimeout);
             var sInfo = new SerializationInfo(GetType(), new FormatterConverter());
             var sctx = new StreamingContext();
 

--- a/iothub/service/tests/Exceptions/IotHubServiceExceptionTests.cs
+++ b/iothub/service/tests/Exceptions/IotHubServiceExceptionTests.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Azure.Devices.Tests.Exceptions
         [TestMethod]
         [DataRow(IotHubServiceErrorCode.DeviceNotFound)]
         [DataRow(IotHubServiceErrorCode.InvalidProtocolVersion)]
-        [DataRow(IotHubServiceErrorCode.Unknown)]
         [DataRow(IotHubServiceErrorCode.InvalidOperation)]
         [DataRow(IotHubServiceErrorCode.ArgumentInvalid)]
         [DataRow(IotHubServiceErrorCode.ArgumentNull)]
@@ -77,42 +76,6 @@ namespace Microsoft.Azure.Devices.Tests.Exceptions
         }
 
         [TestMethod]
-        public void IotHubServiceException_UntrackedErrorCode_NotHttpStatusCodeRequestTimeout_IsNotTransient()
-        {
-            // arrange - act
-            HttpStatusCode statusCode = HttpStatusCode.MovedPermanently; // not HttpStatusCode.RequestTimeout
-
-            var exception = new IotHubServiceException(
-                Message,
-                statusCode,
-                IotHubServiceErrorCode.Unknown);
-
-            // assert
-            exception.StatusCode.Should().Be(statusCode);
-            exception.Message.Should().Be(Message);
-            exception.IsTransient.Should().BeFalse();
-            exception.TrackingId.Should().BeNull();
-        }
-
-        [TestMethod]
-        public void IotHubServiceException_UntrackedErrorCode_HttpStatusCodeRequestTimeout_IsTransient()
-        {
-            // arrange - act
-            HttpStatusCode statusCode = HttpStatusCode.RequestTimeout;
-
-            var exception = new IotHubServiceException(
-                Message,
-                statusCode,
-                IotHubServiceErrorCode.Unknown);
-
-            // assert
-            exception.StatusCode.Should().Be(statusCode);
-            exception.Message.Should().Be(Message);
-            exception.IsTransient.Should().BeTrue();
-            exception.TrackingId.Should().BeNull();
-        }
-
-        [TestMethod]
         public void IotHubServiceException_GetObjectData_NullInfoThrows()
         {
             // arrange - act
@@ -121,7 +84,7 @@ namespace Microsoft.Azure.Devices.Tests.Exceptions
             var exception = new IotHubServiceException(
                 Message,
                 statusCode,
-                IotHubServiceErrorCode.Unknown);
+                IotHubServiceErrorCode.GenericRequestTimeout);
             var sctx = new StreamingContext();
 
             // act
@@ -140,7 +103,7 @@ namespace Microsoft.Azure.Devices.Tests.Exceptions
             var exception = new IotHubServiceException(
                 Message,
                 statusCode,
-                IotHubServiceErrorCode.Unknown);
+                IotHubServiceErrorCode.GenericRequestTimeout);
             var sInfo = new SerializationInfo(GetType(), new FormatterConverter());
             var sctx = new StreamingContext();
 


### PR DESCRIPTION
In the case of mapping `HttpRequestException` into `IotHubServiceException`, we manually put "RequestTimeout" as `StatusCode` and "Unknown" as `ErrorCode` as there's nothing actually returned from the service. Now we add a new ErrorCode "GenericRequestTimeout" and use that instead. 

Also addressing a few more fixes in this PR.