### PR TITLE
Use local Newtonsoft settings when serializing/deserializing instead of assigning global settings

### DIFF
--- a/common/src/HttpMessageHelper.cs
+++ b/common/src/HttpMessageHelper.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Shared
 #if NET451
             requestMessage.Content = new ObjectContent<T>(entity, s_jsonFormatter);
 #else
-            string str = JsonConvert.SerializeObject(entity);
+            string str = JsonConvert.SerializeObject(entity, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
             requestMessage.Content = new StringContent(str, Encoding.UTF8, ApplicationJson);
 #endif
         }

--- a/common/src/service/ExceptionHandlingHelper.cs
+++ b/common/src/service/ExceptionHandlingHelper.cs
@@ -121,14 +121,14 @@ namespace Microsoft.Azure.Devices
             int errorCodeValue = (int)ErrorCode.InvalidErrorCode;
             try
             {
-                IoTHubExceptionResult responseContent = JsonConvert.DeserializeObject<IoTHubExceptionResult>(responseContentStr);
+                IoTHubExceptionResult responseContent = JsonConvert.DeserializeObject<IoTHubExceptionResult>(responseContentStr, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
 
                 try
                 {
                     var messageFields = new Dictionary<string, string>();
                     if (responseContent?.Message != null)
                     {
-                        messageFields = JsonConvert.DeserializeObject<Dictionary<string, string>>(responseContent.Message);
+                        messageFields = JsonConvert.DeserializeObject<Dictionary<string, string>>(responseContent.Message, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                     }
 
                     if (messageFields != null

--- a/common/src/service/HttpClientHelper.cs
+++ b/common/src/service/HttpClientHelper.cs
@@ -49,9 +49,6 @@ namespace Microsoft.Azure.Devices
             _defaultErrorMapping = defaultErrorMapping;
             _defaultOperationTimeout = timeout;
 
-            // Specify the JsonSerializerSettings. Check JsonSerializerSettingsInitializer for more details.
-            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetJsonSerializerSettingsDelegate();
-
             // We need two types of HttpClients, one with our default operation timeout, and one without. The one without will rely on
             // a cancellation token.
 
@@ -312,7 +309,7 @@ namespace Microsoft.Azure.Devices
             }
 
             string str = await message.Content.ReadHttpContentAsStringAsync(token).ConfigureAwait(false);
-            T entity = JsonConvert.DeserializeObject<T>(str);
+            T entity = JsonConvert.DeserializeObject<T>(str, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
 
             // Etag in the header is considered authoritative
             var eTagHolder = entity as IETagHolder;
@@ -575,7 +572,7 @@ namespace Microsoft.Azure.Devices
                     }
                     else
                     {
-                        string str = JsonConvert.SerializeObject(entity);
+                        string str = JsonConvert.SerializeObject(entity, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                         requestMsg.Content = new StringContent(str, System.Text.Encoding.UTF8, ApplicationJson);
                     }
                 }

--- a/e2e/test/JsonSerializerSettingsInitializer.cs
+++ b/e2e/test/JsonSerializerSettingsInitializer.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.Devices.E2ETests
+{
+    /// <summary>
+    /// A class to initialize JsonSerializerSettings which can be applied to the project.
+    /// </summary>
+    internal static class JsonSerializerSettingsInitializer
+    {
+        /// <summary>
+        /// A static instance of JsonSerializerSettings which sets DateParseHandling to None.
+        /// </summary>
+        /// <remarks>
+        /// By default, serializing/deserializing with Newtonsoft.Json will try to parse date-formatted
+        /// strings to a date type, which drops trailing zeros in the microseconds date portion. By
+        /// specifying DateParseHandling with None, the original string will be read as-is. For more details
+        /// about the known issue, see https://github.com/JamesNK/Newtonsoft.Json/issues/1511.
+        /// </remarks>
+        private static readonly JsonSerializerSettings s_settings = new JsonSerializerSettings
+        {
+            DateParseHandling = DateParseHandling.None
+        };
+
+        /// <summary>
+        /// Returns JsonSerializerSettings Func delegate
+        /// </summary>
+        internal static JsonSerializerSettings GetJsonSerializerSettings()
+        {
+            return s_settings;
+        }
+    }
+}

--- a/e2e/test/helpers/ImportExportHelpers.cs
+++ b/e2e/test/helpers/ImportExportHelpers.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Helpers
 
             foreach (T item in items)
             {
-                itemsFileSb.AppendLine(JsonConvert.SerializeObject(item));
+                itemsFileSb.AppendLine(JsonConvert.SerializeObject(item, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()));
             }
 
             byte[] itemsFileInBytes = Encoding.Default.GetBytes(itemsFileSb.ToString());

--- a/e2e/test/iothub/method/MethodE2ETests.cs
+++ b/e2e/test/iothub/method/MethodE2ETests.cs
@@ -29,91 +29,91 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
 
         private static readonly TimeSpan s_defaultMethodTimeoutMinutes = TimeSpan.FromMinutes(2);
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_DeviceReceivesMethodAndResponse_Mqtt()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethodAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_DeviceReceivesMethodAndResponse_MqttWs()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Mqtt_WebSocket_Only, SetDeviceReceiveMethodAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_DeviceUnsubscribes_Mqtt()
         {
             await SendMethodAndUnsubscribeAsync(Client.TransportType.Mqtt_Tcp_Only, SubscribeAndUnsubscribeMethodAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_DeviceUnsubscribes_MqttWs()
         {
             await SendMethodAndUnsubscribeAsync(Client.TransportType.Mqtt_WebSocket_Only, SubscribeAndUnsubscribeMethodAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_DeviceReceivesMethodAndResponseWithDefaultMethodHandler_Mqtt()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Mqtt_Tcp_Only, SetDeviceReceiveMethodDefaultHandlerAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_DeviceReceivesMethodAndResponseWithDefaultMethodHandler_MqttWs()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Mqtt_WebSocket_Only, SetDeviceReceiveMethodDefaultHandlerAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_DeviceReceivesMethodAndResponse_Amqp()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Amqp_Tcp_Only, SetDeviceReceiveMethodAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_DeviceReceivesMethodAndResponse_AmqpWs()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Amqp_WebSocket_Only, SetDeviceReceiveMethodAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_DeviceUnsubscribes_Amqp()
         {
             await SendMethodAndUnsubscribeAsync(Client.TransportType.Amqp_Tcp_Only, SubscribeAndUnsubscribeMethodAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_DeviceUnsubscribes_AmqpWs()
         {
             await SendMethodAndUnsubscribeAsync(Client.TransportType.Amqp_WebSocket_Only, SubscribeAndUnsubscribeMethodAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_DeviceReceivesMethodAndResponseWithDefaultMethodHandler_Amqp()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Amqp_Tcp_Only, SetDeviceReceiveMethodDefaultHandlerAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_DeviceReceivesMethodAndResponseWithDefaultMethodHandler_AmqpWs()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Amqp_WebSocket_Only, SetDeviceReceiveMethodDefaultHandlerAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ServiceSendsMethodThroughProxyWithDefaultTimeout()
         {
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                 .ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ServiceSendsMethodThroughProxyWithCustomTimeout()
         {
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
                 .ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ServiceInvokeDeviceMethodWithUnknownDeviceThrows()
         {
@@ -172,63 +172,63 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await serviceClient.CloseAsync().ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ModuleReceivesMethodAndResponse_Mqtt()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Mqtt_Tcp_Only, SetModuleReceiveMethodAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ModuleReceivesMethodAndResponse_MqttWs()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Mqtt_WebSocket_Only, SetModuleReceiveMethodAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ModuleReceivesMethodAndResponseWithDefaultMethodHandler_Mqtt()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Mqtt_Tcp_Only, SetModuleReceiveMethodDefaultHandlerAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ModuleReceivesMethodAndResponseWithDefaultMethodHandler_MqttWs()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Mqtt_WebSocket_Only, SetModuleReceiveMethodDefaultHandlerAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ModuleReceivesMethodAndResponse_Amqp()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Amqp_Tcp_Only, SetModuleReceiveMethodAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ModuleReceivesMethodAndResponse_AmqpWs()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Amqp_WebSocket_Only, SetModuleReceiveMethodAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ModuleReceivesMethodAndResponseWithDefaultMethodHandler_Amqp()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Amqp_Tcp_Only, SetModuleReceiveMethodDefaultHandlerAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ModuleReceivesMethodAndResponseWithDefaultMethodHandler_AmqpWs()
         {
             await SendMethodAndRespondAsync(Client.TransportType.Amqp_WebSocket_Only, SetModuleReceiveMethodDefaultHandlerAsync).ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ServiceInvokeDeviceMethodWithUnknownModuleThrows()
         {
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             await serviceClient.CloseAsync().ConfigureAwait(false);
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ServiceInvokeDeviceMethodWithNullPayload_DoesNotThrow()
         {
@@ -302,7 +302,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
             }
         }
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Method_ServiceInvokeDeviceMethodWithDateTimePayload_DoesNotThrow()
         {
@@ -310,7 +310,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
 
             var date = new DateTimeOffset(638107582284599400, TimeSpan.FromHours(1));
 
-            string responseJson = JsonConvert.SerializeObject(new TestDateTime { Iso8601String = date.ToString("o", CultureInfo.InvariantCulture) });
+            string responseJson = JsonConvert.SerializeObject(new TestDateTime { Iso8601String = date.ToString("o", CultureInfo.InvariantCulture) }, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
             byte[] responseBytes = Encoding.UTF8.GetBytes(responseJson);
 
             const string commandName = "GetDateTime";
@@ -340,7 +340,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Methods
 
                 CloudToDeviceMethodResult result = await serviceClient.InvokeDeviceMethodAsync(testDevice.Id, c2dMethod).ConfigureAwait(false);
                 string actualResultJson = result.GetPayloadAsJson();
-                TestDateTime myDtoValue = JsonConvert.DeserializeObject<TestDateTime>(actualResultJson);
+                TestDateTime myDtoValue = JsonConvert.DeserializeObject<TestDateTime>(actualResultJson, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                 string value = myDtoValue.Iso8601String;
 
                 Action act = () => DateTimeOffset.ParseExact(value, "o", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);

--- a/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
+++ b/e2e/test/iothub/service/DigitalTwinClientE2ETests.cs
@@ -80,18 +80,18 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                     (request, context) =>
                     {
                         VerboseTestLogger.WriteLine($"{nameof(DigitalTwinWithOnlyRootComponentOperationsAsync)}: Digital twin command received: {request.Name}.");
-                        string payload = JsonConvert.SerializeObject(request.Name);
+                        string payload = JsonConvert.SerializeObject(request.Name, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                         return Task.FromResult(new MethodResponse(Encoding.UTF8.GetBytes(payload), expectedCommandStatus));
                     },
                     null);
 
                 // Invoke the root-level command "getMaxMinReport" on the digital twin.
                 DateTimeOffset since = DateTimeOffset.Now.Subtract(TimeSpan.FromMinutes(1));
-                string payload = JsonConvert.SerializeObject(since);
+                string payload = JsonConvert.SerializeObject(since, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                 HttpOperationResponse<DigitalTwinCommandResponse, DigitalTwinInvokeCommandHeaders> commandResponse =
                     await digitalTwinClient.InvokeCommandAsync(deviceId, commandName, payload).ConfigureAwait(false);
                 commandResponse.Body.Status.Should().Be(expectedCommandStatus);
-                commandResponse.Body.Payload.Should().Be(JsonConvert.SerializeObject(commandName));
+                commandResponse.Body.Payload.Should().Be(JsonConvert.SerializeObject(commandName, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()));
             }
             finally
             {
@@ -161,18 +161,18 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                     (request, context) =>
                     {
                         VerboseTestLogger.WriteLine($"{nameof(DigitalTwinWithComponentOperationsAsync)}: Digital twin command {request.Name} received.");
-                        string payload = JsonConvert.SerializeObject(request.Name);
+                        string payload = JsonConvert.SerializeObject(request.Name, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                         return Task.FromResult(new MethodResponse(Encoding.UTF8.GetBytes(payload), expectedCommandStatus));
                     },
                     null);
 
                 // Invoke the root-level command "reboot" on the digital twin.
                 int delay = 1;
-                string rootCommandPayload = JsonConvert.SerializeObject(delay);
+                string rootCommandPayload = JsonConvert.SerializeObject(delay, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                 HttpOperationResponse<DigitalTwinCommandResponse, DigitalTwinInvokeCommandHeaders> rootCommandResponse =
                     await digitalTwinClient.InvokeCommandAsync(deviceId, rootCommandName, rootCommandPayload).ConfigureAwait(false);
                 rootCommandResponse.Body.Status.Should().Be(expectedCommandStatus);
-                rootCommandResponse.Body.Payload.Should().Be(JsonConvert.SerializeObject(rootCommandName));
+                rootCommandResponse.Body.Payload.Should().Be(JsonConvert.SerializeObject(rootCommandName, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()));
 
                 // Set callback to handle component-level command invocation request.
                 // For a component-level command, the command name is in the format "<component-name>*<command-name>".
@@ -182,18 +182,18 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                     (request, context) =>
                     {
                         VerboseTestLogger.WriteLine($"{nameof(DigitalTwinWithComponentOperationsAsync)}: Digital twin command {request.Name} received.");
-                        string payload = JsonConvert.SerializeObject(request.Name);
+                        string payload = JsonConvert.SerializeObject(request.Name, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                         return Task.FromResult(new MethodResponse(Encoding.UTF8.GetBytes(payload), expectedCommandStatus));
                     },
                     null);
 
                 // Invoke the command "getMaxMinReport" under component "thermostat1" on the digital twin.
                 DateTimeOffset since = DateTimeOffset.Now.Subtract(TimeSpan.FromMinutes(1));
-                string componentCommandPayload = JsonConvert.SerializeObject(since);
+                string componentCommandPayload = JsonConvert.SerializeObject(since, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                 HttpOperationResponse<DigitalTwinCommandResponse, DigitalTwinInvokeCommandHeaders> componentCommandResponse =
                     await digitalTwinClient.InvokeComponentCommandAsync(deviceId, componentName, componentCommandName, componentCommandPayload).ConfigureAwait(false);
                 componentCommandResponse.Body.Status.Should().Be(expectedCommandStatus);
-                componentCommandResponse.Body.Payload.Should().Be(JsonConvert.SerializeObject(componentCommandNamePnp));
+                componentCommandResponse.Body.Payload.Should().Be(JsonConvert.SerializeObject(componentCommandNamePnp, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()));
             }
             finally
             {

--- a/e2e/test/iothub/service/RegistryManagerExportDevicesTests.cs
+++ b/e2e/test/iothub/service/RegistryManagerExportDevicesTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             '\n',
         };
 
-        [TestMethodWithRetry(Max=3)]
+        [TestMethodWithRetry(Max = 3)]
         [Timeout(LongRunningTestTimeoutMilliseconds)]
         [TestCategory("LongRunning")]
         [DoNotParallelize] // the number of jobs that can be run at a time are limited anyway
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
                     break;
                 }
 
-                ExportImportDevice exportedDevice = JsonConvert.DeserializeObject<ExportImportDevice>(serializedDevice);
+                ExportImportDevice exportedDevice = JsonConvert.DeserializeObject<ExportImportDevice>(serializedDevice, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
 
                 if (StringComparer.Ordinal.Equals(exportedDevice.Id, edge1.Id) && exportedDevice.Capabilities.IotEdge)
                 {
@@ -281,7 +281,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
             bool foundConfig = false;
             foreach (string serializedConfig in serializedConfigs)
             {
-                Configuration exportedConfig = JsonConvert.DeserializeObject<Configuration>(serializedConfig);
+                Configuration exportedConfig = JsonConvert.DeserializeObject<Configuration>(serializedConfig, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                 if (StringComparer.Ordinal.Equals(exportedConfig.Id, configuration.Id))
                 {
                     VerboseTestLogger.WriteLine($"Found config in export as [{serializedConfig}]");

--- a/e2e/test/iothub/twin/TwinE2ETests.cs
+++ b/e2e/test/iothub/twin/TwinE2ETests.cs
@@ -505,12 +505,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             // Validate the updated twin from the device-client
             Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
             dynamic actual = deviceTwin.Properties.Reported[propName];
-            Assert.AreEqual(JsonConvert.SerializeObject(actual), JsonConvert.SerializeObject(propValue));
+            Assert.AreEqual(JsonConvert.SerializeObject(actual, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()), JsonConvert.SerializeObject(propValue, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()));
 
             // Validate the updated twin from the service-client
             Twin completeTwin = await _registryManager.GetTwinAsync(deviceId).ConfigureAwait(false);
             dynamic actualProp = completeTwin.Properties.Reported[propName];
-            Assert.AreEqual(JsonConvert.SerializeObject(actualProp), JsonConvert.SerializeObject(propValue));
+            Assert.AreEqual(JsonConvert.SerializeObject(actualProp, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()), JsonConvert.SerializeObject(propValue, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()));
         }
 
         public static async Task<Task> SetTwinPropertyUpdateCallbackHandlerAsync(DeviceClient deviceClient, string expectedPropName, object expectedPropValue)
@@ -526,7 +526,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
                         try
                         {
-                            Assert.AreEqual(JsonConvert.SerializeObject(expectedPropValue), JsonConvert.SerializeObject(patch[expectedPropName]));
+                            Assert.AreEqual(JsonConvert.SerializeObject(expectedPropValue, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()), JsonConvert.SerializeObject(patch[expectedPropName], JsonSerializerSettingsInitializer.GetJsonSerializerSettings()));
                             Assert.AreEqual(userContext, context, "Context");
                         }
                         catch (Exception e)
@@ -646,12 +646,12 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             // Validate the updated twin from the device-client
             Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
             dynamic actual = deviceTwin.Properties.Desired[propName];
-            Assert.AreEqual(JsonConvert.SerializeObject(actual), JsonConvert.SerializeObject(propValue));
+            Assert.AreEqual(JsonConvert.SerializeObject(actual, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()), JsonConvert.SerializeObject(propValue, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()));
 
             // Validate the updated twin from the service-client
             Twin completeTwin = await _registryManager.GetTwinAsync(testDevice.Id).ConfigureAwait(false);
             dynamic actualProp = completeTwin.Properties.Desired[propName];
-            Assert.AreEqual(JsonConvert.SerializeObject(actualProp), JsonConvert.SerializeObject(propValue));
+            Assert.AreEqual(JsonConvert.SerializeObject(actualProp, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()), JsonConvert.SerializeObject(propValue, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()));
 
             await deviceClient.SetDesiredPropertyUpdateCallbackAsync(null, null).ConfigureAwait(false);
             await deviceClient.CloseAsync().ConfigureAwait(false);
@@ -679,7 +679,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
 
         private async Task Twin_ServiceSetsDesiredPropertyAndDeviceReceivesItOnNextGetDateTimePropertiesAsync(Client.TransportType transport)
         {
-            string jsonString = JsonConvert.SerializeObject(s_dateTimeProperty);
+            string jsonString = JsonConvert.SerializeObject(s_dateTimeProperty, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
 
             using TestDevice testDevice = await TestDevice.GetTestDeviceAsync(_devicePrefix).ConfigureAwait(false);
             using var registryManager = RegistryManager.CreateFromConnectionString(TestConfiguration.IotHub.ConnectionString);
@@ -691,7 +691,7 @@ namespace Microsoft.Azure.Devices.E2ETests.Twins
             await registryManager.UpdateTwinAsync(testDevice.Id, twinPatch, "*").ConfigureAwait(false);
 
             Twin deviceTwin = await deviceClient.GetTwinAsync().ConfigureAwait(false);
-            Assert.AreEqual<string>(deviceTwin.Properties.Desired["Iso8601String"].ToString(), DateTimeValue);
+            Assert.AreEqual<string>(DateTimeValue, deviceTwin.Properties.Desired["Iso8601String"].ToString());
 
             await deviceClient.CloseAsync().ConfigureAwait(false);
             await registryManager.CloseAsync().ConfigureAwait(false);

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -13,7 +13,6 @@ using System.Security.Cryptography.X509Certificates;
 using System.IO;
 using Microsoft.Azure.Devices.Client.Exceptions;
 using System.ComponentModel;
-using Newtonsoft.Json;
 
 #if NET451
 
@@ -124,6 +123,7 @@ namespace Microsoft.Azure.Devices.Client
         // Stores methods supported by the client device and their associated delegate.
 
         private bool _isDeviceMethodEnabled;
+
         private readonly Dictionary<string, Tuple<MethodCallback, object>> _deviceMethods =
             new Dictionary<string, Tuple<MethodCallback, object>>();
 
@@ -162,9 +162,6 @@ namespace Microsoft.Azure.Devices.Client
             if (Logging.IsEnabled)
                 Logging.Enter(this, transportSettings, pipelineBuilder, nameof(InternalClient) + "_ctor");
 
-            // Specify the JsonSerializerSettings. Check JsonSerializerSettingsInitializer for more details.
-            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetJsonSerializerSettingsDelegate();
-
             TlsVersions.Instance.SetLegacyAcceptableVersions();
 
             _transportSettings = transportSettings;
@@ -199,6 +196,7 @@ namespace Microsoft.Azure.Devices.Client
             if (Logging.IsEnabled)
                 Logging.Exit(this, transportSettings, pipelineBuilder, nameof(InternalClient) + "_ctor");
         }
+
         internal bool IsDisposed { get; private set; }
 
         /// <summary>

--- a/iothub/device/src/JsonSerializerSettingsInitializer.cs
+++ b/iothub/device/src/JsonSerializerSettingsInitializer.cs
@@ -28,9 +28,9 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Returns JsonSerializerSettings Func delegate
         /// </summary>
-        internal static Func<JsonSerializerSettings> GetJsonSerializerSettingsDelegate()
+        internal static JsonSerializerSettings GetJsonSerializerSettings()
         {
-            return () => s_settings;
+            return s_settings;
         }
     }
 }

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotReceivingLink.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotReceivingLink.cs
@@ -283,14 +283,14 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
                         // Here we are getting desired property update notifications and want to handle it first
                         using var reader = new StreamReader(amqpMessage.BodyStream, System.Text.Encoding.UTF8);
                         string patch = reader.ReadToEnd();
-                        twinProperties = JsonConvert.DeserializeObject<TwinCollection>(patch);
+                        twinProperties = JsonConvert.DeserializeObject<TwinCollection>(patch, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                     }
                     else if (correlationId.StartsWith(AmqpTwinMessageType.Get.ToString(), StringComparison.OrdinalIgnoreCase))
                     {
                         // This a response of a GET TWIN so return (set) the full twin
                         using var reader = new StreamReader(amqpMessage.BodyStream, System.Text.Encoding.UTF8);
                         string body = reader.ReadToEnd();
-                        TwinProperties properties = JsonConvert.DeserializeObject<TwinProperties>(body);
+                        TwinProperties properties = JsonConvert.DeserializeObject<TwinProperties>(body, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                         twin = new Twin(properties);
                     }
                     else if (correlationId.StartsWith(AmqpTwinMessageType.Patch.ToString(), StringComparison.OrdinalIgnoreCase))

--- a/iothub/device/src/Transport/AmqpIot/AmqpIotSendingLink.cs
+++ b/iothub/device/src/Transport/AmqpIot/AmqpIotSendingLink.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.AmqpIot
             if (Logging.IsEnabled)
                 Logging.Enter(this, nameof(SendTwinPatchMessageAsync));
 
-            string body = JsonConvert.SerializeObject(reportedProperties);
+            string body = JsonConvert.SerializeObject(reportedProperties, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
             var bodyStream = new MemoryStream(Encoding.UTF8.GetBytes(body));
 
             using var amqpMessage = AmqpMessage.Create(bodyStream, true);

--- a/iothub/device/src/Transport/Http/HttpClientHelper.cs
+++ b/iothub/device/src/Transport/Http/HttpClientHelper.cs
@@ -598,7 +598,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         private static StringContent CreateContent<T>(T entity)
         {
-            return new StringContent(JsonConvert.SerializeObject(entity), Encoding.UTF8, "application/json");
+            return new StringContent(JsonConvert.SerializeObject(entity, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()), Encoding.UTF8, "application/json");
         }
 
         private static async Task<T> ReadAsAsync<T>(HttpContent content, CancellationToken token)

--- a/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttTransportHandler.cs
@@ -539,7 +539,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 {
                     using var reader = new StreamReader(message.GetBodyStream(), System.Text.Encoding.UTF8);
                     string patch = reader.ReadToEnd();
-                    TwinCollection props = JsonConvert.DeserializeObject<TwinCollection>(patch);
+                    TwinCollection props = JsonConvert.DeserializeObject<TwinCollection>(patch, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                     await Task.Run(() => _onDesiredStatePatchListener(props)).ConfigureAwait(false);
                     // Messages with QoS = 1 need to be Acknowledged otherwise it results in mismatched Ack to IoT Hub
                     // causing next message being replayed and all subsequent messages being queued.
@@ -949,7 +949,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             {
                 return new Twin
                 {
-                    Properties = JsonConvert.DeserializeObject<TwinProperties>(body),
+                    Properties = JsonConvert.DeserializeObject<TwinProperties>(body, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()),
                 };
             }
             catch (JsonReaderException ex) when (Logging.IsEnabled)
@@ -964,7 +964,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             cancellationToken.ThrowIfCancellationRequested();
             EnsureValidState();
 
-            string body = JsonConvert.SerializeObject(reportedProperties);
+            string body = JsonConvert.SerializeObject(reportedProperties, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
             using var bodyStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(body));
 
             using var request = new Message(bodyStream);

--- a/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
+++ b/iothub/device/tests/Transport/Mqtt/MqttTransportHandlerTests.cs
@@ -1,4 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information
 
 using System;
@@ -39,6 +41,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
         private const int StatusFailure = 400;
         private const string FakeResponseId = "FakeResponseId";
         private static readonly TimeSpan s_receiveTimeoutBuffer = TimeSpan.FromSeconds(5);
+
         private delegate bool MessageMatcher(Message msg);
 
         [TestMethod]
@@ -367,7 +370,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
             var transport = CreateTransportHandlerWithMockChannel(out IChannel channel);
             var twin = new Twin();
             twin.Properties.Desired = new TwinCollection(twinJson);
-            var twinByteStream = System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(twin.Properties));
+            var twinByteStream = System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(twin.Properties, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()));
             channel
                 .WriteAndFlushAsync(Arg.Is<Message>(msg => msg.MqttTopicName.StartsWith(TwinGetTopicPrefix)))
                 .Returns(msg =>
@@ -458,7 +461,7 @@ namespace Microsoft.Azure.Devices.Client.Test.Transport
             await transport.SendTwinPatchAsync(props, CancellationToken.None).ConfigureAwait(false);
 
             // assert
-            string expectedBody = JsonConvert.SerializeObject(props);
+            string expectedBody = JsonConvert.SerializeObject(props, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
             Assert.AreEqual<string>(expectedBody, receivedBody);
         }
 

--- a/iothub/service/src/Amqp/AmqpClientHelper.cs
+++ b/iothub/service/src/Amqp/AmqpClientHelper.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Devices
         {
             using var reader = new StreamReader(amqpMessage.BodyStream, Encoding.UTF8);
             string jsonString = await reader.ReadToEndAsync().ConfigureAwait(false);
-            return JsonConvert.DeserializeObject<T>(jsonString);
+            return JsonConvert.DeserializeObject<T>(jsonString, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
         }
     }
 }

--- a/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
+++ b/iothub/service/src/DigitalTwin/DigitalTwinClient.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Devices
                 .ConfigureAwait(false);
             return new HttpOperationResponse<T, DigitalTwinGetHeaders>
             {
-                Body = typeof(T) == typeof(string) ? (T)(object)response.Body : JsonConvert.DeserializeObject<T>(response.Body),
+                Body = typeof(T) == typeof(string) ? (T)(object)response.Body : JsonConvert.DeserializeObject<T>(response.Body, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()),
                 Headers = response.Headers,
                 Request = response.Request,
                 Response = response.Response

--- a/iothub/service/src/DigitalTwin/Serialization/UpdateOperationsUtility.cs
+++ b/iothub/service/src/DigitalTwin/Serialization/UpdateOperationsUtility.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.Devices.Serialization
         /// <returns>A string of the json payload.</returns>
         public string Serialize()
         {
-            return JsonConvert.SerializeObject(_ops);
+            return JsonConvert.SerializeObject(_ops, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
         }
     }
 }

--- a/iothub/service/src/Query/QueryResult.cs
+++ b/iothub/service/src/Query/QueryResult.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices
     /// <summary>
     ///     Contains the result of a device, device job or device aggregate query
     /// </summary>
-    class QueryResult
+    internal class QueryResult
     {
         private const string ContinuationTokenHeader = "x-ms-continuation";
         private const string QueryResultTypeHeader = "x-ms-item-type";
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices
             return new QueryResult
             {
 #if !NET451
-                Items = Newtonsoft.Json.JsonConvert.DeserializeObject<IEnumerable<object>>(await response.Content.ReadAsStringAsync().ConfigureAwait(false)),
+                Items = JsonConvert.DeserializeObject<IEnumerable<object>>(await response.Content.ReadAsStringAsync().ConfigureAwait(false), JsonSerializerSettingsInitializer.GetJsonSerializerSettings()),
 #else // Requires System.Net.Http.Formatting.Extension
                 Items = await response.Content.ReadAsAsync<IEnumerable<object>>().ConfigureAwait(false),
 #endif

--- a/iothub/service/src/Registry/RegistryManager.cs
+++ b/iothub/service/src/Registry/RegistryManager.cs
@@ -1937,7 +1937,7 @@ namespace Microsoft.Azure.Devices
                 }
 
                 // TODO: Do we need to deserialize Twin, only to serialize it again?
-                Twin twin = JsonConvert.DeserializeObject<Twin>(jsonTwinPatch);
+                Twin twin = JsonConvert.DeserializeObject<Twin>(jsonTwinPatch, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                 return UpdateTwinAsync(deviceId, twin, etag, cancellationToken);
             }
             catch (Exception ex)
@@ -2014,7 +2014,7 @@ namespace Microsoft.Azure.Devices
                 }
 
                 // TODO: Do we need to deserialize Twin, only to serialize it again?
-                Twin twin = JsonConvert.DeserializeObject<Twin>(jsonTwinPatch);
+                Twin twin = JsonConvert.DeserializeObject<Twin>(jsonTwinPatch, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                 return UpdateTwinAsync(deviceId, moduleId, twin, etag, cancellationToken);
             }
             catch (Exception ex)
@@ -2134,7 +2134,7 @@ namespace Microsoft.Azure.Devices
                 }
 
                 // TODO: Do we need to deserialize Twin, only to serialize it again?
-                Twin twin = JsonConvert.DeserializeObject<Twin>(newTwinJson);
+                Twin twin = JsonConvert.DeserializeObject<Twin>(newTwinJson, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                 return ReplaceTwinAsync(deviceId, twin, etag, cancellationToken);
             }
             catch (Exception ex)
@@ -2207,7 +2207,7 @@ namespace Microsoft.Azure.Devices
             }
 
             // TODO: Do we need to deserialize Twin, only to serialize it again?
-            Twin twin = JsonConvert.DeserializeObject<Twin>(newTwinJson);
+            Twin twin = JsonConvert.DeserializeObject<Twin>(newTwinJson, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
             return ReplaceTwinAsync(deviceId, moduleId, twin, etag, cancellationToken);
         }
 

--- a/provisioning/device/src/JsonSerializerSettingsInitializer.cs
+++ b/provisioning/device/src/JsonSerializerSettingsInitializer.cs
@@ -28,9 +28,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// <summary>
         /// Returns JsonSerializerSettings Func delegate
         /// </summary>
-        internal static Func<JsonSerializerSettings> GetJsonSerializerSettingsDelegate()
+        internal static JsonSerializerSettings GetJsonSerializerSettings()
         {
-            return () => s_settings;
+            return s_settings;
         }
     }
 }

--- a/provisioning/device/src/ProvisioningDeviceClient.cs
+++ b/provisioning/device/src/ProvisioningDeviceClient.cs
@@ -48,9 +48,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
             SecurityProvider securityProvider,
             ProvisioningTransportHandler transport)
         {
-            // Specify the JsonSerializerSettings. Check JsonSerializerSettingsInitializer for more details.
-            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetJsonSerializerSettingsDelegate();
-
             _globalDeviceEndpoint = globalDeviceEndpoint;
             _idScope = idScope;
             _transport = transport;
@@ -84,7 +81,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// Registers the current device using the Device Provisioning Service and assigns it to an IoT hub.
         /// </summary>
         /// <param name="data">
-        /// The optional additional data that is passed through to the custom allocation policy webhook if 
+        /// The optional additional data that is passed through to the custom allocation policy webhook if
         /// a custom allocation policy webhook is setup for this enrollment.
         /// </param>
         /// <param name="timeout">The maximum amount of time to allow this operation to run for before timing out.</param>
@@ -111,9 +108,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <remarks>
-        /// Due to the AMQP library used by this library uses not accepting cancellation tokens, the provided cancellation token will only be checked 
+        /// Due to the AMQP library used by this library uses not accepting cancellation tokens, the provided cancellation token will only be checked
         /// for cancellation in between AMQP operations, and not during. In order to have a timeout for this operation that is checked during AMQP operations
-        /// (such as opening the connection), you must use <see cref="RegisterAsync(TimeSpan)"/> instead. MQTT and HTTPS connections do not have the same 
+        /// (such as opening the connection), you must use <see cref="RegisterAsync(TimeSpan)"/> instead. MQTT and HTTPS connections do not have the same
         /// behavior as AMQP connections in this regard. MQTT and HTTPS connections will check this cancellation token for cancellation during their protocol level operations.
         /// </remarks>
         /// <returns>The registration result.</returns>
@@ -128,15 +125,15 @@ namespace Microsoft.Azure.Devices.Provisioning.Client
         /// Registers the current device using the Device Provisioning Service and assigns it to an IoT hub.
         /// </summary>
         /// <param name="data">
-        /// The optional additional data that is passed through to the custom allocation policy webhook if 
+        /// The optional additional data that is passed through to the custom allocation policy webhook if
         /// a custom allocation policy webhook is setup for this enrollment.
         /// </param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <remarks>
-        /// Due to the AMQP library used by this library uses not accepting cancellation tokens, the provided cancellation token will only be checked 
+        /// Due to the AMQP library used by this library uses not accepting cancellation tokens, the provided cancellation token will only be checked
         /// for cancellation in between AMQP operations, and not during. In order to have a timeout for this operation that is checked during AMQP operations
-        /// (such as opening the connection), you must use <see cref="RegisterAsync(ProvisioningRegistrationAdditionalData, TimeSpan)">this overload</see> instead. 
-        /// MQTT and HTTPS connections do not have the same behavior as AMQP connections in this regard. MQTT and HTTPS connections will check this cancellation 
+        /// (such as opening the connection), you must use <see cref="RegisterAsync(ProvisioningRegistrationAdditionalData, TimeSpan)">this overload</see> instead.
+        /// MQTT and HTTPS connections do not have the same behavior as AMQP connections in this regard. MQTT and HTTPS connections will check this cancellation
         /// token for cancellation during their protocol level operations.
         /// </remarks>
         /// <returns>The registration result.</returns>

--- a/provisioning/service/src/Config/BulkEnrollmentOperation.cs
+++ b/provisioning/service/src/Config/BulkEnrollmentOperation.cs
@@ -74,9 +74,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// Creates a <c>string</c>, whose content represents the mode and the collection of
         ///     individualEnrollments in a JSON format.
         /// </remarks>
-        /// <param name="mode">the <see cref="BulkOperationMode"/> that defines the single operation to do over the 
+        /// <param name="mode">the <see cref="BulkOperationMode"/> that defines the single operation to do over the
         ///     individualEnrollments.</param>
-        /// <param name="individualEnrollments">the collection of <see cref="IndividualEnrollment"/> that contains the description 
+        /// <param name="individualEnrollments">the collection of <see cref="IndividualEnrollment"/> that contains the description
         ///     of each individualEnrollment.</param>
         /// <returns>The <c>string</c> with the content of this class.</returns>
         /// <exception cref="ArgumentNullException">if the individualEnrollments is null.</exception>
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 Mode = mode,
                 Enrollments = individualEnrollments,
             };
-            return JsonConvert.SerializeObject(bulkOperation);
+            return JsonConvert.SerializeObject(bulkOperation, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
         }
     }
 }

--- a/provisioning/service/src/Config/BulkEnrollmentOperationResult.cs
+++ b/provisioning/service/src/Config/BulkEnrollmentOperationResult.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     /// Representation of a single Device Provisioning Service bulk operation result with a JSON deserializer.
     /// </summary>
     /// <remarks>
-    /// This error is returned as a result of the 
+    /// This error is returned as a result of the
     ///     <see cref="ProvisioningServiceClient.RunBulkEnrollmentOperationAsync(BulkOperationMode, IEnumerable{IndividualEnrollment})"/>.
     ///
     /// The provisioning service provides general bulk result in the isSuccessful, and a individual error result

--- a/provisioning/service/src/Config/QueryResult.cs
+++ b/provisioning/service/src/Config/QueryResult.cs
@@ -128,15 +128,15 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             switch (Type)
             {
                 case QueryResultType.Enrollment:
-                    Items = JsonConvert.DeserializeObject<IEnumerable<IndividualEnrollment>>(bodyString);
+                    Items = JsonConvert.DeserializeObject<IEnumerable<IndividualEnrollment>>(bodyString, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                     break;
 
                 case QueryResultType.EnrollmentGroup:
-                    Items = JsonConvert.DeserializeObject<IEnumerable<EnrollmentGroup>>(bodyString);
+                    Items = JsonConvert.DeserializeObject<IEnumerable<EnrollmentGroup>>(bodyString, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                     break;
 
                 case QueryResultType.DeviceRegistration:
-                    Items = JsonConvert.DeserializeObject<IEnumerable<DeviceRegistrationState>>(bodyString);
+                    Items = JsonConvert.DeserializeObject<IEnumerable<DeviceRegistrationState>>(bodyString, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                     break;
 
                 default:
@@ -148,13 +148,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                     {
                         try
                         {
-                            Items = JsonConvert.DeserializeObject<IEnumerable<JObject>>(bodyString);
+                            Items = JsonConvert.DeserializeObject<IEnumerable<JObject>>(bodyString, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                         }
                         catch (ArgumentException)
                         {
                             try
                             {
-                                Items = JsonConvert.DeserializeObject<IEnumerable<object>>(bodyString);
+                                Items = JsonConvert.DeserializeObject<IEnumerable<object>>(bodyString, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                             }
                             catch (ArgumentException)
                             {
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                         }
                         catch (JsonSerializationException)
                         {
-                            Items = JsonConvert.DeserializeObject<IEnumerable<object>>(bodyString);
+                            Items = JsonConvert.DeserializeObject<IEnumerable<object>>(bodyString, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                         }
                         catch (JsonReaderException)
                         {

--- a/provisioning/service/src/JsonSerializerSettingsInitializer.cs
+++ b/provisioning/service/src/JsonSerializerSettingsInitializer.cs
@@ -28,9 +28,9 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
         /// <summary>
         /// Returns JsonSerializerSettings Func delegate
         /// </summary>
-        internal static Func<JsonSerializerSettings> GetJsonSerializerSettingsDelegate()
+        internal static JsonSerializerSettings GetJsonSerializerSettings()
         {
-            return () => s_settings;
+            return s_settings;
         }
     }
 }

--- a/provisioning/service/src/Manager/EnrollmentGroupManager.cs
+++ b/provisioning/service/src/Manager/EnrollmentGroupManager.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                     HttpMethod.Put,
                     GetEnrollmentUri(enrollmentGroup.EnrollmentGroupId),
                     null,
-                    JsonConvert.SerializeObject(enrollmentGroup),
+                    JsonConvert.SerializeObject(enrollmentGroup, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()),
                     enrollmentGroup.ETag,
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ProvisioningServiceClientHttpException(contractApiResponse, true);
             }
 
-            return JsonConvert.DeserializeObject<EnrollmentGroup>(contractApiResponse.Body);
+            return JsonConvert.DeserializeObject<EnrollmentGroup>(contractApiResponse.Body, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
         }
 
         internal static async Task<EnrollmentGroup> GetAsync(
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ProvisioningServiceClientHttpException(contractApiResponse, true);
             }
 
-            return JsonConvert.DeserializeObject<EnrollmentGroup>(contractApiResponse.Body);
+            return JsonConvert.DeserializeObject<EnrollmentGroup>(contractApiResponse.Body, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
         }
 
         internal static async Task DeleteAsync(
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ProvisioningServiceClientHttpException(contractApiResponse, true);
             }
 
-            return JsonConvert.DeserializeObject<AttestationMechanism>(contractApiResponse.Body);
+            return JsonConvert.DeserializeObject<AttestationMechanism>(contractApiResponse.Body, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
         }
 
         private static Uri GetEnrollmentAttestationUri(string enrollmentGroupId)

--- a/provisioning/service/src/Manager/IndividualEnrollmentManager.cs
+++ b/provisioning/service/src/Manager/IndividualEnrollmentManager.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                     HttpMethod.Put,
                     GetEnrollmentUri(individualEnrollment.RegistrationId),
                     null,
-                    JsonConvert.SerializeObject(individualEnrollment),
+                    JsonConvert.SerializeObject(individualEnrollment, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()),
                     individualEnrollment.ETag,
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ProvisioningServiceClientHttpException(contractApiResponse, true);
             }
 
-            return JsonConvert.DeserializeObject<IndividualEnrollment>(contractApiResponse.Body);
+            return JsonConvert.DeserializeObject<IndividualEnrollment>(contractApiResponse.Body, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
         }
 
         internal static async Task<BulkEnrollmentOperationResult> BulkOperationAsync(
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ProvisioningServiceClientHttpException(contractApiResponse, true);
             }
 
-            return JsonConvert.DeserializeObject<BulkEnrollmentOperationResult>(contractApiResponse.Body);
+            return JsonConvert.DeserializeObject<BulkEnrollmentOperationResult>(contractApiResponse.Body, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
         }
 
         internal static async Task<IndividualEnrollment> GetAsync(
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ProvisioningServiceClientHttpException(contractApiResponse, true);
             }
 
-            return JsonConvert.DeserializeObject<IndividualEnrollment>(contractApiResponse.Body);
+            return JsonConvert.DeserializeObject<IndividualEnrollment>(contractApiResponse.Body, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
         }
 
         internal static async Task DeleteAsync(
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ProvisioningServiceClientHttpException(contractApiResponse, true);
             }
 
-            return JsonConvert.DeserializeObject<AttestationMechanism>(contractApiResponse.Body);
+            return JsonConvert.DeserializeObject<AttestationMechanism>(contractApiResponse.Body, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
         }
 
         private static Uri GetEnrollmentAttestationUri(string enrollmentGroupId)

--- a/provisioning/service/src/Manager/RegistrationStatusManager.cs
+++ b/provisioning/service/src/Manager/RegistrationStatusManager.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ProvisioningServiceClientHttpException(contractApiResponse, true);
             }
 
-            return JsonConvert.DeserializeObject<DeviceRegistrationState>(contractApiResponse.Body);
+            return JsonConvert.DeserializeObject<DeviceRegistrationState>(contractApiResponse.Body, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
         }
 
         internal static async Task DeleteAsync(

--- a/provisioning/service/src/ProvisioningServiceClient.cs
+++ b/provisioning/service/src/ProvisioningServiceClient.cs
@@ -110,9 +110,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
                 throw new ArgumentException($"{nameof(connectionString)} cannot be empty string");
             }
 
-            // Specify the JsonSerializerSettings. Check JsonSerializerSettingsInitializer for more details.
-            JsonConvert.DefaultSettings = JsonSerializerSettingsInitializer.GetJsonSerializerSettingsDelegate();
-
             _provisioningConnectionString = ServiceConnectionString.Parse(connectionString);
             _contractApiHttp = new ContractApiHttp(
                 _provisioningConnectionString.HttpsEndpoint,

--- a/provisioning/service/src/Query.cs
+++ b/provisioning/service/src/Query.cs
@@ -39,18 +39,18 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
     ///     Query Language for the Device Provisioning Service.
     ///
     /// Optionally, an <c>Integer</c> with the <b>page size</b>, can determine the maximum number of the items in the
-    ///     <see cref="QueryResult"/> returned by the <see cref="NextAsync()"/>. It must be any positive integer, and if it 
+    ///     <see cref="QueryResult"/> returned by the <see cref="NextAsync()"/>. It must be any positive integer, and if it
     ///     contains 0, the Device Provisioning Service will ignore it and use a standard page size.
     ///
     /// You can use this Object as a standard iterator, just using the <c>HasNext</c> and <c>NextAsync</c> in a
-    ///     <c>while</c> loop, up to the point where the <c>HasNext</c> contains <c>false</c>. But, keep 
-    ///     in mind that the <see cref="QueryResult"/> can contain a empty list, even if the <c>HasNext</c> contained 
-    ///     <c>true</c>. For example, image that you have 10 IndividualEnrollment in the Device Provisioning Service 
-    ///     and you created new query with the <c>PageSize</c> equals 5. In the first iteration, <c>HasNext</c> 
-    ///     will contains <c>true</c>, and the first <c>NextAsync</c> will return a <c>QueryResult</c> with 
-    ///     5 items. After, your code will check the <c>HasNext</c>, which will contains <c>true</c> again. Now, 
-    ///     before you get the next page, somebody deletes all the IndividualEnrollment. What happened, when you call the 
-    ///     <c>NextAsync</c>, it will return a valid <c>QueryResult</c>, but the <see cref="QueryResult.Items"/> 
+    ///     <c>while</c> loop, up to the point where the <c>HasNext</c> contains <c>false</c>. But, keep
+    ///     in mind that the <see cref="QueryResult"/> can contain a empty list, even if the <c>HasNext</c> contained
+    ///     <c>true</c>. For example, image that you have 10 IndividualEnrollment in the Device Provisioning Service
+    ///     and you created new query with the <c>PageSize</c> equals 5. In the first iteration, <c>HasNext</c>
+    ///     will contains <c>true</c>, and the first <c>NextAsync</c> will return a <c>QueryResult</c> with
+    ///     5 items. After, your code will check the <c>HasNext</c>, which will contains <c>true</c> again. Now,
+    ///     before you get the next page, somebody deletes all the IndividualEnrollment. What happened, when you call the
+    ///     <c>NextAsync</c>, it will return a valid <c>QueryResult</c>, but the <see cref="QueryResult.Items"/>
     ///     will contain an empty list.
     ///
     /// Besides the <c>Items</c>, the <c>QueryResult</c> contains the <see cref="QueryResult.ContinuationToken"/>.
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service
             PageSize = pageSize;
             _cancellationToken = cancellationToken;
 
-            _querySpecificationJson = JsonConvert.SerializeObject(querySpecification);
+            _querySpecificationJson = JsonConvert.SerializeObject(querySpecification, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
 
             _queryPath = GetQueryUri(serviceName);
 

--- a/provisioning/transport/amqp/src/JsonSerializerSettingsInitializer.cs
+++ b/provisioning/transport/amqp/src/JsonSerializerSettingsInitializer.cs
@@ -4,7 +4,7 @@
 using System;
 using Newtonsoft.Json;
 
-namespace Microsoft.Azure.Devices
+namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 {
     /// <summary>
     /// A class to initialize JsonSerializerSettings which can be applied to the project.

--- a/provisioning/transport/http/src/JsonSerializerSettingsInitializer.cs
+++ b/provisioning/transport/http/src/JsonSerializerSettingsInitializer.cs
@@ -4,7 +4,7 @@
 using System;
 using Newtonsoft.Json;
 
-namespace Microsoft.Azure.Devices
+namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 {
     /// <summary>
     /// A class to initialize JsonSerializerSettings which can be applied to the project.

--- a/provisioning/transport/http/src/ProvisioningTransportHandlerHttp.cs
+++ b/provisioning/transport/http/src/ProvisioningTransportHandlerHttp.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
         /// <param name="message">The provisioning message.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The registration result.</returns>
-        public async override Task<DeviceRegistrationResult> RegisterAsync(
+        public override async Task<DeviceRegistrationResult> RegisterAsync(
             ProvisioningTransportRegisterMessage message,
             CancellationToken cancellationToken)
         {
@@ -102,8 +102,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 using var httpClientHandler = new HttpClientHandler()
                 {
                     // Cannot specify a specific protocol here, as desired due to an error:
-                    //   ProvisioningDeviceClient_ValidRegistrationId_AmqpWithProxy_SymmetricKey_RegisterOk_GroupEnrollment failing for me with System.PlatformNotSupportedException: Operation is not supported on this platform.	
-                    // When revisiting TLS12 work for DPS, we should figure out why. Perhaps the service needs to support it.	
+                    //   ProvisioningDeviceClient_ValidRegistrationId_AmqpWithProxy_SymmetricKey_RegisterOk_GroupEnrollment failing for me with System.PlatformNotSupportedException: Operation is not supported on this platform.
+                    // When revisiting TLS12 work for DPS, we should figure out why. Perhaps the service needs to support it.
 
                     //SslProtocols = TlsVersions.Preferred,
                 };
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 
                         try
                         {
-                            ProvisioningErrorDetailsHttp errorDetails = JsonConvert.DeserializeObject<ProvisioningErrorDetailsHttp>(ex.Response.Content);
+                            ProvisioningErrorDetailsHttp errorDetails = JsonConvert.DeserializeObject<ProvisioningErrorDetailsHttp>(ex.Response.Content, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
 
                             if (isTransient)
                             {
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 
                 try
                 {
-                    ProvisioningErrorDetailsHttp errorDetails = JsonConvert.DeserializeObject<ProvisioningErrorDetailsHttp>(ex.Response.Content);
+                    ProvisioningErrorDetailsHttp errorDetails = JsonConvert.DeserializeObject<ProvisioningErrorDetailsHttp>(ex.Response.Content, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                     throw new ProvisioningTransportException(ex.Response.Content, ex, isTransient, errorDetails);
                 }
                 catch (JsonException jex)

--- a/provisioning/transport/http/src/TPM/TpmDelegatingHandler.cs
+++ b/provisioning/transport/http/src/TPM/TpmDelegatingHandler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request, 
+            HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
             if (Logging.IsEnabled)
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 
             HttpResponseMessage response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-            if(response.StatusCode == HttpStatusCode.Unauthorized)
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
 #if NET5_0_OR_GREATER
                 if (request.Options.TryGetValue(new HttpRequestOptionsKey<object>(ProvisioningHeaderName), out object result))
@@ -42,11 +42,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                     {
                         string target = GetTarget(request.RequestUri.LocalPath);
                         string responseContent = await response.Content.ReadHttpContentAsStringAsync(cancellationToken).ConfigureAwait(false);
-                        TpmChallenge challenge = JsonConvert.DeserializeObject<TpmChallenge>(responseContent);
+                        TpmChallenge challenge = JsonConvert.DeserializeObject<TpmChallenge>(responseContent, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
 
                         string sasToken = ProvisioningSasBuilder.ExtractServiceAuthKey(
                             _securityProvider,
-                            target, 
+                            target,
                             Convert.FromBase64String(challenge.AuthenticationKey));
 
                         setSasToken(sasToken);
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 throw new ArgumentException($"Invalid RequestUri LocalPath");
             }
 
-            return string.Concat(parameters[0], "/" , parameters[1], "/", parameters[2]);
+            return string.Concat(parameters[0], "/", parameters[1], "/", parameters[2]);
         }
     }
 }

--- a/provisioning/transport/mqtt/src/JsonSerializerSettingsInitializer.cs
+++ b/provisioning/transport/mqtt/src/JsonSerializerSettingsInitializer.cs
@@ -4,7 +4,7 @@
 using System;
 using Newtonsoft.Json;
 
-namespace Microsoft.Azure.Devices
+namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 {
     /// <summary>
     /// A class to initialize JsonSerializerSettings which can be applied to the project.

--- a/provisioning/transport/mqtt/src/ProvisioningChannelHandlerAdapter.cs
+++ b/provisioning/transport/mqtt/src/ProvisioningChannelHandlerAdapter.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 Logging.Exit(this, context.Name, nameof(ChannelInactive));
         }
 
-        public async override void ChannelRead(IChannelHandlerContext context, object message)
+        public override async void ChannelRead(IChannelHandlerContext context, object message)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, context.Name, nameof(ChannelRead));
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 Logging.Exit(this, context.Name, nameof(ChannelRead));
         }
 
-        public async override void ChannelReadComplete(IChannelHandlerContext context)
+        public override async void ChannelReadComplete(IChannelHandlerContext context)
         {
             if (Logging.IsEnabled)
                 Logging.Enter(this, context.Name, nameof(ChannelReadComplete));
@@ -329,7 +329,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
             if (_message.Payload != null && _message.Payload.Length > 0)
             {
                 var deviceRegistration = new DeviceRegistration { Payload = new JRaw(_message.Payload) };
-                using var customContentStream = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(deviceRegistration)));
+                using var customContentStream = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(deviceRegistration, JsonSerializerSettingsInitializer.GetJsonSerializerSettings())));
                 long streamLength = customContentStream.Length;
                 int length = (int)streamLength;
                 packagePayload = context.Channel.Allocator.Buffer(length, length);
@@ -356,7 +356,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
                 {
                     if (statusCode >= HttpStatusCode.BadRequest)
                     {
-                        ProvisioningErrorDetailsMqtt errorDetails = JsonConvert.DeserializeObject<ProvisioningErrorDetailsMqtt>(jsonData);
+                        ProvisioningErrorDetailsMqtt errorDetails = JsonConvert.DeserializeObject<ProvisioningErrorDetailsMqtt>(jsonData, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
 
                         bool isTransient = statusCode >= HttpStatusCode.InternalServerError || (int)statusCode == 429;
 
@@ -391,7 +391,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Transport
 
                 await VerifyPublishPacketTopicAsync(context, packet.TopicName, jsonData).ConfigureAwait(true);
 
-                RegistrationOperationStatus operation = JsonConvert.DeserializeObject<RegistrationOperationStatus>(jsonData);
+                RegistrationOperationStatus operation = JsonConvert.DeserializeObject<RegistrationOperationStatus>(jsonData, JsonSerializerSettingsInitializer.GetJsonSerializerSettings());
                 string operationId = operation.OperationId;
                 operation.RetryAfter = ProvisioningErrorDetailsMqtt.GetRetryAfterFromTopic(packet.TopicName, s_defaultOperationPoolingInterval);
 

--- a/shared/src/JsonSerializerSettingsInitializer.cs
+++ b/shared/src/JsonSerializerSettingsInitializer.cs
@@ -4,7 +4,7 @@
 using System;
 using Newtonsoft.Json;
 
-namespace Microsoft.Azure.Devices
+namespace Microsoft.Azure.Devices.Shared
 {
     /// <summary>
     /// A class to initialize JsonSerializerSettings which can be applied to the project.

--- a/shared/src/TwinCollection.cs
+++ b/shared/src/TwinCollection.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Devices.Shared
         /// </remarks>
         /// <param name="twinJson">JSON fragment containing the twin data.</param>
         public TwinCollection(string twinJson)
-            : this(JsonConvert.DeserializeObject<JObject>(twinJson))
+            : this(JsonConvert.DeserializeObject<JObject>(twinJson, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()))
         {
         }
 

--- a/shared/src/TwinJsonConverter.cs
+++ b/shared/src/TwinJsonConverter.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Shared
             if (twin.Status != null)
             {
                 writer.WritePropertyName(StatusTag);
-                writer.WriteRawValue(JsonConvert.SerializeObject(twin.Status));
+                writer.WriteRawValue(JsonConvert.SerializeObject(twin.Status, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()));
             }
 
             if (!string.IsNullOrWhiteSpace(twin.StatusReason))
@@ -277,7 +277,7 @@ namespace Microsoft.Azure.Devices.Shared
 
                     case StatusTag:
                         string status = reader.Value as string;
-                        twin.Status = status?[0] == '\"' ? JsonConvert.DeserializeObject<DeviceStatus>(status) : serializer.Deserialize<DeviceStatus>(reader);
+                        twin.Status = status?[0] == '\"' ? JsonConvert.DeserializeObject<DeviceStatus>(status, JsonSerializerSettingsInitializer.GetJsonSerializerSettings()) : serializer.Deserialize<DeviceStatus>(reader);
                         break;
 
                     case StatusReasonTag:
@@ -291,7 +291,7 @@ namespace Microsoft.Azure.Devices.Shared
                     case ConnectionStateTag:
                         string connectionState = reader.Value as string;
                         twin.ConnectionState = connectionState?[0] == '\"'
-                            ? JsonConvert.DeserializeObject<DeviceConnectionState>(connectionState)
+                            ? JsonConvert.DeserializeObject<DeviceConnectionState>(connectionState, JsonSerializerSettingsInitializer.GetJsonSerializerSettings())
                             : serializer.Deserialize<DeviceConnectionState>(reader);
                         break;
 
@@ -306,7 +306,7 @@ namespace Microsoft.Azure.Devices.Shared
                     case AuthenticationTypeTag:
                         string authenticationType = reader.Value as string;
                         twin.AuthenticationType = authenticationType?[0] == '\"'
-                            ? JsonConvert.DeserializeObject<AuthenticationType>(authenticationType)
+                            ? JsonConvert.DeserializeObject<AuthenticationType>(authenticationType, JsonSerializerSettingsInitializer.GetJsonSerializerSettings())
                             : serializer.Deserialize<AuthenticationType>(reader);
                         break;
 


### PR DESCRIPTION
By assigning global settings, this SDK would affect Json serialization done by users with Newtonsoft outside of this SDK. Now we use the same settings as before (to avoid regressing on #3903), but without assigning them globally.

Addresses #3358