### PR TITLE
Remove testing on no-longer supported .net frameworks

### DIFF
--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net7.0;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0;</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
     <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
     <LangVersion>9.0</LangVersion>

--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net7.0;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0;</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
     <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
     <LangVersion>9.0</LangVersion>

--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net7.0;net472;net451</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'">False</IsTestProject>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
+++ b/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net7.0;net472;net451</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'">False</IsTestProject>
 
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>

--- a/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
+++ b/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net7.0;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
     <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
 

--- a/iothub/service/tests/Microsoft.Azure.Devices.Tests.csproj
+++ b/iothub/service/tests/Microsoft.Azure.Devices.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net7.0;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
     <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>

--- a/iothub/service/tests/Microsoft.Azure.Devices.Tests.csproj
+++ b/iothub/service/tests/Microsoft.Azure.Devices.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net7.0;net472;net451</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>

--- a/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.Tests.csproj
+++ b/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.Tests.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
-    <LangVersion>8.0</LangVersion>
+    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'">False</IsTestProject>    <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <!-- Suppress framework end of life warnings as we have to keep supporting these frameworks for our customers -->

--- a/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.Tests.csproj
+++ b/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
     <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>

--- a/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.Tests.csproj
+++ b/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.Tests.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
-    <LangVersion>8.0</LangVersion>
+    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'">False</IsTestProject>    <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <!-- Suppress framework end of life warnings as we have to keep supporting these frameworks for our customers -->

--- a/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.Tests.csproj
+++ b/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
     <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>

--- a/provisioning/transport/amqp/tests/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.Tests.csproj
+++ b/provisioning/transport/amqp/tests/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
     <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>

--- a/provisioning/transport/amqp/tests/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.Tests.csproj
+++ b/provisioning/transport/amqp/tests/Microsoft.Azure.Devices.Provisioning.Transport.Amqp.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
+    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/provisioning/transport/http/tests/Microsoft.Azure.Devices.Provisioning.Transport.Http.Tests.csproj
+++ b/provisioning/transport/http/tests/Microsoft.Azure.Devices.Provisioning.Transport.Http.Tests.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
-    <LangVersion>8.0</LangVersion>
+    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'">False</IsTestProject>    <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <!-- Suppress framework end of life warnings as we have to keep supporting these frameworks for our customers -->

--- a/provisioning/transport/http/tests/Microsoft.Azure.Devices.Provisioning.Transport.Http.Tests.csproj
+++ b/provisioning/transport/http/tests/Microsoft.Azure.Devices.Provisioning.Transport.Http.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
     <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>

--- a/provisioning/transport/mqtt/tests/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.Tests.csproj
+++ b/provisioning/transport/mqtt/tests/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.Tests.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
-    <LangVersion>8.0</LangVersion>
+    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'">False</IsTestProject>    <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <!-- Suppress framework end of life warnings as we have to keep supporting these frameworks for our customers -->

--- a/provisioning/transport/mqtt/tests/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.Tests.csproj
+++ b/provisioning/transport/mqtt/tests/Microsoft.Azure.Devices.Provisioning.Transport.Mqtt.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
     <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>

--- a/security/tpm/tests/Microsoft.Azure.Devices.Provisioning.Security.Tpm.Tests.csproj
+++ b/security/tpm/tests/Microsoft.Azure.Devices.Provisioning.Security.Tpm.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net7.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
     <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
     <LangVersion>8.0</LangVersion>

--- a/security/tpm/tests/Microsoft.Azure.Devices.Provisioning.Security.Tpm.Tests.csproj
+++ b/security/tpm/tests/Microsoft.Azure.Devices.Provisioning.Security.Tpm.Tests.csproj
@@ -4,8 +4,7 @@
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net7.0;net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
-    <LangVersion>8.0</LangVersion>
+    <IsTestProject Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'">False</IsTestProject>    <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <!-- Suppress framework end of life warnings as we have to keep supporting these frameworks for our customers -->

