### PR TITLE
Allow users to pass in HttpClient to use for file upload operations

### DIFF
--- a/e2e/test/iothub/FileUploadE2ETests.cs
+++ b/e2e/test/iothub/FileUploadE2ETests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Client.Exceptions;
 using Microsoft.Azure.Devices.Client.Transport;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -159,18 +160,11 @@ namespace Microsoft.Azure.Devices.E2ETests
             {
                 BlobName = "someBlobName",
             };
+            var ex = await Assert.ThrowsExceptionAsync<IotHubException>(
+                            async () => await deviceClient.GetFileUploadSasUriAsync(request).ConfigureAwait(false));
 
-            try
-            {
-                await deviceClient.GetFileUploadSasUriAsync(request).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                // The custom HttpMessageHandler throws NotImplementedException when making any Http request.
-                // So if this exception is not thrown, then the client didn't use the custom HttpMessageHandler
-                e.InnerException.Should().BeOfType(typeof(NotImplementedException),
-                    "The provided custom HttpMessageHandler throws NotImplementedException when making any HTTP request");
-            }
+            ex.InnerException.Should().BeOfType<NotImplementedException>(
+                "The provided custom HttpMessageHandler throws NotImplementedException when making any HTTP request");
         }
 
         private async Task UploadFileGranularAsync(Stream source, string filename, Http1TransportSettings fileUploadTransportSettings, bool useX509auth = false)
@@ -315,7 +309,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
-                throw new NotImplementedException("Deliberately  not implemented for test purposes");
+                throw new NotImplementedException("Deliberately not implemented for test purposes");
             }
         }
 

--- a/e2e/test/iothub/FileUploadE2ETests.cs
+++ b/e2e/test/iothub/FileUploadE2ETests.cs
@@ -4,8 +4,11 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.Client.Transport;
 using Microsoft.Azure.Devices.E2ETests.Helpers;
@@ -125,6 +128,49 @@ namespace Microsoft.Azure.Devices.E2ETests
             };
 
             await UploadFileGranularAsync(fileStreamSource, filename, fileUploadTransportSettings).ConfigureAwait(false);
+        }
+
+        // File upload requests can be configured to use a user-provided HttpClient
+        [TestMethod]
+        public async Task FileUpload_UsesCustomHttpClient()
+        {
+            using TestDevice testDevice =
+                await TestDevice.GetTestDeviceAsync(_devicePrefix, TestDeviceType.Sasl).ConfigureAwait(false);
+
+            using var CustomHttpMessageHandler = new CustomHttpMessageHandler();
+            var fileUploadSettings = new Http1TransportSettings()
+            {
+                // This HttpClient should throw a NotImplementedException whenever it makes an HTTP
+                // request
+                HttpClient = new HttpClient(CustomHttpMessageHandler),
+            };
+
+            var clientOptions = new ClientOptions()
+            {
+                FileUploadTransportSettings = fileUploadSettings,
+            };
+
+            using var deviceClient =
+                DeviceClient.CreateFromConnectionString(testDevice.ConnectionString, clientOptions);
+
+            await deviceClient.OpenAsync().ConfigureAwait(false);
+
+            var request = new FileUploadSasUriRequest()
+            {
+                BlobName = "someBlobName",
+            };
+
+            try
+            {
+                await deviceClient.GetFileUploadSasUriAsync(request).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                // The custom HttpMessageHandler throws NotImplementedException when making any Http request.
+                // So if this exception is not thrown, then the client didn't use the custom HttpMessageHandler
+                e.InnerException.Should().BeOfType(typeof(NotImplementedException),
+                    "The provided custom HttpMessageHandler throws NotImplementedException when making any HTTP request");
+            }
         }
 
         private async Task UploadFileGranularAsync(Stream source, string filename, Http1TransportSettings fileUploadTransportSettings, bool useX509auth = false)
@@ -263,6 +309,14 @@ namespace Microsoft.Azure.Devices.E2ETests
 #endif
 
             return filePath;
+        }
+
+        private class CustomHttpMessageHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException("Deliberately  not implemented for test purposes");
+            }
         }
 
         [ClassCleanup]

