### PR TITLE
Fix DPS test catching the wrong exception in timeout case

### DIFF
--- a/e2e/Tests/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/Tests/provisioning/ProvisioningE2ETests.cs
@@ -704,11 +704,11 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         VerboseTestLogger.WriteLine($"ProvisioningDeviceClient.RegisterAsync failed because: {ex.Message}");
                         await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
                     }
-                    catch (TaskCanceledException tce) when (cts.IsCancellationRequested && ++tryCount < MaxTryCount)
+                    catch (OperationCanceledException oce) when (cts.IsCancellationRequested && ++tryCount < MaxTryCount)
                     {
                         // This catch statement shouldn't execute when the test itself is cancelled, but will
                         // execute when the registerAsync(cts) call times out 
-                        VerboseTestLogger.WriteLine($"ProvisioningDeviceClient.RegisterAsync timed out because: {tce.Message}");
+                        VerboseTestLogger.WriteLine($"ProvisioningDeviceClient.RegisterAsync timed out because: {oce.Message}");
                         await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
                     }
                 }


### PR DESCRIPTION
registerAsync(...) throws OperationCancelledException when it's token is cancelled, not TaskCanceledException