--- a/shared/tests/Microsoft.Azure.Devices.Shared.Tests.csproj
+++ b/shared/tests/Microsoft.Azure.Devices.Shared.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net7.0;net472;net451</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
-    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'">False</IsTestProject>
 
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>

--- a/shared/tests/Microsoft.Azure.Devices.Shared.Tests.csproj
+++ b/shared/tests/Microsoft.Azure.Devices.Shared.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Microsoft.Azure.Devices.Shared.Tests</RootNamespace>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30;net472;net451</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1.30</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net7.0;net472;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0</TargetFrameworks>
     <!-- By setting this as not a test project for other frameworks, we can run "dotnet test" for a specific framework from the root directory without dotnet throwing if any test project in the solution doesn't support that framework -->
     <IsTestProject Condition="'$(OS)' != 'Windows_NT' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'netcoreapp2.1.30'">False</IsTestProject>
 

--- a/shared/tests/TlsVersionsTests.cs
+++ b/shared/tests/TlsVersionsTests.cs
@@ -80,25 +80,6 @@ namespace Microsoft.Azure.Devices.Shared.Tests
             tlsVersions.Preferred.Should().Be(expected);
         }
 
-        [TestMethod]
-        [DataRow(SslProtocols.Tls)]
-        [DataRow(SslProtocols.Tls11)]
-        [DataRow(SslProtocols.Tls | SslProtocols.Tls11)]
-        [DataRow(SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12)]
-        public void SetMinimumTlsVersions_CanSetToOlderTls(SslProtocols protocol)
-        {
-            // arrange
-            var tlsVersions = new TlsVersions();
-            SslProtocols expected = protocol | SslProtocols.Tls12;
-
-            // act
-            tlsVersions.SetMinimumTlsVersions(protocol);
-
-            // assert
-            tlsVersions.MinimumTlsVersions.Should().Be(expected);
-            tlsVersions.Preferred.Should().Be(expected);
-        }
-
 #pragma warning disable 0618
 
         [TestMethod]

--- a/supported_platforms.md
+++ b/supported_platforms.md
@@ -5,7 +5,8 @@ This SDK is tested nightly on a mix of .NET implementations on both Windows 10 a
 ## Supported .NET versions
 
 The NuGet packages provide support for the following .NET versions:
-- .NET 5.0
+- .NET 6.0
+- .NET 7.0
 - .NET Standard 2.1
 - .NET Standard 2.0
 - .NET Framework 4.7.2 (IoT Hub SDKs only)
@@ -22,9 +23,8 @@ Note that, while we only directly test on Windows 10, we do support other Window
 Nightly test platform details:
 
 .NET versions tested on
-- .NET 5.0
-- .NET Core 3.1
-- .NET Core 2.1.30
+- .NET 6.0
+- .NET 7.0
 - .NET Framework 4.7.2 (only IoT Hub SDKs tested)
 - .NET Framework 4.5.1 (only IoT Hub SDKs tested)
 
@@ -40,9 +40,8 @@ Note that, while we only directly test on Ubuntu 20.04, we do generally support 
 Nightly test platform details:
 
 .NET versions tested on:
-- .NET 5.0
-- .NET Core 3.1
-- .NET Core 2.1.30
+- .NET 6.0
+- .NET 7.0
 
 Default locale: en_US, platform encoding: UTF-8
 

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -332,7 +332,7 @@ jobs:
         .NET 6.0:
           FRAMEWORK: net6.0
           SHOULD_RUN: ${{ eq(variables['testNet60'], 'True') }}
-        .NET 5.0:
+        .NET 7.0:
           FRAMEWORK: net7.0
           SHOULD_RUN: ${{ eq(variables['testNet70'], 'True') }}
         .NET 4.7.2:

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -12,16 +12,14 @@ parameters:
   type: number
   default: 120
 - name: testTargets
