### PR TITLE
[v2 - bug fix] Queue MQTT C2D messages if callback not set

### DIFF
--- a/e2e/Tests/iothub/device/IncomingMessageCallbackE2eTests.cs
+++ b/e2e/Tests/iothub/device/IncomingMessageCallbackE2eTests.cs
@@ -107,14 +107,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             // Now, send a message to the device from the service.
             OutgoingMessage firstMsg = OutgoingMessageHelper.ComposeTestMessage(out string _, out string _);
-            deviceHandler.ExpectedOutgoingMessage = firstMsg;
             await serviceClient.Messages.SendAsync(testDevice.Id, firstMsg, ct).ConfigureAwait(false);
             VerboseTestLogger.WriteLine($"Sent C2D message from service, messageId={firstMsg.MessageId} - to be received on callback");
 
             // re-open the client under test.
             await deviceClient.OpenAsync(ct).ConfigureAwait(false);
-            Thread.Sleep(20000);
+            await Task.Delay(10000, ct).ConfigureAwait(false);
             await deviceHandler.SetIncomingMessageCallbackHandlerAndCompleteMessageAsync<string>(ct).ConfigureAwait(false);
+            deviceHandler.ExpectedOutgoingMessage = firstMsg;
 
             // Now, set a callback on the device client to receive C2D messages.
             await deviceHandler.WaitForIncomingMessageCallbackAsync(ct).ConfigureAwait(false);

--- a/e2e/Tests/iothub/device/IncomingMessageCallbackE2eTests.cs
+++ b/e2e/Tests/iothub/device/IncomingMessageCallbackE2eTests.cs
@@ -112,9 +112,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
             // re-open the client under test.
             await deviceClient.OpenAsync(ct).ConfigureAwait(false);
-            await Task.Delay(10000, ct).ConfigureAwait(false);
-            await deviceHandler.SetIncomingMessageCallbackHandlerAndCompleteMessageAsync<string>(ct).ConfigureAwait(false);
             deviceHandler.ExpectedOutgoingMessage = firstMsg;
+            await deviceHandler.SetIncomingMessageCallbackHandlerAndCompleteMessageAsync<string>(ct).ConfigureAwait(false);
 
             // Now, set a callback on the device client to receive C2D messages.
             await deviceHandler.WaitForIncomingMessageCallbackAsync(ct).ConfigureAwait(false);

--- a/e2e/Tests/iothub/device/IncomingMessageCallbackE2eTests.cs
+++ b/e2e/Tests/iothub/device/IncomingMessageCallbackE2eTests.cs
@@ -80,6 +80,46 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             await ReceiveMessageAfterOpenCloseOpenAsync(new IotHubClientMqttSettings(), ct).ConfigureAwait(false);
         }
 
