### PR TITLE
Rename transport handler base in delegating pipeline

### DIFF
--- a/iothub/device/src/Pipeline/AmqpTransportHandler.cs
+++ b/iothub/device/src/Pipeline/AmqpTransportHandler.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Azure.Devices.Client.Transport
 {
 #pragma warning disable CA1852 // used in debug for unit test mocking
-    internal class AmqpTransportHandler : TransportHandler
+    internal class AmqpTransportHandler : TransportHandlerBase
 #pragma warning restore CA1852
     {
         protected AmqpUnit _amqpUnit;

--- a/iothub/device/src/Pipeline/IDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/IDelegatingHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Devices.Client
 
         bool IsUsable { get; }
 
-        // Telemetry uplink.
+        // Telemetry.
         Task SendTelemetryAsync(TelemetryMessage message, CancellationToken cancellationToken);
 
         Task SendTelemetryAsync(IEnumerable<TelemetryMessage> messages, CancellationToken cancellationToken);
@@ -35,14 +35,6 @@ namespace Microsoft.Azure.Devices.Client
 
         Task SendMethodResponseAsync(DirectMethodResponse methodResponse, CancellationToken cancellationToken);
 
-        Task<DateTime> RefreshSasTokenAsync(CancellationToken cancellationToken);
-
-        DateTime GetSasTokenRefreshesOn();
-
-        void SetSasTokenRefreshesOn();
-
-        Task StopSasTokenLoopAsync();
-
         // Twin.
         Task<TwinProperties> GetTwinAsync(CancellationToken cancellationToken);
 
@@ -51,5 +43,16 @@ namespace Microsoft.Azure.Devices.Client
         Task EnableTwinPatchAsync(CancellationToken cancellationToken);
 
         Task DisableTwinPatchAsync(CancellationToken cancellationToken);
+
+        // Sas token validity
+        Task<DateTime> RefreshSasTokenAsync(CancellationToken cancellationToken);
+
+        DateTime GetSasTokenRefreshesOn();
+
+        void SetSasTokenRefreshesOn();
+
+        Task StopSasTokenLoopAsync();
+
+
     }
 }

--- a/iothub/device/src/Pipeline/MqttTransportHandler.cs
+++ b/iothub/device/src/Pipeline/MqttTransportHandler.cs
@@ -25,7 +25,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Client.Transport
 {
-    internal sealed class MqttTransportHandler : TransportHandler, IDisposable
+    internal sealed class MqttTransportHandler : TransportHandlerBase, IDisposable
     {
         private const int ProtocolGatewayPort = 8883;
 

--- a/iothub/device/src/Pipeline/TransportHandlerBase.cs
+++ b/iothub/device/src/Pipeline/TransportHandlerBase.cs
@@ -8,12 +8,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
     /// <summary>
     /// Base class for transport-specific handlers, i.e. MQTT and AMQP.
     /// </summary>
-    internal abstract class TransportHandler : DefaultDelegatingHandler
+    internal abstract class TransportHandlerBase : DefaultDelegatingHandler
     {
         private TaskCompletionSource<bool> _transportShouldRetry;
         protected readonly IotHubClientTransportSettings _transportSettings;
 
-        protected TransportHandler(PipelineContext context, IotHubClientTransportSettings transportSettings)
+        protected TransportHandlerBase(PipelineContext context, IotHubClientTransportSettings transportSettings)
             : base(context, nextHandler: null)
         {
             _transportSettings = transportSettings;
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         protected private override void Dispose(bool disposing)
         {
             if (Logging.IsEnabled)
-                Logging.Enter(this, $"{nameof(DefaultDelegatingHandler)}.Disposed={_isDisposed}; disposing={disposing}", $"{nameof(TransportHandler)}.{nameof(Dispose)}");
+                Logging.Enter(this, $"{nameof(DefaultDelegatingHandler)}.Disposed={_isDisposed}; disposing={disposing}", $"{nameof(TransportHandlerBase)}.{nameof(Dispose)}");
 
             try
             {
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             finally
             {
                 if (Logging.IsEnabled)
-                    Logging.Exit(this, $"{nameof(DefaultDelegatingHandler)}.Disposed={_isDisposed}; disposing={disposing}", $"{nameof(TransportHandler)}.{nameof(Dispose)}");
+                    Logging.Exit(this, $"{nameof(DefaultDelegatingHandler)}.Disposed={_isDisposed}; disposing={disposing}", $"{nameof(TransportHandlerBase)}.{nameof(Dispose)}");
             }
         }
 

--- a/iothub/device/src/Pipeline/TransportHandlerFactory.cs
+++ b/iothub/device/src/Pipeline/TransportHandlerFactory.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Microsoft.Azure.Devices.Client.Transport.Amqp;
-using Microsoft.Azure.Devices.Client.Transport.Mqtt;
 
 namespace Microsoft.Azure.Devices.Client.Transport
 {

--- a/iothub/device/src/Transport/Http/HttpTransportHandler.cs
+++ b/iothub/device/src/Transport/Http/HttpTransportHandler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
     /// <summary>
     /// The final node in the handler chain, running operations on the HTTP transport.
     /// </summary>
-    internal sealed class HttpTransportHandler : TransportHandler
+    internal sealed class HttpTransportHandler : TransportHandlerBase
     {
         public const string ModuleId = "x-ms-edge-moduleId";
         private static readonly TimeSpan s_defaultOperationTimeout = TimeSpan.FromSeconds(60);


### PR DESCRIPTION
Renamed to disambiguate TransportHandler from similar sounding TransportDelegatingHandler