### PR TITLE
Minimize flaky test impact on the E2E tests

### DIFF
--- a/e2e/test/helpers/ProvisioningServiceRetryPolicy.cs
+++ b/e2e/test/helpers/ProvisioningServiceRetryPolicy.cs
@@ -14,12 +14,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
         private const int MaxRetryCount = 5;
 
         private static readonly TimeSpan s_defaultRetryInterval = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan s_maxBackoff = TimeSpan.FromSeconds(20);
+        private static readonly TimeSpan s_deltaBackoff = TimeSpan.FromMilliseconds(200);
 
         private static readonly IRetryPolicy s_exponentialBackoffRetryStrategy = new ExponentialBackoff(
             retryCount: MaxRetryCount,
             minBackoff: s_defaultRetryInterval,
-            maxBackoff: TimeSpan.FromSeconds(10),
-            deltaBackoff: TimeSpan.FromMilliseconds(100));
+            maxBackoff: s_maxBackoff,
+            deltaBackoff: s_deltaBackoff);
 
         public bool ShouldRetry(int currentRetryCount, Exception lastException, out TimeSpan retryInterval)
         {

--- a/e2e/test/helpers/ProvisioningServiceRetryPolicy.cs
+++ b/e2e/test/helpers/ProvisioningServiceRetryPolicy.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
     public class ProvisioningServiceRetryPolicy : IRetryPolicy
     {
         private const string RetryAfterKey = "Retry-After";
-        private const int MaxRetryCount = 5;
+        private const int MaxRetryCount = 10;
 
         private static readonly TimeSpan s_defaultRetryInterval = TimeSpan.FromSeconds(5);
-        private static readonly TimeSpan s_maxBackoff = TimeSpan.FromSeconds(20);
-        private static readonly TimeSpan s_deltaBackoff = TimeSpan.FromMilliseconds(200);
+        private static readonly TimeSpan s_maxBackoff = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan s_deltaBackoff = TimeSpan.FromMilliseconds(100);
 
         private static readonly IRetryPolicy s_exponentialBackoffRetryStrategy = new ExponentialBackoff(
             retryCount: MaxRetryCount,

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
 {
     public static class FaultInjection
     {
-        public static readonly TimeSpan DefaultFaultDelay = TimeSpan.FromSeconds(2); // Time in seconds after service initiates the fault.
-        public static readonly TimeSpan DefaultFaultDuration = TimeSpan.FromSeconds(5); // Duration in seconds
+        public static readonly TimeSpan DefaultFaultDelay = TimeSpan.FromSeconds(1); // Time in seconds after service initiates the fault.
+        public static readonly TimeSpan DefaultFaultDuration = TimeSpan.FromSeconds(2); // Duration in seconds
         public static readonly TimeSpan LatencyTimeBuffer = TimeSpan.FromSeconds(10); // Buffer time waiting fault occurs or connection recover
 
         public static readonly TimeSpan WaitForDisconnectDuration = TimeSpan.FromTicks(DefaultFaultDelay.Ticks * 3);

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -19,15 +19,15 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
 {
     public static class FaultInjection
     {
-        public static readonly TimeSpan DefaultFaultDelay = TimeSpan.FromSeconds(1); // Time in seconds after service initiates the fault.
+        public static readonly TimeSpan DefaultFaultDelay = TimeSpan.FromSeconds(5); // Time in seconds after service initiates the fault.
         public static readonly TimeSpan DefaultFaultDuration = TimeSpan.FromSeconds(5); // Duration in seconds
         public static readonly TimeSpan LatencyTimeBuffer = TimeSpan.FromSeconds(10); // Buffer time waiting fault occurs or connection recover
 
         public static readonly TimeSpan WaitForDisconnectDuration = TimeSpan.FromTicks(DefaultFaultDelay.Ticks * 3);
         public static readonly TimeSpan WaitForReconnectDuration = TimeSpan.FromTicks(DefaultFaultDuration.Ticks * 2);
-        public static readonly TimeSpan ShortRetryDuration = TimeSpan.FromTicks(DefaultFaultDuration.Ticks / 2);
-
-        public static readonly TimeSpan RecoveryTime = TimeSpan.FromMinutes(5);
+        public static readonly TimeSpan ShortRetryDuration = DefaultFaultDuration;
+        public static readonly TimeSpan DefaultRecoveryTimeout = TimeSpan.FromTicks(LatencyTimeBuffer.Ticks * 2);
+        public static readonly TimeSpan RecoveryTime = TimeSpan.FromTicks(LatencyTimeBuffer.Ticks * 2);
 
         public static Client.Message ComposeErrorInjectionProperties(
             string faultType,

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -21,12 +21,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
     {
         public static readonly TimeSpan DefaultFaultDelay = TimeSpan.FromSeconds(2); // Time in seconds after service initiates the fault.
         public static readonly TimeSpan DefaultFaultDuration = TimeSpan.FromSeconds(5); // Duration in seconds
-        public static readonly TimeSpan LatencyTimeBuffer = TimeSpan.FromSeconds(10); // Buffer time waiting fault occurs or connection recover
+        public static readonly TimeSpan LatencyTimeBuffer = TimeSpan.FromSeconds(20); // Buffer time waiting fault occurs or connection recover
 
         public static readonly TimeSpan WaitForDisconnectDuration = TimeSpan.FromTicks(DefaultFaultDelay.Ticks * 3);
         public static readonly TimeSpan WaitForReconnectDuration = TimeSpan.FromTicks(DefaultFaultDuration.Ticks * 2);
         public static readonly TimeSpan ShortRetryDuration = TimeSpan.FromTicks(DefaultFaultDuration.Ticks / 2);
-        public static readonly TimeSpan RecoveryTime = TimeSpan.FromTicks(LatencyTimeBuffer.Ticks * 2);
+        public static readonly TimeSpan RecoveryTime = TimeSpan.FromSeconds(20);
 
         public static Client.Message ComposeErrorInjectionProperties(
             string faultType,
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                             break;
                         }
 
-                        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                        await Task.Delay(DefaultFaultDelay).ConfigureAwait(false);
                     }
                     connectionChangeWaitDuration.Reset();
 
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                     while (lastConnectionStatus != ConnectionStatus.Connected
                         && connectionChangeWaitDuration.Elapsed < faultDuration.Add(LatencyTimeBuffer))
                     {
-                        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                        await Task.Delay(DefaultFaultDelay).ConfigureAwait(false);
                     }
                     connectionChangeWaitDuration.Reset();
 
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                     {
                         VerboseTestLogger.WriteLine($"{nameof(FaultInjection)}: Performing test operation for device - Run {counter++}.");
                         await testOperation(deviceClient, testDevice).ConfigureAwait(false);
-                        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                        await Task.Delay(DefaultFaultDelay).ConfigureAwait(false);
                     }
                     sw.Reset();
                 }

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -19,14 +19,14 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
 {
     public static class FaultInjection
     {
-        public static readonly TimeSpan DefaultFaultDelay = TimeSpan.FromSeconds(1); // Time in seconds after service initiates the fault.
-        public static readonly TimeSpan DefaultFaultDuration = TimeSpan.FromSeconds(2); // Duration in seconds
+        public static readonly TimeSpan DefaultFaultDelay = TimeSpan.FromSeconds(2); // Time in seconds after service initiates the fault.
+        public static readonly TimeSpan DefaultFaultDuration = TimeSpan.FromSeconds(5); // Duration in seconds
         public static readonly TimeSpan LatencyTimeBuffer = TimeSpan.FromSeconds(5); // Buffer time waiting fault occurs or connection recover
 
         public static readonly TimeSpan WaitForDisconnectDuration = TimeSpan.FromTicks(DefaultFaultDelay.Ticks * 3);
         public static readonly TimeSpan WaitForReconnectDuration = TimeSpan.FromTicks(DefaultFaultDuration.Ticks * 2);
         public static readonly TimeSpan ShortRetryDuration = TimeSpan.FromTicks(DefaultFaultDuration.Ticks / 2);
-        public static readonly TimeSpan RecoveryTime = TimeSpan.FromSeconds(30);
+        public static readonly TimeSpan RecoveryTime = TimeSpan.FromSeconds(20);
 
         public static Client.Message ComposeErrorInjectionProperties(
             string faultType,

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
         public static readonly TimeSpan WaitForDisconnectDuration = TimeSpan.FromTicks(DefaultFaultDelay.Ticks * 3);
         public static readonly TimeSpan WaitForReconnectDuration = TimeSpan.FromTicks(DefaultFaultDuration.Ticks * 2);
         public static readonly TimeSpan ShortRetryDuration = DefaultFaultDuration;
-        public static readonly TimeSpan DefaultRecoveryTimeout = TimeSpan.FromTicks(LatencyTimeBuffer.Ticks * 2);
         public static readonly TimeSpan RecoveryTime = TimeSpan.FromTicks(LatencyTimeBuffer.Ticks * 2);
 
         public static Client.Message ComposeErrorInjectionProperties(

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -19,13 +19,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
 {
     public static class FaultInjection
     {
-        public static readonly TimeSpan DefaultFaultDelay = TimeSpan.FromSeconds(5); // Time in seconds after service initiates the fault.
-        public static readonly TimeSpan DefaultFaultDuration = TimeSpan.FromSeconds(5); // Duration in seconds
+        public static readonly TimeSpan DefaultFaultDelay = TimeSpan.FromSeconds(2); // Time in seconds after service initiates the fault.
+        public static readonly TimeSpan DefaultFaultDuration = TimeSpan.FromSeconds(2); // Duration in seconds
         public static readonly TimeSpan LatencyTimeBuffer = TimeSpan.FromSeconds(10); // Buffer time waiting fault occurs or connection recover
 
         public static readonly TimeSpan WaitForDisconnectDuration = TimeSpan.FromTicks(DefaultFaultDelay.Ticks * 3);
         public static readonly TimeSpan WaitForReconnectDuration = TimeSpan.FromTicks(DefaultFaultDuration.Ticks * 2);
-        public static readonly TimeSpan ShortRetryDuration = DefaultFaultDuration;
+        public static readonly TimeSpan ShortRetryDuration = TimeSpan.FromTicks(DefaultFaultDuration.Ticks / 2);
         public static readonly TimeSpan RecoveryTime = TimeSpan.FromTicks(LatencyTimeBuffer.Ticks * 2);
 
         public static Client.Message ComposeErrorInjectionProperties(

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
     {
         public static readonly TimeSpan DefaultFaultDelay = TimeSpan.FromSeconds(1); // Time in seconds after service initiates the fault.
         public static readonly TimeSpan DefaultFaultDuration = TimeSpan.FromSeconds(2); // Duration in seconds
-        public static readonly TimeSpan LatencyTimeBuffer = TimeSpan.FromSeconds(10); // Buffer time waiting fault occurs or connection recover
+        public static readonly TimeSpan LatencyTimeBuffer = TimeSpan.FromSeconds(5); // Buffer time waiting fault occurs or connection recover
 
         public static readonly TimeSpan WaitForDisconnectDuration = TimeSpan.FromTicks(DefaultFaultDelay.Ticks * 3);
         public static readonly TimeSpan WaitForReconnectDuration = TimeSpan.FromTicks(DefaultFaultDuration.Ticks * 2);

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
     public static class FaultInjection
     {
         public static readonly TimeSpan DefaultFaultDelay = TimeSpan.FromSeconds(2); // Time in seconds after service initiates the fault.
-        public static readonly TimeSpan DefaultFaultDuration = TimeSpan.FromSeconds(2); // Duration in seconds
+        public static readonly TimeSpan DefaultFaultDuration = TimeSpan.FromSeconds(5); // Duration in seconds
         public static readonly TimeSpan LatencyTimeBuffer = TimeSpan.FromSeconds(10); // Buffer time waiting fault occurs or connection recover
 
         public static readonly TimeSpan WaitForDisconnectDuration = TimeSpan.FromTicks(DefaultFaultDelay.Ticks * 3);

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
         public static readonly TimeSpan WaitForDisconnectDuration = TimeSpan.FromTicks(DefaultFaultDelay.Ticks * 3);
         public static readonly TimeSpan WaitForReconnectDuration = TimeSpan.FromTicks(DefaultFaultDuration.Ticks * 2);
         public static readonly TimeSpan ShortRetryDuration = TimeSpan.FromTicks(DefaultFaultDuration.Ticks / 2);
-        public static readonly TimeSpan RecoveryTime = TimeSpan.FromSeconds(20);
+        public static readonly TimeSpan RecoveryTime = TimeSpan.FromSeconds(30);
 
         public static Client.Message ComposeErrorInjectionProperties(
             string faultType,

--- a/e2e/test/helpers/templates/FaultInjection.cs
+++ b/e2e/test/helpers/templates/FaultInjection.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
     {
         public static readonly TimeSpan DefaultFaultDelay = TimeSpan.FromSeconds(2); // Time in seconds after service initiates the fault.
         public static readonly TimeSpan DefaultFaultDuration = TimeSpan.FromSeconds(5); // Duration in seconds
-        public static readonly TimeSpan LatencyTimeBuffer = TimeSpan.FromSeconds(20); // Buffer time waiting fault occurs or connection recover
+        public static readonly TimeSpan LatencyTimeBuffer = TimeSpan.FromSeconds(10); // Buffer time waiting fault occurs or connection recover
 
         public static readonly TimeSpan WaitForDisconnectDuration = TimeSpan.FromTicks(DefaultFaultDelay.Ticks * 3);
         public static readonly TimeSpan WaitForReconnectDuration = TimeSpan.FromTicks(DefaultFaultDuration.Ticks * 2);

--- a/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
             var testDeviceCallbackHandlers = new List<TestDeviceCallbackHandler>(devicesCount);
             var amqpConnectionStatuses = new List<AmqpConnectionStatusChange>(devicesCount);
             var operations = new List<Task>(devicesCount);
-            int faultRetryDelay = TimeSpan.FromSeconds(5);
+            TimeSpan faultRetryDelay = TimeSpan.FromSeconds(5);
 
             // Arrange
 

--- a/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
             var testDeviceCallbackHandlers = new List<TestDeviceCallbackHandler>(devicesCount);
             var amqpConnectionStatuses = new List<AmqpConnectionStatusChange>(devicesCount);
             var operations = new List<Task>(devicesCount);
-            TimeSpan faultRetryDelay = TimeSpan.FromSeconds(5);
+            TimeSpan faultRetryDelay = TimeSpan.FromSeconds(10);
 
             // Arrange
 

--- a/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
             var testDeviceCallbackHandlers = new List<TestDeviceCallbackHandler>(devicesCount);
             var amqpConnectionStatuses = new List<AmqpConnectionStatusChange>(devicesCount);
             var operations = new List<Task>(devicesCount);
-            TimeSpan faultRetryDelay = TimeSpan.FromSeconds(10);
 
             // Arrange
 
@@ -108,7 +107,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                             break;
                         }
 
-                        await Task.Delay(faultRetryDelay).ConfigureAwait(false);
+                        await Task.Delay(FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
                     }
                     connectionChangeWaitDuration.Reset();
 
@@ -128,7 +127,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                             break;
                         }
 
-                        await Task.Delay(faultRetryDelay);
+                        await Task.Delay(FaultInjection.DefaultFaultDelay);
                     }
 
                     if (!isRecovered)
@@ -165,7 +164,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                     {
                         VerboseTestLogger.WriteLine($"{nameof(FaultInjectionPoolingOverAmqp)}: Performing test operation for device 0 - Run {counter++}.");
                         await testOperation(deviceClients[0], testDevices[0], testDeviceCallbackHandlers[0]).ConfigureAwait(false);
-                        await Task.Delay(faultRetryDelay).ConfigureAwait(false);
+                        await Task.Delay(FaultInjection.DefaultFaultDelay).ConfigureAwait(false);
                     }
                 }
 

--- a/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
 {
+    private const int faultRetryDelay = TimeSpan.FromSeconds(5);
     internal static class FaultInjectionPoolingOverAmqp
     {
         public static async Task TestFaultInjectionPoolAmqpAsync(
@@ -107,7 +108,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                             break;
                         }
 
-                        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                        await Task.Delay(faultRetryDelay).ConfigureAwait(false);
                     }
                     connectionChangeWaitDuration.Reset();
 
@@ -127,7 +128,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                             break;
                         }
 
-                        await Task.Delay(TimeSpan.FromSeconds(1));
+                        await Task.Delay(faultRetryDelay);
                     }
 
                     if (!isRecovered)
@@ -164,7 +165,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
                     {
                         VerboseTestLogger.WriteLine($"{nameof(FaultInjectionPoolingOverAmqp)}: Performing test operation for device 0 - Run {counter++}.");
                         await testOperation(deviceClients[0], testDevices[0], testDeviceCallbackHandlers[0]).ConfigureAwait(false);
-                        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                        await Task.Delay(faultRetryDelay).ConfigureAwait(false);
                     }
                 }
 

--- a/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/FaultInjectionPoolingOverAmqp.cs
@@ -13,7 +13,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
 {
-    private const int faultRetryDelay = TimeSpan.FromSeconds(5);
     internal static class FaultInjectionPoolingOverAmqp
     {
         public static async Task TestFaultInjectionPoolAmqpAsync(
@@ -49,6 +48,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
             var testDeviceCallbackHandlers = new List<TestDeviceCallbackHandler>(devicesCount);
             var amqpConnectionStatuses = new List<AmqpConnectionStatusChange>(devicesCount);
             var operations = new List<Task>(devicesCount);
+            int faultRetryDelay = TimeSpan.FromSeconds(5);
 
             // Arrange
 

--- a/e2e/test/helpers/templates/PoolingOverAmqp.cs
+++ b/e2e/test/helpers/templates/PoolingOverAmqp.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers.Templates
         public const int SingleConnection_PoolSize = 1;
         public const int MultipleConnections_DevicesCount = 4;
         public const int MultipleConnections_PoolSize = 2;
-        public const int MaxTestRunCount = 5;
-        public const int TestSuccessRate = 80; // 4 out of 5 (80%) test runs should pass (even after accounting for network instability issues).
+        public const int MaxTestRunCount = 8;
+        public const int TestSuccessRate = 75; // % of test runs should pass (even after accounting for network instability issues).
 
         public static async Task TestPoolAmqpAsync(
             string devicePrefix,

--- a/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
@@ -182,6 +182,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             Shared.Twin twin = await moduleClient.GetTwinAsync().ConfigureAwait(false);
             Assert.IsNotNull(twin);
 
+            await Task.Delay(2000).ConfigureAwait(false);
             // Delete/disable the device in IoT hub.
             using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IotHub.ConnectionString);
             await registryManagerOperation(registryManager, testModule.DeviceId).ConfigureAwait(false);
@@ -189,10 +190,10 @@ namespace Microsoft.Azure.Devices.E2ETests
             VerboseTestLogger.WriteLine($"{nameof(ModuleClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Completed RegistryManager operation.");
 
             // Artificial sleep waiting for the connection status change handler to get triggered.
-            int sleepCount = 50;
+            int sleepCount = 500;
             for (int i = 0; i < sleepCount; i++)
             {
-                await Task.Delay(100).ConfigureAwait(false);
+                await Task.Delay(50).ConfigureAwait(false);
                 if (deviceDisabledReceivedCount == 1)
                 {
                     break;

--- a/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(ConnectionStateChangeTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
+        [DoNotParallelize]
         public async Task DeviceClient_DeviceDeleted_Gives_ConnectionStatus_DeviceDisabled_AmqpTcp()
         {
             await DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base(
@@ -33,6 +34,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestCategory("LongRunning")]
         [TestMethod]
         [Timeout(ConnectionStateChangeTestTimeoutMilliseconds)]
+        [DoNotParallelize]
         public async Task DeviceClient_DeviceDeleted_Gives_ConnectionStatus_DeviceDisabled_AmqpWs()
         {
             await DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base(
@@ -44,6 +46,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(ConnectionStateChangeTestTimeoutMilliseconds)] // This test always takes more than 5 minutes for service to return. Needs investigation.
         [TestCategory("LongRunning")]
+        [DoNotParallelize]
         public async Task DeviceClient_DeviceDisabled_Gives_ConnectionStatus_DeviceDisabled_AmqpTcp()
         {
             await DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base(
@@ -60,6 +63,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(ConnectionStateChangeTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
+        [DoNotParallelize]
         public async Task DeviceClient_DeviceDisabled_Gives_ConnectionStatus_DeviceDisabled_AmqpWs()
         {
             await DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base(
@@ -76,6 +80,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(ConnectionStateChangeTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
+        [DoNotParallelize]
         public async Task ModuleClient_DeviceDeleted_Gives_ConnectionStatus_DeviceDisabled_AmqpTcp()
         {
             await ModuleClient_Gives_ConnectionStatus_DeviceDisabled_Base(
@@ -87,6 +92,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(ConnectionStateChangeTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
+        [DoNotParallelize]
         public async Task ModuleClient_DeviceDeleted_Gives_ConnectionStatus_DeviceDisabled_AmqpWs()
         {
             await ModuleClient_Gives_ConnectionStatus_DeviceDisabled_Base(

--- a/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(ConnectionStateChangeTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
-        [DoNotParallelize]
         public async Task DeviceClient_DeviceDeleted_Gives_ConnectionStatus_DeviceDisabled_AmqpTcp()
         {
             await DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base(
@@ -34,7 +33,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestCategory("LongRunning")]
         [TestMethod]
         [Timeout(ConnectionStateChangeTestTimeoutMilliseconds)]
-        [DoNotParallelize]
         public async Task DeviceClient_DeviceDeleted_Gives_ConnectionStatus_DeviceDisabled_AmqpWs()
         {
             await DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base(
@@ -46,7 +44,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(ConnectionStateChangeTestTimeoutMilliseconds)] // This test always takes more than 5 minutes for service to return. Needs investigation.
         [TestCategory("LongRunning")]
-        [DoNotParallelize]
         public async Task DeviceClient_DeviceDisabled_Gives_ConnectionStatus_DeviceDisabled_AmqpTcp()
         {
             await DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base(
@@ -63,7 +60,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(ConnectionStateChangeTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
-        [DoNotParallelize]
         public async Task DeviceClient_DeviceDisabled_Gives_ConnectionStatus_DeviceDisabled_AmqpWs()
         {
             await DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base(
@@ -80,7 +76,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(ConnectionStateChangeTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
-        [DoNotParallelize]
         public async Task ModuleClient_DeviceDeleted_Gives_ConnectionStatus_DeviceDisabled_AmqpTcp()
         {
             await ModuleClient_Gives_ConnectionStatus_DeviceDisabled_Base(
@@ -92,7 +87,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(ConnectionStateChangeTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
-        [DoNotParallelize]
         public async Task ModuleClient_DeviceDeleted_Gives_ConnectionStatus_DeviceDisabled_AmqpWs()
         {
             await ModuleClient_Gives_ConnectionStatus_DeviceDisabled_Base(

--- a/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
+++ b/e2e/test/iothub/ConnectionStatusChangeHandlerTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             while (deviceDisabledReceivedCount <= 0)
             {
                 VerboseTestLogger.WriteLine($"{nameof(DeviceClient_Gives_ConnectionStatus_DeviceDisabled_Base)}: Still waiting for connection update {sw.Elapsed} after device status was changed.");
-                await Task.Delay(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+                await Task.Delay(100).ConfigureAwait(false);
             }
 
             deviceDisabledReceivedCount.Should().Be(1);
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.Devices.E2ETests
             int sleepCount = 50;
             for (int i = 0; i < sleepCount; i++)
             {
-                await Task.Delay(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+                await Task.Delay(100).ConfigureAwait(false);
                 if (deviceDisabledReceivedCount == 1)
                 {
                     break;

--- a/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
+++ b/e2e/test/iothub/DeviceTokenRefreshE2ETests.cs
@@ -70,8 +70,10 @@ namespace Microsoft.Azure.Devices.E2ETests
             await DeviceClient_TokenIsRefreshed_Internal(Client.TransportType.Amqp).ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [Timeout(TokenRefreshTestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
         [TestCategory("LongRunning")]
         public async Task DeviceClient_TokenIsRefreshed_Ok_Mqtt()
         {

--- a/e2e/test/iothub/messaging/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
+++ b/e2e/test/iothub/messaging/AzureSecurityCenterForIoTSecurityMessageE2ETests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
     [TestCategory("E2E")]
     [TestCategory("IoTHub")]
     [TestCategory("LongRunning")]
+    [DoNotParallelize]
     public class AzureSecurityCenterForIoTSecurityMessageE2ETests : E2EMsTestBase
     {
         private readonly string _devicePrefix = $"{nameof(AzureSecurityCenterForIoTSecurityMessageE2ETests)}_";

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.E2ETests
     public partial class FaultInjectionPoolAmqpTests
     {
         private const string MessageSend_DevicePrefix = "MessageSendFaultInjectionPoolAmqpTests";
-        private static readonly TimeSpan s_faultInjectionTestTimeout = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan s_faultInjectionTestTimeout = TimeSpan.FromSeconds(60);
 
 
         // TODO: #943 - Honor different pool sizes for different connection pool settings.

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -445,6 +445,8 @@ namespace Microsoft.Azure.Devices.E2ETests
         // Test device client recovery when proxy settings are enabled
         [TestCategory("Proxy")]
         [TestMethod]
+        [TestCategory("Flaky")]
+        [DoNotParallelize]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         public async Task Message_TcpConnectionLossSendRecovery_MultipleConnections_AmqpWs_WithProxy()
         {

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -235,6 +235,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
         public async Task Message_TcpConnectionLossSendRecovery_MultipleConnections_Amqp()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -261,6 +262,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
         public async Task Message_AmqpConnectionLossSendRecovery_MultipleConnections_Amqp()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -274,6 +276,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
         public async Task Message_AmqpConnectionLossSendRecovery_MultipleConnections_AmqpWs()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -288,6 +291,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
         public async Task Message_AmqpSessionLossSendRecovery_MultipleConnections_Amqp()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -316,6 +320,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
         public async Task Message_AmqpD2cLinkDropSendRecovery_MultipleConnections_Amqp()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -236,6 +236,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
+        [DoNotParallelize]
         public async Task Message_TcpConnectionLossSendRecovery_MultipleConnections_Amqp()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -250,6 +251,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
+        [DoNotParallelize]
         public async Task Message_TcpConnectionLossSendRecovery_MultipleConnections_AmqpWs()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -264,6 +266,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
+        [DoNotParallelize]
         public async Task Message_AmqpConnectionLossSendRecovery_MultipleConnections_Amqp()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -278,6 +281,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
+        [DoNotParallelize]
         public async Task Message_AmqpConnectionLossSendRecovery_MultipleConnections_AmqpWs()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -293,6 +297,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
+        [DoNotParallelize]
         public async Task Message_AmqpSessionLossSendRecovery_MultipleConnections_Amqp()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -308,6 +313,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
+        [DoNotParallelize]
         public async Task Message_AmqpSessionLossSendRecovery_MultipleConnections_AmqpWs()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -323,6 +329,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
+        [DoNotParallelize]
         public async Task Message_AmqpD2cLinkDropSendRecovery_MultipleConnections_Amqp()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -338,6 +345,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
+        [DoNotParallelize]
         public async Task Message_AmqpD2cLinkDropSendRecovery_MultipleConnections_AmqpWs()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -353,6 +361,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
         [TestCategory("Flaky")]
+        [DoNotParallelize]
         public async Task Message_GracefulShutdownSendRecovery_MultipleConnections_Amqp()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -367,6 +376,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
+        [DoNotParallelize]
         public async Task Message_GracefulShutdownSendRecovery_MultipleConnections_AmqpWs()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Azure.Devices.E2ETests
     public partial class FaultInjectionPoolAmqpTests
     {
         private const string MessageSend_DevicePrefix = "MessageSendFaultInjectionPoolAmqpTests";
+        private static readonly TimeSpan s_faultInjectionTestTimeout = TimeSpan.FromSeconds(30);
+
 
         // TODO: #943 - Honor different pool sizes for different connection pool settings.
         [Ignore]
@@ -233,7 +235,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -249,7 +250,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -265,7 +265,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -281,7 +280,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -298,7 +296,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -315,7 +312,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -332,7 +328,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -349,7 +344,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -365,7 +359,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
@@ -382,7 +375,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -398,7 +390,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         public async Task Message_ThrottledConnectionRecovery_MultipleConnections_Amqp()
@@ -412,7 +403,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         public async Task Message_ThrottledConnectionRecovery_MultipleConnections_AmqpWs()
@@ -426,7 +416,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [ExpectedException(typeof(UnauthorizedException))]
@@ -441,7 +430,6 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
-        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [ExpectedException(typeof(UnauthorizedException))]
@@ -457,7 +445,6 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         // Test device client recovery when proxy settings are enabled
-        [Ignore]
         [TestCategory("Proxy")]
         [TestMethod]
         [TestCategory("Flaky")]
@@ -485,7 +472,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         {
             async Task TestInitAsync(DeviceClient deviceClient, TestDevice testDevice, TestDeviceCallbackHandler callbackHandler)
             {
-                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+                using var cts = new CancellationTokenSource(s_faultInjectionTestTimeout);
                 await deviceClient.OpenAsync(cts.Token).ConfigureAwait(false);
             }
 
@@ -494,7 +481,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 using Client.Message testMessage = MessageSendE2ETests.ComposeD2cTestMessage(out string payload, out string p1Value);
 
                 VerboseTestLogger.WriteLine($"{nameof(FaultInjectionPoolAmqpTests)}.{testDevice.Id}: payload='{payload}' p1Value='{p1Value}'");
-                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+                using var cts = new CancellationTokenSource(s_faultInjectionTestTimeout);
                 await deviceClient.SendEventAsync(testMessage, cts.Token).ConfigureAwait(false);
             }
 

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -249,6 +249,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
         public async Task Message_TcpConnectionLossSendRecovery_MultipleConnections_AmqpWs()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -306,6 +307,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
         public async Task Message_AmqpSessionLossSendRecovery_MultipleConnections_AmqpWs()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -335,6 +337,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
         public async Task Message_AmqpD2cLinkDropSendRecovery_MultipleConnections_AmqpWs()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -349,6 +352,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
+        [TestCategory("Flaky")]
         public async Task Message_GracefulShutdownSendRecovery_MultipleConnections_Amqp()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(
@@ -362,6 +366,7 @@ namespace Microsoft.Azure.Devices.E2ETests
 
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
         public async Task Message_GracefulShutdownSendRecovery_MultipleConnections_AmqpWs()
         {
             await SendMessageRecoveryPoolOverAmqpAsync(

--- a/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
+++ b/e2e/test/iothub/messaging/FaultInjectionPoolAmqpTests.MessageSendFaultInjectionPoolAmqpTests.cs
@@ -233,6 +233,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -248,6 +249,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -263,6 +265,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -278,6 +281,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -294,6 +298,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -310,6 +315,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -326,6 +332,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -342,6 +349,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         // TODO: #950 - Link/session faults for message send/ method/ twin operations closes the connection.
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -357,6 +365,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
@@ -373,6 +382,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
@@ -388,6 +398,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         public async Task Message_ThrottledConnectionRecovery_MultipleConnections_Amqp()
@@ -401,6 +412,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         public async Task Message_ThrottledConnectionRecovery_MultipleConnections_AmqpWs()
@@ -414,6 +426,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [ExpectedException(typeof(UnauthorizedException))]
@@ -428,6 +441,7 @@ namespace Microsoft.Azure.Devices.E2ETests
                 .ConfigureAwait(false);
         }
 
+        [Ignore]
         [TestMethod]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [ExpectedException(typeof(UnauthorizedException))]
@@ -443,6 +457,7 @@ namespace Microsoft.Azure.Devices.E2ETests
         }
 
         // Test device client recovery when proxy settings are enabled
+        [Ignore]
         [TestCategory("Proxy")]
         [TestMethod]
         [TestCategory("Flaky")]

--- a/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageReceiveE2ETests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
     [TestCategory("E2E")]
     [TestCategory("IoTHub")]
     [TestCategory("LongRunning")]
+    [DoNotParallelize]
     public partial class MessageReceiveE2ETests : E2EMsTestBase
     {
         private static readonly string s_devicePrefix = $"{nameof(MessageReceiveE2ETests)}_";

--- a/e2e/test/iothub/messaging/MessageSendE2ETests.cs
+++ b/e2e/test/iothub/messaging/MessageSendE2ETests.cs
@@ -317,7 +317,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [DataRow(TestDeviceType.X509, Client.TransportType.Mqtt_WebSocket_Only, LargeMessageSizeInBytes)]
         [DataRow(TestDeviceType.X509, Client.TransportType.Amqp_Tcp_Only, LargeMessageSizeInBytes)]
         [DataRow(TestDeviceType.X509, Client.TransportType.Amqp_WebSocket_Only, LargeMessageSizeInBytes)]
-        [DataRow(TestDeviceType.X509, Client.TransportType.Http1, LargeMessageSizeInBytes)]
+        // Ignore - network error and win32 exception
+        //[DataRow(TestDeviceType.X509, Client.TransportType.Http1, LargeMessageSizeInBytes)]
         public async Task Message_DeviceSendSingleLargeMessageAsync(TestDeviceType testDeviceType, Client.TransportType transportType, int messageSize)
         {
             await SendSingleMessage(testDeviceType, transportType, messageSize).ConfigureAwait(false);

--- a/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
@@ -173,6 +173,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
         [TestCategory("Flaky")]
+        [DoNotParallelize]
         public async Task Message_ThrottledConnectionRecovery_AmqpWs()
         {
             await SendMessageRecoveryAsync(
@@ -184,6 +185,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
         [DoNotParallelize]
         public async Task Message_ThrottledConnectionLongTimeNoRecovery_Amqp()
         {
@@ -208,6 +210,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
         [DoNotParallelize]
         public async Task Message_ThrottledConnectionLongTimeNoRecovery_AmqpWs()
         {
@@ -231,6 +234,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
+        [DoNotParallelize]
         public async Task Message_ThrottledConnectionLongTimeNoRecovery_Http()
         {
             try

--- a/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
@@ -397,6 +397,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
             TimeSpan operationTimeout = retryDuration == TimeSpan.Zero
                 ? FaultInjection.RecoveryTime
                 : retryDuration;
+            
+            TimeSpan DefaultRecoveryTimeout = TimeSpan.FromSeconds(20);
 
             async Task InitAsync(DeviceClient deviceClient, TestDevice testDevice)
             {

--- a/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
@@ -404,7 +404,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 // But it could probably just as easily be done with cancellation tokens.
                 deviceClient.OperationTimeoutInMilliseconds = (uint)operationTimeout.TotalMilliseconds;
 
-                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+                using var cts = new CancellationTokenSource(DefaultRecoveryTimeout);
                 await deviceClient.OpenAsync(cts.Token).ConfigureAwait(false);
                 deviceClient.OperationTimeoutInMilliseconds = (uint)retryDuration.TotalMilliseconds;
             }

--- a/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
+++ b/e2e/test/iothub/messaging/MessageSendFaultInjectionTests.cs
@@ -398,15 +398,13 @@ namespace Microsoft.Azure.Devices.E2ETests.Messaging
                 ? FaultInjection.RecoveryTime
                 : retryDuration;
             
-            TimeSpan DefaultRecoveryTimeout = TimeSpan.FromSeconds(20);
-
             async Task InitAsync(DeviceClient deviceClient, TestDevice testDevice)
             {
                 // Some tests rely on the operation timing out before fault injection ends, so this is important to set.
                 // But it could probably just as easily be done with cancellation tokens.
                 deviceClient.OperationTimeoutInMilliseconds = (uint)operationTimeout.TotalMilliseconds;
 
-                using var cts = new CancellationTokenSource(DefaultRecoveryTimeout);
+                using var cts = new CancellationTokenSource(FaultInjection.RecoveryTime);
                 await deviceClient.OpenAsync(cts.Token).ConfigureAwait(false);
                 deviceClient.OperationTimeoutInMilliseconds = (uint)retryDuration.TotalMilliseconds;
             }

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -651,6 +651,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                 responseTimeout,
                 serviceClientTransportSettings);
 
+            await Task.Delay(2000).ConfigureAwait(false);
+
             await Task.WhenAll(serviceSendTask, methodReceivedTask).ConfigureAwait(false);
 
             await deviceClient.CloseAsync().ConfigureAwait(false);
@@ -662,6 +664,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             using var moduleClient = ModuleClient.CreateFromConnectionString(testModule.ConnectionString, transport);
 
             Task methodReceivedTask = await setDeviceReceiveMethod(moduleClient, MethodName).ConfigureAwait(false);
+
+            await Task.Delay(2000).ConfigureAwait(false);
 
             await Task
                 .WhenAll(

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
     [TestClass]
     [TestCategory("E2E")]
     [TestCategory("IoTHub")]
+    [DoNotParallelize]
     public class MethodE2ETests : E2EMsTestBase
     {
         public const string DeviceResponseJson = "{\"name\":\"e2e_test\"}";

--- a/e2e/test/iothub/method/MethodFaultInjectionTests.cs
+++ b/e2e/test/iothub/method/MethodFaultInjectionTests.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                 {
                     exceptionDispatchInfo = ExceptionDispatchInfo.Capture(ex);
                     VerboseTestLogger.WriteLine($"{nameof(ServiceSendMethodAndVerifyResponseAsync)}: [Tried {attempt} time(s)] ServiceClient exception caught: {ex}.");
-                    await Task.Delay(1000).ConfigureAwait(false);
+                    await Task.Delay(5000).ConfigureAwait(false);
                 }
             }
 

--- a/e2e/test/iothub/service/IoTHubServiceProxyE2ETests.cs
+++ b/e2e/test/iothub/service/IoTHubServiceProxyE2ETests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
     [TestCategory("E2E")]
     [TestCategory("IoTHub")]
     [TestCategory("Proxy")]
+    [DoNotParallelize]
     public class IoTHubServiceProxyE2ETests : E2EMsTestBase
     {
         private readonly string DevicePrefix = $"{nameof(IoTHubServiceProxyE2ETests)}_";
@@ -25,7 +26,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         private static string s_connectionString = TestConfiguration.IotHub.ConnectionString;
         private static string s_proxyServerAddress = TestConfiguration.IotHub.ProxyServerAddress;
         private const int MaxIterationWait = 30;
-        private static readonly TimeSpan _waitDuration = TimeSpan.FromSeconds(5);
+        private const int jobRetryTimeInMinutes = 3;
+        private static readonly TimeSpan _waitDuration = TimeSpan.FromSeconds(10);
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
@@ -51,6 +53,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
         [TestMethod]
         [TestCategory("LongRunning")]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
+        [TestCategory("Flaky")]
         public async Task JobClient_ScheduleAndRunTwinJob_WithProxy()
         {
             var httpTransportSettings = new HttpTransportSettings
@@ -103,7 +106,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                     string jobId = "JOBSAMPLE" + Guid.NewGuid().ToString();
                     string query = $"DeviceId IN ['{JobDeviceId}']";
                     JobResponse createJobResponse = await jobClient
-                        .ScheduleTwinUpdateAsync(jobId, query, twin, DateTime.UtcNow, (long)TimeSpan.FromMinutes(2).TotalSeconds)
+                        .ScheduleTwinUpdateAsync(jobId, query, twin, DateTime.UtcNow, (long)TimeSpan.FromMinutes(jobRetryTimeInMinutes).TotalSeconds)
                         .ConfigureAwait(false);
                     break;
                 }

--- a/e2e/test/iothub/service/PnpServiceTests.cs
+++ b/e2e/test/iothub/service/PnpServiceTests.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
     [TestCategory("E2E")]
     [TestCategory("IoTHub")]
     [TestCategory("PlugAndPlay")]
+    [DoNotParallelize]
+
     public class PnpServiceTests : E2EMsTestBase
     {
         private const string DevicePrefix = "plugAndPlayDevice";

--- a/e2e/test/iothub/service/RegistryManagerE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryManagerE2ETests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
     [TestClass]
     [TestCategory("E2E")]
     [TestCategory("IoTHub")]
+    [DoNotParallelize]
     public class RegistryManagerE2ETests : E2EMsTestBase
     {
         private readonly string _idPrefix = $"E2E_{nameof(RegistryManagerE2ETests)}_";

--- a/e2e/test/iothub/service/RegistryManagerE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryManagerE2ETests.cs
@@ -454,6 +454,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             Device device = null;
             using var client = RegistryManager.CreateFromConnectionString(TestConfiguration.IotHub.ConnectionString);
 
+            await Task.Delay(2000).ConfigureAwait(false);
+
             try
             {
                 // Create a device to house the modules
@@ -467,7 +469,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 }
 
                 // Give the hub a moment
-                await Task.Delay(500).ConfigureAwait(false);
+                await Task.Delay(2000).ConfigureAwait(false);
 
                 // List the modules on the test device
                 IEnumerable<Module> modulesOnDevice = await client.GetModulesOnDeviceAsync(testDeviceId).ConfigureAwait(false);
@@ -504,6 +506,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             // Create a device to house the module
             Device device = await regClient.AddDeviceAsync(new Device(testDeviceId)).ConfigureAwait(false);
 
+            await Task.Delay(2000).ConfigureAwait(false);
+
             try
             {
                 // Create a module on the device
@@ -513,6 +517,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
                 createdModule.DeviceId.Should().Be(testDeviceId);
                 createdModule.Id.Should().Be(testModuleId);
+
+                await Task.Delay(2000).ConfigureAwait(false);
 
                 // Get device
                 // Get the device and compare ETag values (should remain unchanged)
@@ -548,6 +554,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             using var client = RegistryManager.CreateFromConnectionString(TestConfiguration.IotHub.ConnectionString);
             TestModule module = await TestModule.GetTestModuleAsync(_idPrefix, _idPrefix).ConfigureAwait(false);
 
+            await Task.Delay(2000).ConfigureAwait(false);
+
             try
             {
                 // Get the module twin
@@ -559,6 +567,8 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 string propName = "username";
                 string propValue = "userA";
                 moduleTwin.Properties.Desired[propName] = propValue;
+
+                await Task.Delay(2000).ConfigureAwait(false);
 
                 Twin updatedModuleTwin = await client.UpdateTwinAsync(module.DeviceId, module.Id, moduleTwin, moduleTwin.ETag).ConfigureAwait(false);
 
@@ -584,6 +594,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             // cleanup
             try
             {
+                await Task.Delay(2000).ConfigureAwait(false);
                 await client.RemoveDeviceAsync(deviceId).ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/e2e/test/iothub/service/RegistryManagerE2ETests.cs
+++ b/e2e/test/iothub/service/RegistryManagerE2ETests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 do
                 {
                     // allow some time for the device registry to update the cache
-                    await Task.Delay(50).ConfigureAwait(false);
+                    await Task.Delay(1000).ConfigureAwait(false);
                     actual = await registryManager.GetDeviceAsync(deviceId).ConfigureAwait(false);
                 } while (actual == null);
 
@@ -467,7 +467,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                 }
 
                 // Give the hub a moment
-                await Task.Delay(250).ConfigureAwait(false);
+                await Task.Delay(500).ConfigureAwait(false);
 
                 // List the modules on the test device
                 IEnumerable<Module> modulesOnDevice = await client.GetModulesOnDeviceAsync(testDeviceId).ConfigureAwait(false);

--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
     [TestClass]
     [TestCategory("E2E")]
     [TestCategory("IoTHub")]
+    [DoNotParallelize]
     public class TwinE2ETests : E2EMsTestBase
     {
         private readonly string _devicePrefix = $"{nameof(TwinE2ETests)}_";

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
     {
         private const int PassingTimeoutMiliseconds = 10 * 60 * 1000;
         private const int FailingTimeoutMiliseconds = 10 * 1000;
-        private const int MaxTryCount = 5;
+        private const int MaxTryCount = 10;
         private const int RetryDelay = 10;
         private const string InvalidIdScope = "0neFFFFFFFF";
         private const string PayloadJsonData = "{\"testKey\":\"testValue\"}";

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
     {
         private const int PassingTimeoutMiliseconds = 10 * 60 * 1000;
         private const int FailingTimeoutMiliseconds = 10 * 1000;
-        private const int MaxTryCount = 10;
+        private const int MaxTryCount = 5;
+        private const int RetryDelay = TimeSpan.FromSeconds(10);
         private const string InvalidIdScope = "0neFFFFFFFF";
         private const string PayloadJsonData = "{\"testKey\":\"testValue\"}";
         private const string InvalidGlobalAddress = "httpbin.org";
@@ -719,7 +720,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     catch (ProvisioningTransportException ex) when (++tryCount < MaxTryCount)
                     {
                         VerboseTestLogger.WriteLine($"ProvisioningDeviceClient RegisterAsync failed because: {ex.Message}");
-                        await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+                        await Task.Delay(RetryDelay).ConfigureAwait(false);
                     }
                 }
 

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         private const int PassingTimeoutMiliseconds = 10 * 60 * 1000;
         private const int FailingTimeoutMiliseconds = 10 * 1000;
         private const int MaxTryCount = 5;
-        private const int RetryDelay = TimeSpan.FromSeconds(10);
+        private const TimeSpan RetryDelay = TimeSpan.FromSeconds(10);
         private const string InvalidIdScope = "0neFFFFFFFF";
         private const string PayloadJsonData = "{\"testKey\":\"testValue\"}";
         private const string InvalidGlobalAddress = "httpbin.org";

--- a/e2e/test/provisioning/ProvisioningE2ETests.cs
+++ b/e2e/test/provisioning/ProvisioningE2ETests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
         private const int PassingTimeoutMiliseconds = 10 * 60 * 1000;
         private const int FailingTimeoutMiliseconds = 10 * 1000;
         private const int MaxTryCount = 5;
-        private const TimeSpan RetryDelay = TimeSpan.FromSeconds(10);
+        private const int RetryDelay = 10;
         private const string InvalidIdScope = "0neFFFFFFFF";
         private const string PayloadJsonData = "{\"testKey\":\"testValue\"}";
         private const string InvalidGlobalAddress = "httpbin.org";
@@ -720,7 +720,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Provisioning
                     catch (ProvisioningTransportException ex) when (++tryCount < MaxTryCount)
                     {
                         VerboseTestLogger.WriteLine($"ProvisioningDeviceClient RegisterAsync failed because: {ex.Message}");
-                        await Task.Delay(RetryDelay).ConfigureAwait(false);
+                        await Task.Delay(TimeSpan.FromSeconds(RetryDelay)).ConfigureAwait(false);
                     }
                 }
 

--- a/iothub/device/tests/Authentication/AuthenticationWithTokenRefreshTests.cs
+++ b/iothub/device/tests/Authentication/AuthenticationWithTokenRefreshTests.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             {
                 _callCount++;
 
-                await Task.Delay(10).ConfigureAwait(false);
+                await Task.Delay(100).ConfigureAwait(false);
 
                 int ttl = suggestedTimeToLive;
                 if (ActualTimeToLive > 0)

--- a/iothub/device/tests/Authentication/DeviceAuthenticationWithTokenRefreshTests.cs
+++ b/iothub/device/tests/Authentication/DeviceAuthenticationWithTokenRefreshTests.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.Devices.Client.Test
             {
                 _callCount++;
 
-                await Task.Delay(10).ConfigureAwait(false);
+                await Task.Delay(100).ConfigureAwait(false);
 
                 int ttl = suggestedTimeToLive;
                 if (ActualTimeToLive > 0)


### PR DESCRIPTION
Added flaky/ignore labels to tests that has random timeout and network failure.
Added do not parallelize labels to reduce testing interference.