### PR TITLE
Add DeviceNotOnline to error codes

### DIFF
--- a/iothub/service/src/Common/Exceptions/ErrorCode.cs
+++ b/iothub/service/src/Common/Exceptions/ErrorCode.cs
@@ -206,6 +206,14 @@ namespace Microsoft.Azure.Devices.Common.Exceptions
         JobNotFound = 404002,
 
         /// <summary>
+        /// The operation failed because the device is offline or the direct method callback isn't registered.
+        /// <para>
+        /// For more information, see <see href="https://aka.ms/iothub404103">404103 Device not online</see>.
+        /// </para>
+        /// </summary>
+        DeviceNotOnline = 404103,
+
+        /// <summary>
         /// The error is internal to IoT hub and is likely transient.
         /// <para>
         /// For more information, see <see href="https://docs.microsoft.com/azure/iot-hub/iot-hub-troubleshoot-error-503003-partitionnotfound">503003 PartitionNotFound</see>.

--- a/iothub/service/tests/ExceptionHandlingHelperTests.cs
+++ b/iothub/service/tests/ExceptionHandlingHelperTests.cs
@@ -34,6 +34,25 @@ namespace Microsoft.Azure.Devices.Test
         }
 
         [TestMethod]
+        public async Task GetExceptionCodeAsync_ContentAndHeadersMatch_ValidErrorCode_DeviceNotOnline()
+        {
+            // arrange
+            var httpResponseMessage = new HttpResponseMessage(System.Net.HttpStatusCode.BadRequest);
+            var exceptionResult = new IoTHubExceptionResult
+            {
+                Message = "{\"errorCode\":404103}"
+            };
+            httpResponseMessage.Content = new StringContent(JsonConvert.SerializeObject(exceptionResult));
+            httpResponseMessage.Headers.Add(CommonConstants.HttpErrorCodeName, "DeviceNotOnline");
+
+            // act
+            ErrorCode errorCode = await ExceptionHandlingHelper.GetExceptionCodeAsync(httpResponseMessage);
+
+            // assert
+            Assert.AreEqual(ErrorCode.DeviceNotOnline, errorCode);
+        }
+
+        [TestMethod]
         public async Task GetExceptionCodeAsync_ContentAndHeadersMisMatch_InvalidErrorCode()
         {
             // arrange


### PR DESCRIPTION
## Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `main` branch.
<!-- If not against main, please add the reason. -->

## Description of the changes
Added the error code: 404103 for Device online. So users can handle this error gracefully. 

## Reference/Link to the issue solved with this PR (if any)
Fixes: https://github.com/Azure/azure-iot-sdk-csharp/issues/3442