+        [TestMethod]
+        public async Task DeviceReceiveMessageSetCallbackAfterReconnect_Mqtt()
+        {
+            // Setting up one cancellation token for the complete test flow
+            using var cts = new CancellationTokenSource(s_testTimeout);
+            CancellationToken ct = cts.Token;
+
+            await ReceiveMessageSetCallbackAfterReconnect(new IotHubClientMqttSettings(), ct).ConfigureAwait(false);
+        }
+
+        private static async Task ReceiveMessageSetCallbackAfterReconnect(IotHubClientTransportSettings transportSettings, CancellationToken ct)
+        {
+            await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(s_devicePrefix, ct: ct).ConfigureAwait(false);
+            IotHubDeviceClient deviceClient = testDevice.CreateDeviceClient(new IotHubClientOptions(transportSettings));
+            await testDevice.OpenWithRetryAsync(ct).ConfigureAwait(false);
+            using var deviceHandler = new TestDeviceCallbackHandler(deviceClient, testDevice.Id);
+
+            IotHubServiceClient serviceClient = TestDevice.ServiceClient;
+
+            await serviceClient.Messages.OpenAsync(ct).ConfigureAwait(false);
+
+            await deviceHandler.SetIncomingMessageCallbackHandlerAndCompleteMessageAsync<string>(ct).ConfigureAwait(false);
+            await deviceClient.CloseAsync(ct).ConfigureAwait(false);
+
+
+            // Now, send a message to the device from the service.
+            OutgoingMessage firstMsg = OutgoingMessageHelper.ComposeTestMessage(out string _, out string _);
+            deviceHandler.ExpectedOutgoingMessage = firstMsg;
+            await serviceClient.Messages.SendAsync(testDevice.Id, firstMsg, ct).ConfigureAwait(false);
+            VerboseTestLogger.WriteLine($"Sent C2D message from service, messageId={firstMsg.MessageId} - to be received on callback");
+
+            // re-open the client under test.
+            await deviceClient.OpenAsync(ct).ConfigureAwait(false);
+            Thread.Sleep(20000);
+            await deviceHandler.SetIncomingMessageCallbackHandlerAndCompleteMessageAsync<string>(ct).ConfigureAwait(false);
+
+            // Now, set a callback on the device client to receive C2D messages.
+            await deviceHandler.WaitForIncomingMessageCallbackAsync(ct).ConfigureAwait(false);
+        }
+
         private static async Task ReceiveMessageUsingCallbackAndUnsubscribeAsync(IotHubClientTransportSettings transportSettings, CancellationToken ct)
         {
             await using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(s_devicePrefix, ct: ct).ConfigureAwait(false);

--- a/iothub/device/src/IotHubBaseClient.cs
+++ b/iothub/device/src/IotHubBaseClient.cs
@@ -277,6 +277,11 @@ namespace Microsoft.Azure.Devices.Client
         /// This user-supplied callback is awaited by the SDK. All of requests will be processed as they arrive.
         /// Exceptions thrown within the callback will be caught and logged by the SDK internally.
         /// </para>
+        /// <para>
+        /// For MQTT, if the callback is not set and client connects with <see cref="IotHubClientMqttSettings.CleanSession" /> set to <c>false</c>,
+        /// cloud-to-device messages are stored in a message queue and not processed until callback is set. 
+        /// The size of the queue can be set using <see cref="IotHubClientMqttSettings.IncomingMessageQueueSize"/>.
+        /// </para>
         /// </remarks>
         /// <param name="messageCallback">The callback to be invoked when a cloud-to-device message is received by the client.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>

--- a/iothub/device/src/Pipeline/AmqpTransportHandler.cs
+++ b/iothub/device/src/Pipeline/AmqpTransportHandler.cs
@@ -243,6 +243,13 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
         }
 
+        // This method is added to ensure that over MQTT devices can receive messages that were sent when it was disconnected.
+        // This behavior is available by default over AMQP, so no additional implementation is required here.
+        public override Task EnsurePendingMessagesAreDeliveredAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
         public override async Task DisableReceiveMessageAsync(CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)

--- a/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/DefaultDelegatingHandler.cs
@@ -70,6 +70,14 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return NextHandler?.EnableReceiveMessageAsync(cancellationToken) ?? Task.CompletedTask;
         }
 
+        // This is to ensure that if device connects over MQTT with CleanSession flag set to false,
+        // then any message sent while the device was disconnected is delivered on the callback.
+        public virtual Task EnsurePendingMessagesAreDeliveredAsync(CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            return NextHandler?.EnsurePendingMessagesAreDeliveredAsync(cancellationToken);
+        }
+
         public virtual Task DisableReceiveMessageAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();

--- a/iothub/device/src/Pipeline/ExceptionRemappingHandler.cs
+++ b/iothub/device/src/Pipeline/ExceptionRemappingHandler.cs
@@ -45,6 +45,13 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return ExecuteWithExceptionRemappingAsync(() => base.EnableReceiveMessageAsync(cancellationToken));
         }
 
+        // This is to ensure that if device connects over MQTT with CleanSession flag set to false,
+        // then any message sent while the device was disconnected is delivered on the callback.
+        public override Task EnsurePendingMessagesAreDeliveredAsync(CancellationToken cancellationToken)
+        {
+            return ExecuteWithExceptionRemappingAsync(() => base.EnsurePendingMessagesAreDeliveredAsync(cancellationToken));
+        }
+
         public override Task DisableReceiveMessageAsync(CancellationToken cancellationToken)
         {
             return ExecuteWithExceptionRemappingAsync(() => base.DisableReceiveMessageAsync(cancellationToken));

--- a/iothub/device/src/Pipeline/IDelegatingHandler.cs
+++ b/iothub/device/src/Pipeline/IDelegatingHandler.cs
@@ -26,6 +26,10 @@ namespace Microsoft.Azure.Devices.Client
 
         Task EnableReceiveMessageAsync(CancellationToken cancellationToken);
 
+        // This is to ensure that if device connects over MQTT with CleanSession flag set to false,
+        // then any message sent while the device was disconnected is delivered on the callback.
+        Task EnsurePendingMessagesAreDeliveredAsync(CancellationToken cancellationToken);
+
         Task DisableReceiveMessageAsync(CancellationToken cancellationToken);
 
         // Methods.

--- a/iothub/device/src/Pipeline/MqttTransportHandler.cs
+++ b/iothub/device/src/Pipeline/MqttTransportHandler.cs
@@ -1147,6 +1147,11 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 while(_messageQueue.Count > MessageQueueSize)
                 {
                     _messageQueue.TryDequeue(out _);
+                    if (Logging.IsEnabled)
+                    {
+                        Logging.Info(this, $"Queue size of {MessageQueueSize} for C2D messages has been reached, removing oldest queued C2D message. " +
+                            $"To avoid losing further messages, set SetIncomingMessageCallbackAsync() to process the messages.");
+                    }
                 }
             }
             else if (Logging.IsEnabled)

