### PR TITLE
Remove support for .net core 3.1

### DIFF
--- a/e2e/Tests/E2ETests.csproj
+++ b/e2e/Tests/E2ETests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net7.0;net6.0;netcoreapp3.1;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net7.0;net6.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net7.0;net6.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <AnalysisLevel>latest-minimum</AnalysisLevel>

--- a/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
+++ b/iothub/device/tests/Microsoft.Azure.Devices.Client.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net7.0;net6.0;netcoreapp3.1;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net7.0;net6.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net7.0;net6.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>

--- a/iothub/service/tests/Microsoft.Azure.Devices.Tests.csproj
+++ b/iothub/service/tests/Microsoft.Azure.Devices.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net7.0;net6.0;netcoreapp3.1;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net7.0;net6.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net7.0;net6.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>

--- a/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.UnitTests.csproj
+++ b/provisioning/device/tests/Microsoft.Azure.Devices.Provisioning.Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net7.0;net6.0;netcoreapp3.1;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net7.0;net6.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net7.0;net6.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <AnalysisLevel>latest-minimum</AnalysisLevel>

--- a/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.Tests.csproj
+++ b/provisioning/service/tests/Microsoft.Azure.Devices.Provisioning.Service.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net7.0;net6.0;netcoreapp3.1;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net7.0;net6.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net7.0;net6.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <AnalysisLevel>latest-minimum</AnalysisLevel>

--- a/supported_platforms.md
+++ b/supported_platforms.md
@@ -20,7 +20,6 @@ Nightly test platform details:
 .NET versions tested on
 - .NET 7.0
 - .NET 6.0
-- .NET Core 3.1
 - .NET Framework 4.7.2
 
 
@@ -37,7 +36,6 @@ Nightly test platform details:
 .NET versions tested on:
 - .NET 7.0
 - .NET 6.0
-- .NET Core 3.1
 
 Default locale: en_US, platform encoding: UTF-8
 

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -20,7 +20,6 @@ parameters:
     - min-matrix
     - net7.0
     - net6.0
-    - netcore3.1
     - net4.7.2
   default: default
 
@@ -42,7 +41,6 @@ variables:
   testNet60: ${{ or(eq(variables['minMatrix'], 'True'), contains(parameters['testTargets'], 'net6.0')) }}
 
 # The remaining build/test targets.
-  testNetcore31: ${{ or(eq(variables['allTestTargets'], 'True'), contains(parameters['testTargets'], 'netcore3.1')) }}
   testNet472: ${{ or(eq(variables['allTestTargets'], 'True'), contains(parameters['testTargets'], 'net4.7.2')) }}
 
 trigger:
@@ -77,9 +75,6 @@ jobs:
         .NET 6.0:
           FRAMEWORK: net6.0
           SHOULD_RUN: ${{ eq(variables['testNet60'], 'True') }}
-        .NET CoreApp 3.1:
-          FRAMEWORK: netcoreapp3.1
-          SHOULD_RUN: ${{ eq(variables['testNetcore31'], 'True') }}
 
     pool:
       # If this is changed, don't forget to update supported_platforms.md in the root directory. That document outlines what OS we test on and should stay up to date.
@@ -376,9 +371,6 @@ jobs:
         .NET 6.0:
           FRAMEWORK: net6.0
           SHOULD_RUN: ${{ eq(variables['testNet60'], 'True') }}
-        .NET CoreApp 3.1:
-          FRAMEWORK: netcoreapp3.1
-          SHOULD_RUN: ${{ eq(variables['testNetcore31'], 'True') }}
         .NET 4.7.2:
           FRAMEWORK: net472
           SHOULD_RUN: ${{ eq(variables['testNet472'], 'True') }}


### PR DESCRIPTION
.NET itself doesn't support .NET core 3.1 anymore, so we shouldn't either