--- a/iothub/device/src/ClientSettings/Http1TransportSettings.cs
+++ b/iothub/device/src/ClientSettings/Http1TransportSettings.cs
@@ -49,6 +49,9 @@ namespace Microsoft.Azure.Devices.Client
         /// <inheritdoc/>
         public IWebProxy Proxy { get; set; }
 
+        /// <summary>
+        /// The HTTP client to use for all HTTP operations.
+        /// </summary>
         /// <remarks>
         /// If not provided, an HTTP client will be created for you based on the other settings provided.
         /// <para>

--- a/iothub/device/src/ClientSettings/Http1TransportSettings.cs
+++ b/iothub/device/src/ClientSettings/Http1TransportSettings.cs
@@ -55,6 +55,9 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// If not provided, an HTTP client will be created for you based on the other settings provided.
         /// <para>
+        /// This HTTP client instance will be disposed when the device/module client using it is disposed.
+        /// </para>
+        /// <para>
         /// If provided, all other HTTP-specific settings (such as proxy, SSL protocols, and certificate revocation check)
         /// on this class will be ignored and must be specified on this HttpClient instance.
         /// </para>

--- a/iothub/device/src/ClientSettings/Http1TransportSettings.cs
+++ b/iothub/device/src/ClientSettings/Http1TransportSettings.cs
@@ -49,10 +49,13 @@ namespace Microsoft.Azure.Devices.Client
         /// <inheritdoc/>
         public IWebProxy Proxy { get; set; }
 
-        /// <summary>
-        /// The handler that this client will instantiate its HttpClient with. If this value
-        /// is provided, all other options will be ignored in favor of this handler.
-        /// </summary>
-        public HttpMessageHandler HttpMessageHandler { get; set; }
+        /// <remarks>
+        /// If not provided, an HTTP client will be created for you based on the other settings provided.
+        /// <para>
+        /// If provided, all other HTTP-specific settings (such as proxy, SSL protocols, and certificate revocation check)
+        /// on this class will be ignored and must be specified on this HttpClient instance.
+        /// </para>
+        /// </remarks>
+        public HttpClient HttpClient { get; set; }
     }
 }

--- a/iothub/device/src/ClientSettings/Http1TransportSettings.cs
+++ b/iothub/device/src/ClientSettings/Http1TransportSettings.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net;
+using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Azure.Devices.Shared;
 
@@ -47,5 +48,11 @@ namespace Microsoft.Azure.Devices.Client
 
         /// <inheritdoc/>
         public IWebProxy Proxy { get; set; }
+
+        /// <summary>
+        /// The handler that this client will instantiate its HttpClient with. If this value
+        /// is provided, all other options will be ignored in favor of this handler.
+        /// </summary>
+        public HttpMessageHandler HttpMessageHandler { get; set; }
     }
 }

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -829,7 +829,7 @@ namespace Microsoft.Azure.Devices.Client
             }
             methodRequest.ThrowIfNull(nameof(methodRequest));
 
-            HttpClientHandler httpClientHandler = null;
+            HttpMessageHandler httpMessageHandler = null;
             Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> customCertificateValidation = _certValidator.GetCustomCertificateValidation();
 
             try
@@ -854,7 +854,7 @@ namespace Microsoft.Azure.Devices.Client
                     TlsVersions.Instance.SetLegacyAcceptableVersions();
 
 #if !NET451
-                    httpClientHandler = new HttpClientHandler
+                    httpMessageHandler = new HttpClientHandler
                     {
                         ServerCertificateCustomValidationCallback = customCertificateValidation,
                         SslProtocols = TlsVersions.Instance.Preferred,
@@ -862,9 +862,9 @@ namespace Microsoft.Azure.Devices.Client
 #else
 #pragma warning disable CA2000 // Dispose objects before losing scope
                     // This object is given to an HTTP client to use, so it can't be disposed yet
-                    var httpMessageHandler = new WebRequestHandler();
+                    httpMessageHandler = new WebRequestHandler();
 #pragma warning restore CA2000 // Dispose objects before losing scope
-                    ((WebRequestHandler)httpClientHandler).ServerCertificateValidationCallback = (sender, certificate, chain, errors) =>
+                    ((WebRequestHandler)httpMessageHandler).ServerCertificateValidationCallback = (sender, certificate, chain, errors) =>
                     {
                         return customCertificateValidation(sender, certificate, chain, errors);
                     };
@@ -881,7 +881,7 @@ namespace Microsoft.Azure.Devices.Client
             }
             finally
             {
-                httpClientHandler?.Dispose();
+                httpMessageHandler?.Dispose();
             }
         }
 

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -860,11 +860,16 @@ namespace Microsoft.Azure.Devices.Client
                         SslProtocols = TlsVersions.Instance.Preferred,
                     };
 #else
