### PR TITLE
Stop the resource group cleanup deleting gate runs that are still in flight

### DIFF
--- a/e2e/Tests/prerequisites/e2eTestsSetup.ps1
+++ b/e2e/Tests/prerequisites/e2eTestsSetup.ps1
@@ -235,10 +235,12 @@ if ($rgExists -eq "False")
     Write-Host "`nCreating resource group $ResourceGroup in $Region"
 
     # Tagged as part of the creation itself, not afterwards: vsts/resource-group-cleanup.yaml
-    # uses 'CreatedOn' to tell a leftover group from one whose gate run is still in flight, and
-    # a group created in one step and tagged in a second can be left untagged forever if the run
-    # dies in between. A single tag is passed here on purpose -- under the AzureCLI@2 task,
-    # '--tags' with several key=value arguments collapses them into one tag value.
+    # uses 'CreatedOn' to tell a leftover group from one whose gate run is still in flight.
+    # Tagging in a second, separate call would leave a window where a run that dies in between
+    # produces an untagged group. That cleanup still reclaims such a group, but only via the
+    # slower 24-hour first-observed fallback rather than the 3-hour path. A single tag is passed
+    # here on purpose -- under the AzureCLI@2 task, '--tags' with several key=value arguments
+    # collapses them into one tag value.
     az group create --name $ResourceGroup --location $Region --tags "CreatedOn=$([datetime]::UtcNow.ToString('o'))" --output none
 }
 

--- a/e2e/Tests/prerequisites/e2eTestsSetup.ps1
+++ b/e2e/Tests/prerequisites/e2eTestsSetup.ps1
@@ -233,7 +233,13 @@ $rgExists = az group exists --name $ResourceGroup
 if ($rgExists -eq "False")
 {
     Write-Host "`nCreating resource group $ResourceGroup in $Region"
-    az group create --name $ResourceGroup --location $Region --output none
+
+    # Tagged as part of the creation itself, not afterwards: vsts/resource-group-cleanup.yaml
+    # uses 'CreatedOn' to tell a leftover group from one whose gate run is still in flight, and
+    # a group created in one step and tagged in a second can be left untagged forever if the run
+    # dies in between. A single tag is passed here on purpose -- under the AzureCLI@2 task,
+    # '--tags' with several key=value arguments collapses them into one tag value.
+    az group create --name $ResourceGroup --location $Region --tags "CreatedOn=$([datetime]::UtcNow.ToString('o'))" --output none
 }
 
 $resourceGroupId = az group show -n $ResourceGroup --query id --out tsv

--- a/vsts/resource-group-cleanup.yaml
+++ b/vsts/resource-group-cleanup.yaml
@@ -14,6 +14,16 @@ variables:
   # See https://aka.ms/codeql3000 and https://aka.ms/sdlfaqcodeql.
   Codeql.Enabled: false
 
+  # A resource group is only deleted once it is at least this old, so that a gate
+  # run still in flight is never torn down underneath itself.
+  MinimumAgeHours: 3
+
+  # How long a resource group with no usable 'CreatedOn' tag is left alone after
+  # this cleanup first sees it. Longer than MinimumAgeHours because the real age
+  # of such a group is unknown, so this grace period is the only thing standing
+  # between an in-flight run and deletion.
+  UntaggedMinimumAgeHours: 24
+
 jobs:
   - job: Cleanup
     displayName: Cleanup
@@ -29,15 +39,162 @@ jobs:
         scriptLocation: 'inlineScript'
         pwsh: true
         inlineScript: |
-          $jsonContent = az group list
-          $jsonArray = $jsonContent | ConvertFrom-Json
+          $ErrorActionPreference = 'Stop'
 