--- a/iothub/device/src/Pipeline/MqttTransportHandler.cs
+++ b/iothub/device/src/Pipeline/MqttTransportHandler.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
             _hostName = context.IotHubConnectionCredentials.HostName;
             _connectionCredentials = context.IotHubConnectionCredentials;
-            _messageQueueSize = _mqttTransportSettings.MessageQueueSize;
+            _messageQueueSize = _mqttTransportSettings.IncomingMessageQueueSize;
 
             if (_mqttTransportSettings.Protocol == IotHubClientTransportProtocol.Tcp)
             {

--- a/iothub/device/src/TransportSettings/IotHubClientMqttSettings.cs
+++ b/iothub/device/src/TransportSettings/IotHubClientMqttSettings.cs
@@ -96,13 +96,14 @@ namespace Microsoft.Azure.Devices.Client
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 
         /// <summary>
-        /// C2D message queue size when callback has not been set.
+        /// Cloud-to-device message queue size for storing offline messages when the client connects with <see cref="CleanSession" /> set to <c>false</c>.
         /// </summary>
         /// <remarks>
-        /// If C2D message callback is not set, messages from service are received and stored in a queue until a callback is set. 
-        /// If the number of messages sent is greater than queue size, older messages are removed as latest messages are added.
+        /// If incoming message callback is not set, messages from service are received and stored in a queue until a callback is set. 
+        /// If the number of messages sent is greater than queue size, older messages are removed as newer messages are added. 
+        /// Setting this to a low value can cause offline undelivered messages to get lost.
         /// </remarks>
-        public int MessageQueueSize { get; set; } = 10;
+        public int IncomingMessageQueueSize { get; set; } = 10;
 
         /// <summary>
         /// Used by Edge runtime to specify an authentication chain for Edge-to-Edge connections.
@@ -125,7 +126,7 @@ namespace Microsoft.Azure.Devices.Client
                 WillMessage = WillMessage,
                 RemoteCertificateValidationCallback = RemoteCertificateValidationCallback,
                 AuthenticationChain = AuthenticationChain,
-                MessageQueueSize = MessageQueueSize,
+                IncomingMessageQueueSize = IncomingMessageQueueSize,
             };
         }
     }

--- a/iothub/device/src/TransportSettings/IotHubClientMqttSettings.cs
+++ b/iothub/device/src/TransportSettings/IotHubClientMqttSettings.cs
@@ -96,6 +96,15 @@ namespace Microsoft.Azure.Devices.Client
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 
         /// <summary>
+        /// C2D message queue size when callback has not been set.
+        /// </summary>
+        /// <remarks>
+        /// If C2D message callback is not set, messages from service are received and stored in a queue until a callback is set. 
+        /// If the number of messages sent is greater than queue size, older messages are removed as latest messages are added.
+        /// </remarks>
+        public int MessageQueueSize { get; set; } = 10;
+
+        /// <summary>
         /// Used by Edge runtime to specify an authentication chain for Edge-to-Edge connections.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -116,6 +125,7 @@ namespace Microsoft.Azure.Devices.Client
                 WillMessage = WillMessage,
                 RemoteCertificateValidationCallback = RemoteCertificateValidationCallback,
                 AuthenticationChain = AuthenticationChain,
+                MessageQueueSize = MessageQueueSize,
             };
         }
     }


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-iot-sdk-csharp/issues/3335

In v2, if incoming message callback has not been set, messages are still received because cleanSession = false (default) and the client subscribes to topic from last session. This causes messages to be received but the callback has not been set and the message is eventually completed, since MQTT messages cannot be rejected or abandoned. 
This PR adds changes where we queue the received messages if callback has not been set and processes them later when callback has been set.