-                    transportSettings.HttpMessageHandler = new WebRequestHandler();
+#pragma warning disable CA2000 // Dispose objects before losing scope
+                    // This object is given to an HTTP client to use, so it can't be disposed yet
+                    var httpMessageHandler = new WebRequestHandler();
+#pragma warning restore CA2000 // Dispose objects before losing scope
                     ((WebRequestHandler)httpClientHandler).ServerCertificateValidationCallback = (sender, certificate, chain, errors) =>
                     {
                         return customCertificateValidation(sender, certificate, chain, errors);
                     };
+
+                    transportSettings.HttpClient = new HttpClient(httpMessageHandler);
 #endif
                 }
 

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -867,11 +867,12 @@ namespace Microsoft.Azure.Devices.Client
                     httpMessageHandler.ClientCertificates.Add(InternalClient.Certificate);
                 }
 
-                HttpClient httpClient = new HttpClient(httpMessageHandler, true);
-
+                // Note that this client is ignoring any HttpTransportSettings that the user may have
+                // provided. This is because the kinds of settings a user would want to override
+                // aren't as applicable for this particular operation.
                 var transportSettings = new Http1TransportSettings()
                 {
-                    HttpClient = httpClient
+                    HttpClient = new HttpClient(httpMessageHandler, true)
                 };
 
                 var context = new PipelineContext

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -866,7 +866,7 @@ namespace Microsoft.Azure.Devices.Client
                         return customCertificateValidation(sender, certificate, chain, errors);
                     };
 
-                    transportSettings.HttpClient = new HttpClient(httpMessageHandler);
+                    transportSettings.HttpClient = new HttpClient(httpMessageHandler, true);
 #endif
                 }
 

--- a/iothub/device/src/ModuleClient.cs
+++ b/iothub/device/src/ModuleClient.cs
@@ -860,10 +860,7 @@ namespace Microsoft.Azure.Devices.Client
                         SslProtocols = TlsVersions.Instance.Preferred,
                     };
 #else
-#pragma warning disable CA2000 // Dispose objects before losing scope
-                    // This object is given to an HTTP client to use, so it can't be disposed yet
                     httpMessageHandler = new WebRequestHandler();
