### PR TITLE
Create samples that demonstrate connecting to IoT hub over TLS 1.3

### DIFF
--- a/azureiot.sln
+++ b/azureiot.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.1.32328.378
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11702.344 oobstable
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "iothub", "iothub", "{537FA828-124D-4C70-9FC1-89301D9E776D}"
 EndProject
@@ -208,6 +208,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "prerequisites", "prerequisi
 		e2e\test\prerequisites\E2ETestsSetup\test-resources.bicep = e2e\test\prerequisites\E2ETestsSetup\test-resources.bicep
 		e2e\test\prerequisites\E2ETestsSetup\test-resources.json = e2e\test\prerequisites\E2ETestsSetup\test-resources.json
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tls13Sample", "iothub\device\samples\how to guides\Tls13Sample\Tls13Sample.csproj", "{553DD24F-4040-6207-906D-FD5E4EF49350}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tls13ServiceClientSample", "iothub\service\samples\how to guides\Tls13ServiceClientSample\Tls13ServiceClientSample.csproj", "{34162CFA-C6FC-D37A-D6CC-493775DBF707}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -438,6 +442,14 @@ Global
 		{184F07FC-A5CA-43F5-8742-0B6DF6825A1F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{184F07FC-A5CA-43F5-8742-0B6DF6825A1F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{184F07FC-A5CA-43F5-8742-0B6DF6825A1F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{553DD24F-4040-6207-906D-FD5E4EF49350}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{553DD24F-4040-6207-906D-FD5E4EF49350}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{553DD24F-4040-6207-906D-FD5E4EF49350}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{553DD24F-4040-6207-906D-FD5E4EF49350}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34162CFA-C6FC-D37A-D6CC-493775DBF707}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34162CFA-C6FC-D37A-D6CC-493775DBF707}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34162CFA-C6FC-D37A-D6CC-493775DBF707}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34162CFA-C6FC-D37A-D6CC-493775DBF707}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -529,6 +541,8 @@ Global
 		{89643F18-7B22-41BD-8342-49251943C984} = {4CF9A9B8-9D3F-44F6-B965-DF2B7EEA024E}
 		{184F07FC-A5CA-43F5-8742-0B6DF6825A1F} = {89643F18-7B22-41BD-8342-49251943C984}
 		{CA137E4E-4684-442D-92FC-20ADACCB5D62} = {9C260BF0-1CCA-45A2-AAB8-6419291B8B88}
+		{553DD24F-4040-6207-906D-FD5E4EF49350} = {FA7C7E33-CC9C-4ACD-A761-C2B4C55E82F6}
+		{34162CFA-C6FC-D37A-D6CC-493775DBF707} = {73EFBF28-CA06-4A08-88BC-CCDA2C498C76}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AF61665D-340A-494B-9705-571456BDC752}

--- a/iothub/device/samples/how to guides/Tls13Sample/Program.cs
+++ b/iothub/device/samples/how to guides/Tls13Sample/Program.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Shared;
+
+string? deviceConnectionString = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_CONNECTION_STRING");
+
+if (string.IsNullOrEmpty(deviceConnectionString) || !deviceConnectionString.Contains(".device.azure-devices."))
+{
+    Console.WriteLine("Must set environment variable \"IOTHUB_DEVICE_CONNECTION_STRING\" with value that matches the pattern \"<hub name>.device.azure-devices.<dnsSuffix>\". Connection strings that look like \"<hub name>.azure-devices.<dnsSuffix>\" do not support TLS 1.3");
+    return -1;
+}
+
+// This sample explicitly sets the minimum TLS version to 1.3 for reference purposes only. Without setting this, the SDK should still connect using TLS 1.3 when available since it is the newest available supported version.
+TlsVersions.Instance.SetMinimumTlsVersions(System.Security.Authentication.SslProtocols.Tls13);
+
+// All protocols (AMQP, AMQP_WS, MQTT, MQTT_WS, and HTTP) support TLS 1.3 currently
+using DeviceClient client = DeviceClient.CreateFromConnectionString(deviceConnectionString, TransportType.Amqp_Tcp_Only);
+
+Console.WriteLine("Opening TLS 1.3 connection");
+await client.OpenAsync();
+
+Console.WriteLine("Sending telemetry on TLS 1.3 connection");
+using Message msg = new Message(Encoding.UTF8.GetBytes("Hello from TLS 1.3 sample!"));
+await client.SendEventAsync(msg);
+
+Console.WriteLine("Closing client");
+await client.CloseAsync();
+
+return 0;

