### PR TITLE
Allow users to pass in HttpClient for file upload/module method requests

### DIFF
--- a/e2e/Tests/iothub/device/FileUploadE2ETests.cs
+++ b/e2e/Tests/iothub/device/FileUploadE2ETests.cs
@@ -111,9 +111,12 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .GetTestDeviceAsync(_devicePrefix, TestDeviceType.Sasl, cts.Token)
                 .ConfigureAwait(false);
 
+            using var CustomHttpMessageHandler = new CustomHttpMessageHandler();
             var fileUploadSettings = new IotHubClientHttpSettings()
             {
-                HttpMessageHandler = new CustomHttpMessageHandler(),
+                // This HttpClient should throw a NotImplementedException whenever it makes an HTTP
+                // request
+                HttpClient = new HttpClient(CustomHttpMessageHandler),
             };
 
             var clientOptions = new IotHubClientOptions
@@ -139,15 +142,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 // So if this exception is not thrown, then the client didn't use the custom HttpMessageHandler
                 e.Should().BeOfType(typeof(NotImplementedException),
                     "The provided custom HttpMessageHandler throws NotImplementedException when making any HTTP request");
-            }
-        }
-
-        
-        private class CustomHttpMessageHandler : HttpMessageHandler
-        {
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException("Deliberately  not implemented for test purposes");
             }
         }
 
@@ -302,6 +296,14 @@ namespace Microsoft.Azure.Devices.E2ETests
            // {
            //     disposableCertificate?.Dispose();
            // }
+        }
+
+        private class CustomHttpMessageHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException("Deliberately  not implemented for test purposes");
+            }
         }
     }
 }

--- a/e2e/Tests/iothub/device/FileUploadE2ETests.cs
+++ b/e2e/Tests/iothub/device/FileUploadE2ETests.cs
@@ -131,9 +131,10 @@ namespace Microsoft.Azure.Devices.E2ETests
             await deviceClient.OpenAsync(cts.Token).ConfigureAwait(false);
 
             var request = new FileUploadSasUriRequest("someBlobName");
-            var ex = await Assert.ThrowsExceptionAsync<NotImplementedException>(
+            var ex = await Assert.ThrowsExceptionAsync<IotHubClientException>(
                         async () => await deviceClient.GetFileUploadSasUriAsync(request).ConfigureAwait(false),
                         "The provided custom HttpMessageHandler throws NotImplementedException when making any HTTP request");
+            ex.InnerException.Should().BeOfType(typeof(NotImplementedException));
         }
 
         private async Task UploadFileGranularAsync(

--- a/e2e/Tests/iothub/device/FileUploadE2ETests.cs
+++ b/e2e/Tests/iothub/device/FileUploadE2ETests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             var clientOptions = new IotHubClientOptions
             {
-                FileUploadTransportSettings = fileUploadSettings,
+                HttpOperationTransportSettings = fileUploadSettings,
                 RetryPolicy = new IotHubClientNoRetry(),
             };
 
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             IotHubDeviceClient deviceClient;
             var clientOptions = new IotHubClientOptions
             {
-                FileUploadTransportSettings = fileUploadTransportSettings,
+                HttpOperationTransportSettings = fileUploadTransportSettings,
 
                 // Turn off retry policy so that correlation ID mis-match errors are returned to the app immediately
                 RetryPolicy = new IotHubClientNoRetry(),
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 cert = s_selfSignedCertificate;
                 x509Auth = new ClientAuthenticationWithX509Certificate(cert, testDevice.Id);
 
-                deviceClient = new IotHubDeviceClient(testDevice.IotHubHostName, x509Auth, new IotHubClientOptions { FileUploadTransportSettings = fileUploadTransportSettings });
+                deviceClient = new IotHubDeviceClient(testDevice.IotHubHostName, x509Auth, new IotHubClientOptions { HttpOperationTransportSettings = fileUploadTransportSettings });
             }
             else
             {
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
             var options = new IotHubClientOptions(clientMainTransport)
             {
-                FileUploadTransportSettings = fileUploadSettings,
+                HttpOperationTransportSettings = fileUploadSettings,
             };
             IotHubDeviceClient deviceClient;
             X509Certificate2 cert = null;

--- a/e2e/Tests/iothub/device/FileUploadE2ETests.cs
+++ b/e2e/Tests/iothub/device/FileUploadE2ETests.cs
@@ -292,10 +292,10 @@ namespace Microsoft.Azure.Devices.E2ETests
         [ClassCleanup]
         public static void CleanupCertificates()
         {
-            //if (s_selfSignedCertificate is IDisposable disposableCertificate)
-           // {
-           //     disposableCertificate?.Dispose();
-           // }
+            if (s_selfSignedCertificate is IDisposable disposableCertificate)
+            {
+                disposableCertificate?.Dispose();
+            }
         }
 
         private class CustomHttpMessageHandler : HttpMessageHandler

--- a/e2e/Tests/iothub/device/FileUploadE2ETests.cs
+++ b/e2e/Tests/iothub/device/FileUploadE2ETests.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
-                throw new NotImplementedException("Deliberately  not implemented for test purposes");
+                throw new NotImplementedException("Deliberately not implemented for test purposes");
             }
         }
     }

