### PR TITLE
Preview 006 release version bump

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0-preview005</Version>
+    <Version>2.0.0-preview006</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0-preview005</Version>
+    <Version>2.0.0-preview006</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0-preview005</Version>
+    <Version>2.0.0-preview006</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0-preview005</Version>
+    <Version>2.0.0-preview006</Version>
     <Title>Microsoft Azure IoT Provisioning Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,5 +1,5 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 2.0.0-preview005
-iothub\service\src\Microsoft.Azure.Devices.csproj, 2.0.0-preview005
-provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 2.0.0-preview005
-provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 2.0.0-preview005
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 2.0.0-preview006
+iothub\service\src\Microsoft.Azure.Devices.csproj, 2.0.0-preview006
+provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 2.0.0-preview006
+provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 2.0.0-preview006


### PR DESCRIPTION
This is the sixth preview of the v2 clients. You can read about the changes in this [migration guide](https://github.com/Azure/azure-iot-sdk-csharp/blob/previews/v2/SDK%20v2%20migration%20guide.md).

## Relevant changes

* Make currentRetryCount consistent across IotHub and DPS by @patilsnr in https://github.com/Azure/azure-iot-sdk-csharp/pull/3355
* addresses supporting byte[] in direct methods and making TwinProperties able to be directly converted to json by @patilsnr in https://github.com/Azure/azure-iot-sdk-csharp/pull/3340
* [v2 - bug fix] Queue MQTT C2D messages if callback not set by @tmahmood-microsoft https://github.com/Azure/azure-iot-sdk-csharp/pull/3336
* Add comment explaining twin patch over edge isn't applied immediately by @abhipsaMisra in https://github.com/Azure/azure-iot-sdk-csharp/pull/3331
* Exception on passing different gateway hostnames through different inputs by @abhipsaMisra in https://github.com/Azure/azure-iot-sdk-csharp/pull/3330
* Remove default remote certificate callback by @timtay-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3329
* Use gateway hostname from options for connection string flow by @abhipsaMisra in https://github.com/Azure/azure-iot-sdk-csharp/pull/3326
* Throw exception if IoT device module invokes an IoT edge module API by @abhipsaMisra in https://github.com/Azure/azure-iot-sdk-csharp/pull/3323
* Fix twin desired property payload conversion - MQTT by @tmahmood-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3322
* Make DirectMethodPrequest.Payload to be settable by client applications by @abhipsaMisra in https://github.com/Azure/azure-iot-sdk-csharp/pull/3317
* Update service error codes by @drwill-ms in https://github.com/Azure/azure-iot-sdk-csharp/pull/3316
* Add code examples for public APIs in IotHubDeviceClient, IotHubModuleClient, IotHubBaseClient and retry policies by @brycewang-microsoft in https://github.com/Azure/azure-iot-sdk-csharp/pull/3308
