### PR TITLE
Handle connection lease timeout for all target frameworks

### DIFF
--- a/iothub/device/src/Transport/Http/ServicePointHelpers.cs
+++ b/iothub/device/src/Transport/Http/ServicePointHelpers.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Microsoft.Azure.Devices.Client
+{
+    // This type manages changing HttpClient/HttpWebRequest defaults to more appropriate values
+    // There are two limits we target:
+    // - Per Server Connection Limit
+    // - Keep Alive Connection Timeout
+    // On .NET Core 2.1 & NET 5.0 the HttpClientTransport would default to using the SocketClientHandler
+    //   we adjust both limits on the client handler
+    // On .NET Standard & NET 4.6+ the HttpClientTransport would default to using the HttpClientHandler
+    //   and there is no easy way to set Keep Alive Connection Timeout but it's mitigated by WebHttpRequestTransport
+    //   being the default on NET 4.6.1
+    // The default transport on NET 4.6.1 is WebHttpRequestTransport the default and we are updating both
+    //  limits on the service point
+
+    internal static class ServicePointHelpers
+    {
+        private const int RuntimeDefaultConnectionLimit = 2;
+        private const int IncreasedConnectionLimit = 50;
+        private const int IncreasedConnectionLeaseTimeout = 300 * 1000;
+        private const int DefaultConnectionLeaseTimeout = Timeout.Infinite;
+
+#if NETCOREAPP
+        // These constants are only used in NET core apps
+        private static TimeSpan DefaultConnectionLeaseTimeoutTimeSpan = Timeout.InfiniteTimeSpan;
+        private static TimeSpan IncreasedConnectionLeaseTimeoutTimeSpan = TimeSpan.FromMilliseconds(IncreasedConnectionLeaseTimeout);
+#endif
+
+        public static void SetLimits(HttpMessageHandler messageHandler, Uri baseAddress)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
+            {
+                return;
+            }
+
+            try
+            {
+                switch (messageHandler)
+                {
+                    case HttpClientHandler httpClientHandler:
+                        // Only change when the default runtime limit is used
+                        if (httpClientHandler.MaxConnectionsPerServer == RuntimeDefaultConnectionLimit)
+                        {
+                            httpClientHandler.MaxConnectionsPerServer = IncreasedConnectionLimit;
+                        }
+                        ServicePoint requestServicePoint = ServicePointManager.FindServicePoint(baseAddress);
+                        if (requestServicePoint.ConnectionLeaseTimeout == DefaultConnectionLeaseTimeout)
+                        {
+                            requestServicePoint.ConnectionLeaseTimeout = IncreasedConnectionLeaseTimeout;
+                        }
+                        break;
+#if NETCOREAPP
+                case SocketsHttpHandler socketsHttpHandler:
+                    if (socketsHttpHandler.MaxConnectionsPerServer == RuntimeDefaultConnectionLimit)
+                    {
+                        socketsHttpHandler.MaxConnectionsPerServer = IncreasedConnectionLimit;
+                    }
+                    if (socketsHttpHandler.PooledConnectionLifetime == DefaultConnectionLeaseTimeoutTimeSpan)
+                    {
+                        socketsHttpHandler.PooledConnectionLifetime = IncreasedConnectionLeaseTimeoutTimeSpan;
+                    }
+                    break;
+#endif
+                    default:
+                        Debug.Assert(false, "Unknown handler type");
+                        break;
+                }
+            }
+            catch (NotSupportedException)
+            {
+                // Some platforms might throw NotSupportedException
+                // when accessing handler options
+            }
+            catch (NotImplementedException)
+            {
+                // Some platforms (like Unity) might throw NotImplementedException
+                // when accessing handler options
+            }
+        }
+    }
+}

--- a/iothub/service/src/Http/ServicePointHelpers.cs
+++ b/iothub/service/src/Http/ServicePointHelpers.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Microsoft.Azure.Devices
+{
+    // This type manages changing HttpClient/HttpWebRequest defaults to more appropriate values
+    // There are two limits we target:
+    // - Per Server Connection Limit
+    // - Keep Alive Connection Timeout
+    // On .NET Core 2.1 & NET 5.0 the HttpClientTransport would default to using the SocketClientHandler
+    //   we adjust both limits on the client handler
+    // On .NET Standard & NET 4.6+ the HttpClientTransport would default to using the HttpClientHandler
+    //   and there is no easy way to set Keep Alive Connection Timeout but it's mitigated by WebHttpRequestTransport
+    //   being the default on NET 4.6.1
+    // The default transport on NET 4.6.1 is WebHttpRequestTransport the default and we are updating both
+    //  limits on the service point
+
+    internal static class ServicePointHelpers
+    {
+        private const int RuntimeDefaultConnectionLimit = 2;
+        private const int IncreasedConnectionLimit = 50;
+        private const int IncreasedConnectionLeaseTimeout = 300 * 1000;
+        private const int DefaultConnectionLeaseTimeout = Timeout.Infinite;
+
+#if NETCOREAPP
+        // These constants are only used in NET core apps
+        private static TimeSpan DefaultConnectionLeaseTimeoutTimeSpan = Timeout.InfiniteTimeSpan;
+        private static TimeSpan IncreasedConnectionLeaseTimeoutTimeSpan = TimeSpan.FromMilliseconds(IncreasedConnectionLeaseTimeout);
+#endif
+
+        public static void SetLimits(HttpMessageHandler messageHandler, Uri baseAddress)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
+            {
+                return;
+            }
+
+            try
+            {
+                switch (messageHandler)
+                {
+                    case HttpClientHandler httpClientHandler:
+                        // Only change when the default runtime limit is used
+                        if (httpClientHandler.MaxConnectionsPerServer == RuntimeDefaultConnectionLimit)
+                        {
+                            httpClientHandler.MaxConnectionsPerServer = IncreasedConnectionLimit;
+                        }
+                        ServicePoint requestServicePoint = ServicePointManager.FindServicePoint(baseAddress);
+                        if (requestServicePoint.ConnectionLeaseTimeout == DefaultConnectionLeaseTimeout)
+                        {
+                            requestServicePoint.ConnectionLeaseTimeout = IncreasedConnectionLeaseTimeout;
+                        }
+                        break;
+#if NETCOREAPP
+                    case SocketsHttpHandler socketsHttpHandler:
+                        if (socketsHttpHandler.MaxConnectionsPerServer == RuntimeDefaultConnectionLimit)
+                        {
+                            socketsHttpHandler.MaxConnectionsPerServer = IncreasedConnectionLimit;
+                        }
+                        if (socketsHttpHandler.PooledConnectionLifetime == DefaultConnectionLeaseTimeoutTimeSpan)
+                        {
+                            socketsHttpHandler.PooledConnectionLifetime = IncreasedConnectionLeaseTimeoutTimeSpan;
+                        }
+                        break;
+#endif
+                    default:
+                        Debug.Assert(false, "Unknown handler type");
+                        break;
+                }
+            }
+            catch (NotSupportedException)
+            {
+                // Some platforms might throw NotSupportedException
+                // when accessing handler options
+            }
+            catch (NotImplementedException)
+            {
+                // Some platforms (like Unity) might throw NotImplementedException
+                // when accessing handler options
+            }
+        }
+    }
+}


### PR DESCRIPTION
Setting the connection lease timeout via the ServicePointManager doesn't work for .NET core, so this adds the appropriate handling.

This is based heavily on the ServicePointHelper class defined in Azure.Core (with some small modifications)