### PR TITLE
Fix bug where device operations not recovering after reconnect

### DIFF
--- a/e2e/LongHaul/device/IotHub.cs
+++ b/e2e/LongHaul/device/IotHub.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
                     {
                         await Task.Delay(s_messageLoopSleepTime, ct).ConfigureAwait(false);
                     }
-                    catch (TaskCanceledException)
+                    catch (OperationCanceledException)
                     {
                         // App is signalled to exit
                         _logger.Trace($"Exit signal encountered. Terminating telemetry message pump.", TraceSeverity.Verbose);
@@ -169,12 +169,13 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
                 {
                     if (pendingMessages.Count > 1)
                     {
-                        logger.Trace($"Sending {pendingMessages.Count} messages in bulk.");
+                        logger.Trace($"Sending {pendingMessages.Count} telemetry messages in bulk.", TraceSeverity.Information);
                         sw.Restart();
                         await _deviceClient.SendTelemetryAsync(pendingMessages, ct).ConfigureAwait(false);
                     }
                     else
                     {
+                        logger.Trace("Sending a telemetry message.", TraceSeverity.Information);
                         sw.Restart();
                         await _deviceClient.SendTelemetryAsync(pendingMessages.First(), ct).ConfigureAwait(false);
                     }
@@ -206,6 +207,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
                         { "TotalTelemetryMessagesSent", _totalTelemetryMessagesSent },
                     };
 
+                    logger.Trace($"Updating reported properties.", TraceSeverity.Information);
                     sw.Restart();
                     await _deviceClient.UpdateReportedPropertiesAsync(reported, ct).ConfigureAwait(false);
                     sw.Stop();

--- a/e2e/LongHaul/device/Parameters.cs
+++ b/e2e/LongHaul/device/Parameters.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
             "TransportProtocol",
             Default = IotHubClientTransportProtocol.Tcp,
             Required = false,
-            HelpText = "The protocol over which a transport (i.e., MQTT, AMQP) communicates.")]
+            HelpText = "The protocol over which a transport communicates (i.e., Tcp, WebSocket).")]
         public IotHubClientTransportProtocol TransportProtocol { get; set; }
 
         [Option(

--- a/e2e/LongHaul/device/Program.cs
+++ b/e2e/LongHaul/device/Program.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Devices.LongHaul.Device
                         iotHub.UploadFilesAsync(s_logger.Clone(), cancellationTokenSource.Token))
                     .ConfigureAwait(false);
             }
-            catch (TaskCanceledException) { } // user signalled an exit
+            catch (OperationCanceledException) { } // user signalled an exit
             catch (Exception ex)
             {
                 s_logger.Trace($"Device app failed with exception {ex}", TraceSeverity.Error);

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotSendingLink.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotSendingLink.cs
@@ -130,6 +130,13 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
                         cancellationToken)
                     .ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (!cancellationToken.IsCancellationRequested)
+            {
+                // OperationCanceledException may be thrown here when there is networking disconnect
+                // even if cancellation has not been requested yet. This case is treated as a transient
+                // network error rather than an OperationCanceledException.
+                throw new IotHubClientException(oce.Message, IotHubClientErrorCode.NetworkErrors, oce);
+            }
             catch (Exception ex) when (!Fx.IsFatal(ex))
             {
                 Exception iotEx = AmqpIotExceptionAdapter.ConvertToIotHubException(ex, _sendingAmqpLink);


### PR DESCRIPTION
Using Amqp (with TCP), when device client disconnects for a duration like 10 sec and then re-connects, some operations will not recover by retries. It appears that an `OperationCanceledException` would be thrown from SendAmqpMessageAsync() call in "AmqpIotSendingLink" [class](https://github.com/Azure/azure-iot-sdk-csharp/blob/previews/v2/iothub/device/src/Transport/AmqpIot/AmqpIotSendingLink.cs#L125), even if cancellation has not been requested yet.