### PR TITLE
Fix bug where module client send batch fails if output name already set

### DIFF
--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -1570,7 +1570,7 @@ namespace Microsoft.Azure.Devices.Client
                     throw new ArgumentNullException(nameof(messages));
                 }
 
-                messagesList.ForEach(m => m.SystemProperties.Add(MessageSystemPropertyNames.OutputName, outputName));
+                messagesList.ForEach(m => m.SystemProperties[MessageSystemPropertyNames.OutputName] = outputName);
 
                 return InnerHandler.SendEventAsync(messagesList, cancellationToken);
             }


### PR DESCRIPTION
#3434

The method ```Add``` on a dictionary throws if the key is already present. This change will overwrite any previously set output name without throwing.