-  displayName: The .NET test targets to build and run. 'all' and 'min-matrix' (net6.0, netcore3.1) are aggregates of the remaining values.
+  displayName: The .NET test targets to build and run. 'all' and 'min-matrix' (net6.0) are aggregates of the remaining values.
   type: string
   values:
     - default
     - all
     - min-matrix
+    - net7.0
     - net6.0
-    - net5.0
-    - netcore3.1
-    - netcore2.1
     - net4.7.2
     - net4.5.1
   default: default
@@ -41,11 +39,9 @@ variables:
 
 # The minimum matrix build/test targets.
   testNet60: ${{ or(eq(variables['minMatrix'], 'True'), contains(parameters['testTargets'], 'net6.0')) }}
-  testNetcore31: ${{ or(eq(variables['minMatrix'], 'True'), contains(parameters['testTargets'], 'netcore3.1')) }}
 
 # The remaining build/test targets.
-  testNet50: ${{ or(eq(variables['allTestTargets'], 'True'), contains(parameters['testTargets'], 'net5.0')) }}
-  testNetcore21: ${{ or(eq(variables['allTestTargets'], 'True'), contains(parameters['testTargets'], 'netcore2.1')) }}
+  testNet70: ${{ or(eq(variables['allTestTargets'], 'True'), contains(parameters['testTargets'], 'net7.0')) }}
   testNet472: ${{ or(eq(variables['allTestTargets'], 'True'), contains(parameters['testTargets'], 'net4.7.2')) }}
   testNet451: ${{ or(eq(variables['allTestTargets'], 'True'), contains(parameters['testTargets'], 'net4.5.1')) }}
 
@@ -78,15 +74,9 @@ jobs:
           FRAMEWORK: net6.0
           # Can't find a good way to skip matrix elements so for now we set an environment variable that the script will use to bail out.
           SHOULD_RUN: ${{ eq(variables['testNet60'], 'True') }}
-        .NET 5.0:
-          FRAMEWORK: net5.0
-          SHOULD_RUN: ${{ eq(variables['testNet50'], 'True') }}
-        .NET CoreApp 3.1:
-          FRAMEWORK: netcoreapp3.1
-          SHOULD_RUN: ${{ eq(variables['testNetcore31'], 'True') }}
-        .NET CoreApp 2.1.30:
-          FRAMEWORK: netcoreapp2.1.30
-          SHOULD_RUN: ${{ eq(variables['testNetcore21'], 'True') }}
+        .NET 7.0:
+          FRAMEWORK: net7.0
+          SHOULD_RUN: ${{ eq(variables['testNet70'], 'True') }}
     pool:
       # If this is changed, don't forget to update supported_platforms.md in the root directory. That document outlines what OS we test on and should stay up to date.
       vmImage: ubuntu-20.04
@@ -118,30 +108,12 @@ jobs:
          performMultiLevelLookup: true
          installationPath: $(Agent.ToolsDirectory)/dotnet
 
-      - ${{ if eq(variables['testNet50'], 'True') }}:
+      - ${{ if eq(variables['testNet70'], 'True') }}:
         - task: UseDotNet@2
-          displayName: 'Use .NET SDK 5.0'
+          displayName: 'Use .NET SDK 7.0'
           inputs:
             packageType: sdk
-            version: 5.x
-            performMultiLevelLookup: true
-            installationPath: $(Agent.ToolsDirectory)/dotnet
-
-      - ${{ if eq(variables['testNetcore31'], 'True') }}:
-        - task: UseDotNet@2
-          displayName: 'Use .NET Core SDK 3.1'
-          inputs:
-            packageType: sdk
-            version: 3.1.x
-            performMultiLevelLookup: true
-            installationPath: $(Agent.ToolsDirectory)/dotnet
-
-      - ${{ if eq(variables['testNetcore21'], 'True') }}:
-        - task: UseDotNet@2
-          displayName: 'Use .NET Core SDK 2.1'
-          inputs:
-            packageType: sdk
-            version: 2.1.x
+            version: 7.x
             performMultiLevelLookup: true
             installationPath: $(Agent.ToolsDirectory)/dotnet
 
