### PR TITLE
Update Azure Identity dependency version, disable RBAC tests

### DIFF
--- a/e2e/test/E2ETests.csproj
+++ b/e2e/test/E2ETests.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.3" />
-    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+    <PackageReference Include="Azure.Identity" Version="1.11.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(AZURE_IOT_LOCALPACKAGES)' == '' ">

--- a/e2e/test/iothub/TokenCredentialAuthenticationTests.cs
+++ b/e2e/test/iothub/TokenCredentialAuthenticationTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
+        [Ignore("Test infrastructure not currently available")]
         public async Task RegistryManager_Http_TokenCredentialAuth_Success()
         {
             // arrange
@@ -58,6 +59,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
+        [Ignore("Test infrastructure not currently available")]
         public async Task JobClient_Http_TokenCredentialAuth_Success()
         {
             // arrange
@@ -90,6 +92,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
+        [Ignore("Test infrastructure not currently available")]
         public async Task DigitalTwinClient_Http_TokenCredentialAuth_Success()
         {
             // arrange
@@ -125,6 +128,7 @@ namespace Microsoft.Azure.Devices.E2ETests.IotHub.Service
 
         [TestMethod]
         [Timeout(TestTimeoutMilliseconds)]
+        [Ignore("Test infrastructure not currently available")]
         public async Task Service_Amqp_TokenCredentialAuth_Success()
         {
             // arrange

--- a/iothub/service/samples/how to guides/RoleBasedAuthenticationSample/RoleBasedAuthenticationSample.csproj
+++ b/iothub/service/samples/how to guides/RoleBasedAuthenticationSample/RoleBasedAuthenticationSample.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.36.0" />
-    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+    <PackageReference Include="Azure.Core" Version="1.39.0" />
+    <PackageReference Include="Azure.Identity" Version="1.11.2" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
   </ItemGroup>
 


### PR DESCRIPTION
RBAC test infrastructure is currently not set up with the new federated standard, so we should disable them for now