### PR TITLE
Clean up exception declarations in doc comments

### DIFF
--- a/iothub/device/src/Authentication/ClientAuthenticationWithSharedAccessKeyRefresh.cs
+++ b/iothub/device/src/Authentication/ClientAuthenticationWithSharedAccessKeyRefresh.cs
@@ -30,10 +30,10 @@ namespace Microsoft.Azure.Devices.Client
         /// The default behavior is that the token will be renewed when it has 15% or less of its lifespan left.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        /// Thrown when <paramref name="sharedAccessKey"/> or <paramref name="sharedAccessKeyName"/> is null.
+        /// <paramref name="sharedAccessKey"/> or <paramref name="sharedAccessKeyName"/> is null.
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// Thrown when <paramref name="sharedAccessKey"/> or <paramref name="sharedAccessKeyName"/> is empty or whitespace.
+        /// <paramref name="sharedAccessKey"/> or <paramref name="sharedAccessKeyName"/> is empty or whitespace.
         /// </exception>
         public ClientAuthenticationWithSharedAccessKeyRefresh(
             string sharedAccessKey,
@@ -69,10 +69,8 @@ namespace Microsoft.Azure.Devices.Client
         /// The time buffer before expiry when the token should be renewed, expressed as a percentage of the time to live.
         /// The default behavior is that the token will be renewed when it has 15% or less of its lifespan left.
         /// </param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="sharedAccessKey"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// Thrown when <paramref name="sharedAccessKey"/> is empty or whitespace.
-        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="sharedAccessKey"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="sharedAccessKey"/> is empty or whitespace.</exception>
         public ClientAuthenticationWithSharedAccessKeyRefresh(
             string sharedAccessKey,
             string deviceId,
@@ -104,8 +102,8 @@ namespace Microsoft.Azure.Devices.Client
         /// The time buffer before expiry when the token should be renewed, expressed as a percentage of the time to live.
         /// The default behavior is that the token will be renewed when it has 15% or less of its lifespan left.
         /// </param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="connectionString"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString"/> is empty or whitespace.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="connectionString"/> is empty or whitespace.</exception>
         public ClientAuthenticationWithSharedAccessKeyRefresh(
             string connectionString,
             TimeSpan sasTokenTimeToLive = default,
@@ -136,7 +134,7 @@ namespace Microsoft.Azure.Devices.Client
         /// the current instance.
         /// </summary>
         /// <param name="iotHubConnectionCredentials">Instance to populate.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="iotHubConnectionCredentials"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="iotHubConnectionCredentials"/> is null.</exception>
         public override void Populate(ref IotHubConnectionCredentials iotHubConnectionCredentials)
         {
             Argument.AssertNotNull(iotHubConnectionCredentials, nameof(iotHubConnectionCredentials));

--- a/iothub/device/src/Authentication/ClientAuthenticationWithSharedAccessSignature.cs
+++ b/iothub/device/src/Authentication/ClientAuthenticationWithSharedAccessSignature.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Devices.Client
         /// Populates a supplied instance based on the properties of the current instance.
         /// </summary>
         /// <param name="iotHubConnectionCredentials">Instance to populate.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="iotHubConnectionCredentials"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="iotHubConnectionCredentials"/> is null.</exception>
         public void Populate(ref IotHubConnectionCredentials iotHubConnectionCredentials)
         {
             Argument.AssertNotNull(iotHubConnectionCredentials, nameof(iotHubConnectionCredentials));

--- a/iothub/device/src/Authentication/ClientAuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/Authentication/ClientAuthenticationWithTokenRefresh.cs
@@ -29,12 +29,10 @@ namespace Microsoft.Azure.Devices.Client
         /// The time buffer before expiry when the token should be renewed, expressed as a percentage of the time to live.
         /// The default behavior is that the token will be renewed when it has <see cref="DefaultSasRenewalBufferPercentage"/> percent or less of its lifespan left.
         /// </param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="deviceId"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// Thrown when <paramref name="deviceId"/> or <paramref name="moduleId"/> is empty or whitespace.
-        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="deviceId"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="deviceId"/> or <paramref name="moduleId"/> is empty or whitespace.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-        /// Thrown if <paramref name="suggestedTimeToLive"/> is a negative timespan, or if <paramref name="timeBufferPercentage"/> is outside the range 0-100.
+        /// <paramref name="suggestedTimeToLive"/> is a negative timespan, or <paramref name="timeBufferPercentage"/> is outside the range 0-100.
         /// </exception>
         public ClientAuthenticationWithTokenRefresh(
             string deviceId,
@@ -147,7 +145,7 @@ namespace Microsoft.Azure.Devices.Client
         /// the current instance.
         /// </summary>
         /// <param name="iotHubConnectionCredentials">Instance to populate.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="iotHubConnectionCredentials"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="iotHubConnectionCredentials"/> is null.</exception>
         public virtual void Populate(ref IotHubConnectionCredentials iotHubConnectionCredentials)
         {
             Argument.AssertNotNull(iotHubConnectionCredentials, nameof(iotHubConnectionCredentials));

--- a/iothub/device/src/Authentication/ClientAuthenticationWithX509Certificate.cs
+++ b/iothub/device/src/Authentication/ClientAuthenticationWithX509Certificate.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="certificateChain">Certificates in the device certificate chain.</param>
         /// <param name="deviceId">Device identifier.</param>
         /// <param name="moduleId">Module identifier.</param>
-        /// <exception cref="ArgumentException">When <paramref name="clientCertificate"/> or <paramref name="certificateChain"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="clientCertificate"/> or <paramref name="certificateChain"/> is null.</exception>
         public ClientAuthenticationWithX509Certificate(
             X509Certificate2 clientCertificate,
             X509Certificate2Collection certificateChain,
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="certificate">X.509 certificate.</param>
         /// <param name="deviceId">Device identifier.</param>
         /// <param name="moduleId">Module identifier.</param>
-        /// <exception cref="ArgumentException">When <paramref name="certificate"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="certificate"/> is null.</exception>
         public ClientAuthenticationWithX509Certificate(
             X509Certificate2 certificate,
             string deviceId,
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Devices.Client
         /// Populates a supplied instance based on the properties of the current instance.
         /// </summary>
         /// <param name="iotHubConnectionCredentials">Instance to populate.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="iotHubConnectionCredentials"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="iotHubConnectionCredentials"/> is null.</exception>
         public void Populate(ref IotHubConnectionCredentials iotHubConnectionCredentials)
         {
             Argument.AssertNotNull(iotHubConnectionCredentials, nameof(iotHubConnectionCredentials));

--- a/iothub/device/src/Authentication/IotHubConnectionCredentials.cs
+++ b/iothub/device/src/Authentication/IotHubConnectionCredentials.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <exception cref="ArgumentException"><see cref="ClientAuthenticationWithX509Certificate.CertificateChain"/> is used over a protocol other than MQTT over TCP or AMQP over TCP.</exception>
         /// <exception cref="FormatException">Neither shared access key, shared access signature or X509 certificates were presented for authentication.</exception>
         /// <exception cref="FormatException">Either shared access key or shared access signature where presented together with X509 certificates for authentication.</exception>
-        /// <exception cref="IotHubClientException">When <see cref="ClientAuthenticationWithX509Certificate.CertificateChain"/> could not be installed.</exception>
+        /// <exception cref="IotHubClientException"><see cref="ClientAuthenticationWithX509Certificate.CertificateChain"/> could not be installed.</exception>
         public IotHubConnectionCredentials(IAuthenticationMethod authenticationMethod, string hostName, string gatewayHostName = null)
         {
             Argument.AssertNotNull(authenticationMethod, nameof(authenticationMethod));

--- a/iothub/device/src/Authentication/Security/SharedAccessSignatureParser.cs
+++ b/iothub/device/src/Authentication/Security/SharedAccessSignatureParser.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="rawToken">The shared access signature token</param>
         /// <returns>The shared access signature instance that represents the passed in raw token.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="rawToken"/> is null, empty or whitespace.</exception>
-        /// <exception cref="FormatException">Thrown if the supplied shared access signature doesn't contain the expected fields.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="rawToken"/> is null, empty or whitespace.</exception>
+        /// <exception cref="FormatException">The supplied shared access signature doesn't contain the expected fields.</exception>
         internal static SharedAccessSignature Parse(string rawToken)
         {
             Argument.AssertNotNullOrWhiteSpace(rawToken, nameof(rawToken));

--- a/iothub/device/src/FileUpload/FileUploadCompletionNotification.cs
+++ b/iothub/device/src/FileUpload/FileUploadCompletionNotification.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="correlationId">The correlation Id of the SAS URI.</param>
         /// <param name="isSuccess">Whether the file upload was successful or not.</param>
-        /// <exception cref="ArgumentNullException">When the provided <paramref name="correlationId"/> is null.</exception>
-        /// <exception cref="ArgumentException">If the provided <paramref name="correlationId"/> is empty or whitespace.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="correlationId"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="correlationId"/> is empty or whitespace.</exception>
         public FileUploadCompletionNotification(string correlationId, bool isSuccess)
         {
             Argument.AssertNotNullOrWhiteSpace(correlationId, nameof(correlationId));

--- a/iothub/device/src/FileUpload/FileUploadSasUriRequest.cs
+++ b/iothub/device/src/FileUpload/FileUploadSasUriRequest.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Azure.Devices.Client
         /// The request parameters when getting a file upload SAS URI from IoT hub.
         /// </summary>
         /// <param name="blobName">The name of the file for which a SAS URI will be generated.</param>
-        /// <exception cref="ArgumentNullException">When the provided <paramref name="blobName"/> is null.</exception>
-        /// <exception cref="ArgumentException">If the provided <paramref name="blobName"/> is empty or whitespace.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="blobName"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="blobName"/> is empty or whitespace.</exception>
         public FileUploadSasUriRequest(string blobName)
         {
             Argument.AssertNotNullOrWhiteSpace(blobName, nameof(blobName));

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -131,8 +131,9 @@ namespace Microsoft.Azure.Devices.Client
         /// re-opening a client.
         /// </remarks>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         public async Task OpenAsync(CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -156,11 +157,11 @@ namespace Microsoft.Azure.Devices.Client
         /// </remarks>
         /// <param name="message">The message to send.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="message"/> is null.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
-        /// <exception cref="IotHubClientException">Thrown if an error occurs when communicating with IoT hub service.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The client instance is not already open.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         public async Task SendTelemetryAsync(TelemetryMessage message, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(message, nameof(message));
@@ -207,10 +208,12 @@ namespace Microsoft.Azure.Devices.Client
         /// </remarks>
         /// <param name="messages">An <see cref="IEnumerable{Message}"/> set of message objects.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
-        /// <exception cref="InvalidOperationException">When this method is called when the client is configured to use MQTT.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="messages"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The client instance is not already open.</exception>
+        /// <exception cref="InvalidOperationException">This method is called when the client is configured to use MQTT.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         public async Task SendTelemetryAsync(IEnumerable<TelemetryMessage> messages, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(messages, nameof(messages));
@@ -250,9 +253,10 @@ namespace Microsoft.Azure.Devices.Client
         /// </remarks>
         /// <param name="messageCallback">The callback to be invoked when a cloud-to-device message is received by the client.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="InvalidOperationException">The client instance is not already open.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         public async Task SetIncomingMessageCallbackAsync(
             Func<IncomingMessage, Task<MessageAcknowledgement>> messageCallback,
             CancellationToken cancellationToken = default)
@@ -306,9 +310,10 @@ namespace Microsoft.Azure.Devices.Client
         /// </remarks>
         /// <param name="directMethodCallback">The callback to be invoked when any method is invoked by the cloud service.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="InvalidOperationException">The client instance is not already open.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         public async Task SetDirectMethodCallbackAsync(
             Func<DirectMethodRequest, Task<DirectMethodResponse>> directMethodCallback,
             CancellationToken cancellationToken = default)
@@ -352,9 +357,10 @@ namespace Microsoft.Azure.Devices.Client
         /// </para>
         /// </remarks>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="InvalidOperationException">The client instance is not already open.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         /// <returns>The twin object for the current client.</returns>
         public async Task<TwinProperties> GetTwinPropertiesAsync(CancellationToken cancellationToken = default)
         {
@@ -371,9 +377,11 @@ namespace Microsoft.Azure.Devices.Client
         /// </remarks>
         /// <param name="reportedProperties">Reported properties to push</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="reportedProperties"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The client instance is not already open.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         /// <returns>The new version of the updated twin if the update was successful.</returns>
         public async Task<long> UpdateReportedPropertiesAsync(ReportedProperties reportedProperties, CancellationToken cancellationToken = default)
         {
@@ -402,9 +410,10 @@ namespace Microsoft.Azure.Devices.Client
         /// </remarks>
         /// <param name="callback">The callback to be invoked when a desired property update is received from the service.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="InvalidOperationException">The client instance is not already open.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         public async Task SetDesiredPropertyUpdateCallbackAsync(
             Func<DesiredProperties, Task> callback,
             CancellationToken cancellationToken = default)
@@ -448,8 +457,8 @@ namespace Microsoft.Azure.Devices.Client
         /// to cloud to device messages/twin/methods do not persist when re-opening a client.
         /// </remarks>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         public async Task CloseAsync(CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/iothub/device/src/IotHubClientOptions.cs
+++ b/iothub/device/src/IotHubClientOptions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </summary>
         /// <param name="transportSettings">The transport settings to use (i.e., <see cref="IotHubClientMqttSettings"/> or
         /// <see cref="IotHubClientAmqpSettings"/>.</param>
-        /// <exception cref="ArgumentNullException">When <paramref name="transportSettings"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="transportSettings"/> is null.</exception>
         public IotHubClientOptions(IotHubClientTransportSettings transportSettings)
         {
             TransportSettings = transportSettings ?? throw new ArgumentNullException(nameof(transportSettings));

--- a/iothub/device/src/IotHubDeviceClient.cs
+++ b/iothub/device/src/IotHubDeviceClient.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <exception cref="ArgumentException">Either <paramref name="connectionString"/> is an empty string or consists only of white-space characters,
         /// or the IoT hub host name or device Id in the connection string are an empty string or consist only of white-space characters.</exception>
         /// <exception cref="ArgumentException">Neither shared access key nor shared access signature were presented for authentication.</exception>
-        /// <exception cref="ArgumentException">A module Id was specified in the connection string. <see cref="IotHubModuleClient"/> should be used for modules.</exception>
+        /// <exception cref="InvalidOperationException">A module Id was specified in the connection string. <see cref="IotHubModuleClient"/> should be used for modules.</exception>
         public IotHubDeviceClient(string connectionString, IotHubClientOptions options = default)
             : this(new IotHubConnectionCredentials(connectionString), options)
         {
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <exception cref="ArgumentException">Either shared access key or shared access signature were presented together with X509 certificates for authentication.</exception>
         /// <exception cref="ArgumentException"><see cref="ClientAuthenticationWithX509Certificate.CertificateChain"/> is used over a protocol other than MQTT over TCP or AMQP over TCP></exception>
         /// <exception cref="IotHubClientException"><see cref="ClientAuthenticationWithX509Certificate.CertificateChain"/> could not be installed.</exception>
-        /// <exception cref="InvalidOperationException">A module Id was specified in the connection string. <see cref="IotHubModuleClient"/> should be used for modules.</exception>
+        /// <exception cref="InvalidOperationException">A module Id was specified in the provided <paramref name="authenticationMethod"/>. <see cref="IotHubModuleClient"/> should be used for modules.</exception>
         public IotHubDeviceClient(string hostName, IAuthenticationMethod authenticationMethod, IotHubClientOptions options = default)
             : this(new IotHubConnectionCredentials(authenticationMethod, hostName, options?.GatewayHostName), options)
         {
@@ -95,10 +95,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="request">The request details for getting the SAS URI, including the destination blob name.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The file upload details to be used with the Azure Storage SDK in order to upload a file from this device.</returns>
-        /// <exception cref="ArgumentNullException">When <paramref name="request"/> is null.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The client instance is not already open.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         public Task<FileUploadSasUriResponse> GetFileUploadSasUriAsync(
             FileUploadSasUriRequest request,
             CancellationToken cancellationToken = default)
@@ -115,10 +116,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <seealso href="https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload#notify-iot-hub-of-a-completed-file-upload" />.
         /// <param name="notification">The notification details, including if the file upload succeeded.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <exception cref="ArgumentNullException">When <paramref name="notification"/> is null.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="notification"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The client instance is not already open.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         public Task CompleteFileUploadAsync(FileUploadCompletionNotification notification, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(notification, nameof(notification));

--- a/iothub/device/src/IotHubModuleClient.cs
+++ b/iothub/device/src/IotHubModuleClient.cs
@@ -31,11 +31,12 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="connectionString">The connection string based on shared access key used in API calls which allows the module to communicate with IoT Hub.</param>
         /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>A disposable client instance.</returns>
-        /// <exception cref="ArgumentNullException">When <paramref name="connectionString"/> is null.</exception>
-        /// <exception cref="ArgumentException">When <paramref name="connectionString"/> is empty or white-space.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="connectionString"/> is empty or white-space.</exception>
+        /// <exception cref="ArgumentException">Neither shared access key nor shared access signature were presented for authentication.</exception>
         /// <exception cref="InvalidOperationException">Required key/value pairs were missing from the connection string.</exception>
         /// <returns>A disposable client instance.</returns>
-        /// <exception cref="ArgumentException">Neither shared access key nor shared access signature were presented for authentication.</exception>
+        /// <exception cref="InvalidOperationException">A module Id was missing in the connection string. <see cref="IotHubDeviceClient"/> should be used for devices.</exception>
         public IotHubModuleClient(string connectionString, IotHubClientOptions options = default)
             : this(new IotHubConnectionCredentials(connectionString), options, null)
         {
@@ -55,10 +56,11 @@ namespace Microsoft.Azure.Devices.Client
         /// </param>
         /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
         /// <returns>A disposable <c>IotHubModuleClient</c> instance.</returns>
-        /// <exception cref="ArgumentNullException">When <paramref name="hostName"/> or <paramref name="authenticationMethod"/> is null.</exception>
-        /// <exception cref="ArgumentException">When <paramref name="hostName"/>is empty or white-space.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="hostName"/> or <paramref name="authenticationMethod"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="hostName"/>is empty or white-space.</exception>
         /// <exception cref="ArgumentException">Neither shared access key, shared access signature, nor X509 certificates were presented for authentication.</exception>
         /// <exception cref="ArgumentException">Either shared access key or shared access signature were presented together with X509 certificates for authentication.</exception>
+        /// <exception cref="InvalidOperationException">A module Id was missing in the provided <paramref name="authenticationMethod"/>. <see cref="IotHubDeviceClient"/> should be used for devices.</exception>
         /// <returns>A disposable client instance.</returns>
         public IotHubModuleClient(string hostName, IAuthenticationMethod authenticationMethod, IotHubClientOptions options = default)
             : this(new IotHubConnectionCredentials(authenticationMethod, hostName, options?.GatewayHostName), options, null)
@@ -85,6 +87,7 @@ namespace Microsoft.Azure.Devices.Client
         /// Creates a disposable <c>IotHubModuleClient</c> instance in an IoT Edge deployment based on environment variables.
         /// </summary>
         /// <param name="options">The options that allow configuration of the module client instance during initialization.</param>
+        /// <exception cref="InvalidOperationException">The required environmental variables were missing. Check the exception thrown for additional details.</exception>
         /// <returns>A disposable client instance.</returns>
         public static async Task<IotHubModuleClient> CreateFromEnvironmentAsync(IotHubClientOptions options = default)
         {
@@ -114,11 +117,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="outputName">The named module route for sending the given message.</param>
         /// <param name="message">The message to send.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <exception cref="ArgumentNullException">Thrown when a required parameter is null.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
-        /// <exception cref="IotHubClientException">Thrown if an error occurs when communicating with IoT hub service.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="outputName"/> or <paramref name="message"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The client instance is not already open.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         public async Task SendMessageToRouteAsync(string outputName, TelemetryMessage message, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
@@ -154,9 +157,12 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="messages">A list of one or more messages to send.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <returns>The task containing the event.</returns>
-        /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="outputName"/> or <paramref name="messages"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The client instance is not already open.</exception>
+        /// <exception cref="InvalidOperationException">This method is called when the client is configured to use MQTT.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         public async Task SendMessagesToRouteAsync(string outputName, IEnumerable<TelemetryMessage> messages, CancellationToken cancellationToken = default)
         {
             if (Logging.IsEnabled)
@@ -195,11 +201,14 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="methodRequest">The details of the method to invoke.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <returns>The result of the method invocation.</returns>
-        /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="deviceId"/> or <paramref name="methodRequest"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The client instance is not already open.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         public Task<DirectMethodResponse> InvokeMethodAsync(string deviceId, DirectMethodRequest methodRequest, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
             Argument.AssertNotNull(methodRequest, nameof(methodRequest));
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -221,11 +230,15 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="methodRequest">The details of the method to invoke.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <returns>The result of the method invocation.</returns>
-        /// <exception cref="InvalidOperationException">Thrown if the client instance is not opened already.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been canceled.</exception>
-        /// <exception cref="ObjectDisposedException">When the client has been disposed.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="deviceId"/>, <paramref name="moduleId"/> or <paramref name="methodRequest"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The client instance is not already open.</exception>
+        /// <exception cref="OperationCanceledException">The operation has been canceled.</exception>
+        /// <exception cref="IotHubClientException">An error occured when communicating with IoT hub service.</exception>
+        /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
         public Task<DirectMethodResponse> InvokeMethodAsync(string deviceId, string moduleId, DirectMethodRequest methodRequest, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNullOrWhiteSpace(deviceId, nameof(deviceId));
+            Argument.AssertNotNullOrWhiteSpace(moduleId, nameof(moduleId));
             Argument.AssertNotNull(methodRequest, nameof(methodRequest));
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/iothub/device/src/Pipeline/ClientTransportStateMachine.cs
+++ b/iothub/device/src/Pipeline/ClientTransportStateMachine.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         /// </summary>
         /// <param name="action">The action executed on the delegating pipeline.</param>
         /// <param name="desiredState">The desired state to transition the delegating pipeline to.</param>
-        /// <exception cref="InvalidOperationException">Thrown if the requested state transition is not a valid transition.</exception>
+        /// <exception cref="InvalidOperationException">The requested state transition is not a valid transition.</exception>
         internal void MoveNext(ClientStateAction action, ClientTransportState desiredState)
         {
             lock (_stateTransitionLock)

--- a/iothub/device/src/Transport/Amqp/AmqpUnit.cs
+++ b/iothub/device/src/Transport/Amqp/AmqpUnit.cs
@@ -121,8 +121,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
         /// Under a semaphore, fetch the reference to an AMQP session that is open and active, and has a reference to an opened telemetry sending link.
         /// </summary>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <exception cref="IotHubClientException">Thrown if an attempt is made to open a session on a client that is already closed.</exception>
-        /// <exception cref="OperationCanceledException"> Thrown if the operation canceled before it could gain access to the semaphore for retrieving the session reference.</exception>
+        /// <exception cref="IotHubClientException">An attempt is made to open a session on a client that is already closed.</exception>
+        /// <exception cref="OperationCanceledException"> The operation canceled before it could gain access to the semaphore for retrieving the session reference.</exception>
         internal async Task<AmqpIotSession> EnsureSessionIsOpenAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)


### PR DESCRIPTION
Following the convention of avoiding the "Thrown if..." text in exception declaration.
This is similar to the pattern followed by the .NET team: [httpClient.SendAsync()](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.sendasync?view=net-8.0#system-net-http-httpclient-sendasync(system-net-http-httprequestmessage-system-net-http-httpcompletionoption-system-threading-cancellationtoken))