--- a/e2e/Tests/iothub/device/FileUploadE2ETests.cs
+++ b/e2e/Tests/iothub/device/FileUploadE2ETests.cs
@@ -131,18 +131,9 @@ namespace Microsoft.Azure.Devices.E2ETests
             await deviceClient.OpenAsync(cts.Token).ConfigureAwait(false);
 
             var request = new FileUploadSasUriRequest("someBlobName");
-
-            try
-            {
-                await deviceClient.GetFileUploadSasUriAsync(request, cts.Token).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                // The custom HttpMessageHandler throws NotImplementedException when making any Http request.
-                // So if this exception is not thrown, then the client didn't use the custom HttpMessageHandler
-                e.Should().BeOfType(typeof(NotImplementedException),
-                    "The provided custom HttpMessageHandler throws NotImplementedException when making any HTTP request");
-            }
+            var ex = await Assert.ThrowsExceptionAsync<NotImplementedException>(
+                        async () => await deviceClient.GetFileUploadSasUriAsync(request).ConfigureAwait(false),
+                        "The provided custom HttpMessageHandler throws NotImplementedException when making any HTTP request");
         }
 
         private async Task UploadFileGranularAsync(

--- a/e2e/Tests/iothub/device/FileUploadE2ETests.cs
+++ b/e2e/Tests/iothub/device/FileUploadE2ETests.cs
@@ -101,9 +101,9 @@ namespace Microsoft.Azure.Devices.E2ETests
             await UploadFileGranularAsync(fileStreamSource, filename, fileUploadTransportSettings, isCorrelationIdValid: true, ct: cts.Token).ConfigureAwait(false);
         }
 
-        // File upload requests can be configured to use a user-provided HttpMessageHandler
+        // File upload requests can be configured to use a user-provided HttpClient
         [TestMethod]
-        public async Task FileUpload_UsesCustomHttpMessageHandler()
+        public async Task FileUpload_UsesCustomHttpClient()
         {
             using var cts = new CancellationTokenSource(s_testTimeout);
 

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -70,19 +70,14 @@ namespace Microsoft.Azure.Devices.Client
                 RetryPolicy = _clientOptions.RetryPolicy ?? new IotHubClientNoRetry(),
             };
 
-            if (IotHubConnectionCredentials.ModuleId.IsNullOrWhiteSpace())
-            {
-                // Set up file upload settings over HTTP for the device client
-                PipelineContext.HttpOperationTransportSettings = _clientOptions.HttpOperationTransportSettings;
-            }
-            else
+            PipelineContext.HttpOperationTransportSettings = _clientOptions.HttpOperationTransportSettings;
+
+            if (!IotHubConnectionCredentials.ModuleId.IsNullOrWhiteSpace())
             {
                 // Set the remote certificate validator for the module client
                 _certValidator = certificateValidator ?? NullCertificateValidator.Instance;
-                PipelineContext.HttpOperationTransportSettings = new IotHubClientHttpSettings
-                {
-                    ServerCertificateCustomValidationCallback = _certValidator.GetCustomCertificateValidation()
-                };
+                PipelineContext.HttpOperationTransportSettings.ServerCertificateCustomValidationCallback =
+                    _certValidator.GetCustomCertificateValidation();
             }
 
             InnerHandler = pipelineBuilder.Build(PipelineContext);

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -68,10 +68,9 @@ namespace Microsoft.Azure.Devices.Client
                 ConnectionStatusChangeHandler = OnConnectionStatusChanged,
                 MessageEventCallback = OnMessageReceivedAsync,
                 RetryPolicy = _clientOptions.RetryPolicy ?? new IotHubClientNoRetry(),
+                HttpOperationTransportSettings = _clientOptions.HttpOperationTransportSettings,
             };