-#pragma warning restore CA2000 // Dispose objects before losing scope
                     ((WebRequestHandler)httpMessageHandler).ServerCertificateValidationCallback = (sender, certificate, chain, errors) =>
                     {
                         return customCertificateValidation(sender, certificate, chain, errors);

--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
 
             _httpMessageHandler = socketsHandler;
-#else
+#else // cases other than Net 5.0+ and net451
             var httpClientHandler = new HttpClientHandler();
             httpClientHandler.SslProtocols = TlsVersions.Instance.Preferred;
             httpClientHandler.CheckCertificateRevocationList = TlsVersions.Instance.CertificateRevocationCheck;
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
             ServicePointHelpers.SetLimits(_httpMessageHandler, _baseAddress);
 
-            _httpClientObj = new HttpClient(_httpMessageHandler);
+            _httpClientObj = new HttpClient(_httpMessageHandler, true);
 
             _httpClientObj.BaseAddress = _baseAddress;
             _httpClientObj.Timeout = timeout;
@@ -566,14 +566,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 {
                     _httpClientObj.Dispose();
                     _httpClientObj = null;
-                }
-
-                // HttpClientHandler that is used to create HttpClient will automatically be disposed when HttpClient is disposed
-                // But in case the client handler didn't end up being used by the HttpClient, we explicitly dispose it here.
-                if (_httpMessageHandler != null)
-                {
-                    _httpMessageHandler?.Dispose();
-                    _httpMessageHandler = null;
                 }
 
                 // The associated TokenRefresher should be disposed by the http client helper only when the http client

--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -104,7 +104,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
             if (transportSettings.ClientCertificate != null)
             {
-                socketsHandler.SslOptions.ClientCertificates.Add(transportSettings.ClientCertificate);
+                socketsHandler.SslOptions.ClientCertificates =
+                    new X509CertificateCollection() { transportSettings.ClientCertificate };
             }
             else
             {

--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -75,7 +75,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
             if (transportSettings.ClientCertificate != null)
             {
-                webRequestHandler.ClientCertificates.Add(transportSettings.ClientCertificate);
+                webRequestHandler.ClientCertificates =
+                    new X509CertificateCollection() { transportSettings.ClientCertificate };
                 _usingX509ClientCert = true;
             }
             else
@@ -130,7 +131,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
             if (transportSettings.ClientCertificate != null)
             {
-                httpClientHandler.ClientCertificates.Add(transportSettings.ClientCertificate);
+                httpClientHandler.ClientCertificates =
+                    new X509CertificateCollection() { transportSettings.ClientCertificate };
                 _usingX509ClientCert = true;
             }
             else

--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             {
                 socketsHandler.SslOptions.ClientCertificates =
                     new X509CertificateCollection() { transportSettings.ClientCertificate };
+                _usingX509ClientCert = true;
             }
             else
             {

--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -75,8 +75,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
             if (transportSettings.ClientCertificate != null)
             {
-                webRequestHandler.ClientCertificates =
-                    new X509CertificateCollection() { transportSettings.ClientCertificate };
+                webRequestHandler.ClientCertificates.Add(transportSettings.ClientCertificate);
                 _usingX509ClientCert = true;
             }
             else
@@ -131,8 +130,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
             if (transportSettings.ClientCertificate != null)
             {
-                httpClientHandler.ClientCertificates =
-                    new X509CertificateCollection() { transportSettings.ClientCertificate };
+                httpClientHandler.ClientCertificates.Add(transportSettings.ClientCertificate);
                 _usingX509ClientCert = true;
             }
             else

--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -75,9 +75,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
             _authenticationHeaderProvider = authenticationHeaderProvider;
             _defaultErrorMapping = new ReadOnlyDictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>(defaultErrorMapping);
 
-            ServicePoint servicePoint = ServicePointManager.FindServicePoint(_baseAddress);
-            servicePoint.ConnectionLeaseTimeout = s_defaultConnectionLeaseTimeout.Milliseconds;
-
 #if NET451
             TlsVersions.Instance.SetLegacyAcceptableVersions();
 
@@ -104,8 +101,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 _httpClientHandler.UseProxy = (proxy != null);
                 _httpClientHandler.Proxy = proxy;
             }
-
-            _httpClientObj = _httpClientHandler != null ? new HttpClient(_httpClientHandler) : new HttpClient();
 #else
 
             _httpClientHandler = httpClientHandler ?? new HttpClientHandler();
@@ -123,11 +118,11 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 _httpClientHandler.UseProxy = proxy != null;
                 _httpClientHandler.Proxy = proxy;
             }
-
-            _httpClientHandler.MaxConnectionsPerServer = DefaultMaxConnectionsPerServer;
-
-            _httpClientObj = new HttpClient(_httpClientHandler);
 #endif
+
+            ServicePointHelpers.SetLimits(_httpClientHandler, _baseAddress);
+
+            _httpClientObj = _httpClientHandler != null ? new HttpClient(_httpClientHandler) : new HttpClient();
 
             _httpClientObj.BaseAddress = _baseAddress;
             _httpClientObj.Timeout = timeout;

--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
 
             HttpMessageHandler httpMessageHandler;
+            _usingX509ClientCert = transportSettings.ClientCertificate != null;
 #if NET451
             TlsVersions.Instance.SetLegacyAcceptableVersions();
 
@@ -73,14 +74,9 @@ namespace Microsoft.Azure.Devices.Client.Transport
             var webRequestHandler = new WebRequestHandler();
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-            if (transportSettings.ClientCertificate != null)
+            if (_usingX509ClientCert)
             {
                 webRequestHandler.ClientCertificates.Add(transportSettings.ClientCertificate);
-                _usingX509ClientCert = true;
-            }
-            else
-            {
-                _usingX509ClientCert = false;
             }
 
             if (proxy != DefaultWebProxySettings.Instance)
@@ -102,15 +98,10 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 socketsHandler.SslOptions.CertificateRevocationCheckMode = X509RevocationMode.NoCheck;
             }
 
