### PR TITLE
Refactor to not send the same element through multiple objects

### DIFF
--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Azure.Devices.Client
                 ModelId = _clientOptions.ModelId,
                 PayloadConvention = _clientOptions.PayloadConvention,
                 IotHubClientTransportSettings = _clientOptions.TransportSettings,
+                FileUploadTransportSettings = _clientOptions.FileUploadTransportSettings,
                 MethodCallback = OnMethodCalledAsync,
                 DesiredPropertyUpdateCallback = OnDesiredStatePatchReceived,
                 ConnectionStatusChangeHandler = OnConnectionStatusChanged,

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Devices.Client
                 ModelId = _clientOptions.ModelId,
                 PayloadConvention = _clientOptions.PayloadConvention,
                 IotHubClientTransportSettings = _clientOptions.TransportSettings,
-                FileUploadTransportSettings = _clientOptions.FileUploadTransportSettings,
+                HttpOperationTransportSettings = _clientOptions.FileUploadTransportSettings,
                 MethodCallback = OnMethodCalledAsync,
                 DesiredPropertyUpdateCallback = OnDesiredStatePatchReceived,
                 ConnectionStatusChangeHandler = OnConnectionStatusChanged,

--- a/iothub/device/src/IotHubDeviceClient.cs
+++ b/iothub/device/src/IotHubDeviceClient.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Azure.Devices.Client
     /// <threadsafety static="true" instance="true" />
     public class IotHubDeviceClient : IotHubBaseClient
     {
+        // File upload operation
+        private readonly HttpTransportHandler _fileUploadHttpTransportHandler;
+
         /// <summary>
         /// Creates a disposable client from the specified connection string.
         /// </summary>
@@ -80,7 +83,7 @@ namespace Microsoft.Azure.Devices.Client
                 }
             }
 