-
-            PipelineContext.HttpOperationTransportSettings = _clientOptions.HttpOperationTransportSettings;
-
+            
             if (!IotHubConnectionCredentials.ModuleId.IsNullOrWhiteSpace())
             {
                 // Set the remote certificate validator for the module client

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Client
             if (IotHubConnectionCredentials.ModuleId.IsNullOrWhiteSpace())
             {
                 // Set up file upload settings over HTTP for the device client
-                PipelineContext.HttpOperationTransportSettings = _clientOptions.FileUploadTransportSettings;
+                PipelineContext.HttpOperationTransportSettings = _clientOptions.HttpOperationTransportSettings;
             }
             else
             {

--- a/iothub/device/src/IotHubClientOptions.cs
+++ b/iothub/device/src/IotHubClientOptions.cs
@@ -40,10 +40,15 @@ namespace Microsoft.Azure.Devices.Client
         public IotHubClientTransportSettings TransportSettings { get; }
 
         /// <summary>
-        /// The transport settings to use for all file upload operations, regardless of what protocol the device
-        /// client is configured with. All file upload operations take place over https.
+        /// The transport settings to use for all HTTP requests made by this client.
         /// </summary>
-        public IotHubClientHttpSettings FileUploadTransportSettings { get; set; } = new IotHubClientHttpSettings();
+        /// <remarks>
+        /// All <see cref="IotHubDeviceClient"/> file upload operations take place over HTTP regardless of the configured protocol. 
+        /// Additionally, all <see cref="IotHubModuleClient"/> direct method invoking operations (such as 
+        /// <see cref="IotHubModuleClient.InvokeMethodAsync(string, DirectMethodRequest, System.Threading.CancellationToken)"/>) 
+        /// take place over HTTP as well. The settings provided in this class will be used for all these operations.
+        /// </remarks>
+        public IotHubClientHttpSettings HttpOperationTransportSettings { get; set; } = new IotHubClientHttpSettings();
 
         /// <summary>
         /// The payload convention to be used to serialize and encode the payloads exchanged with the service.
@@ -105,7 +110,7 @@ namespace Microsoft.Azure.Devices.Client
 
             return new IotHubClientOptions(transport)
             {
-                FileUploadTransportSettings = (IotHubClientHttpSettings)FileUploadTransportSettings.Clone(),
+                HttpOperationTransportSettings = (IotHubClientHttpSettings)HttpOperationTransportSettings.Clone(),
                 PayloadConvention = PayloadConvention,
                 GatewayHostName = GatewayHostName,
                 ModelId = ModelId,

--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             _baseAddress = baseAddress;
             _connectionCredentials = connectionCredentials;
             _defaultErrorMapping = new ReadOnlyDictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>(defaultErrorMapping);
+            _additionalClientInformation = additionalClientInformation;
 
             if (iotHubClientHttpSettings.HttpClient != null)
             {
@@ -100,7 +101,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
             _httpClient.DefaultRequestHeaders.Accept.Add(
                 new MediaTypeWithQualityHeaderValue(CommonConstants.MediaTypeForDeviceManagementApis));
             _httpClient.DefaultRequestHeaders.ExpectContinue = false;
-            _additionalClientInformation = additionalClientInformation;
         }
 
         private static async Task<T> ReadResponseMessageAsync<T>(HttpResponseMessage message, CancellationToken token)

--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
             _httpMessageHandler = httpClientHandler;
 
-            _httpClientObj = new HttpClient(_httpMessageHandler)
+            _httpClientObj = new HttpClient(_httpMessageHandler, true)
             {
                 BaseAddress = _baseAddress,
                 Timeout = timeout,

--- a/iothub/device/src/TransportSettings/IotHubClientHttpSettings.cs
+++ b/iothub/device/src/TransportSettings/IotHubClientHttpSettings.cs
@@ -22,6 +22,12 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
+        /// The handler that this client will instantiate its HttpClient with. If this value
+        /// is provided, all other options will be ignored in favor of this handler.
+        /// </summary>
+        public HttpMessageHandler HttpMessageHandler { get; set; }
+
+        /// <summary>
         /// Gets or sets a callback method to validate the server certificate.
         /// </summary>
         /// <remarks>

--- a/iothub/device/src/TransportSettings/IotHubClientHttpSettings.cs
+++ b/iothub/device/src/TransportSettings/IotHubClientHttpSettings.cs
@@ -22,10 +22,16 @@ namespace Microsoft.Azure.Devices.Client
         }
 
         /// <summary>
-        /// The handler that this client will instantiate its HttpClient with. If this value
-        /// is provided, all other options will be ignored in favor of this handler.
+        /// The HTTP client to use for all HTTP operations.
         /// </summary>
-        public HttpMessageHandler HttpMessageHandler { get; set; }
+        /// <remarks>
+        /// If not provided, an HTTP client will be created for you based on the other settings provided.
+        /// <para>
+        /// If provided, all other HTTP-specific settings (such as proxy, SSL protocols, and CertificateRevocationCheck)
+        /// on this class will be ignored and must be specified on the custom HttpClient instance.
+        /// </para>
+        /// </remarks>
+        public HttpClient HttpClient { get; set; }
 
         /// <summary>
         /// Gets or sets a callback method to validate the server certificate.

--- a/iothub/device/src/TransportSettings/IotHubClientHttpSettings.cs
+++ b/iothub/device/src/TransportSettings/IotHubClientHttpSettings.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Azure.Devices.Client
         /// <remarks>
         /// If not provided, an HTTP client will be created for you based on the other settings provided.
         /// <para>
+        /// This HTTP client instance will be disposed when the device/module client using it is disposed.
+        /// </para>
+        /// <para>
         /// If provided, all other HTTP-specific settings (such as proxy, SSL protocols, and CertificateRevocationCheck)
         /// on this class will be ignored and must be specified on the custom HttpClient instance.
         /// </para>

--- a/iothub/device/src/TransportSettings/IotHubClientHttpSettings.cs
+++ b/iothub/device/src/TransportSettings/IotHubClientHttpSettings.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Azure.Devices.Client
                 SslProtocols = SslProtocols,
                 CertificateRevocationCheck = CertificateRevocationCheck,
                 ServerCertificateCustomValidationCallback = ServerCertificateCustomValidationCallback,
+                HttpClient = HttpClient,
             };
         }
     }