-          # Loop through each item
-          foreach ($resourceGroupJsonObject in $jsonArray) {
-              $rgName = $($resourceGroupJsonObject.name)
-              if ($rgName.StartsWith("javasdkgate") -or $rgName.StartsWith("dotnetsdkgate")) 
-              {
-                  Write-Host "Deleting resource group with name:" $rgName
-                  az group delete --name $rgName --yes
+          # Only resource groups whose name starts with one of these is ever considered.
+          $prefixes = @('javasdkgate', 'dotnetsdkgate')
+
+          $minimumAgeHours = [int]'$(MinimumAgeHours)'
+          $untaggedMinimumAgeHours = [int]'$(UntaggedMinimumAgeHours)'
+
+          # Written by this cleanup on a matching group that has no usable 'CreatedOn'.
+          # It records when the group was first seen, which is what lets an untagged group
+          # age out instead of being either deleted on sight or skipped forever.
+          $firstObservedTagName = 'CleanupFirstObservedOn'
+
+          $now = [datetime]::UtcNow
+          $cutoff = $now.AddHours(-$minimumAgeHours)
+          $untaggedCutoff = $now.AddHours(-$untaggedMinimumAgeHours)
+
+          Write-Host "Cleanup run (UTC)     : $($now.ToString('o'))"
+          Write-Host "Prefixes              : $($prefixes -join ', ')"
+          Write-Host "Minimum age to delete : $minimumAgeHours hour(s) (delete when created at or before $($cutoff.ToString('o')))"
+          Write-Host "Untagged grace period : $untaggedMinimumAgeHours hour(s) after this cleanup first observes the group"
+
+          function ConvertTo-UtcDateTime {
+              # Returns $null rather than throwing when the value is missing or unparseable,
+              # so the caller decides what an unknown timestamp means.
+              param($Value)
+
+              if ($null -eq $Value -or [string]::IsNullOrWhiteSpace([string]$Value)) {
+                  return $null
               }
+
+              try {
+                  if ($Value -is [datetimeoffset]) { return $Value.UtcDateTime }
+                  if ($Value -is [datetime]) { return ([datetimeoffset]$Value).UtcDateTime }
+
+                  return [datetimeoffset]::Parse(
+                      [string]$Value,
+                      [System.Globalization.CultureInfo]::InvariantCulture,
+                      [System.Globalization.DateTimeStyles]::AssumeUniversal).UtcDateTime
+              } catch {
+                  return $null
+              }
+          }
+
+          function Add-ResourceGroupTag {
+              # Uses the tags endpoint with an explicit Merge so the group's other tags
+              # survive; PATCHing the group itself would replace the whole tags collection.
+              # The body goes through a file because passing tags as '--tags key=value'
+              # arguments collapses them into a single tag value under the AzureCLI@2 task.
+              param([string]$ResourceGroupId, [hashtable]$Tags)
+
+              $bodyFile = New-TemporaryFile
+              try {
+                  $payload = @{ operation = 'Merge'; properties = @{ tags = $Tags } } | ConvertTo-Json -Compress -Depth 5
+                  Set-Content -Path $bodyFile -Value $payload -Encoding utf8 -NoNewline
+                  az rest `
+                      --method PATCH `
+                      --url "https://management.azure.com$ResourceGroupId/providers/Microsoft.Resources/tags/default?api-version=2021-04-01" `
+                      --body "@$bodyFile" `
+                      --only-show-errors | Out-Null
+              }
+              finally {
+                  Remove-Item -Path $bodyFile -ErrorAction SilentlyContinue
+              }
+          }
+
+          $rawJson = az group list --query "[].{name:name, id:id, createdOn:tags.CreatedOn, firstObservedOn:tags.$firstObservedTagName}" -o json --only-show-errors
+          if ($LASTEXITCODE -ne 0) {
+              throw "Failed to list Azure resource groups (az exit code $LASTEXITCODE)."
+          }
+
+          $groups = @($rawJson | ConvertFrom-Json | Where-Object {
+              $name = $_.name
+              $name -and @($prefixes | Where-Object { $name.StartsWith($_, [System.StringComparison]::OrdinalIgnoreCase) }).Count -gt 0
+          })
+
+          Write-Host "Found $($groups.Count) resource group(s) matching the prefixes."
+
+          $deleted = [System.Collections.Generic.List[string]]::new()
+          $skipped = [System.Collections.Generic.List[string]]::new()
+          $stamped = [System.Collections.Generic.List[string]]::new()
+          $failed = [System.Collections.Generic.List[string]]::new()
+
+          function Remove-Group {
+              param([string]$Name, [string]$Because)
+
+              Write-Host "DELETE $Name : $Because."
+              az group delete --name $Name --yes --no-wait --only-show-errors | Out-Null
+              if ($LASTEXITCODE -ne 0) {
+                  Write-Warning "Failed to queue deletion of $Name (az exit code $LASTEXITCODE)."
+                  $script:failed.Add($Name)
+              } else {
+                  $script:deleted.Add($Name)
+              }
+          }
+
+          foreach ($group in $groups) {
+              $name = $group.name
+              $createdOnValue = $group.createdOn
+              $createdOn = ConvertTo-UtcDateTime -Value $createdOnValue
+
+              if ($null -eq $createdOn) {
+                  $reason = if ([string]::IsNullOrWhiteSpace([string]$createdOnValue)) {
+                      "no 'CreatedOn' tag"
+                  } else {
+                      "unparseable 'CreatedOn' tag value '$createdOnValue'"
+                  }
+
+                  $firstObserved = ConvertTo-UtcDateTime -Value $group.firstObservedOn
+
+                  if ($null -eq $firstObserved) {
+                      Write-Host "STAMP  $name : $reason; recording first-observed time, eligible for deletion after $untaggedMinimumAgeHours h."
+                      Add-ResourceGroupTag -ResourceGroupId $group.id -Tags @{ $firstObservedTagName = $now.ToString('o') }
+                      if ($LASTEXITCODE -ne 0) {
+                          Write-Warning "Failed to stamp $name (az exit code $LASTEXITCODE); it will be retried on the next run."
+                          $global:LASTEXITCODE = 0
+                          $skipped.Add($name)
+                      } else {
+                          $stamped.Add($name)
+                      }
+                      continue
+                  }
+
+                  $observedAgeHours = [math]::Round(($now - $firstObserved).TotalHours, 2)
+
+                  if ($firstObserved -ge $untaggedCutoff) {
+                      Write-Host "SKIP   $name : $reason; first observed $observedAgeHours h ago, within the $untaggedMinimumAgeHours h untagged grace period."
+                      $skipped.Add($name)
+                      continue
+                  }
+
+                  Remove-Group -Name $name -Because "$reason; first observed $observedAgeHours h ago, exceeding the $untaggedMinimumAgeHours h untagged grace period"
+                  continue
+              }
+
+              $ageHours = [math]::Round(($now - $createdOn).TotalHours, 2)
+
+              if ($createdOn -ge $cutoff) {
+                  Write-Host "SKIP   $name : age $ageHours h is within the $minimumAgeHours h threshold (created $($createdOn.ToString('o')))."
+                  $skipped.Add($name)
+                  continue
+              }
+
+              Remove-Group -Name $name -Because "age $ageHours h exceeds $minimumAgeHours h (created $($createdOn.ToString('o')))"
+          }
+
+          Write-Host ""
+          Write-Host "==== Cleanup summary ===="
+          Write-Host "Queued for deletion        : $($deleted.Count)"
+          Write-Host "Skipped (still too new)    : $($skipped.Count)"
+          Write-Host "Stamped (untagged, ageing) : $($stamped.Count)"
+          Write-Host "Failed to queue            : $($failed.Count)"
+          if ($deleted.Count -gt 0) { Write-Host "Deleted: $($deleted -join ', ')" }
+          if ($stamped.Count -gt 0) { Write-Host "Stamped: $($stamped -join ', ')" }
+          if ($failed.Count -gt 0) { Write-Host "Failed : $($failed -join ', ')" }
+
+          if ($failed.Count -gt 0) {
+              throw "$($failed.Count) resource group deletion(s) could not be queued."
           }

--- a/vsts/resource-group-cleanup.yaml
+++ b/vsts/resource-group-cleanup.yaml
@@ -188,7 +188,7 @@ jobs:
           Write-Host ""
           Write-Host "==== Cleanup summary ===="
           Write-Host "Queued for deletion        : $($deleted.Count)"
-          Write-Host "Skipped (still too new)    : $($skipped.Count)"
+          Write-Host "Skipped / not processed    : $($skipped.Count)"
           Write-Host "Stamped (untagged, ageing) : $($stamped.Count)"
           Write-Host "Failed to queue            : $($failed.Count)"
           if ($deleted.Count -gt 0) { Write-Host "Deleted: $($deleted -join ', ')" }


### PR DESCRIPTION
## The problem

`vsts/resource-group-cleanup.yaml` deletes **every** resource group named `javasdkgate*` or `dotnetsdkgate*`, with no age check at all:

```powershell
if ($rgName.StartsWith("javasdkgate") -or $rgName.StartsWith("dotnetsdkgate"))
{
    Write-Host "Deleting resource group with name:" $rgName
    az group delete --name $rgName --yes
}
```

Those are exactly the names `vsts/templates/DeployCloudResources.yaml` generates for a gate run **that is currently executing** (`'dotnetsdkgate'+$CloudResourceUniqueSuffix`). The pipeline is scheduled, so any time it fires while a Java or .NET gate run is in flight, it deletes that run's IoT hub, DPS instance and storage account out from under it. The run then fails on unrelated, confusing errors, and the cleanup reports success.

There is no guard of any kind today — not a tag, not a lock, not a naming convention that distinguishes a live run from a leftover.

## The fix

Delete a group only once it is at least `MinimumAgeHours` (**3**) old, from a `CreatedOn` tag.

**These groups carry no tags at all today**, in either repo — so an age check on its own would either skip every group forever (leaking all of them) or fall back to today's unsafe behaviour. Two changes together:

1. **`e2e/Tests/prerequisites/e2eTestsSetup.ps1`** now sets `CreatedOn` *as part of* `az group create`, so the fast 3 h path applies to new groups. Tagging in a second, separate call would reintroduce the same class of bug: a run that dies in between leaves an untagged group.
2. **Untagged groups are aged from first sight.** The cleanup stamps `CleanupFirstObservedOn` the first time it sees one and deletes it only once that stamp is older than `UntaggedMinimumAgeHours` (**24**). Nothing is ever deleted on sight.

That second part matters for rollout: it drains the groups that already exist, untagged, with **no manual step** — and it does so safely, because a group belonging to a live run gets a full 24 h grace period first. The longest gate run I measured is well under 2 h.

Also: deletion moves to `--no-wait` and its exit code is checked, so a failure to queue is reported rather than passing silently inside the job's 30-minute timeout.

## Note on `javasdkgate*`

This pipeline deletes the **Java** SDK's resource groups too, but it lives in this repo. `Azure/azure-iot-sdk-java` needs the matching one-line tagging change so its groups also get the fast 3 h path instead of the 24 h untagged one — sent separately as Azure/azure-iot-sdk-java#1865. **This PR is safe to merge before that one**: untagged Java groups keep being cleaned up, just on the slower, safer path.

## Testing

I have no ARM credential in this environment, so this is **not** verified against live Azure — please confirm on a scheduled run.

Verified locally: the pipeline YAML parses, and the inline script (with `$(MinimumAgeHours)` / `$(UntaggedMinimumAgeHours)` macro-expanded as ADO would) parses and runs under PowerShell 7.4.6 against a stubbed `az`:

| group | state | outcome |
|---|---|---|
| `dotnetsdkgateaaaaa` | `CreatedOn` 0.5 h | **SKIP** — old script would have deleted this live run |
| `javasdkgatebbbbb` | `CreatedOn` 9 h | DELETE |
| `javasdkgateccccc` | untagged, never seen | STAMP, not deleted |
| `dotnetsdkgateddddd` | untagged, first seen 2 h ago | SKIP (within grace) |
| `javasdkgateeeeee` | untagged, first seen 30 h ago | DELETE |
| `rg-iot-sdk-e2e-zzz` | 99 h old, other prefix | not matched |
| `prod-critical-rg` | untagged | not matched |

Also confirmed: the stamp uses the `Microsoft.Resources/tags` endpoint with an explicit `Merge` (PATCHing the group itself would replace its whole tags collection); a failing stamp warns, counts as skipped and is retried next run rather than aborting; and the `CreatedOn` value written by `e2eTestsSetup.ps1` reaches `az` as a **single** argument token and round-trips through the exact parser the cleanup uses.

## Background

Found while investigating an S360 alert on three `rg-iot-sdk-e2e-*` storage accounts. Those turned out to be healthy — but this pipeline is the one genuinely unsafe piece of resource-group cleanup in the family. Two related hardening PRs are open against `Azure/iot-sdks-e2e-fx` (#442, #443); that repo's cleanup already had a 3 h age guard, which is where the threshold here comes from.
