### PR TITLE
docs: fix errors with params documentation

### DIFF
--- a/iothub/device/src/Authentication/AuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/Authentication/AuthenticationWithTokenRefresh.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.Client
         /// may choose to ignore this value.</param>
         /// <param name="timeBufferPercentage">Time buffer before expiry when the token should be renewed expressed as
         /// a percentage of the time to live.</param>
-        /// <param name="disposeWithClient "><c>true</c> if the authentication method should be disposed of by the client
+        /// <param name="disposeWithClient"><c>true</c> if the authentication method should be disposed of by the client
         /// when the client using this instance is itself disposed; <c>false</c> if you intend to reuse the authentication method.</param>
         public AuthenticationWithTokenRefresh(
             int suggestedTimeToLiveSeconds,

--- a/iothub/device/src/Authentication/DeviceAuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/Authentication/DeviceAuthenticationWithTokenRefresh.cs
@@ -65,9 +65,9 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="timeBufferPercentage">
         /// The time buffer before expiry when the token should be renewed, expressed as a percentage of the time to live.
         /// The default behavior is that the token will be renewed when it has 15% or less of its lifespan left.
-        ///</param>
-        ///<param name="disposeWithClient ">
-        ///<c>true</c> if the authentication method should be disposed of by the client
+        /// </param>
+        /// <param name="disposeWithClient">
+        /// <c>true</c> if the authentication method should be disposed of by the client
         /// when the client using this instance is itself disposed; <c>false</c> if you intend to reuse the authentication method.
         /// </param>
         public DeviceAuthenticationWithTokenRefresh(

--- a/iothub/device/src/Authentication/DeviceAuthenticationWithTpm.cs
+++ b/iothub/device/src/Authentication/DeviceAuthenticationWithTpm.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="suggestedTimeToLiveSeconds">Token time to live suggested value.</param>
         /// <param name="timeBufferPercentage">Time buffer before expiry when the token should be renewed expressed as percentage of
         /// the time to live. EX: If you want a SAS token to live for 85% of life before proactive renewal, this value should be 15.</param>
-        /// <param name="disposeWithClient "><c>true</c> if the authentication method should be disposed of by the client
+        /// <param name="disposeWithClient"><c>true</c> if the authentication method should be disposed of by the client
         /// when the client using this instance is itself disposed; <c>false</c> if you intend to reuse the authentication method.</param>
         public DeviceAuthenticationWithTpm(
             string deviceId,

--- a/iothub/device/src/Authentication/ModuleAuthenticationWithTokenRefresh.cs
+++ b/iothub/device/src/Authentication/ModuleAuthenticationWithTokenRefresh.cs
@@ -71,9 +71,9 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="timeBufferPercentage">
         /// The time buffer before expiry when the token should be renewed, expressed as a percentage of the time to live.
         /// The default behavior is that the token will be renewed when it has 15% or less of its lifespan left.
-        ///</param>
-        ///<param name="disposeWithClient ">
-        ///<c>true</c> if the authentication method should be disposed of by the client
+        /// </param>
+        /// <param name="disposeWithClient">
+        /// <c>true</c> if the authentication method should be disposed of by the client
         /// when the client using this instance is itself disposed; <c>false</c> if you intend to reuse the authentication method.
         /// </param>
         public ModuleAuthenticationWithTokenRefresh(


### PR DESCRIPTION
- remove white space from param name (obvious typos) showing as errors in some IDEs setups.

Thanks!

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-csharp/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- [x] This pull-request is submitted against the `main` branch.

## Description of the changes

Obvious typos correction in a documentation for parameters 

## Reference/Link to the issue solved with this PR (if any)
n/a
