### PR TITLE
Remove default remote certificate callback

### DIFF
--- a/iothub/service/src/IotHubServiceClientOptions.cs
+++ b/iothub/service/src/IotHubServiceClientOptions.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Devices
         /// does not support this feature.
         /// </para>
         /// </remarks>
-        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; } = DefaultRemoteCertificateValidation;
+        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 
         /// <summary>
         /// Sets the retry policy used in the operation retries.
@@ -125,17 +125,6 @@ namespace Microsoft.Azure.Devices
         /// or a custom one by inheriting from <see cref="IIotHubServiceRetryPolicy"/>.
         /// </remarks>
         public IIotHubServiceRetryPolicy RetryPolicy { get; set; } = new IotHubServiceExponentialBackoffRetryPolicy(0, TimeSpan.FromHours(12), true);
-
-        // The default remote certificate validation callback. It returns false if any SSL level exceptions occurred
-        // during the handshake.
-        private static bool DefaultRemoteCertificateValidation(
-            object sender,
-            X509Certificate certificate,
-            X509Chain chain,
-            SslPolicyErrors sslPolicyErrors)
-        {
-            return sslPolicyErrors == SslPolicyErrors.None;
-        }
 
         internal IotHubServiceClientOptions Clone()
         {

--- a/provisioning/device/src/TransportSettings/ProvisioningClientTransportSettings.cs
+++ b/provisioning/device/src/TransportSettings/ProvisioningClientTransportSettings.cs
@@ -88,18 +88,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// </para>
         /// </remarks>
         /// <seealso href="https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.remotecertificatevalidationcallback"/>
-        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; } = DefaultRemoteCertificateValidation;
-
-        // The default remote certificate validation callback. It returns false if any SSL level exceptions occurred
-        // during the handshake.
-        internal static bool DefaultRemoteCertificateValidation(
-            object sender,
-            X509Certificate certificate,
-            X509Chain chain,
-            SslPolicyErrors sslPolicyErrors)
-        {
-            return sslPolicyErrors == SslPolicyErrors.None;
-        }
+        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/provisioning/device/tests/amqp/ProvisioningClientAmqpSettingsTests.cs
+++ b/provisioning/device/tests/amqp/ProvisioningClientAmqpSettingsTests.cs
@@ -45,19 +45,5 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.UnitTests
             amqpSettings.CertificateRevocationCheck = false;
             amqpSettings.Should().NotBeEquivalentTo(clone);
         }
-
-        [TestMethod]
-        [DataRow(SslPolicyErrors.None)]
-        [DataRow(SslPolicyErrors.RemoteCertificateNotAvailable)]
-        [DataRow(SslPolicyErrors.RemoteCertificateNameMismatch)]
-        [DataRow(SslPolicyErrors.RemoteCertificateChainErrors)]
-        public void DefaultRemoteCertificateValidation_DifferentSslPolicyErrors(SslPolicyErrors sslPolicyErrors)
-        {
-            // arrange - act
-            var validation = ProvisioningClientTransportSettings.DefaultRemoteCertificateValidation("sender", null, null, sslPolicyErrors);
-
-            // assert
-            validation.Should().Be(sslPolicyErrors == SslPolicyErrors.None);
-        }
     }
 }

--- a/provisioning/device/tests/mqtt/ProvisioningClientMqttSettingsTests.cs
+++ b/provisioning/device/tests/mqtt/ProvisioningClientMqttSettingsTests.cs
@@ -48,19 +48,5 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.UnitTests
             mqttSettings.CertificateRevocationCheck = false;
             mqttSettings.Should().NotBeEquivalentTo(clone);
         }
-
-        [TestMethod]
-        [DataRow(SslPolicyErrors.None)]
-        [DataRow(SslPolicyErrors.RemoteCertificateNotAvailable)]
-        [DataRow(SslPolicyErrors.RemoteCertificateNameMismatch)]
-        [DataRow(SslPolicyErrors.RemoteCertificateChainErrors)]
-        public void DefaultRemoteCertificateValidation_DifferentSslPolicyErrors(SslPolicyErrors sslPolicyErrors)
-        {
-            // arrange - act
-            var validation = ProvisioningClientTransportSettings.DefaultRemoteCertificateValidation("sender", null, null, sslPolicyErrors);
-
-            // assert
-            validation.Should().Be(sslPolicyErrors == SslPolicyErrors.None);
-        }
     }
 }


### PR DESCRIPTION
The ClientWebSocket instance used by our MQTT/AMQP libraries already have a default remote certificate validation callback, so there is no need for us to define it as well.

In addition, now that we aren't passing in a default value for this field every time, we don't have to worry about the .NET 472 case that #3328 had to work around.

IoT hub device client already had this behavior, but now the provisioning device client and the IoT hub service client do as well. This is why we only saw these .NET 472 test failures in our DPS tests (since no Hub service client operations use MQTT)