--- a/iothub/device/tests/ClientSettings/TransportSettingsTests.cs
+++ b/iothub/device/tests/ClientSettings/TransportSettingsTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices.Client.Test
         {
             var options = new IotHubClientOptions();
             options.TransportSettings.Should().BeOfType(typeof(IotHubClientMqttSettings));
-            options.FileUploadTransportSettings.Should().BeOfType(typeof(IotHubClientHttpSettings));
+            options.HttpOperationTransportSettings.Should().BeOfType(typeof(IotHubClientHttpSettings));
             options.PayloadConvention.Should().Be(DefaultPayloadConvention.Instance);
             options.SdkAssignsMessageId.Should().Be(SdkAssignsMessageId.Never);
         }
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             const string hostName = "acme.azure-devices.net";
             var authMethod = new ClientAuthenticationWithX509Certificate(s_cert, "device1");
             var options = new IotHubClientOptions(new IotHubClientAmqpSettings { PrefetchCount = 100 });
-            options.FileUploadTransportSettings = new IotHubClientHttpSettings()
+            options.HttpOperationTransportSettings = new IotHubClientHttpSettings()
             {
                 Proxy = new WebProxy(),
             };
@@ -170,7 +170,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             {
                 GatewayHostName = "sampleHost",
                 SdkAssignsMessageId = SdkAssignsMessageId.WhenUnset,
-                FileUploadTransportSettings = new IotHubClientHttpSettings(),
+                HttpOperationTransportSettings = new IotHubClientHttpSettings(),
                 PayloadConvention = DefaultPayloadConvention.Instance,
                 ModelId = "Id",
                 AdditionalUserAgentInfo = "info"
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             {
                 GatewayHostName = "sampleHost",
                 SdkAssignsMessageId = SdkAssignsMessageId.WhenUnset,
-                FileUploadTransportSettings = new IotHubClientHttpSettings(),
+                HttpOperationTransportSettings = new IotHubClientHttpSettings(),
                 PayloadConvention = DefaultPayloadConvention.Instance,
                 ModelId = "Id",
                 AdditionalUserAgentInfo = "info"

--- a/iothub/device/tests/IotHubDeviceClientOptionsCloneTest.cs
+++ b/iothub/device/tests/IotHubDeviceClientOptionsCloneTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
             {
                 GatewayHostName = "sampleHost",
                 SdkAssignsMessageId = SdkAssignsMessageId.WhenUnset,
-                FileUploadTransportSettings = new IotHubClientHttpSettings(),
+                HttpOperationTransportSettings = new IotHubClientHttpSettings(),
                 PayloadConvention = DefaultPayloadConvention.Instance,
                 ModelId = "Id",
                 AdditionalUserAgentInfo = "info"
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
             {
                 GatewayHostName = "sampleHost",
                 SdkAssignsMessageId = SdkAssignsMessageId.WhenUnset,
-                FileUploadTransportSettings = new IotHubClientHttpSettings(),
+                HttpOperationTransportSettings = new IotHubClientHttpSettings(),
                 PayloadConvention = DefaultPayloadConvention.Instance,
                 ModelId = "Id",
                 AdditionalUserAgentInfo = "info"


### PR DESCRIPTION
The implementation already uses the settings for both file upload operations and module HTTP operations, but this now adds the option to pass in an HTTP client.

Similar to #3923, but for v2