### PR TITLE
Fix .NET 472 specific E2E test bug

### DIFF
--- a/e2e/Tests/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/Tests/provisioning/ProvisioningE2ETests.cs
@@ -900,8 +900,18 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     : new ProvisioningClientOptions(new ProvisioningClientAmqpSettings(ProvisioningClientTransportProtocol.WebSocket)),
 
                 IotHubClientMqttSettings => transportSettings.Protocol == IotHubClientTransportProtocol.Tcp
-                    ? new ProvisioningClientOptions(new ProvisioningClientMqttSettings(ProvisioningClientTransportProtocol.Tcp))
-                    : new ProvisioningClientOptions(new ProvisioningClientMqttSettings(ProvisioningClientTransportProtocol.WebSocket)),
+                    ? new ProvisioningClientOptions(new ProvisioningClientMqttSettings(ProvisioningClientTransportProtocol.Tcp)
+                    {
+#if NET472
+                        RemoteCertificateValidationCallback = null,
+#endif
+                    })
+                    : new ProvisioningClientOptions(new ProvisioningClientMqttSettings(ProvisioningClientTransportProtocol.WebSocket)
+                    {
+#if NET472
+                        RemoteCertificateValidationCallback = null,
+#endif
+                    }),
 
                 _ => throw new NotSupportedException($"Unknown transport: '{transportSettings}'.")
             };

--- a/e2e/Tests/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/Tests/provisioning/ProvisioningE2ETests.cs
@@ -904,6 +904,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     : new ProvisioningClientOptions(new ProvisioningClientMqttSettings(ProvisioningClientTransportProtocol.WebSocket)
                     {
 #if NET472
+                        // MQTTNET doesn't support setting this callback on older .NET framework versions
+                        // https://github.com/dotnet/MQTTnet/blob/99f4f46062611cd08e18b82515962b69e8c619e4/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs#L222
                         RemoteCertificateValidationCallback = null,
 #endif
                     }),

--- a/e2e/Tests/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/Tests/provisioning/ProvisioningE2ETests.cs
@@ -900,12 +900,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     : new ProvisioningClientOptions(new ProvisioningClientAmqpSettings(ProvisioningClientTransportProtocol.WebSocket)),
 
                 IotHubClientMqttSettings => transportSettings.Protocol == IotHubClientTransportProtocol.Tcp
-                    ? new ProvisioningClientOptions(new ProvisioningClientMqttSettings(ProvisioningClientTransportProtocol.Tcp)
-                    {
-#if NET472
-                        RemoteCertificateValidationCallback = null,
-#endif
-                    })
+                    ? new ProvisioningClientOptions(new ProvisioningClientMqttSettings(ProvisioningClientTransportProtocol.Tcp))
                     : new ProvisioningClientOptions(new ProvisioningClientMqttSettings(ProvisioningClientTransportProtocol.WebSocket)
                     {
 #if NET472


### PR DESCRIPTION
MQTTNET does not allows older .NET frameworks to set the certificate validation handler when connecting over websocket, and that caused our MQTT_WS provisioning tests to fail consistently on .NET 472

Now we deliberately opt-out of setting this handler in the above situation