### PR TITLE
Use gateway hostname from options for connection string flow

### DIFF
--- a/iothub/device/src/IotHubClientOptions.cs
+++ b/iothub/device/src/IotHubClientOptions.cs
@@ -85,6 +85,10 @@ namespace Microsoft.Azure.Devices.Client
         /// <para>
         /// It can also be used for other, custom transparent or protocol gateways.
         /// </para>
+        /// <para>
+        /// If the client uses a connection string badsed authentication mechanism, and has a gateway hostname specified in the connection string
+        /// then the value set in options will be ignored.
+        /// </para>
         /// </remarks>
         public string GatewayHostName { get; set; }
 

--- a/iothub/device/src/IotHubClientOptions.cs
+++ b/iothub/device/src/IotHubClientOptions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Devices.Client
         /// It can also be used for other, custom transparent or protocol gateways.
         /// </para>
         /// <para>
-        /// If the client uses a connection string based authentication mechanism, and has a gateway hostname specified in the connection string
+        /// If the client uses a connection string-based authentication mechanism, and has a gateway hostname specified in the connection string
         /// then the value set in options will be ignored.
         /// </para>
         /// </remarks>

--- a/iothub/device/src/IotHubClientOptions.cs
+++ b/iothub/device/src/IotHubClientOptions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Devices.Client
         /// It can also be used for other, custom transparent or protocol gateways.
         /// </para>
         /// <para>
-        /// If the client uses a connection string badsed authentication mechanism, and has a gateway hostname specified in the connection string
+        /// If the client uses a connection string based authentication mechanism, and has a gateway hostname specified in the connection string
         /// then the value set in options will be ignored.
         /// </para>
         /// </remarks>

--- a/iothub/device/src/IotHubDeviceClient.cs
+++ b/iothub/device/src/IotHubDeviceClient.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </code>
         /// </example>
         public IotHubDeviceClient(string connectionString, IotHubClientOptions options = default)
-            : this(new IotHubConnectionCredentials(connectionString), options)
+            : this(new IotHubConnectionCredentials(connectionString, options?.GatewayHostName), options)
         {
         }
 

--- a/iothub/device/src/IotHubModuleClient.cs
+++ b/iothub/device/src/IotHubModuleClient.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Devices.Client
         /// </code>
         /// </example>
         public IotHubModuleClient(string connectionString, IotHubClientOptions options = default)
-            : this(new IotHubConnectionCredentials(connectionString), options, null)
+            : this(new IotHubConnectionCredentials(connectionString, options?.GatewayHostName), options, null)
         {
         }
 

--- a/iothub/device/tests/IotHubDeviceClientTests.cs
+++ b/iothub/device/tests/IotHubDeviceClientTests.cs
@@ -22,7 +22,10 @@ namespace Microsoft.Azure.Devices.Client.Tests
         private const string FakeDeviceId = "fake";
         private const string FakeSharedAccessKey = "dGVzdFN0cmluZzE=";
         private const string FakeSharedAccessKeyName = "AllAccessKey";
+        private const string FakeGatewayHostNameOptions = "my-custom-gateway-options";
+        private const string FakeGatewayHostNameCs = "my-custom-gateway-cs";
         private static readonly string s_fakeConnectionString = $"HostName={FakeHostName};SharedAccessKeyName={FakeSharedAccessKeyName};DeviceId={FakeDeviceId};SharedAccessKey={FakeSharedAccessKey}";
+        private static readonly string s_fakeConnectionStringWithGatewayHostName = $"GatewayHostName={FakeGatewayHostNameCs};HostName={FakeHostName};SharedAccessKeyName={FakeSharedAccessKeyName};DeviceId={FakeDeviceId};SharedAccessKey={FakeSharedAccessKey}";
 
         private static readonly IotHubConnectionCredentials s_iotHubConnectionCredentials = new(s_fakeConnectionString);
 
@@ -1628,6 +1631,42 @@ namespace Microsoft.Azure.Devices.Client.Tests
 
             // assert
             act.Should().NotThrowAsync();
+        }
+
+        [TestMethod]
+        public async Task IotHubDeviceClient_CreateFromConnectionString_WithoutWithGatewayHostname_UseIotHubClientOptionsGatewayHostName()
+        {
+            // arrange
+            var clientOptions = new IotHubClientOptions
+            {
+                GatewayHostName = FakeGatewayHostNameOptions,
+            };
+
+            // act
+            await using var deviceClient = new IotHubDeviceClient(s_fakeConnectionString, clientOptions);
+
+            // assert
+            deviceClient.IotHubConnectionCredentials.IotHubHostName.Should().Be(FakeHostName);
+            deviceClient.IotHubConnectionCredentials.GatewayHostName.Should().Be(FakeGatewayHostNameOptions);
+            deviceClient.IotHubConnectionCredentials.HostName.Should().Be(FakeGatewayHostNameOptions);
+        }
+
+        [TestMethod]
+        public async Task IotHubDeviceClient_CreateFromConnectionString_WithGatewayHostname_OverrideIotHubClientOptionsGatewayHostName()
+        {
+            // arrange
+            var clientOptions = new IotHubClientOptions
+            {
+                GatewayHostName = FakeGatewayHostNameOptions,
+            };
+
+            // act
+            await using var deviceClient = new IotHubDeviceClient(s_fakeConnectionStringWithGatewayHostName, clientOptions);
+
+            // assert
+            deviceClient.IotHubConnectionCredentials.IotHubHostName.Should().Be(FakeHostName);
+            deviceClient.IotHubConnectionCredentials.GatewayHostName.Should().Be(FakeGatewayHostNameCs);
+            deviceClient.IotHubConnectionCredentials.HostName.Should().Be(FakeGatewayHostNameCs);
         }
 
         private class TestDeviceAuthenticationWithTokenRefresh : ClientAuthenticationWithTokenRefresh


### PR DESCRIPTION
The GatewayHostName set in IotHubClientOptions was being ignored for the connection string flow.
This PR updates our SDK to consider this value even when connection strings are used. If a gateway hostname is already specified in the connection string directly, then the value set through options is ignored.