--- a/iothub/device/samples/how to guides/Tls13Sample/Program.cs
+++ b/iothub/device/samples/how to guides/Tls13Sample/Program.cs
@@ -9,7 +9,7 @@ string? deviceConnectionString = Environment.GetEnvironmentVariable("IOTHUB_DEVI
 
 if (string.IsNullOrEmpty(deviceConnectionString) || !deviceConnectionString.Contains(".device.azure-devices."))
 {
-    Console.WriteLine("Must set environment variable \"IOTHUB_DEVICE_CONNECTION_STRING\" with value that matches the pattern \"<hub name>.device.azure-devices.<dnsSuffix>\". Connection strings that look like \"<hub name>.azure-devices.<dnsSuffix>\" do not support TLS 1.3");
+    Console.WriteLine("Must set environment variable \"IOTHUB_DEVICE_CONNECTION_STRING\" with value that matches the pattern \"<hub name>.device.azure-devices.<dnsSuffix>\". Endpoints with connection strings that look like \"<hub name>.azure-devices.<dnsSuffix>\" do not support TLS 1.3");
     return -1;
 }
 

--- a/iothub/device/samples/how to guides/Tls13Sample/README.md
+++ b/iothub/device/samples/how to guides/Tls13Sample/README.md
@@ -1,0 +1,44 @@
+# TLS 1.3 Sample
+
+## SCENARIO
+
+Connect to an IoT hub using TLS 1.3 (currently in preview) and then send a telemetry message.
+
+## CONTEXT
+
+### IoT hub support for TLS 1.3
+IoT Hub is currently previewing the ability to use TLS 1.3, but accessing that requires some small changes on the client side.
+
+Up until now, connection strings would always follow a format like:
+
+```
+<hub name>.azure-devices.<dnsSuffix> 
+```
+
+and this IoT hub endpoint supports TLS versions 1.0, 1.1, and 1.2
+
+IoT hub is previewing offering TLS version 1.2 + 1.3 support in endpoints with connection strings like
+
+```
+device connection string:
+<hub name>.device.azure-devices.<dnsSuffix> 
+```
+
+and
+
+```
+service connection string:
+<hub name>.service.azure-devices.<dnsSuffix> 
+```
+
+This sample expects the environment variable "IOTHUB_DEVICE_CONNECTION_STRING" to contain a connection string that follows the device connection string pattern above
+
+### SDK behavior
+
+When you run this sample, the "Client Hello" message in the TLS layer will advertise to IoT hub that this client supports TLS 1.2 and TLS 1.3. In the "Server Hello" response, IoT hub will then choose TLS 1.3 as the version for both client and server to use for this connection.
+
+Note that the SDK behavior here is unchanged as it has always advertised support for TLS 1.2 and TLS 1.3. The only change to make the connection use TLS 1.3 is to connect with the connection string of the host that also supports TLS 1.3
+
+## ADDITIONAL CONSIDERATIONS
+
+This feature is not generally available yet nor is it available in preview for all IoT hubs. As such, the above connection string pattern my yield a "host not found" exception.

--- a/iothub/device/samples/how to guides/Tls13Sample/Tls13Sample.csproj
+++ b/iothub/device/samples/how to guides/Tls13Sample/Tls13Sample.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(Configuration)' == 'Release'">
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.41.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <ProjectReference Include="..\..\..\src\Microsoft.Azure.Devices.Client.csproj" />
+  </ItemGroup>
+</Project>

--- a/iothub/service/samples/how to guides/Tls13ServiceClientSample/Program.cs
+++ b/iothub/service/samples/how to guides/Tls13ServiceClientSample/Program.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using Microsoft.Azure.Devices;
+using Microsoft.Azure.Devices.Shared;
+
+string? serviceConnectionString = Environment.GetEnvironmentVariable("IOTHUB_SERVICE_CONNECTION_STRING");
+
+if (string.IsNullOrEmpty(serviceConnectionString) || !serviceConnectionString.Contains(".service.azure-devices."))
+{
+    Console.WriteLine("Must set environment variable \"IOTHUB_SERVICE_CONNECTION_STRING\" with value that matches the pattern \"<hub name>.service.azure-devices.<dnsSuffix>\". Connection strings that look like \"<hub name>.azure-devices.<dnsSuffix>\" do not support TLS 1.3");
+    return -1;
+}
+
+// This sample explicitly sets the minimum TLS version to 1.3 for reference purposes only. Without setting this, the SDK should still connect using TLS 1.3 when available since it is the newest available supported version.
+TlsVersions.Instance.SetMinimumTlsVersions(System.Security.Authentication.SslProtocols.Tls13);
+
+using RegistryManager registryManager = RegistryManager.CreateFromConnectionString(serviceConnectionString);
+
+string deviceId = Guid.NewGuid().ToString();
+Device deviceToCreate = new Device(deviceId);
+
+Console.WriteLine("Creating device over HTTP connection");
+await registryManager.AddDeviceAsync(deviceToCreate);
+
+using ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(serviceConnectionString, TransportType.Amqp);
+
+Console.WriteLine("Sending message over AMQP connection");
+using Message msg = new Message(Encoding.UTF8.GetBytes("Hello from TLS 1.3 sample!"));
+await serviceClient.SendAsync(deviceId, msg);
+
+Console.WriteLine("Closing service client");
+await serviceClient.CloseAsync();
+
+return 0;

--- a/iothub/service/samples/how to guides/Tls13ServiceClientSample/Program.cs
+++ b/iothub/service/samples/how to guides/Tls13ServiceClientSample/Program.cs
@@ -9,7 +9,7 @@ string? serviceConnectionString = Environment.GetEnvironmentVariable("IOTHUB_SER
 
 if (string.IsNullOrEmpty(serviceConnectionString) || !serviceConnectionString.Contains(".service.azure-devices."))
 {
-    Console.WriteLine("Must set environment variable \"IOTHUB_SERVICE_CONNECTION_STRING\" with value that matches the pattern \"<hub name>.service.azure-devices.<dnsSuffix>\". Connection strings that look like \"<hub name>.azure-devices.<dnsSuffix>\" do not support TLS 1.3");
+    Console.WriteLine("Must set environment variable \"IOTHUB_SERVICE_CONNECTION_STRING\" with value that matches the pattern \"<hub name>.service.azure-devices.<dnsSuffix>\". Endpoints with connection strings that look like \"<hub name>.azure-devices.<dnsSuffix>\" do not support TLS 1.3");
     return -1;
 }
 

--- a/iothub/service/samples/how to guides/Tls13ServiceClientSample/README.md
+++ b/iothub/service/samples/how to guides/Tls13ServiceClientSample/README.md
@@ -1,0 +1,44 @@
+# TLS 1.3 Sample
+
+## SCENARIO
+
+Connect to an IoT hub using TLS 1.3 (currently in preview) and then send a telemetry message.
+
+## CONTEXT
+
+### IoT hub support for TLS 1.3
+IoT Hub is currently previewing the ability to use TLS 1.3, but accessing that requires some small changes on the client side.
+
+Up until now, connection strings would always follow a format like:
+
+```
+<hub name>.azure-devices.<dnsSuffix> 
+```
+
+and this IoT hub endpoint supports TLS versions 1.0, 1.1, and 1.2
+
+IoT hub is previewing offering TLS version 1.2 + 1.3 support in endpoints with connection strings like
+
+```
+device connection string:
+<hub name>.device.azure-devices.<dnsSuffix> 
+```
+
+and
+
+```
+service connection string:
+<hub name>.service.azure-devices.<dnsSuffix> 
+```
+
+This sample expects the environment variable "IOTHUB_SERVICE_CONNECTION_STRING" to contain a connection string that follows the service connection string pattern above
+
+### SDK behavior
+
+When you run this sample, the "Client Hello" message in the TLS layer will advertise to IoT hub that this client supports TLS 1.2 and TLS 1.3. In the "Server Hello" response, IoT hub will then choose TLS 1.3 as the version for both client and server to use for this connection.
+
+Note that the SDK behavior here is unchanged as it has always advertised support for TLS 1.2 and TLS 1.3. The only change to make the connection use TLS 1.3 is to connect with the connection string of the host that also supports TLS 1.3. 
+
+## ADDITIONAL CONSIDERATIONS
+
+This feature is not generally available yet nor is it available in preview for all IoT hubs. As such, the above connection string pattern my yield a "host not found" exception.

--- a/iothub/service/samples/how to guides/Tls13ServiceClientSample/Tls13ServiceClientSample.csproj
+++ b/iothub/service/samples/how to guides/Tls13ServiceClientSample/Tls13ServiceClientSample.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(Configuration)' == 'Release'">
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.38.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <ProjectReference Include="..\..\..\src\Microsoft.Azure.Devices.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
TLS 1.3 works as expected for all transport protocols in both device + service clients