### PR TITLE
refactor(csr): update CertificateSigningRequest constructor

### DIFF
--- a/iothub/device/src/CertificateSigningRequest.cs
+++ b/iothub/device/src/CertificateSigningRequest.cs
@@ -15,27 +15,40 @@ namespace Microsoft.Azure.Devices.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="CertificateSigningRequest"/> class.
         /// </summary>
-        /// <param name="id">The device ID the certificate will be issued for. Must match the currently authenticated device ID.</param>
+        /// <param name="deviceId">The device ID the certificate will be issued for. Must match the device ID of the currently authenticated device.</param>
         /// <param name="csrData">The Base64-encoded PKCS#10 CSR without PEM headers/footers or newlines.</param>
-        public CertificateSigningRequest(string id, string csrData)
+        /// <param name="requestId">Optional. The request ID to associate with this certificate signing request.
+        /// This value should be unique from any ongoing certificate signing request (for example, a GUID).
+        /// If null or empty, a new GUID will be generated.
+        /// The use case for providing a specific value here is for re-submitting a certificate signing request,
+        /// which should be done if the client loses connection at any point during the certificate signing process.</param>
+        /// <param name="replace">Optional. The request ID to replace, or "*" to replace any active request.
+        /// To not replace any pending certificate signing operation, this value should be null (the default).</param>
+        public CertificateSigningRequest(string deviceId, string csrData, string? requestId = null, string? replace = null)
         {
-            Id = id;
+            DeviceId = deviceId;
             CertificateSigningRequestData = csrData;
+            RequestId = string.IsNullOrEmpty(requestId) ? Guid.NewGuid().ToString() : requestId!;
+            Replace = replace;
         }
         
         /// <summary>
-        /// Request id identifies specific certificate signing request. May be used as a value for <see cref="Replace"/>
-        /// property to replace an existing pending request.
+        /// The request ID associated with this certificate signing request.
+        /// Users may assign this value via <see cref="CertificateSigningRequest(string, string, string?, string?)"/>;
+        /// if not provided, a random GUID is generated.
+        /// The use case for providing a specific value is for re-submitting a certificate signing request,
+        /// which should be done if the client loses connection at any point during the certificate signing process.
+        /// May be used as a value for <see cref="Replace"/> property to replace an existing pending request.
         /// </summary>
         [JsonIgnore]
-        public readonly string RequestId = Guid.NewGuid().ToString();
+        public readonly string RequestId;
         
         /// <summary>
         /// Required. The device ID the certificate will be issued for.
-        /// Must match the currently authenticated device ID.
+        /// Must match the device ID of the currently authenticated device.
         /// </summary>
         [JsonProperty("id")]
-        public string Id { get; set; }
+        public string DeviceId { get; set; }
 
         /// <summary>
         /// Required. The Base64-encoded PKCS#10 CSR without PEM headers/footers or newlines.
@@ -48,7 +61,7 @@ namespace Microsoft.Azure.Devices.Client
         /// Use when:
         /// - The CSR is known to be different from a previous incomplete request
         /// - Client received 409005 and doesn't know if CSR has changed (e.g., storage failure)
-        /// Default: null (will fail with 409005 if an active operation exists)
+        /// To not replace any pending certificate signing operation, this value should be null (the default).
         /// </summary>
         [JsonProperty("replace", NullValueHandling = NullValueHandling.Ignore)]
         public string? Replace { get; set; }

--- a/iothub/device/src/CertificateSigningRequest.cs
+++ b/iothub/device/src/CertificateSigningRequest.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="deviceId">The device ID the certificate will be issued for. Must match the device ID of the currently authenticated device.</param>
         /// <param name="csrData">The Base64-encoded PKCS#10 CSR without PEM headers/footers or newlines.</param>
         /// <param name="requestId">Optional. The request ID to associate with this certificate signing request.
+        /// Must be 4 to 36 characters, ASCII alphanumerics and dashes only, and must not begin or end with a dash.
         /// This value should be unique from any ongoing certificate signing request (for example, a GUID).
         /// If null or empty, a new GUID will be generated.
         /// The use case for providing a specific value here is for re-submitting a certificate signing request,
@@ -34,6 +35,7 @@ namespace Microsoft.Azure.Devices.Client
         
         /// <summary>
         /// The request ID associated with this certificate signing request.
+        /// Must be 4 to 36 characters, ASCII alphanumerics and dashes only, and must not begin or end with a dash.
         /// Users may assign this value via <see cref="CertificateSigningRequest(string, string, string?, string?)"/>;
         /// if not provided, a random GUID is generated.
         /// The use case for providing a specific value is for re-submitting a certificate signing request,

