### PR TITLE
Bug fix: Direct method subscription not removed after disconnect

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="Azure.Core" Version="1.31.0" />
     <PackageReference Include="MQTTnet" Version="4.1.4.563" />
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.6.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="Azure.Core" Version="1.31.0" />
     <PackageReference Include="MQTTnet" Version="4.1.4.563" />
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.6.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="Azure.Core" Version="1.31.0" />
     <PackageReference Include="MQTTnet" Version="4.1.4.563" />
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.6.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4-preview1.23354.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/iothub/device/src/Pipeline/MqttTransportHandler.cs
+++ b/iothub/device/src/Pipeline/MqttTransportHandler.cs
@@ -1069,16 +1069,13 @@ namespace Microsoft.Azure.Devices.Client.Transport
             if (Logging.IsEnabled)
                 Logging.Info(this, $"MQTT connection was lost {disconnectedEventArgs.Exception}", nameof(HandleDisconnectionAsync));
 
-            if (disconnectedEventArgs.ClientWasConnected)
-            {
-                OnTransportDisconnected();
+            OnTransportDisconnected();
 
-                // During a disconnection, any pending twin updates won't be received, so we'll preemptively
-                // cancel these operations so the client can retry once reconnected.
-                RemoveOldOperations(TimeSpan.Zero);
+            // During a disconnection, any pending twin updates won't be received, so we'll preemptively
+            // cancel these operations so the client can retry once reconnected.
+            RemoveOldOperations(TimeSpan.Zero);
 
-                _mqttClient.ApplicationMessageReceivedAsync -= HandleReceivedMessageAsync;
-            }
+            _mqttClient.ApplicationMessageReceivedAsync -= HandleReceivedMessageAsync;
 
             return Task.CompletedTask;
         }

--- a/iothub/device/src/Pipeline/MqttTransportHandler.cs
+++ b/iothub/device/src/Pipeline/MqttTransportHandler.cs
@@ -1389,6 +1389,9 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     })
                 .Count();
 
+            _mqttClient.DisconnectedAsync -= HandleDisconnectionAsync;
+            _mqttClient.ApplicationMessageReceivedAsync -= HandleReceivedMessageAsync;
+
             if (Logging.IsEnabled)
                 Logging.Error(this, $"Removed {canceledOperations} twin responses", nameof(RemoveOldOperations));
         }

--- a/iothub/device/src/Pipeline/MqttTransportHandler.cs
+++ b/iothub/device/src/Pipeline/MqttTransportHandler.cs
@@ -1076,6 +1076,9 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 // During a disconnection, any pending twin updates won't be received, so we'll preemptively
                 // cancel these operations so the client can retry once reconnected.
                 RemoveOldOperations(TimeSpan.Zero);
+
+                _mqttClient.DisconnectedAsync -= HandleDisconnectionAsync;
+                _mqttClient.ApplicationMessageReceivedAsync -= HandleReceivedMessageAsync;
             }
 
             return Task.CompletedTask;
@@ -1388,9 +1391,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         return true;
                     })
                 .Count();
-
-            _mqttClient.DisconnectedAsync -= HandleDisconnectionAsync;
-            _mqttClient.ApplicationMessageReceivedAsync -= HandleReceivedMessageAsync;
 
             if (Logging.IsEnabled)
                 Logging.Error(this, $"Removed {canceledOperations} twin responses", nameof(RemoveOldOperations));

--- a/iothub/device/src/Pipeline/MqttTransportHandler.cs
+++ b/iothub/device/src/Pipeline/MqttTransportHandler.cs
@@ -1077,7 +1077,6 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 // cancel these operations so the client can retry once reconnected.
                 RemoveOldOperations(TimeSpan.Zero);
 
-                _mqttClient.DisconnectedAsync -= HandleDisconnectionAsync;
                 _mqttClient.ApplicationMessageReceivedAsync -= HandleReceivedMessageAsync;
             }
 

--- a/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
+++ b/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client.Transport;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -7,6 +8,8 @@ using MQTTnet.Client;
 
 namespace Microsoft.Azure.Devices.Client.Tests.Transport.Mqtt
 {
+    [TestClass]
+    [TestCategory("Unit")]
     public class MqttTransportHandlerTests
     {
         [TestMethod]
@@ -22,6 +25,20 @@ namespace Microsoft.Azure.Devices.Client.Tests.Transport.Mqtt
             await mqttTransportHandler.OpenAsync(cancellationToken);
 
             mockMqttClient.Verify(p => p.ConnectAsync(It.IsAny<MqttClientOptions>(), cancellationToken));
+        }
+
+        [TestMethod]
+        public async Task mqtt()
+        {
+            var cancellationToken = new CancellationToken();
+            var options = new MqttClientOptions();
+
+            var mockMqttClient = new Mock<IMqttClient>();
+            using MqttTransportHandler mqttTransportHandler = CreateTransportHandler(mockMqttClient.Object);
+            await mqttTransportHandler.OpenAsync(cancellationToken);
+            mockMqttClient.VerifyAdd(p => p.ApplicationMessageReceivedAsync += It.IsAny<Func<MqttApplicationMessageReceivedEventArgs, Task>>());
+            mockMqttClient.Raise(p => p.DisconnectedAsync += null, It.IsAny<Func<MqttClientDisconnectedEventArgs, Task>>());
+            mockMqttClient.VerifyRemove(p => p.ApplicationMessageReceivedAsync -= It.IsAny<Func<MqttApplicationMessageReceivedEventArgs, Task>>());
         }
 
         internal static MqttTransportHandler CreateTransportHandler(IMqttClient mockMqttClient)

--- a/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
+++ b/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
@@ -9,7 +9,6 @@ using MQTTnet.Client;
 namespace Microsoft.Azure.Devices.Client.Tests.Transport.Mqtt
 {
     [TestClass]
-    [TestCategory("Unit")]
     public class MqttTransportHandlerTests
     {
         [TestMethod]
@@ -28,7 +27,7 @@ namespace Microsoft.Azure.Devices.Client.Tests.Transport.Mqtt
         }
 
         [TestMethod]
-        public async Task mqtt()
+        public async Task MqttTransportHandler_Disconnect_UnhooksMessageProcessorHandler()
         {
             var cancellationToken = new CancellationToken();
             var options = new MqttClientOptions();

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -64,7 +64,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -64,7 +64,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4-preview1.23354.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -64,7 +64,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -65,7 +65,7 @@
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.6.2" />
     <PackageReference Include="MQTTnet" Version="4.1.4.563" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -65,7 +65,7 @@
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.6.2" />
     <PackageReference Include="MQTTnet" Version="4.1.4.563" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4-preview1.23354.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -65,7 +65,7 @@
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.6.2" />
     <PackageReference Include="MQTTnet" Version="4.1.4.563" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -58,7 +58,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.31.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -58,7 +58,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.31.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4-preview1.23354.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -58,7 +58,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.31.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
After a disconnect event, when the client reconnects, client subscribes to message receive event again resulting in multiple calls to direct method callback.
The root cause was missing unsubscription after a disconnect event.

github issue: https://github.com/Azure/azure-iot-sdk-csharp/issues/3354