### PR TITLE
Increase timeout for registerAsync in provisioning e2e tests

### DIFF
--- a/e2e/Tests/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/Tests/provisioning/ProvisioningE2ETests.cs
@@ -708,7 +708,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                         VerboseTestLogger.WriteLine($"ProvisioningDeviceClient.RegisterAsync failed because: {ex.Message}");
                         await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
                     }
-                    catch (OperationCanceledException oce) when (overallCts.IsCancellationRequested)
+                    catch (OperationCanceledException oce) when (!overallCts.IsCancellationRequested)
                     {
                         // This catch statement shouldn't execute when the test itself is cancelled, but will
                         // execute when the registerAsync(cts) call times out 

--- a/e2e/Tests/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/Tests/provisioning/ProvisioningE2ETests.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
     [TestCategory("DPS")]
     public class ProvisioningE2ETests : E2EMsTestBase
     {
-        private const int PassingTimeoutMilliseconds = 60 * 1000;
+        private const int RegisterWithRetryTimeoutMilliseconds = 3 * 60 * 1000;
+        private const int RegisterTimeoutMilliseconds = 60 * 1000;
         private const int FailingTimeoutMilliseconds = 10 * 1000;
         private const int MaxTryCount = 10;
         private const string InvalidIdScope = "0neFFFFFFFF";
@@ -686,12 +687,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
 
             try
             {
-                using var overallCts = new CancellationTokenSource(PassingTimeoutMilliseconds);
+                using var overallCts = new CancellationTokenSource(RegisterWithRetryTimeoutMilliseconds);
 
                 // Trying to register simultaneously can cause conflicts (409). Retry in those scenarios to succeed.
                 while (true)
                 {
-                    using var attemptCts = new CancellationTokenSource(FailingTimeoutMilliseconds);
+                    using var attemptCts = new CancellationTokenSource(RegisterTimeoutMilliseconds);
                     using var opCts = CancellationTokenSource.CreateLinkedTokenSource(overallCts.Token, attemptCts.Token);
 
                     try


### PR DESCRIPTION
Previously 10 seconds, now 60 seconds.

A normal provisioning request can take longer than 10 seconds. Plus, if the DPS instance is busy handling the other requests that this test suite makes, then they would take even longer than normal.

Also fix the retry logic in this test