--- a/iothub/device/src/DeviceClient.cs
+++ b/iothub/device/src/DeviceClient.cs
@@ -628,7 +628,10 @@ namespace Microsoft.Azure.Devices.Client
         /// </para>
         /// <para><b>Reconnection Behavior:</b></para>
         /// <para>
-        /// If the device disconnects at any point during the CSR operation, reconnect and call <see cref="SendCertificateSigningRequest"/> again.
+        /// If the device disconnects at any point during the CSR operation (which you can monitor via
+        /// <see cref="SetConnectionStatusChangesHandler"/>), the SDK will automatically restore the connection.
+        /// Once reconnected, re-submit the same certificate signing request (including the same request ID)
+        /// by calling <see cref="SendCertificateSigningRequest"/> again.
         /// If error 409005 (CredentialOperationActive) is received, set <see cref="CertificateSigningRequest.Replace"/> to "*"
         /// to replace any active operation, or to the specific request ID of your previous request if you saved it.
         /// </para>

--- a/iothub/device/src/InternalClient.cs
+++ b/iothub/device/src/InternalClient.cs
@@ -730,8 +730,8 @@ namespace Microsoft.Azure.Devices.Client
         /// <param name="request">The certificate signing request containing the CSR.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The response containing the issued certificate chain.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when request, request.Id, or request.Csr is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when request.Id or request.Csr is empty, or Csr is not valid Base64.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when request, request.DeviceId, or request.Csr is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when request.DeviceId or request.Csr is empty, or Csr is not valid Base64.</exception>
         /// <exception cref="NotSupportedException">Thrown when using non-MQTT transport.</exception>
         /// <exception cref="IotHubException">Thrown when the request fails.</exception>
         /// <exception cref="TimeoutException">Thrown when the operation times out.</exception>
@@ -744,10 +744,10 @@ namespace Microsoft.Azure.Devices.Client
                 throw new ArgumentNullException(nameof(request));
             }
 
-            if (string.IsNullOrEmpty(request.Id))
+            if (string.IsNullOrEmpty(request.DeviceId))
             {
                 throw new ArgumentException(@"Value cannot be null or empty.",
-                    $"{nameof(request)}.{nameof(request.Id)}");
+                    $"{nameof(request)}.{nameof(request.DeviceId)}");
             }
 
             if (string.IsNullOrEmpty(request.CertificateSigningRequestData))


### PR DESCRIPTION
This pull request updates the `CertificateSigningRequest` class and related documentation to clarify and improve how certificate signing requests are created, tracked, and retried in the device SDK. The main changes include renaming the `Id` property to `DeviceId`, introducing explicit handling for `RequestId` and `Replace` parameters, and improving documentation and error handling related to reconnection and retry scenarios.

**API and Property Changes:**

* Renamed the `Id` property to `DeviceId` throughout the `CertificateSigningRequest` class and related methods, and updated all references and documentation accordingly. [[1]](diffhunk://#diff-cb9db14962299bb0f781ebb2a0b63fc3ff07677f8da5c29cfb4cd84751a50282L18-R51) [[2]](diffhunk://#diff-5a149b072a4e7b9db5b9050e5e7ef0eaf7dee49d1fd3f854a241d68cc687ccf5L733-R734) [[3]](diffhunk://#diff-5a149b072a4e7b9db5b9050e5e7ef0eaf7dee49d1fd3f854a241d68cc687ccf5L747-R750)
* Changed the constructor for `CertificateSigningRequest` to accept `deviceId`, `csrData`, an optional `requestId`, and an optional `replace` parameter. If `requestId` is not provided, a new GUID is generated.

**Certificate Signing Request Management:**

* Added and documented the `Replace` property to allow replacing an active certificate signing request, and clarified its usage in both the code and XML comments. [[1]](diffhunk://#diff-cb9db14962299bb0f781ebb2a0b63fc3ff07677f8da5c29cfb4cd84751a50282L18-R51) [[2]](diffhunk://#diff-cb9db14962299bb0f781ebb2a0b63fc3ff07677f8da5c29cfb4cd84751a50282L51-R64)
* Improved the documentation for reconnection handling: clarified that when a device disconnects during a CSR operation, the SDK will restore the connection, and the same request (with the same `RequestId`) should be re-submitted.

**Error Handling and Validation:**

* Updated parameter validation and exception messages to use `DeviceId` instead of `Id`, and clarified exception conditions in documentation. [[1]](diffhunk://#diff-5a149b072a4e7b9db5b9050e5e7ef0eaf7dee49d1fd3f854a241d68cc687ccf5L733-R734) [[2]](diffhunk://#diff-5a149b072a4e7b9db5b9050e5e7ef0eaf7dee49d1fd3f854a241d68cc687ccf5L747-R750)