-            _fileUploadHttpTransportHandler = new HttpTransportHandler(PipelineContext, _clientOptions.FileUploadTransportSettings);
+            _fileUploadHttpTransportHandler = new HttpTransportHandler(PipelineContext);
 
             if (Logging.IsEnabled)
                 Logging.CreateClient(

--- a/iothub/device/src/IotHubDeviceClient.cs
+++ b/iothub/device/src/IotHubDeviceClient.cs
@@ -14,9 +14,6 @@ namespace Microsoft.Azure.Devices.Client
     /// <threadsafety static="true" instance="true" />
     public class IotHubDeviceClient : IotHubBaseClient
     {
-        // File upload operation
-        private readonly HttpTransportHandler _fileUploadHttpTransportHandler;
-
         /// <summary>
         /// Creates a disposable client from the specified connection string.
         /// </summary>

--- a/iothub/device/src/IotHubModuleClient.cs
+++ b/iothub/device/src/IotHubModuleClient.cs
@@ -266,19 +266,20 @@ namespace Microsoft.Azure.Devices.Client
 
             try
             {
+                var pipelineContext = new PipelineContext
+                {
+                    IotHubConnectionCredentials = IotHubConnectionCredentials,
+                    HttpOperationTransportSettings = new IotHubClientHttpSettings(),
+                };
+
                 if (customCertificateValidation != null)
                 {
                     httpClientHandler = new HttpClientHandler
                     {
                         ServerCertificateCustomValidationCallback = customCertificateValidation,
-                        SslProtocols = SslProtocols.None,
+                        SslProtocols = pipelineContext.HttpOperationTransportSettings.SslProtocols,
                     };
                 }
-
-                var pipelineContext = new PipelineContext
-                {
-                    IotHubConnectionCredentials = IotHubConnectionCredentials,
-                };
 
                 using var httpTransport = new HttpTransportHandler(pipelineContext, httpClientHandler);
                 methodRequest.PayloadConvention = _clientOptions.PayloadConvention;

--- a/iothub/device/src/IotHubModuleClient.cs
+++ b/iothub/device/src/IotHubModuleClient.cs
@@ -8,8 +8,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
-using System.Net.Sockets;
-using System.Net.WebSockets;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -267,14 +266,12 @@ namespace Microsoft.Azure.Devices.Client
 
             try
             {
-                var transportSettings = new IotHubClientHttpSettings();
-
                 if (customCertificateValidation != null)
                 {
                     httpClientHandler = new HttpClientHandler
                     {
                         ServerCertificateCustomValidationCallback = customCertificateValidation,
-                        SslProtocols = transportSettings.SslProtocols,
+                        SslProtocols = SslProtocols.None,
                     };
                 }
 
@@ -283,7 +280,7 @@ namespace Microsoft.Azure.Devices.Client
                     IotHubConnectionCredentials = IotHubConnectionCredentials,
                 };
 
-                using var httpTransport = new HttpTransportHandler(pipelineContext, transportSettings, httpClientHandler);
+                using var httpTransport = new HttpTransportHandler(pipelineContext, httpClientHandler);
                 methodRequest.PayloadConvention = _clientOptions.PayloadConvention;
 
                 DirectMethodResponse result = await httpTransport.InvokeMethodAsync(methodRequest, uri, cancellationToken).ConfigureAwait(false);

--- a/iothub/device/src/Pipeline/AmqpTransportHandler.cs
+++ b/iothub/device/src/Pipeline/AmqpTransportHandler.cs
@@ -49,10 +49,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
-        internal AmqpTransportHandler(
-            PipelineContext context,
-            IotHubClientAmqpSettings transportSettings)
-            : base(context, transportSettings)
+        internal AmqpTransportHandler(PipelineContext context)
+            : base(context)
         {
             _onDesiredStatePatchListener = context.DesiredPropertyUpdateCallback;
 
@@ -68,7 +66,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             _amqpUnit = AmqpUnitManager.GetInstance().CreateAmqpUnit(
                 _connectionCredentials,
                 additionalClientInformation,
-                transportSettings,
+                (IotHubClientAmqpSettings)context.IotHubClientTransportSettings,
                 context.MethodCallback,
                 TwinMessageListener,
                 context.MessageEventCallback,

--- a/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
@@ -153,18 +153,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return NextHandler?.StopSasTokenLoopAsync() ?? Task.CompletedTask;
         }
 
-        public virtual Task<FileUploadSasUriResponse> GetFileUploadSasUriAsync(FileUploadSasUriRequest request, CancellationToken cancellationToken)
-        {
-            ThrowIfDisposed();
-            return NextHandler?.GetFileUploadSasUriAsync(request, cancellationToken) ?? Task.FromResult<FileUploadSasUriResponse>(null);
-        }
-
-        public virtual Task CompleteFileUploadAsync(FileUploadCompletionNotification notification, CancellationToken cancellationToken)
-        {
-            ThrowIfDisposed();
-            return NextHandler?.CompleteFileUploadAsync(notification, cancellationToken) ?? Task.CompletedTask;
-        }
-
         public virtual void Dispose()
         {
             Dispose(true);

--- a/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
+        public virtual bool IsUsable => NextHandler?.IsUsable ?? true;
+
         public virtual Task OpenAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
@@ -151,7 +153,17 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return NextHandler?.StopSasTokenLoopAsync() ?? Task.CompletedTask;
         }
 
-        public virtual bool IsUsable => NextHandler?.IsUsable ?? true;
+        public virtual Task<FileUploadSasUriResponse> GetFileUploadSasUriAsync(FileUploadSasUriRequest request, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            return NextHandler?.GetFileUploadSasUriAsync(request, cancellationToken) ?? Task.FromResult<FileUploadSasUriResponse>(null);
+        }
+
+        public virtual Task CompleteFileUploadAsync(FileUploadCompletionNotification notification, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            return NextHandler?.CompleteFileUploadAsync(notification, cancellationToken) ?? Task.CompletedTask;
+        }
 
         public virtual void Dispose()
         {

--- a/iothub/device/src/Pipeline/IDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/IDelegatingHandler.cs
@@ -52,10 +52,5 @@ namespace Microsoft.Azure.Devices.Client
         void SetSasTokenRefreshesOn();
 
         Task StopSasTokenLoopAsync();
-
-        // File upload - over HTTP (IotHubDeviceClient only)
-        Task<FileUploadSasUriResponse> GetFileUploadSasUriAsync(FileUploadSasUriRequest request, CancellationToken cancellationToken);
-
-        Task CompleteFileUploadAsync(FileUploadCompletionNotification notification, CancellationToken cancellationToken);
     }
 }

--- a/iothub/device/src/Pipeline/IDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/IDelegatingHandler.cs
@@ -53,6 +53,9 @@ namespace Microsoft.Azure.Devices.Client
 
         Task StopSasTokenLoopAsync();
 
+        // File upload - over HTTP (IotHubDeviceClient only)
+        Task<FileUploadSasUriResponse> GetFileUploadSasUriAsync(FileUploadSasUriRequest request, CancellationToken cancellationToken);
 
+        Task CompleteFileUploadAsync(FileUploadCompletionNotification notification, CancellationToken cancellationToken);
     }
 }

--- a/iothub/device/src/Pipeline/MqttTransportHandler.cs
+++ b/iothub/device/src/Pipeline/MqttTransportHandler.cs
@@ -159,10 +159,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         private MqttClientOptions _mqttClientOptions;
 
-        internal MqttTransportHandler(PipelineContext context, IotHubClientMqttSettings settings)
-            : base(context, settings)
+        internal MqttTransportHandler(PipelineContext context)
+            : base(context)
         {
-            _mqttTransportSettings = settings;
+            _mqttTransportSettings = (IotHubClientMqttSettings)context.IotHubClientTransportSettings;
             _deviceId = context.IotHubConnectionCredentials.DeviceId;
             _moduleId = context.IotHubConnectionCredentials.ModuleId;
 
@@ -197,11 +197,11 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 string uri = $"wss://{_hostName}/$iothub/websocket";
                 _mqttClientOptionsBuilder.WithWebSocketServer(uri);
 
-                IWebProxy proxy = _transportSettings.Proxy;
+                IWebProxy proxy = _mqttTransportSettings.Proxy;
                 if (proxy != null)
                 {
                     Uri serviceUri = new(uri);
-                    Uri proxyUri = _transportSettings.Proxy.GetProxy(serviceUri);
+                    Uri proxyUri = _mqttTransportSettings.Proxy.GetProxy(serviceUri);
 
                     if (proxy.Credentials != null)
                     {
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 : new List<X509Certificate> { _connectionCredentials.ClientCertificate };
 
             tlsParameters.Certificates = certs;
-            tlsParameters.IgnoreCertificateRevocationErrors = !settings.CertificateRevocationCheck;
+            tlsParameters.IgnoreCertificateRevocationErrors = !_mqttTransportSettings.CertificateRevocationCheck;
 
             if (_mqttTransportSettings?.RemoteCertificateValidationCallback != null)
             {

--- a/iothub/device/src/Pipeline/PipelineContext.cs
+++ b/iothub/device/src/Pipeline/PipelineContext.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.Client
 
         internal IotHubClientTransportSettings IotHubClientTransportSettings { get; set; }
 
-        internal IotHubClientHttpSettings FileUploadTransportSettings { get; set; }
+        internal IotHubClientHttpSettings HttpOperationTransportSettings { get; set; }
 
         internal Action<ConnectionStatusInfo> ConnectionStatusChangeHandler { get; set; }
 

--- a/iothub/device/src/Pipeline/PipelineContext.cs
+++ b/iothub/device/src/Pipeline/PipelineContext.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Azure.Devices.Client
 
         internal IotHubClientTransportSettings IotHubClientTransportSettings { get; set; }
 
+        internal IotHubClientHttpSettings FileUploadTransportSettings { get; set; }
+
         internal Action<ConnectionStatusInfo> ConnectionStatusChangeHandler { get; set; }
 
         internal Action<DesiredProperties> DesiredPropertyUpdateCallback { get; set; }

--- a/iothub/device/src/Pipeline/TransportHandlerBase.cs
+++ b/iothub/device/src/Pipeline/TransportHandlerBase.cs
@@ -11,12 +11,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
     internal abstract class TransportHandlerBase : DefaultDelegatingHandler
     {
         private TaskCompletionSource<bool> _transportShouldRetry;
-        protected readonly IotHubClientTransportSettings _transportSettings;
 
-        protected TransportHandlerBase(PipelineContext context, IotHubClientTransportSettings transportSettings)
+        protected TransportHandlerBase(PipelineContext context)
             : base(context, nextHandler: null)
         {
-            _transportSettings = transportSettings;
         }
 
         public override Task WaitForTransportClosedAsync()

--- a/iothub/device/src/Pipeline/TransportHandlerFactory.cs
+++ b/iothub/device/src/Pipeline/TransportHandlerFactory.cs
@@ -10,16 +10,11 @@ namespace Microsoft.Azure.Devices.Client.Transport
         public IDelegatingHandler Create(PipelineContext context)
         {
             IotHubClientTransportSettings transportSettings = context.IotHubClientTransportSettings;
-
             return transportSettings switch
             {
-                IotHubClientAmqpSettings iotHubClientAmqpSettings => new AmqpTransportHandler(
-                    context,
-                    iotHubClientAmqpSettings),
+                IotHubClientAmqpSettings => new AmqpTransportHandler(context),
 
-                IotHubClientMqttSettings iotHubClientMqttSettings => new MqttTransportHandler(
-                    context,
-                    iotHubClientMqttSettings),
+                IotHubClientMqttSettings => new MqttTransportHandler(context),
 
                 _ => throw new InvalidOperationException($"Unsupported transport setting {context.IotHubClientTransportSettings.GetType()}")
             };

--- a/iothub/device/src/Transport/Http/HttpTransportHandler.cs
+++ b/iothub/device/src/Transport/Http/HttpTransportHandler.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 ClientExceptionHandlingHelper.GetDefaultErrorMapping(),
                 s_defaultOperationTimeout,
                 httpClientHandler,
-                context.FileUploadTransportSettings);
+                context.HttpOperationTransportSettings);
         }
 
         internal async Task<FileUploadSasUriResponse> GetFileUploadSasUriAsync(FileUploadSasUriRequest request, CancellationToken cancellationToken)

--- a/iothub/device/src/Transport/Http/HttpTransportHandler.cs
+++ b/iothub/device/src/Transport/Http/HttpTransportHandler.cs
@@ -25,9 +25,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         internal HttpTransportHandler(
             PipelineContext context,
-            IotHubClientHttpSettings transportSettings,
             HttpClientHandler httpClientHandler = null)
-            : base(context, transportSettings)
+            : base(context)
         {
             var additionalClientInformation = new AdditionalClientInformation
             {
@@ -45,12 +44,13 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 ClientExceptionHandlingHelper.GetDefaultErrorMapping(),
                 s_defaultOperationTimeout,
                 httpClientHandler,
-                transportSettings);
+                context.FileUploadTransportSettings);
         }
 
         internal async Task<FileUploadSasUriResponse> GetFileUploadSasUriAsync(FileUploadSasUriRequest request, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
             return await _httpClientHelper
                 .PostAsync<FileUploadSasUriRequest, FileUploadSasUriResponse>(
                     GetRequestUri(_deviceId, CommonConstants.BlobUploadPathTemplate, null),

--- a/iothub/device/tests/Transport/Amqp/AmqpTransportHandlerTests.cs
+++ b/iothub/device/tests/Transport/Amqp/AmqpTransportHandlerTests.cs
@@ -70,9 +70,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
                 IotHubClientTransportSettings = transportSettings1,
             };
 
-            using var amqpTransportHandler1 = new AmqpTransportHandler(
-                pipelineContext1,
-                transportSettings1);
+            using var amqpTransportHandler1 = new AmqpTransportHandler(pipelineContext1);
 
             try
             {
@@ -91,9 +89,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
                     IotHubClientTransportSettings = transportSettings2,
                 };
 
-                using var amqpTransportHandler2 = new AmqpTransportHandler(
-                    pipelineContext2,
-                    transportSettings2);
+                using var amqpTransportHandler2 = new AmqpTransportHandler(pipelineContext2);
             }
             catch (ArgumentException ex)
             {
@@ -122,9 +118,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
                 IotHubClientTransportSettings = new IotHubClientAmqpSettings(),
             };
 
-            return new AmqpTransportHandler(
-                pipelineContext,
-                new IotHubClientAmqpSettings());
+            return new AmqpTransportHandler(pipelineContext);
         }
     }
 }

