### PR TITLE
Make the secondary key for symmetric key attestation optional

### DIFF
--- a/provisioning/device/src/Authentication/AuthenticationProviderSymmetricKey.cs
+++ b/provisioning/device/src/Authentication/AuthenticationProviderSymmetricKey.cs
@@ -18,13 +18,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// <param name="registrationId">The Provisioning service Registration Id for this device.</param>
         /// <param name="primaryKey">The primary key for this device.</param>
         /// <param name="secondaryKey">The secondary key for this device.</param>
-        /// <exception cref="ArgumentException">Thrown when the required parameter is an empty string or consists only of white-space characters.</exception>
-        /// <exception cref="ArgumentNullException">Thrown when the required parameter is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the registration id or primary key is an empty string or consists only of white-space characters.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the registration id or primary key is null.</exception>
         public AuthenticationProviderSymmetricKey(string registrationId, string primaryKey, string secondaryKey)
         {
             Argument.AssertNotNullOrWhiteSpace(registrationId, nameof(registrationId));
             Argument.AssertNotNullOrWhiteSpace(primaryKey, nameof(primaryKey));
-            Argument.AssertNotNullOrWhiteSpace(secondaryKey, nameof(secondaryKey));
 
             _registrationId = registrationId;
             PrimaryKey = primaryKey;

--- a/provisioning/device/tests/AuthenticationProviderSymmetricKeyTests.cs
+++ b/provisioning/device/tests/AuthenticationProviderSymmetricKeyTests.cs
@@ -64,25 +64,5 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.UnitTests
             // assert
             act.Should().Throw<ArgumentNullException>().WithParameterName("primaryKey");
         }
-
-        [TestMethod]
-        public void AuthenticationProviderSymmetricKey_SecondaryKey_EmptyString_Throws()
-        {
-            // arrange - act
-            Func<AuthenticationProviderSymmetricKey> act = () => _ = new AuthenticationProviderSymmetricKey(FakeRegistrationId, FakePrimaryKey, "");
-
-            // assert
-            act.Should().Throw<ArgumentException>().WithParameterName("secondaryKey");
-        }
-
-        [TestMethod]
-        public void AuthenticationProviderSymmetricKey_SecondaryKey_Null_Throws()
-        {
-            // arrange - act
-            Func<AuthenticationProviderSymmetricKey> act = () => _ = new AuthenticationProviderSymmetricKey(FakeRegistrationId, FakePrimaryKey, null);
-
-            // assert
-            act.Should().Throw<ArgumentNullException>().WithParameterName("secondaryKey");
-        }
     }
 }


### PR DESCRIPTION
The service doesn't require one so we shouldn't either

fixes #3363