### PR TITLE
Previews/v2 -version 8

### DIFF
--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0-preview007</Version>
+    <Version>2.0.0-preview008</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/service/src/Microsoft.Azure.Devices.csproj
+++ b/iothub/service/src/Microsoft.Azure.Devices.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0-preview007</Version>
+    <Version>2.0.0-preview008</Version>
     <Title>Microsoft Azure IoT Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
+++ b/provisioning/device/src/Microsoft.Azure.Devices.Provisioning.Client.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0-preview007</Version>
+    <Version>2.0.0-preview008</Version>
     <Title>Microsoft Azure IoT Provisioning Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
+++ b/provisioning/service/src/Microsoft.Azure.Devices.Provisioning.Service.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0-preview007</Version>
+    <Version>2.0.0-preview008</Version>
     <Title>Microsoft Azure IoT Provisioning Service Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/versions.csv
+++ b/versions.csv
@@ -1,5 +1,5 @@
 AssemblyPath, Version
-iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 2.0.0-preview007
-iothub\service\src\Microsoft.Azure.Devices.csproj, 2.0.0-preview007
-provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 2.0.0-preview007
-provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 2.0.0-preview007
+iothub\device\src\Microsoft.Azure.Devices.Client.csproj, 2.0.0-preview008
+iothub\service\src\Microsoft.Azure.Devices.csproj, 2.0.0-preview008
+provisioning\device\src\Microsoft.Azure.Devices.Provisioning.Client.csproj, 2.0.0-preview008
+provisioning\service\src\Microsoft.Azure.Devices.Provisioning.Service.csproj, 2.0.0-preview008


### PR DESCRIPTION
This is the eighth preview of the v2 clients. You can read about the changes in this [migration guide](https://github.com/Azure/azure-iot-sdk-csharp/blob/previews/v2/SDK%20v2%20migration%20guide.md).

## Relevant changes

* Make the secondary key for symmetric key attestation optional in https://github.com/Azure/azure-iot-sdk-csharp/pull/3382
* Update payload convention number of serializations in https://github.com/Azure/azure-iot-sdk-csharp/pull/3391
* Remove "key" and "value" keys from returned json in https://github.com/Azure/azure-iot-sdk-csharp/pull/3388
* Set bulk operation limit in https://github.com/Azure/azure-iot-sdk-csharp/pull/3385
* Remove support for .net core 3.1 in https://github.com/Azure/azure-iot-sdk-csharp/pull/3378