-            if (transportSettings.ClientCertificate != null)
+            if (_usingX509ClientCert)
             {
                 socketsHandler.SslOptions.ClientCertificates =
                     new X509CertificateCollection() { transportSettings.ClientCertificate };
-                _usingX509ClientCert = true;
-            }
-            else
-            {
-                _usingX509ClientCert = false;
             }
 
             if (proxy != DefaultWebProxySettings.Instance)
@@ -129,14 +120,9 @@ namespace Microsoft.Azure.Devices.Client.Transport
             httpClientHandler.SslProtocols = TlsVersions.Instance.Preferred;
             httpClientHandler.CheckCertificateRevocationList = TlsVersions.Instance.CertificateRevocationCheck;
 
-            if (transportSettings.ClientCertificate != null)
+            if (_usingX509ClientCert)
             {
                 httpClientHandler.ClientCertificates.Add(transportSettings.ClientCertificate);
-                _usingX509ClientCert = true;
-            }
-            else
-            {
-                _usingX509ClientCert = false;
             }
 
             if (proxy != DefaultWebProxySettings.Instance)

--- a/iothub/device/src/Transport/Http/HttpTransportHandler.cs
+++ b/iothub/device/src/Transport/Http/HttpTransportHandler.cs
@@ -75,7 +75,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 iotHubConnectionString,
                 ExceptionHandlingHelper.GetDefaultErrorMapping(),
                 s_defaultOperationTimeout,
-                null,
                 transportSettings,
                 productInfo,
                 transportSettings.Proxy,

--- a/iothub/device/src/Transport/Http/HttpTransportHandler.cs
+++ b/iothub/device/src/Transport/Http/HttpTransportHandler.cs
@@ -64,7 +64,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
             PipelineContext context,
             IotHubConnectionString iotHubConnectionString,
             Http1TransportSettings transportSettings,
-            HttpClientHandler httpClientHandler = null,
             bool isClientPrimaryTransportHandler = false)
             : base(context, transportSettings)
         {
@@ -77,8 +76,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 ExceptionHandlingHelper.GetDefaultErrorMapping(),
                 s_defaultOperationTimeout,
                 null,
-                transportSettings.ClientCertificate,
-                httpClientHandler,
+                transportSettings,
                 productInfo,
                 transportSettings.Proxy,
                 isClientPrimaryTransportHandler);

--- a/iothub/device/src/Transport/Http/ServicePointHelpers.cs
+++ b/iothub/device/src/Transport/Http/ServicePointHelpers.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.Client
                     ServicePoint servicePoint = ServicePointManager.FindServicePoint(baseUri);
                     servicePoint.ConnectionLeaseTimeout = connectionLeaseTimeoutMilliseconds;
                     break;
-#if NET5_0_OR_GREATER
+#if NETCOREAPP2_1_OR_GREATER || NET5_0_OR_GREATER
                 // SocketsHttpHandler is only available in netcore2.1 and onwards and .NET 5 and onwards.
                 // This library does not target netcore2.1+ though, so there is no way to set these timeouts
                 // within this library for netcore2.1+ cases though. Users will need to pass in this handler

--- a/iothub/device/src/Transport/Http/ServicePointHelpers.cs
+++ b/iothub/device/src/Transport/Http/ServicePointHelpers.cs
@@ -41,8 +41,11 @@ namespace Microsoft.Azure.Devices.Client
                     ServicePoint servicePoint = ServicePointManager.FindServicePoint(baseUri);
                     servicePoint.ConnectionLeaseTimeout = connectionLeaseTimeoutMilliseconds;
                     break;
