### PR TITLE
Remove "key" and "value" keys from returned json

### DIFF
--- a/iothub/device/src/Twin/DesiredProperties.cs
+++ b/iothub/device/src/Twin/DesiredProperties.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Client
         /// This class can be inherited from and set by unit tests for mocking purposes.
         /// </remarks>
         protected internal DesiredProperties(Dictionary<string, object> desiredProperties)
-            : base(desiredProperties, true)
+            : base(desiredProperties, false)
         {
         }
     }

--- a/iothub/device/src/Twin/TwinProperties.cs
+++ b/iothub/device/src/Twin/TwinProperties.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Devices.Client
@@ -41,7 +42,13 @@ namespace Microsoft.Azure.Devices.Client
         /// <returns>JSON string</returns>
         public string ToJson(Formatting formatting = Formatting.None)
         {
-            return JsonConvert.SerializeObject(this, formatting);
+            var twin = new Dictionary<string, string>
+            {
+                { "desired", Desired.GetSerializedString() },
+                { "reported", Reported.GetSerializedString() }
+            };
+
+            return JsonConvert.SerializeObject(twin);
         }
     }
 }

--- a/iothub/device/src/Twin/TwinProperties.cs
+++ b/iothub/device/src/Twin/TwinProperties.cs
@@ -40,13 +40,13 @@ namespace Microsoft.Azure.Devices.Client
         /// <returns>JSON string</returns>
         public string ToJson(Formatting formatting = Formatting.None)
         {
-            var properties = new Dictionary<string, string>
+            var properties = new Dictionary<string, object>
             {
-                { "desired", Desired.GetSerializedString() },
-                { "reported", Reported.GetSerializedString() }
+                { "desired", JsonConvert.DeserializeObject(Desired.GetSerializedString()) },
+                { "reported", JsonConvert.DeserializeObject(Reported.GetSerializedString()) }
             };
 
-            var formattedTwinProperties = new Dictionary<string, Dictionary<string, string>>
+            var formattedTwinProperties = new Dictionary<string, Dictionary<string, object>>
             {
                 { "properties", properties },
             };

--- a/iothub/device/src/Twin/TwinProperties.cs
+++ b/iothub/device/src/Twin/TwinProperties.cs
@@ -26,13 +26,11 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// The collection of desired property update requests received from service.
         /// </summary>
-        [JsonProperty("desired")]
         public DesiredProperties Desired { get; }
 
         /// <summary>
         /// The collection of twin properties reported by the client.
         /// </summary>
-        [JsonProperty("reported")]
         public ReportedProperties Reported { get; }
 
         /// <summary>
@@ -42,13 +40,18 @@ namespace Microsoft.Azure.Devices.Client
         /// <returns>JSON string</returns>
         public string ToJson(Formatting formatting = Formatting.None)
         {
-            var twin = new Dictionary<string, string>
+            var properties = new Dictionary<string, string>
             {
                 { "desired", Desired.GetSerializedString() },
                 { "reported", Reported.GetSerializedString() }
             };
 
-            return JsonConvert.SerializeObject(twin);
+            var formattedTwinProperties = new Dictionary<string, Dictionary<string, string>>
+            {
+                { "properties", properties },
+            };
+
+            return JsonConvert.SerializeObject(formattedTwinProperties);
         }
     }
 }

--- a/iothub/device/tests/TwinPropertiesTests.cs
+++ b/iothub/device/tests/TwinPropertiesTests.cs
@@ -20,13 +20,20 @@ namespace Microsoft.Azure.Devices.Client.Tests
         public void TwinProperties_SerializesCorrectly()
         {
             // arrange
-            var twinProperties = new TwinProperties(null, new ReportedProperties());
+            var properties = new Dictionary<string, object>
+            {
+                { "$version", "1" }
+            };
+
+            var desired = new DesiredProperties(properties);
+            var reported = new ReportedProperties(properties, false);
+            var twinProperties = new TwinProperties(desired, reported);
 
             // act
             string jsonTwinProperties = twinProperties.ToJson();
-            
+
             // assert
-            jsonTwinProperties.Should().BeEquivalentTo(JsonConvert.SerializeObject(twinProperties));
+            jsonTwinProperties.Should().BeEquivalentTo("{\"properties\":{\"desired\":\"{\\\"$version\\\":\\\"1\\\"}\",\"reported\":\"{\\\"$version\\\":\\\"1\\\"}\"}}");
         }
     }
 }

--- a/iothub/device/tests/TwinPropertiesTests.cs
+++ b/iothub/device/tests/TwinPropertiesTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
             // arrange
             var properties = new Dictionary<string, object>
             {
-                { "$version", "1" }
+                { "$version", 1 }
             };
 
             var desired = new DesiredProperties(properties);
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.Client.Tests
             string jsonTwinProperties = twinProperties.ToJson();
 
             // assert
-            jsonTwinProperties.Should().BeEquivalentTo("{\"properties\":{\"desired\":\"{\\\"$version\\\":\\\"1\\\"}\",\"reported\":\"{\\\"$version\\\":\\\"1\\\"}\"}}");
+            jsonTwinProperties.Should().BeEquivalentTo("{\"properties\":{\"desired\":{\"$version\":1},\"reported\":{\"$version\":1}}}");
         }
     }
 }


### PR DESCRIPTION
`TwinProperties.ToJson()` will now return something like this:
```json
{
  "properties" : {
      "desired" : {
           "myProp" : "myValue",
           "$version" : 3
      },
     "reported" : {
            "myProp" : "myValue",
           "$version" : 4
     }
   }
}
```