@@ -361,14 +333,8 @@ jobs:
           FRAMEWORK: net6.0
           SHOULD_RUN: ${{ eq(variables['testNet60'], 'True') }}
         .NET 5.0:
-          FRAMEWORK: net5.0
-          SHOULD_RUN: ${{ eq(variables['testNet50'], 'True') }}
-        .NET CoreApp 3.1:
-          FRAMEWORK: netcoreapp3.1
-          SHOULD_RUN: ${{ eq(variables['testNetcore31'], 'True') }}
-        .NET CoreApp 2.1.30:
-          FRAMEWORK: netcoreapp2.1.30
-          SHOULD_RUN: ${{ eq(variables['testNetcore21'], 'True') }}
+          FRAMEWORK: net7.0
+          SHOULD_RUN: ${{ eq(variables['testNet70'], 'True') }}
         .NET 4.7.2:
           FRAMEWORK: net472
           SHOULD_RUN: ${{ eq(variables['testNet472'], 'True') }}
@@ -405,29 +371,14 @@ jobs:
             performMultiLevelLookup: true
             installationPath: $(Agent.ToolsDirectory)/dotnet
 
-      - ${{ if eq(variables['testNet50'], 'True') }}:
+      - ${{ if eq(variables['testNet70'], 'True') }}:
         - task: UseDotNet@2
-          displayName: 'Use .NET SDK 5.0'
+          displayName: 'Use .NET SDK 7.0'
           inputs:
             packageType: sdk
-            version: 5.x
+            version: 7.x
             performMultiLevelLookup: true
             installationPath: $(Agent.ToolsDirectory)/dotnet
-
-      - ${{ if eq(variables['testNetcore31'], 'True') }}:
-        - task: UseDotNet@2
-          displayName: 'Use .NET Core SDK 3.1'
-          inputs:
-            packageType: sdk
-            version: 3.1.x
-            performMultiLevelLookup: true
-            installationPath: $(Agent.ToolsDirectory)/dotnet
-
-      - ${{ if eq(variables['testNetcore21'], 'True') }}:
-        - task: CmdLine@2
-          displayName: 'Install .NET Core 2.1'
-          inputs:
-            script: 'choco install dotnetcore-2.1-sdk'
 
       - ${{ if eq(variables['testNet472'], 'True') }}:
         - task: CmdLine@2

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -104,7 +104,7 @@ jobs:
         displayName: 'Use .NET SDK 7.0'
         inputs:
          packageType: sdk
-         version: 6.x
+         version: 7.x
          performMultiLevelLookup: true
          installationPath: $(Agent.ToolsDirectory)/dotnet
 

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -99,21 +99,21 @@ jobs:
 
       # https://docs.microsoft.com/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
 
-      # Linux requires .NET 6.0 install for tests to run, no matter which framework target is being tested
+      # Linux requires .NET 7.0 install for tests to run, no matter which framework target is being tested
       - task: UseDotNet@2
-        displayName: 'Use .NET SDK 6.0'
+        displayName: 'Use .NET SDK 7.0'
         inputs:
          packageType: sdk
          version: 6.x
          performMultiLevelLookup: true
          installationPath: $(Agent.ToolsDirectory)/dotnet
 
-      - ${{ if eq(variables['testNet70'], 'True') }}:
+      - ${{ if eq(variables['testNet60'], 'True') }}:
         - task: UseDotNet@2
-          displayName: 'Use .NET SDK 7.0'
+          displayName: 'Use .NET SDK 6.0'
           inputs:
             packageType: sdk
-            version: 7.x
+            version: 6.x
             performMultiLevelLookup: true
             installationPath: $(Agent.ToolsDirectory)/dotnet
 


### PR DESCRIPTION
.NET 5.0, .NET core 3.1 and .NET core 2.1 are all no longer supported by .NET, so we shouldn't claim to support/test them either.

Add support for testing .NET 7, though