--- a/iothub/device/tests/Transport/Amqp/MockableAmqpTransportHandler.cs
+++ b/iothub/device/tests/Transport/Amqp/MockableAmqpTransportHandler.cs
@@ -13,17 +13,12 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
                 {
                     IotHubConnectionCredentials = new IotHubConnectionCredentials(AmqpTransportHandlerTests.TestConnectionString),
                     IotHubClientTransportSettings = new IotHubClientAmqpSettings(),
-                },
-                new IotHubClientAmqpSettings())
+                })
         {
         }
 
-        internal MockableAmqpTransportHandler(
-            PipelineContext context,
-            IotHubClientAmqpSettings transportSettings)
-            : base(
-                context,
-                transportSettings)
+        internal MockableAmqpTransportHandler(PipelineContext context)
+            : base(context)
         {
             _amqpUnit = new MockableAmqpUnit();
         }

--- a/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
+++ b/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
@@ -28,13 +28,12 @@ namespace Microsoft.Azure.Devices.Client.Tests.Transport.Mqtt
         {
             var pipelineContext = new PipelineContext();
             var clientConfigurationMock = new IotHubConnectionCredentials();
-            //clientConfigurationMock.SetupGet(x => x.ClientOptions).Returns(clientOptionsMock.Object);
             pipelineContext.IotHubConnectionCredentials = clientConfigurationMock;
             pipelineContext.ProductInfo = new ProductInfo();
+            pipelineContext.IotHubClientTransportSettings = new IotHubClientMqttSettings();
 
-            var transportHandler = new MqttTransportHandler(
-                pipelineContext,
-                new IotHubClientMqttSettings())
+
+            var transportHandler = new MqttTransportHandler(pipelineContext)
             {
                 // make the mqtt client used by the handler mocked so no network calls are actually made
                 _mqttClient = mockMqttClient


### PR DESCRIPTION
The transport settings are available through the PipelineContext, but were being set on the TransportHandler explicitly again.