### PR TITLE
Own the CodeQL snapshots from the SDL pipeline

### DIFF
--- a/vsts/horton-e2e.yaml
+++ b/vsts/horton-e2e.yaml
@@ -5,6 +5,11 @@ variables:
   Horton.Repo: $(Build.Repository.Uri)
   Horton.Commit: $(Build.SourceBranch)
   Horton.ForcedImage: ''
+  # This is an e2e gate, not the SDL scanning pipeline. Auto-injected CodeQL here
+  # produces incidental databases that displace the ones from 'Dotnet SDL'
+  # (vsts/vsts_sdl.yaml), because S360 records arg_max(SnapshotDate) per
+  # (repo, language). See https://aka.ms/codeql3000.
+  Codeql.Enabled: false
 
 resources:
   repositories:

--- a/vsts/resource-group-cleanup.yaml
+++ b/vsts/resource-group-cleanup.yaml
@@ -4,6 +4,16 @@ resources:
   - repo: self
     clean: true
 
+variables:
+  # This pipeline only deletes leftover Azure resource groups -- it builds
+  # nothing. The auto-injected CodeQL here was producing the "Database failed to
+  # finalize or no source code was built!" entries for this repo in the
+  # Microsoft.Security.CodeQL.10000 S360 report, because S360 records the most
+  # recent attempt per (repo, language). The real snapshot comes from the
+  # 'Dotnet SDL' pipeline (vsts/vsts_sdl.yaml).
+  # See https://aka.ms/codeql3000 and https://aka.ms/sdlfaqcodeql.
+  Codeql.Enabled: false
+
 jobs:
   - job: Cleanup
     displayName: Cleanup

--- a/vsts/vsts_sdl.yaml
+++ b/vsts/vsts_sdl.yaml
@@ -39,20 +39,33 @@ jobs:
     steps:
       - task: CodeQL3000Init@0
         displayName: Initialize CodeQL
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
-      - powershell: .\build.ps1 -clean -build -configutaion Debug -package
+      - powershell: .\build.ps1 -clean -build -configuration Debug -package
         displayName: Build Package
 
       # GitHub reports 'java' among this repo's languages because of testProxy/
       # (a single Main.java used by the E2E tests), so S360 grades us on it and
-      # CodeQL needs a traced java build to produce that database. This is the
-      # same command vsts/vsts.yaml already runs on a windows-2022 agent.
+      # CodeQL needs a traced java build to produce that database.
+      # testProxy/pom.xml sets maven.compiler.target=11, and the windows-2022
+      # image defaults JAVA_HOME to JDK 8 ('invalid target release: 11'), so the
+      # JDK has to be selected explicitly. Both steps run only on main, where
+      # CodeQL is enabled -- PR builds should not pay for a java build.
+      - task: JavaToolInstaller@0
+        displayName: Use JDK 11 (for the test proxy build)
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+        inputs:
+          versionSpec: '11'
+          jdkArchitectureOption: 'x64'
+          jdkSourceOption: 'PreInstalled'
+
       - powershell: mvn -f $(Build.SourcesDirectory)/testProxy/pom.xml clean install -q
         displayName: Build test proxy (java, for CodeQL)
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
       - task: CodeQL3000Finalize@0
         displayName: Finalize CodeQL
-        condition: always()
+        condition: and(always(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
       - task: ComponentGovernanceComponentDetection@0
         displayName: "Component Detection"

--- a/vsts/vsts_sdl.yaml
+++ b/vsts/vsts_sdl.yaml
@@ -21,12 +21,38 @@ jobs:
   - job: DOTNet_SDL_Analyzers
     displayName: .Net SDL Analyzers
     condition: succeeded()
-    timeoutInMinutes: 60
+    # CodeQL traces the builds below, which roughly doubles their wall time.
+    timeoutInMinutes: 90
+    variables:
+      # Owns the 'csharp' and 'java' CodeQL snapshots for this repo
+      # (Microsoft.Security.CodeQL.10000). Declaring the tasks explicitly, rather
+      # than leaning on the auto-injected CodeQL, keeps the snapshot S360 records
+      # tied to this job -- the one that actually builds the product. S360 keeps
+      # arg_max(SnapshotDate) per (repo, language), so without this the most
+      # recent incidental attempt wins instead.
+      # Only on main; this pipeline also runs on PRs, which need no snapshot.
+      # See https://aka.ms/codeql3000 and https://aka.ms/sdlfaqcodeql.
+      Codeql.Enabled: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+      Codeql.Language: csharp,java
     pool:
       vmImage: windows-2022
     steps:
+      - task: CodeQL3000Init@0
+        displayName: Initialize CodeQL
+
       - powershell: .\build.ps1 -clean -build -configutaion Debug -package
         displayName: Build Package
+
+      # GitHub reports 'java' among this repo's languages because of testProxy/
+      # (a single Main.java used by the E2E tests), so S360 grades us on it and
+      # CodeQL needs a traced java build to produce that database. This is the
+      # same command vsts/vsts.yaml already runs on a windows-2022 agent.
+      - powershell: mvn -f $(Build.SourcesDirectory)/testProxy/pom.xml clean install -q
+        displayName: Build test proxy (java, for CodeQL)
+
+      - task: CodeQL3000Finalize@0
+        displayName: Finalize CodeQL
+        condition: always()
 
       - task: ComponentGovernanceComponentDetection@0
         displayName: "Component Detection"


### PR DESCRIPTION
Own the CodeQL snapshots from the SDL pipeline

S360 grades this repo on 'csharp' and 'java' for
Microsoft.Security.CodeQL.10000, and both were reported as
"Database failed to finalize or no source code was built!". The databases behind
those entries were produced by the auto-injected CodeQL in the "Cleanup test
resource groups" pipeline -- a job whose only work is deleting leftover Azure
resource groups. S360 records arg_max(SnapshotDate) per (repo, language), so the
most recent incidental attempt wins over the real one.

Two changes:

1. vsts/vsts_sdl.yaml declares CodeQL3000Init/Finalize explicitly around the
   build in the .Net SDL Analyzers job, which already builds and packs the whole
   solution successfully every night. A maven build of testProxy is added so the
   'java' database has a traced compilation to come from; GitHub reports java as
   one of this repo's languages because of testProxy/src/main/java/.../Main.java,
   and that is the same command vsts/vsts.yaml already runs on windows-2022.
   The job timeout goes from 60 to 90 minutes because CodeQL tracing roughly
   doubles build wall time.

2. vsts/resource-group-cleanup.yaml and vsts/horton-e2e.yaml opt out of CodeQL.
   Neither builds the product.

CodeQL is enabled only on main; the SDL pipeline also runs on PRs, which do not
need to produce a snapshot.

An alternative for 'java' would be to mark testProxy/ as non-production (for
example linguist-vendored in .gitattributes) so S360 stops grading this repo on
java at all. That is an SDL-scope decision rather than a pipeline fix, so this
change simply produces the database instead.