-#if NETCOREAPP2_1_OR_GREATER || NET5_0_OR_GREATER
-                // SocketsHttpHandler is only available in netcore2.1 and onwards
+#if NET5_0_OR_GREATER
+                // SocketsHttpHandler is only available in netcore2.1 and onwards and .NET 5 and onwards.
+                // This library does not target netcore2.1+ though, so there is no way to set these timeouts
+                // within this library for netcore2.1+ cases though. Users will need to pass in this handler
+                // themselves in netcore2.1+ cases
                 case SocketsHttpHandler socketsHttpHandler:
                     socketsHttpHandler.MaxConnectionsPerServer = DefaultMaxConnectionsPerServer;
                     socketsHttpHandler.PooledConnectionLifetime = TimeSpan.FromMilliseconds(connectionLeaseTimeoutMilliseconds);

--- a/iothub/device/src/Transport/Http/ServicePointHelpers.cs
+++ b/iothub/device/src/Transport/Http/ServicePointHelpers.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+
+namespace Microsoft.Azure.Devices.Client
+{
+    // This type manages changing HttpClient defaults to more appropriate values
+    // There are two limits we target:
+    // - Per Server Connection Limit
+    // - Keep Alive Connection Timeout
+    // On .NET Core 2.1+ the HttpClient defaults to using the HttpSocketHandler so we adjust both limits on the client handler
+    //
+    // On .NET Standard & NET 4.51+ the HttpClient defaults to using the HttpClientHandler
+    //   and there is no easy way to set Keep Alive Connection Timeout but it's mitigated by setting the service point's connection lease timeout
+    internal static class ServicePointHelpers
+    {
+        // These default values are consistent with Azure.Core default values:
+        // https://github.com/Azure/azure-sdk-for-net/blob/7e3cf643977591e9041f4c628fd4d28237398e0b/sdk/core/Azure.Core/src/Pipeline/ServicePointHelpers.cs#L28
+        internal const int DefaultMaxConnectionsPerServer = 50;
+
+        internal const int DefaultConnectionLeaseTimeout = 300 * 1000; // 5 minutes
+
+        // messageHandler passed in is an HttpClientHandler for .NET Framework and .NET standard, and a SocketsHttpHandler for .NET core
+        public static void SetLimits(HttpMessageHandler messageHandler, Uri baseUri, int connectionLeaseTimeoutMilliseconds = DefaultConnectionLeaseTimeout)
+        {
+            if (messageHandler == null)
+            {
+                // no limits can be set if no handler is provided
+                return;
+            }
+
+            switch (messageHandler)
+            {
+                case HttpClientHandler httpClientHandler:
+#if !NET451
+                    httpClientHandler.MaxConnectionsPerServer = DefaultMaxConnectionsPerServer;
+#endif
+                    ServicePoint servicePoint = ServicePointManager.FindServicePoint(baseUri);
+                    servicePoint.ConnectionLeaseTimeout = connectionLeaseTimeoutMilliseconds;
+                    break;
+#if NETCOREAPP2_1_OR_GREATER || NET5_0_OR_GREATER
+                // SocketsHttpHandler is only available in netcore2.1 and onwards
+                case SocketsHttpHandler socketsHttpHandler:
+                    socketsHttpHandler.MaxConnectionsPerServer = DefaultMaxConnectionsPerServer;
+                    socketsHttpHandler.PooledConnectionLifetime = TimeSpan.FromMilliseconds(connectionLeaseTimeoutMilliseconds);
+                    break;
+#endif
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since we don't target any version of .NET core in our device SDK, there is no way for us to create an HttpClient that sets the connection lease timeout for the user by default. Instead, we will allow users to pass in an HttpClient that we will use. This allows .NET core users to construct an HTTP client with their desired connection lease timeout, and give it to the SDK to use.

For .NET standard, net472, and .NET 5+ cases, the SDK can set the connection lease timeout for the user by default.

On the service SDK side, .NET standard, net472, .NET 5+ and .NET core 2.1+ cases will create an HttpClient with the connection lease timeout set by default.