### PR TITLE
Preview release version bump

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0-preview004</Version>
+    <Version>2.0.0-preview005</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/device/src/Pipeline/ClientTransportStateMachine.cs
+++ b/iothub/device/src/Pipeline/ClientTransportStateMachine.cs
@@ -33,13 +33,15 @@ namespace Microsoft.Azure.Devices.Client.Transport
     /// <summary>
     /// This state machine stores the current state of the delegating pipeline and evalautes if the requested state transition is possible.
     /// </summary>
+#pragma warning disable CA1852 // used in debug for unit test mocking
     internal class ClientTransportStateMachine
+#pragma warning restore CA1852
     {
         /// <summary>
         /// This internal class is created for the purpose of evaluating if the proposed state transition is acceptable.
         /// Objects of this class are maintained in a dictionary of "acceptable" state transitions.
         /// </summary>
-        internal class StateTransition
+        internal sealed class StateTransition
         {
             private readonly ClientTransportState _currentState;
             private readonly ClientStateAction _nextAction;

--- a/iothub/device/src/Transport/Amqp/PendingAmqpTwinOperation.cs
+++ b/iothub/device/src/Transport/Amqp/PendingAmqpTwinOperation.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Amqp
     /// receiving link, we need a way to identify the request, when it was sent, and the task completion source to complete the
     /// waiting user's task.
     /// </summary>
-    internal class PendingAmqpTwinOperation
+    internal sealed class PendingAmqpTwinOperation
     {
         public PendingAmqpTwinOperation(TaskCompletionSource<AmqpMessage> completionTask)
         {

--- a/iothub/device/src/Transport/Mqtt/PendingMqttTwinOperation.cs
+++ b/iothub/device/src/Transport/Mqtt/PendingMqttTwinOperation.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
     /// topic, we need a way to identify the request, when it was sent, and the task completion source to complete the
     /// waiting user's task.
     /// </summary>
-    internal class PendingMqttTwinOperation
+    internal sealed class PendingMqttTwinOperation
     {
         /// <summary>
         /// Constructor for get twin operations.

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0-preview004</Version>
+    <Version>2.0.0-preview005</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Query/PageableHelpers.cs
+++ b/iothub/service/src/Query/PageableHelpers.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices
         internal delegate Task<Page<T>> AsyncPageFunc<T>(string continuationToken = default, int? pageSizeHint = default);
         internal delegate Page<T> PageFunc<T>(string continuationToken = default, int? pageSizeHint = default);
 
-        internal class FuncAsyncPageable<T> : AsyncPageable<T> where T : notnull
+        internal sealed class FuncAsyncPageable<T> : AsyncPageable<T> where T : notnull
         {
             private readonly AsyncPageFunc<T> _firstPageFunc;
             private readonly AsyncPageFunc<T> _nextPageFunc;

--- a/iothub/service/src/Query/QueryResponse.cs
+++ b/iothub/service/src/Query/QueryResponse.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices
     /// helper functions to instantiate the abstract class Response, but this library is not in that repo yet. Because of that,
     /// we need to implement the abstract class.
     /// </summary>
-    internal class QueryResponse : Response
+    internal sealed class QueryResponse : Response
     {
         private HttpResponseMessage _httpResponse;
         private List<HttpHeader> _httpHeaders;

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0-preview004</Version>
+    <Version>2.0.0-preview005</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0-preview004</Version>
+    <Version>2.0.0-preview005</Version>
     <Title>Microsoft Azure IoT Provisioning Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/service/src/Models/QueryResponse.cs
+++ b/provisioning/service/src/Models/QueryResponse.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// helper functions to instantiate the abstract class Response, but this library is not in that repo yet. Because of that,
     /// we need to implement the abstract class.
     /// </summary>
-    internal class QueryResponse : Response
+    internal sealed class QueryResponse : Response
     {
         private HttpResponseMessage _httpResponse;
         private List<HttpHeader> _httpHeaders;

--- a/provisioning/service/src/Utilities/PageableHelpers.cs
+++ b/provisioning/service/src/Utilities/PageableHelpers.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         internal delegate Task<Page<T>> AsyncPageFunc<T>(string continuationToken = default, int? pageSizeHint = default);
         internal delegate Page<T> PageFunc<T>(string continuationToken = default, int? pageSizeHint = default);
 
-        internal class FuncAsyncPageable<T> : AsyncPageable<T> where T : notnull
+        internal sealed class FuncAsyncPageable<T> : AsyncPageable<T> where T : notnull
         {
             private readonly AsyncPageFunc<T> _firstPageFunc;
             private readonly AsyncPageFunc<T> _nextPageFunc;

--- a/provisioning/service/src/Utilities/QueryBuilder.cs
+++ b/provisioning/service/src/Utilities/QueryBuilder.cs
@@ -12,7 +12,7 @@ using System.Net.Http;
 
 namespace Microsoft.Azure.Devices.Provisioning.Service
 {
-    internal class QueryBuilder
+    internal sealed class QueryBuilder
     {
         private const string ContinuationTokenHeaderKey = "x-ms-continuation";
         private const string PageSizeHeaderKey = "x-ms-max-item-count";

--- a/versions.csv
+++ b/versions.csv
@@ -1,5 +1,5 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 2.0.0-preview004
-iothub\service\src\Microsoft.Azure.Devices.csproj, 2.0.0-preview004
-provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 2.0.0-preview004
-provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 2.0.0-preview004
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 2.0.0-preview005
+iothub\service\src\Microsoft.Azure.Devices.csproj, 2.0.0-preview005
+provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 2.0.0-preview005
+provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 2.0.0-preview005


### PR DESCRIPTION
This is the fifth preview of the v2 clients. You can read about the changes in this [migration guide](https://github.com/Azure/azure-iot-sdk-csharp/blob/previews/v2/SDK%20v2%20migration%20guide.md).

## Relevant changes

* Set state to 'closed' when CloseAsync() is called by @abhipsaMisra in https://github.com/Azure/azure-iot-sdk-csharp/pull/3149
* For c2d, take payload as object, similar to other operations by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3154
* Make exception ctors public by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3158
* Make ConnectionStatusInfo ctors public by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3167
* Throw IotHubClientException for file uploading with invalid correlation id by @brycewang-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3159
* Utilize AsyncPageable for query return types by @timtay-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3165
* Drop dependency on the hub service client from the device client by @brycewang-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3178
* Utilize AsyncPageable for DPS query return types by @timtay-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3176
* Fix bug where reconnection failed if client had been previously closed by @abhipsaMisra in https://github.com/Azure/azure-iot-sdk-csharp/pull/3196
* Simplify PayloadConvention to enable non-JSON payloads by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3189
* Make file upload notification callback async by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3224
* Pass byte[] through as payload for C2D for binary payloads by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3229
* Rename and cleanup ErrorDelegatingHandler by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3234
* TelemetryMessage should be able to take bytes and not serialize them by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3242
* Cleanup more device sdk handlers by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3245
* Separate out semaphores for subscription and client open-close by @abhipsaMisra in https://github.com/Azure/azure-iot-sdk-csharp/pull/3249
* Ensure client throws ObjectDisposedException when disposed by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3250
* Unsubscribe from connection loss events when closing service client AMQP connection by @timtay-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3237
* Fix some ErrorCode in IotHubServiceException by @brycewang-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3254
* Simplify/rename error class given to IoT hub service client error processors by @timtay-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3255
* Fix bug where error processor would execute 3 times on a connection loss event by @timtay-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3261
* Miscellaneous DPS service client cleanup by @timtay-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3264
* Connection state management by @abhipsaMisra in https://github.com/Azure/azure-iot-sdk-csharp/pull/3251
* Update misc NuGet dependency versions by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3274
* Rename transport handler base in delegating pipeline by @abhipsaMisra in https://github.com/Azure/azure-iot-sdk-csharp/pull/3277
* Update MQTT and AMQP minor package versions by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3278
* Refactor to not send the same element through multiple objects by @abhipsaMisra in https://github.com/Azure/azure-iot-sdk-csharp/pull/3282
* Fix bug where device operations not recovering after reconnect by @brycewang-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3281
* Remove methods from PayloadConvention that are only needed by the DefaultPayloadConvention class by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3286
* Open failure on reconnection shouldn't transition to Closed by @abhipsaMisra in https://github.com/Azure/azure-iot-sdk-csharp/pull/3289
* Add transport pipeline capabilities to HTTP based operations by @abhipsaMisra in https://github.com/Azure/azure-iot-sdk-csharp/pull/3285
* Cancel twin ops on disconnect by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3287
* Small logical fix in MqttTransportHandler by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3291
* Update cert chains codes by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3301
* Allow users to pass in HttpClient for file upload/module method requests by @timtay-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3299
* Fix device AMQP layer not proactively renewing tokens by @timtay-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3303